### PR TITLE
Add test adapter self-tests (ROADMAP #3)

### DIFF
--- a/packages/bijou/src/adapters/test/context.test.ts
+++ b/packages/bijou/src/adapters/test/context.test.ts
@@ -4,11 +4,11 @@ import { createTestContext } from './index.js';
 describe('createTestContext()', () => {
   it('returns BijouContext with all fields', () => {
     const ctx = createTestContext();
-    expect(ctx.theme).toBeDefined();
-    expect(ctx.mode).toBeDefined();
-    expect(ctx.runtime).toBeDefined();
-    expect(ctx.io).toBeDefined();
-    expect(ctx.style).toBeDefined();
+    expect(ctx.runtime.env).toBeTypeOf('function');
+    expect(ctx.io.write).toBeTypeOf('function');
+    expect(ctx.style.bold).toBeTypeOf('function');
+    expect(ctx.theme.noColor).toBeTypeOf('boolean');
+    expect(typeof ctx.mode).toBe('string');
   });
 
   it('defaults to interactive mode', () => {
@@ -32,5 +32,15 @@ describe('createTestContext()', () => {
     const ctx = createTestContext();
     ctx.io.write('test');
     expect(ctx.io.written).toEqual(['test']);
+  });
+
+  it('forwards runtime options', () => {
+    const ctx = createTestContext({ runtime: { columns: 120 } });
+    expect(ctx.runtime.columns).toBe(120);
+  });
+
+  it('forwards io options', async () => {
+    const ctx = createTestContext({ io: { answers: ['yes'] } });
+    expect(await ctx.io.question('? ')).toBe('yes');
   });
 });

--- a/packages/bijou/src/adapters/test/context.test.ts
+++ b/packages/bijou/src/adapters/test/context.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { createTestContext } from './index.js';
+
+describe('createTestContext()', () => {
+  it('returns BijouContext with all fields', () => {
+    const ctx = createTestContext();
+    expect(ctx.theme).toBeDefined();
+    expect(ctx.mode).toBeDefined();
+    expect(ctx.runtime).toBeDefined();
+    expect(ctx.io).toBeDefined();
+    expect(ctx.style).toBeDefined();
+  });
+
+  it('defaults to interactive mode', () => {
+    expect(createTestContext().mode).toBe('interactive');
+  });
+
+  it('uses specified mode', () => {
+    expect(createTestContext({ mode: 'pipe' }).mode).toBe('pipe');
+    expect(createTestContext({ mode: 'accessible' }).mode).toBe('accessible');
+  });
+
+  it('theme is resolved with noColor false by default', () => {
+    expect(createTestContext().theme.noColor).toBe(false);
+  });
+
+  it('theme respects noColor option', () => {
+    expect(createTestContext({ noColor: true }).theme.noColor).toBe(true);
+  });
+
+  it('io is a MockIO with written buffer and answer queue', () => {
+    const ctx = createTestContext();
+    ctx.io.write('test');
+    expect(ctx.io.written).toEqual(['test']);
+  });
+});

--- a/packages/bijou/src/adapters/test/io.test.ts
+++ b/packages/bijou/src/adapters/test/io.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mockIO } from './io.js';
+
+describe('mockIO()', () => {
+  it('write() captures output to written buffer', () => {
+    const io = mockIO();
+    io.write('hello');
+    io.write('world');
+    expect(io.written).toEqual(['hello', 'world']);
+  });
+
+  it('question() captures prompt and returns queued answers', async () => {
+    const io = mockIO({ answers: ['alice', 'bob'] });
+    const a1 = await io.question('Name? ');
+    const a2 = await io.question('Friend? ');
+    expect(a1).toBe('alice');
+    expect(a2).toBe('bob');
+    expect(io.written).toEqual(['Name? ', 'Friend? ']);
+  });
+
+  it('question() returns empty string when queue is exhausted', async () => {
+    const io = mockIO({ answers: ['once'] });
+    await io.question('1? ');
+    const result = await io.question('2? ');
+    expect(result).toBe('');
+  });
+
+  it('readFile() returns content from mock filesystem', () => {
+    const io = mockIO({ files: { '/tmp/a.txt': 'contents' } });
+    expect(io.readFile('/tmp/a.txt')).toBe('contents');
+  });
+
+  it('readFile() throws for missing file', () => {
+    const io = mockIO();
+    expect(() => io.readFile('/nope')).toThrow('Mock: file not found');
+  });
+
+  it('readDir() returns entries from mock dirs', () => {
+    const io = mockIO({ dirs: { '/logos': ['a.txt', 'b.txt'] } });
+    expect(io.readDir('/logos')).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('readDir() returns empty array for unknown directory', () => {
+    const io = mockIO();
+    expect(io.readDir('/nope')).toEqual([]);
+  });
+
+  it('joinPath() joins path segments', () => {
+    const io = mockIO();
+    expect(io.joinPath('/foo', 'bar', 'baz.txt')).toBe('/foo/bar/baz.txt');
+  });
+
+  it('rawInput() returns a disposable handle', () => {
+    const io = mockIO();
+    const handle = io.rawInput(() => {});
+    expect(handle.dispose).toBeTypeOf('function');
+    handle.dispose(); // should not throw
+  });
+
+  it('setInterval() returns a disposable handle', () => {
+    const io = mockIO();
+    const handle = io.setInterval(() => {}, 1000);
+    expect(handle.dispose).toBeTypeOf('function');
+    handle.dispose(); // cleans up
+  });
+});

--- a/packages/bijou/src/adapters/test/io.test.ts
+++ b/packages/bijou/src/adapters/test/io.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { join } from 'path';
 import { mockIO } from './io.js';
 
 describe('mockIO()', () => {
@@ -47,7 +48,7 @@ describe('mockIO()', () => {
 
   it('joinPath() joins path segments', () => {
     const io = mockIO();
-    expect(io.joinPath('/foo', 'bar', 'baz.txt')).toBe('/foo/bar/baz.txt');
+    expect(io.joinPath('/foo', 'bar', 'baz.txt')).toBe(join('/foo', 'bar', 'baz.txt'));
   });
 
   it('rawInput() returns a disposable handle', () => {

--- a/packages/bijou/src/adapters/test/runtime.test.ts
+++ b/packages/bijou/src/adapters/test/runtime.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mockRuntime } from './runtime.js';
+
+describe('mockRuntime()', () => {
+  it('env() returns values from provided env map', () => {
+    const rt = mockRuntime({ env: { FOO: 'bar' } });
+    expect(rt.env('FOO')).toBe('bar');
+  });
+
+  it('env() returns undefined for missing keys', () => {
+    const rt = mockRuntime({ env: { FOO: 'bar' } });
+    expect(rt.env('MISSING')).toBeUndefined();
+  });
+
+  it('env() returns undefined by default with no env map', () => {
+    const rt = mockRuntime();
+    expect(rt.env('ANYTHING')).toBeUndefined();
+  });
+
+  it('stdoutIsTTY defaults to true', () => {
+    expect(mockRuntime().stdoutIsTTY).toBe(true);
+  });
+
+  it('stdoutIsTTY reflects options', () => {
+    expect(mockRuntime({ stdoutIsTTY: false }).stdoutIsTTY).toBe(false);
+  });
+
+  it('stdinIsTTY defaults to true', () => {
+    expect(mockRuntime().stdinIsTTY).toBe(true);
+  });
+
+  it('stdinIsTTY reflects options', () => {
+    expect(mockRuntime({ stdinIsTTY: false }).stdinIsTTY).toBe(false);
+  });
+
+  it('columns defaults to 80', () => {
+    expect(mockRuntime().columns).toBe(80);
+  });
+
+  it('columns reflects options', () => {
+    expect(mockRuntime({ columns: 120 }).columns).toBe(120);
+  });
+
+  it('rows defaults to 24', () => {
+    expect(mockRuntime().rows).toBe(24);
+  });
+
+  it('rows reflects options', () => {
+    expect(mockRuntime({ rows: 50 }).rows).toBe(50);
+  });
+});

--- a/packages/bijou/src/adapters/test/style.test.ts
+++ b/packages/bijou/src/adapters/test/style.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { plainStyle } from './style.js';
+
+describe('plainStyle()', () => {
+  const style = plainStyle();
+
+  it('styled() returns text unchanged', () => {
+    expect(style.styled({ hex: '#ff0000', modifiers: [] }, 'hello')).toBe('hello');
+  });
+
+  it('bold() returns text unchanged', () => {
+    expect(style.bold('strong')).toBe('strong');
+  });
+
+  it('rgb() returns text unchanged', () => {
+    expect(style.rgb(255, 0, 0, 'red')).toBe('red');
+  });
+
+  it('hex() returns text unchanged', () => {
+    expect(style.hex('#00ff00', 'green')).toBe('green');
+  });
+});


### PR DESCRIPTION
## Summary
- `runtime.test.ts` (11 tests): env lookup, missing keys, defaults, TTY states, dimensions
- `io.test.ts` (10 tests): write capture, answer queue, queue exhaustion, mock filesystem, disposable handles
- `style.test.ts` (4 tests): styled/bold/rgb/hex all pass-through unchanged
- `context.test.ts` (6 tests): field population, default mode, mode override, noColor

Test count: 113 → 144

## Test plan
- `npm test` — 144 passing