### PR TITLE
Add CHANGELOG for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - **DTCG interop**: `fromDTCG()` / `toDTCG()` for Design Token Community Group JSON
 - **Gradient text**: `lerp3()` interpolation, `gradientText()` with NO_COLOR support
 - **Theme resolver**: `createThemeResolver()` factory with configurable env var, presets, fallback
-- **Output detection**: `detectOutputMode()` → `rich` | `pipe` | `accessible`, respects `NO_COLOR`, `TERM=dumb`, `CI`, `BIJOU_ACCESSIBLE`
+- **Output detection**: `detectOutputMode()` → `interactive` | `static` | `pipe` | `accessible`, respects `NO_COLOR`, `TERM=dumb`, `CI`, `BIJOU_ACCESSIBLE`
 - **Components**: `box()`, `headerBox()`, `table()`, `progressBar()`, `spinnerFrame()`, `createSpinner()`, `loadRandomLogo()`, `selectLogoSize()`
 - **Forms**: `input()`, `select()`, `multiselect()`, `confirm()`, `group()`
 - **Graceful degradation** across all output modes for every component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,5 @@ All notable changes to this project will be documented in this file.
 - **Environment integration** (24 tests): NO_COLOR compliance, piped output degradation, CI/TERM=dumb detection, accessible mode, conflicting env vars
 - **DTCG edge cases** (8 tests): round-trip for all presets, unresolvable/circular refs, missing groups, modifier preservation
 - **bijou-node adapters** (29 tests): `nodeRuntime()`, `nodeIO()`, `chalkStyle()`, `createBijouNode()` integration
+
+[0.1.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@ All notable changes to this project will be documented in this file.
 - **Test adapter self-tests** (31 tests): `mockRuntime()`, `mockIO()`, `plainStyle()`, `createTestContext()`
 - **Environment integration** (24 tests): NO_COLOR compliance, piped output degradation, CI/TERM=dumb detection, accessible mode, conflicting env vars
 - **DTCG edge cases** (8 tests): round-trip for all presets, unresolvable/circular refs, missing groups, modifier preservation
+- **bijou-node adapters** (29 tests): `nodeRuntime()`, `nodeIO()`, `chalkStyle()`, `createBijouNode()` integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-02-23
+
+### Added
+
+- **Hexagonal architecture monorepo** with `@flyingrobots/bijou` (zero-dep core) and `@flyingrobots/bijou-node` (chalk/readline/process adapter)
+- **Port interfaces**: `RuntimePort`, `IOPort`, `StylePort`, `BijouContext`
+- **Test adapters**: `mockRuntime()`, `mockIO()`, `plainStyle()`, `createTestContext()`
+- **Theme engine**: `Theme<S, U, G>` triple-generic, two presets (`cyan-magenta`, `teal-orange-pink`), `BIJOU_THEME` env var selection
+- **DTCG interop**: `fromDTCG()` / `toDTCG()` for Design Token Community Group JSON
+- **Gradient text**: `lerp3()` interpolation, `gradientText()` with NO_COLOR support
+- **Theme resolver**: `createThemeResolver()` factory with configurable env var, presets, fallback
+- **Output detection**: `detectOutputMode()` → `rich` | `pipe` | `accessible`, respects `NO_COLOR`, `TERM=dumb`, `CI`, `BIJOU_ACCESSIBLE`
+- **Components**: `box()`, `headerBox()`, `table()`, `progressBar()`, `spinnerFrame()`, `createSpinner()`, `loadRandomLogo()`, `selectLogoSize()`
+- **Forms**: `input()`, `select()`, `multiselect()`, `confirm()`, `group()`
+- **Graceful degradation** across all output modes for every component
+- **CI workflow**: test + typecheck on Node 18/20/22
+- **Release workflow**: tag-based publish with OIDC provenance, tag-on-main guard, version verification, retry with backoff, prerelease dist-tags
+- **Lockstep versioning**: `npm run version <ver>` bumps all packages and cross-deps in one command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
 ## [0.1.0] - 2026-02-23
 
 ### Added
@@ -32,4 +34,5 @@ All notable changes to this project will be documented in this file.
 - **DTCG edge cases** (8 tests): round-trip for all presets, unresolvable/circular refs, missing groups, modifier preservation
 - **bijou-node adapters** (29 tests): `nodeRuntime()`, `nodeIO()`, `chalkStyle()`, `createBijouNode()` integration
 
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,13 @@ All notable changes to this project will be documented in this file.
 - **CI workflow**: test + typecheck on Node 18/20/22
 - **Release workflow**: tag-based publish with OIDC provenance, tag-on-main guard, version verification, retry with backoff, prerelease dist-tags
 - **Lockstep versioning**: `npm run version <ver>` bumps all packages and cross-deps in one command
+- **README** with install, quick start, architecture, and compatibility notes
+- **ROADMAP** with "Tests ARE the Spec" format: user stories, requirements, acceptance criteria, test plans
+
+### Tested
+
+- **Form functions** (42 tests): `confirm()`, `input()`, `select()`, `multiselect()` across pipe, accessible, and non-interactive modes
+- **Factory + context** (15 tests): `createBijou()` wiring, theme resolution, NO_COLOR, default context singleton
+- **Test adapter self-tests** (31 tests): `mockRuntime()`, `mockIO()`, `plainStyle()`, `createTestContext()`
+- **Environment integration** (24 tests): NO_COLOR compliance, piped output degradation, CI/TERM=dumb detection, accessible mode, conflicting env vars
+- **DTCG edge cases** (8 tests): round-trip for all presets, unresolvable/circular refs, missing groups, modifier preservation


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md documenting everything shipped in v0.1.0
- Covers architecture, theme engine, components, forms, CI/CD, versioning

## Test plan
- No code changes, documentation only