### PR TITLE
Add factory and default context tests

### DIFF
--- a/packages/bijou/src/context.test.ts
+++ b/packages/bijou/src/context.test.ts
@@ -28,6 +28,6 @@ describe('default context', () => {
   it('_resetDefaultContextForTesting() clears the singleton', () => {
     setDefaultContext(createTestContext());
     _resetDefaultContextForTesting();
-    expect(() => getDefaultContext()).toThrow();
+    expect(() => getDefaultContext()).toThrow('[bijou] No default context configured');
   });
 });

--- a/packages/bijou/src/context.test.ts
+++ b/packages/bijou/src/context.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getDefaultContext, setDefaultContext, _resetDefaultContextForTesting } from './context.js';
 import { createTestContext } from './adapters/test/index.js';
 
 describe('default context', () => {
   beforeEach(() => {
+    _resetDefaultContextForTesting();
+  });
+
+  afterEach(() => {
     _resetDefaultContextForTesting();
   });
 

--- a/packages/bijou/src/context.test.ts
+++ b/packages/bijou/src/context.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getDefaultContext, setDefaultContext, _resetDefaultContextForTesting } from './context.js';
+import { createTestContext } from './adapters/test/index.js';
+
+describe('default context', () => {
+  beforeEach(() => {
+    _resetDefaultContextForTesting();
+  });
+
+  it('getDefaultContext() throws before setDefaultContext()', () => {
+    expect(() => getDefaultContext()).toThrow('[bijou] No default context configured');
+  });
+
+  it('setDefaultContext() makes context available via getDefaultContext()', () => {
+    const ctx = createTestContext();
+    setDefaultContext(ctx);
+    expect(getDefaultContext()).toBe(ctx);
+  });
+
+  it('setDefaultContext() overwrites previous context', () => {
+    const ctx1 = createTestContext({ mode: 'interactive' });
+    const ctx2 = createTestContext({ mode: 'pipe' });
+    setDefaultContext(ctx1);
+    setDefaultContext(ctx2);
+    expect(getDefaultContext()).toBe(ctx2);
+  });
+
+  it('_resetDefaultContextForTesting() clears the singleton', () => {
+    setDefaultContext(createTestContext());
+    _resetDefaultContextForTesting();
+    expect(() => getDefaultContext()).toThrow();
+  });
+});

--- a/packages/bijou/src/factory.test.ts
+++ b/packages/bijou/src/factory.test.ts
@@ -3,7 +3,7 @@ import { createBijou } from './factory.js';
 import { mockRuntime } from './adapters/test/runtime.js';
 import { mockIO } from './adapters/test/io.js';
 import { plainStyle } from './adapters/test/style.js';
-import { CYAN_MAGENTA, TEAL_ORANGE_PINK, PRESETS } from './core/theme/presets.js';
+import { CYAN_MAGENTA, TEAL_ORANGE_PINK } from './core/theme/presets.js';
 
 function basePorts(env: Record<string, string> = {}, tty = true) {
   return {
@@ -65,7 +65,7 @@ describe('createBijou()', () => {
     expect(ctx.theme.noColor).toBe(false);
   });
 
-  it('detects rich mode when stdout is TTY', () => {
+  it('detects interactive mode when stdout is TTY', () => {
     const ctx = createBijou(basePorts({}, true));
     expect(ctx.mode).toBe('interactive');
   });

--- a/packages/bijou/src/factory.test.ts
+++ b/packages/bijou/src/factory.test.ts
@@ -15,12 +15,13 @@ function basePorts(env: Record<string, string> = {}, tty = true) {
 
 describe('createBijou()', () => {
   it('returns BijouContext with all five fields populated', () => {
-    const ctx = createBijou(basePorts());
-    expect(ctx.theme).toBeDefined();
-    expect(ctx.mode).toBeDefined();
-    expect(ctx.runtime).toBeDefined();
-    expect(ctx.io).toBeDefined();
-    expect(ctx.style).toBeDefined();
+    const ports = basePorts();
+    const ctx = createBijou(ports);
+    expect(ctx.runtime).toBe(ports.runtime);
+    expect(ctx.io).toBe(ports.io);
+    expect(ctx.style).toBe(ports.style);
+    expect(ctx.mode).toBe('interactive');
+    expect(ctx.theme.theme).toBe(CYAN_MAGENTA);
   });
 
   it('reads BIJOU_THEME from runtime.env and resolves matching preset', () => {
@@ -75,8 +76,22 @@ describe('createBijou()', () => {
     expect(ctx.mode).toBe('pipe');
   });
 
-  it('defaults to CYAN_MAGENTA when no BIJOU_THEME env var is set', () => {
-    const ctx = createBijou(basePorts());
-    expect(ctx.theme.theme).toBe(CYAN_MAGENTA);
+  it('detects static mode when CI is set with TTY', () => {
+    const ctx = createBijou(basePorts({ CI: 'true' }, true));
+    expect(ctx.mode).toBe('static');
+  });
+
+  it('detects accessible mode when BIJOU_ACCESSIBLE is set', () => {
+    const ctx = createBijou(basePorts({ BIJOU_ACCESSIBLE: '1' }, true));
+    expect(ctx.mode).toBe('accessible');
+  });
+
+  it('uses custom fallback theme when BIJOU_THEME is unrecognized', () => {
+    const custom = { ...CYAN_MAGENTA, name: 'my-fallback' };
+    const ctx = createBijou({
+      ...basePorts({ BIJOU_THEME: 'nonexistent' }),
+      theme: custom,
+    });
+    expect(ctx.theme.theme).toBe(custom);
   });
 });

--- a/packages/bijou/src/factory.test.ts
+++ b/packages/bijou/src/factory.test.ts
@@ -77,6 +77,6 @@ describe('createBijou()', () => {
 
   it('defaults to CYAN_MAGENTA when no BIJOU_THEME env var is set', () => {
     const ctx = createBijou(basePorts());
-    expect(ctx.theme.theme.name).toBe(CYAN_MAGENTA.name);
+    expect(ctx.theme.theme).toBe(CYAN_MAGENTA);
   });
 });

--- a/packages/bijou/src/factory.test.ts
+++ b/packages/bijou/src/factory.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { createBijou } from './factory.js';
+import { mockRuntime } from './adapters/test/runtime.js';
+import { mockIO } from './adapters/test/io.js';
+import { plainStyle } from './adapters/test/style.js';
+import { CYAN_MAGENTA, TEAL_ORANGE_PINK, PRESETS } from './core/theme/presets.js';
+
+function basePorts(env: Record<string, string> = {}, tty = true) {
+  return {
+    runtime: mockRuntime({ env, stdoutIsTTY: tty }),
+    io: mockIO(),
+    style: plainStyle(),
+  };
+}
+
+describe('createBijou()', () => {
+  it('returns BijouContext with all five fields populated', () => {
+    const ctx = createBijou(basePorts());
+    expect(ctx.theme).toBeDefined();
+    expect(ctx.mode).toBeDefined();
+    expect(ctx.runtime).toBeDefined();
+    expect(ctx.io).toBeDefined();
+    expect(ctx.style).toBeDefined();
+  });
+
+  it('reads BIJOU_THEME from runtime.env and resolves matching preset', () => {
+    const ctx = createBijou(basePorts({ BIJOU_THEME: 'teal-orange-pink' }));
+    expect(ctx.theme.theme).toBe(TEAL_ORANGE_PINK);
+  });
+
+  it('falls back to CYAN_MAGENTA when BIJOU_THEME is unrecognized', () => {
+    const ctx = createBijou(basePorts({ BIJOU_THEME: 'nonexistent' }));
+    expect(ctx.theme.theme).toBe(CYAN_MAGENTA);
+  });
+
+  it('uses custom envVar when provided', () => {
+    const ctx = createBijou({
+      ...basePorts({ MY_THEME: 'teal-orange-pink' }),
+      envVar: 'MY_THEME',
+    });
+    expect(ctx.theme.theme).toBe(TEAL_ORANGE_PINK);
+  });
+
+  it('uses custom presets registry when provided', () => {
+    const custom = { ...CYAN_MAGENTA, name: 'custom' };
+    const ctx = createBijou({
+      ...basePorts({ BIJOU_THEME: 'custom' }),
+      presets: { custom },
+    });
+    expect(ctx.theme.theme).toBe(custom);
+  });
+
+  it('sets noColor: true when NO_COLOR is defined', () => {
+    const ctx = createBijou(basePorts({ NO_COLOR: '1' }));
+    expect(ctx.theme.noColor).toBe(true);
+  });
+
+  it('sets noColor: true when NO_COLOR is empty string', () => {
+    const ctx = createBijou(basePorts({ NO_COLOR: '' }));
+    expect(ctx.theme.noColor).toBe(true);
+  });
+
+  it('sets noColor: false when NO_COLOR is absent', () => {
+    const ctx = createBijou(basePorts());
+    expect(ctx.theme.noColor).toBe(false);
+  });
+
+  it('detects rich mode when stdout is TTY', () => {
+    const ctx = createBijou(basePorts({}, true));
+    expect(ctx.mode).toBe('interactive');
+  });
+
+  it('detects pipe mode when stdout is not TTY', () => {
+    const ctx = createBijou(basePorts({}, false));
+    expect(ctx.mode).toBe('pipe');
+  });
+
+  it('defaults to CYAN_MAGENTA when no BIJOU_THEME env var is set', () => {
+    const ctx = createBijou(basePorts());
+    expect(ctx.theme.theme.name).toBe(CYAN_MAGENTA.name);
+  });
+});


### PR DESCRIPTION
## Summary
- ROADMAP item #2: factory and context management tests
- `factory.test.ts` (11 tests): context creation, theme resolution via env var, unknown theme fallback, custom envVar/presets, NO_COLOR handling, output mode detection
- `context.test.ts` (4 tests): get-before-set throws, set+get round-trip, overwrite, reset

Test count: 113 → 128

## Test plan
- `npm test` — 128 passing