### PR TITLE
Add DTCG edge-case tests (ROADMAP #6)

### DIFF
--- a/packages/bijou/src/core/theme/dtcg.test.ts
+++ b/packages/bijou/src/core/theme/dtcg.test.ts
@@ -268,8 +268,9 @@ describe('DTCG interop', () => {
         },
       };
 
-      // Should not throw — just returns the ref string as-is since it resolves to another ref
-      expect(() => fromDTCG(doc)).not.toThrow();
+      // Should not throw — resolves one level: {a} → $value of a = '{b}'
+      const theme = fromDTCG(doc);
+      expect(theme.status.success.hex).toBe('{b}');
     });
 
     it('missing optional groups produce default #000000 tokens', () => {

--- a/packages/bijou/src/core/theme/dtcg.test.ts
+++ b/packages/bijou/src/core/theme/dtcg.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { fromDTCG, toDTCG, type DTCGDocument } from './dtcg.js';
-import { CYAN_MAGENTA, TEAL_ORANGE_PINK, PRESETS } from './presets.js';
+import { CYAN_MAGENTA, PRESETS } from './presets.js';
 
 describe('DTCG interop', () => {
   describe('toDTCG', () => {
@@ -188,7 +188,7 @@ describe('DTCG interop', () => {
   });
 
   describe('fromDTCG edge cases', () => {
-    it('unresolvable reference falls back to #000000', () => {
+    it('unresolvable reference passes raw ref string as hex value', () => {
       const doc: DTCGDocument = {
         name: { $type: 'string', $value: 'ref-broken' },
         status: {
@@ -209,9 +209,21 @@ describe('DTCG interop', () => {
           muted: { $type: 'color', $value: '#808080' },
           primary: { $type: 'color', $value: '#ffffff' },
         },
-        gradient: { brand: { $type: 'gradient', $value: [] }, progress: { $type: 'gradient', $value: [] } },
-        border: { primary: { $value: '#aaa' }, secondary: { $value: '#aaa' }, success: { $value: '#aaa' }, warning: { $value: '#aaa' }, error: { $value: '#aaa' }, muted: { $value: '#aaa' } },
-        ui: { cursor: { $value: '#aaa' }, scrollThumb: { $value: '#aaa' }, scrollTrack: { $value: '#aaa' }, sectionHeader: { $value: '#aaa' }, logo: { $value: '#aaa' }, tableHeader: { $value: '#aaa' }, trackEmpty: { $value: '#aaa' } },
+        gradient: {
+          brand: { $type: 'gradient', $value: [] },
+          progress: { $type: 'gradient', $value: [] },
+        },
+        border: {
+          primary: { $value: '#aaa' }, secondary: { $value: '#aaa' },
+          success: { $value: '#aaa' }, warning: { $value: '#aaa' },
+          error: { $value: '#aaa' }, muted: { $value: '#aaa' },
+        },
+        ui: {
+          cursor: { $value: '#aaa' }, scrollThumb: { $value: '#aaa' },
+          scrollTrack: { $value: '#aaa' }, sectionHeader: { $value: '#aaa' },
+          logo: { $value: '#aaa' }, tableHeader: { $value: '#aaa' },
+          trackEmpty: { $value: '#aaa' },
+        },
       };
 
       const theme = fromDTCG(doc);
@@ -233,10 +245,27 @@ describe('DTCG interop', () => {
           active: { $type: 'color', $value: '#00ffff' },
           muted: { $type: 'color', $value: '#808080' },
         },
-        semantic: { success: { $value: '#0f0' }, error: { $value: '#f00' }, warning: { $value: '#ff0' }, info: { $value: '#0ff' }, accent: { $value: '#f0f' }, muted: { $value: '#888' }, primary: { $value: '#fff' } },
-        gradient: { brand: { $type: 'gradient', $value: [] }, progress: { $type: 'gradient', $value: [] } },
-        border: { primary: { $value: '#aaa' }, secondary: { $value: '#aaa' }, success: { $value: '#aaa' }, warning: { $value: '#aaa' }, error: { $value: '#aaa' }, muted: { $value: '#aaa' } },
-        ui: { cursor: { $value: '#aaa' }, scrollThumb: { $value: '#aaa' }, scrollTrack: { $value: '#aaa' }, sectionHeader: { $value: '#aaa' }, logo: { $value: '#aaa' }, tableHeader: { $value: '#aaa' }, trackEmpty: { $value: '#aaa' } },
+        semantic: {
+          success: { $value: '#0f0' }, error: { $value: '#f00' },
+          warning: { $value: '#ff0' }, info: { $value: '#0ff' },
+          accent: { $value: '#f0f' }, muted: { $value: '#888' },
+          primary: { $value: '#fff' },
+        },
+        gradient: {
+          brand: { $type: 'gradient', $value: [] },
+          progress: { $type: 'gradient', $value: [] },
+        },
+        border: {
+          primary: { $value: '#aaa' }, secondary: { $value: '#aaa' },
+          success: { $value: '#aaa' }, warning: { $value: '#aaa' },
+          error: { $value: '#aaa' }, muted: { $value: '#aaa' },
+        },
+        ui: {
+          cursor: { $value: '#aaa' }, scrollThumb: { $value: '#aaa' },
+          scrollTrack: { $value: '#aaa' }, sectionHeader: { $value: '#aaa' },
+          logo: { $value: '#aaa' }, tableHeader: { $value: '#aaa' },
+          trackEmpty: { $value: '#aaa' },
+        },
       };
 
       // Should not throw — just returns the ref string as-is since it resolves to another ref

--- a/packages/bijou/src/core/theme/dtcg.test.ts
+++ b/packages/bijou/src/core/theme/dtcg.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { fromDTCG, toDTCG, type DTCGDocument } from './dtcg.js';
-import { CYAN_MAGENTA } from './presets.js';
+import { CYAN_MAGENTA, TEAL_ORANGE_PINK, PRESETS } from './presets.js';
 
 describe('DTCG interop', () => {
   describe('toDTCG', () => {
@@ -170,6 +170,126 @@ describe('DTCG interop', () => {
       expect(roundTripped.semantic.accent.hex).toBe(CYAN_MAGENTA.semantic.accent.hex);
       expect(roundTripped.border.primary.hex).toBe(CYAN_MAGENTA.border.primary.hex);
       expect(roundTripped.ui.cursor.hex).toBe(CYAN_MAGENTA.ui.cursor.hex);
+    });
+
+    it('every built-in preset survives round-trip', () => {
+      for (const [name, preset] of Object.entries(PRESETS)) {
+        const rt = fromDTCG(toDTCG(preset));
+        expect(rt.name).toBe(name);
+        expect(rt.status.success.hex).toBe(preset.status.success.hex);
+        expect(rt.status.error.hex).toBe(preset.status.error.hex);
+        expect(rt.border.primary.hex).toBe(preset.border.primary.hex);
+        expect(rt.ui.cursor.hex).toBe(preset.ui.cursor.hex);
+        // Gradient stop count preserved
+        expect(rt.gradient.brand).toHaveLength(preset.gradient.brand.length);
+        expect(rt.gradient.progress).toHaveLength(preset.gradient.progress.length);
+      }
+    });
+  });
+
+  describe('fromDTCG edge cases', () => {
+    it('unresolvable reference falls back to #000000', () => {
+      const doc: DTCGDocument = {
+        name: { $type: 'string', $value: 'ref-broken' },
+        status: {
+          success: { $type: 'color', $value: '{nonexistent.path}' },
+          error: { $type: 'color', $value: '#ff0000' },
+          warning: { $type: 'color', $value: '#ffff00' },
+          info: { $type: 'color', $value: '#00ffff' },
+          pending: { $type: 'color', $value: '#808080' },
+          active: { $type: 'color', $value: '#00ffff' },
+          muted: { $type: 'color', $value: '#808080' },
+        },
+        semantic: {
+          success: { $type: 'color', $value: '#00ff00' },
+          error: { $type: 'color', $value: '#ff0000' },
+          warning: { $type: 'color', $value: '#ffff00' },
+          info: { $type: 'color', $value: '#00ffff' },
+          accent: { $type: 'color', $value: '#ff00ff' },
+          muted: { $type: 'color', $value: '#808080' },
+          primary: { $type: 'color', $value: '#ffffff' },
+        },
+        gradient: { brand: { $type: 'gradient', $value: [] }, progress: { $type: 'gradient', $value: [] } },
+        border: { primary: { $value: '#aaa' }, secondary: { $value: '#aaa' }, success: { $value: '#aaa' }, warning: { $value: '#aaa' }, error: { $value: '#aaa' }, muted: { $value: '#aaa' } },
+        ui: { cursor: { $value: '#aaa' }, scrollThumb: { $value: '#aaa' }, scrollTrack: { $value: '#aaa' }, sectionHeader: { $value: '#aaa' }, logo: { $value: '#aaa' }, tableHeader: { $value: '#aaa' }, trackEmpty: { $value: '#aaa' } },
+      };
+
+      const theme = fromDTCG(doc);
+      // Unresolvable ref string is treated as the hex value
+      expect(theme.status.success.hex).toBe('{nonexistent.path}');
+    });
+
+    it('circular references do not crash (return raw ref string)', () => {
+      const doc: DTCGDocument = {
+        a: { $type: 'color', $value: '{b}' },
+        b: { $type: 'color', $value: '{a}' },
+        name: { $type: 'string', $value: 'circular' },
+        status: {
+          success: { $type: 'color', $value: '{a}' },
+          error: { $type: 'color', $value: '#ff0000' },
+          warning: { $type: 'color', $value: '#ffff00' },
+          info: { $type: 'color', $value: '#00ffff' },
+          pending: { $type: 'color', $value: '#808080' },
+          active: { $type: 'color', $value: '#00ffff' },
+          muted: { $type: 'color', $value: '#808080' },
+        },
+        semantic: { success: { $value: '#0f0' }, error: { $value: '#f00' }, warning: { $value: '#ff0' }, info: { $value: '#0ff' }, accent: { $value: '#f0f' }, muted: { $value: '#888' }, primary: { $value: '#fff' } },
+        gradient: { brand: { $type: 'gradient', $value: [] }, progress: { $type: 'gradient', $value: [] } },
+        border: { primary: { $value: '#aaa' }, secondary: { $value: '#aaa' }, success: { $value: '#aaa' }, warning: { $value: '#aaa' }, error: { $value: '#aaa' }, muted: { $value: '#aaa' } },
+        ui: { cursor: { $value: '#aaa' }, scrollThumb: { $value: '#aaa' }, scrollTrack: { $value: '#aaa' }, sectionHeader: { $value: '#aaa' }, logo: { $value: '#aaa' }, tableHeader: { $value: '#aaa' }, trackEmpty: { $value: '#aaa' } },
+      };
+
+      // Should not throw — just returns the ref string as-is since it resolves to another ref
+      expect(() => fromDTCG(doc)).not.toThrow();
+    });
+
+    it('missing optional groups produce default #000000 tokens', () => {
+      const doc: DTCGDocument = {
+        name: { $type: 'string', $value: 'minimal' },
+        // Everything else missing
+      };
+
+      const theme = fromDTCG(doc);
+      expect(theme.name).toBe('minimal');
+      expect(theme.status.success.hex).toBe('#000000');
+      expect(theme.semantic.primary.hex).toBe('#000000');
+      expect(theme.border.primary.hex).toBe('#000000');
+      expect(theme.ui.cursor.hex).toBe('#000000');
+      expect(theme.gradient.brand).toEqual([]);
+    });
+
+    it('missing name defaults to "imported"', () => {
+      const doc: DTCGDocument = {};
+      const theme = fromDTCG(doc);
+      expect(theme.name).toBe('imported');
+    });
+  });
+
+  describe('toDTCG edge cases', () => {
+    it('preserves modifier metadata through toDTCG', () => {
+      const doc = toDTCG(CYAN_MAGENTA);
+      const status = doc['status'] as Record<string, { $type: string; $value: unknown }>;
+      // pending has ['dim'] modifier
+      const pending = status['pending']!.$value as { hex: string; modifiers: string[] };
+      expect(pending.modifiers).toEqual(['dim']);
+    });
+
+    it('tokens without modifiers are encoded as plain hex strings', () => {
+      const doc = toDTCG(CYAN_MAGENTA);
+      const status = doc['status'] as Record<string, { $type: string; $value: unknown }>;
+      // success has no modifiers
+      expect(typeof status['success']!.$value).toBe('string');
+    });
+
+    it('gradient stops encode RGB as hex strings', () => {
+      const doc = toDTCG(CYAN_MAGENTA);
+      const gradient = doc['gradient'] as Record<string, { $value: unknown }>;
+      const stops = gradient['brand']!.$value as Array<{ pos: number; color: string }>;
+      expect(stops.length).toBeGreaterThan(0);
+      for (const stop of stops) {
+        expect(stop.color).toMatch(/^#[0-9a-f]{6}$/);
+        expect(typeof stop.pos).toBe('number');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
8 new tests hardening DTCG theme interop:

- **round-trip**: every built-in preset survives `fromDTCG(toDTCG(preset))`
- **fromDTCG**: unresolvable refs, circular refs don't crash, missing groups → `#000000`, missing name → `"imported"`
- **toDTCG**: modifier preservation, plain hex encoding, gradient RGB→hex format

Test count: 113 → 121

## Test plan
- `npm test` — 121 passing