### PR TITLE
Add bijou-node adapter tests (ROADMAP #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **initDefaultContext() test coverage**: added `_resetInitializedForTesting()` helper and tests verifying first-call sets default context, subsequent calls don't overwrite it
+- **Consistent env stubbing**: replaced direct `process.env` mutation in `runtime.test.ts` with `vi.stubEnv()`/`vi.unstubAllEnvs()`
+- **Modifier ANSI assertions**: added conditional `it.runIf` tests for bold, dim, strikethrough, and inverse modifiers in `style.test.ts`
+- **TTY coverage documentation**: noted `question()`/`rawInput()` are not unit-testable without a TTY
+
+### Added
+
+- `_resetDefaultContextForTesting` re-exported from `@flyingrobots/bijou` barrel
+
 ## [0.1.0] - 2026-02-23
 
 ### Added

--- a/packages/bijou-node/src/index.test.ts
+++ b/packages/bijou-node/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createNodeContext } from './index.js';
 
 describe('createNodeContext()', () => {
@@ -23,7 +23,12 @@ describe('createNodeContext()', () => {
   });
 
   it('runtime reads process.env', () => {
+    vi.stubEnv('__BIJOU_TEST_CTX__', 'test-value');
     const ctx = createNodeContext();
-    expect(ctx.runtime.env('PATH')).toBeDefined();
+    expect(ctx.runtime.env('__BIJOU_TEST_CTX__')).toBe('test-value');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 });

--- a/packages/bijou-node/src/index.test.ts
+++ b/packages/bijou-node/src/index.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
-import { createNodeContext } from './index.js';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { createNodeContext, initDefaultContext, _resetInitializedForTesting } from './index.js';
+import { getDefaultContext, _resetDefaultContextForTesting } from '@flyingrobots/bijou';
 
 describe('createNodeContext()', () => {
   afterEach(() => {
@@ -30,5 +31,38 @@ describe('createNodeContext()', () => {
     vi.stubEnv('__BIJOU_TEST_CTX__', 'test-value');
     const ctx = createNodeContext();
     expect(ctx.runtime.env('__BIJOU_TEST_CTX__')).toBe('test-value');
+  });
+});
+
+describe('initDefaultContext()', () => {
+  beforeEach(() => {
+    _resetInitializedForTesting();
+    _resetDefaultContextForTesting();
+  });
+
+  afterEach(() => {
+    _resetInitializedForTesting();
+    _resetDefaultContextForTesting();
+  });
+
+  it('first call returns a BijouContext with all five fields', () => {
+    const ctx = initDefaultContext();
+    expect(ctx.theme).toBeDefined();
+    expect(ctx.mode).toBeDefined();
+    expect(ctx.runtime).toBeDefined();
+    expect(ctx.io).toBeDefined();
+    expect(ctx.style).toBeDefined();
+  });
+
+  it('first call sets the default context', () => {
+    const ctx = initDefaultContext();
+    expect(getDefaultContext()).toBe(ctx);
+  });
+
+  it('subsequent call returns a new context without overwriting the default', () => {
+    const first = initDefaultContext();
+    const second = initDefaultContext();
+    expect(second).not.toBe(first);
+    expect(getDefaultContext()).toBe(first);
   });
 });

--- a/packages/bijou-node/src/index.test.ts
+++ b/packages/bijou-node/src/index.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createNodeContext } from './index.js';
 
 describe('createNodeContext()', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('returns BijouContext with all five fields', () => {
     const ctx = createNodeContext();
     expect(ctx.theme).toBeDefined();
@@ -26,9 +30,5 @@ describe('createNodeContext()', () => {
     vi.stubEnv('__BIJOU_TEST_CTX__', 'test-value');
     const ctx = createNodeContext();
     expect(ctx.runtime.env('__BIJOU_TEST_CTX__')).toBe('test-value');
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
   });
 });

--- a/packages/bijou-node/src/index.test.ts
+++ b/packages/bijou-node/src/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { createNodeContext } from './index.js';
+
+describe('createNodeContext()', () => {
+  it('returns BijouContext with all five fields', () => {
+    const ctx = createNodeContext();
+    expect(ctx.theme).toBeDefined();
+    expect(ctx.mode).toBeDefined();
+    expect(ctx.runtime).toBeDefined();
+    expect(ctx.io).toBeDefined();
+    expect(ctx.style).toBeDefined();
+  });
+
+  it('theme is resolved with a name', () => {
+    const ctx = createNodeContext();
+    expect(typeof ctx.theme.theme.name).toBe('string');
+    expect(typeof ctx.theme.noColor).toBe('boolean');
+  });
+
+  it('mode is a valid OutputMode', () => {
+    const ctx = createNodeContext();
+    expect(['interactive', 'static', 'pipe', 'accessible']).toContain(ctx.mode);
+  });
+
+  it('runtime reads process.env', () => {
+    const ctx = createNodeContext();
+    expect(ctx.runtime.env('PATH')).toBeDefined();
+  });
+});

--- a/packages/bijou-node/src/index.ts
+++ b/packages/bijou-node/src/index.ts
@@ -19,6 +19,9 @@ export function createNodeContext(): BijouContext {
 }
 
 let initialized = false;
+export function _resetInitializedForTesting(): void {
+  initialized = false;
+}
 export function initDefaultContext(): BijouContext {
   if (!initialized) {
     const ctx = createNodeContext();

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { nodeIO } from './io.js';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -56,8 +56,7 @@ describe('nodeIO()', () => {
 
   it('setInterval() returns a disposable handle', () => {
     const io = nodeIO();
-    let count = 0;
-    const handle = io.setInterval(() => { count++; }, 10_000);
+    const handle = io.setInterval(() => {}, 10_000);
     expect(handle.dispose).toBeTypeOf('function');
     handle.dispose();
   });

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -30,7 +30,8 @@ describe('nodeIO()', () => {
 
   it('readFile() throws for missing file', () => {
     const io = nodeIO();
-    expect(() => io.readFile('/tmp/bijou-nonexistent-file-xyz')).toThrow();
+    const missingFile = join(tmpdir(), `bijou-missing-${Date.now()}.txt`);
+    expect(() => io.readFile(missingFile)).toThrow();
   });
 
   it('readDir() lists real directory contents', () => {
@@ -46,12 +47,13 @@ describe('nodeIO()', () => {
 
   it('readDir() throws for missing directory', () => {
     const io = nodeIO();
-    expect(() => io.readDir('/tmp/bijou-nonexistent-dir-xyz')).toThrow();
+    const missingDir = join(tmpdir(), `bijou-missing-${Date.now()}`);
+    expect(() => io.readDir(missingDir)).toThrow();
   });
 
   it('joinPath() joins segments', () => {
     const io = nodeIO();
-    expect(io.joinPath('/foo', 'bar', 'baz.txt')).toBe('/foo/bar/baz.txt');
+    expect(io.joinPath('/foo', 'bar', 'baz.txt')).toBe(join('/foo', 'bar', 'baz.txt'));
   });
 
   it('setInterval() returns a disposable handle', () => {

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { nodeIO } from './io.js';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('nodeIO()', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('write() calls process.stdout.write', () => {
+    const io = nodeIO();
+    // Just verify it doesn't throw — stdout.write in test runner is fine
+    expect(() => io.write('')).not.toThrow();
+  });
+
+  it('readFile() reads a real file', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bijou-test-'));
+    const filePath = join(tempDir, 'test.txt');
+    writeFileSync(filePath, 'hello bijou');
+
+    const io = nodeIO();
+    expect(io.readFile(filePath)).toBe('hello bijou');
+  });
+
+  it('readFile() throws for missing file', () => {
+    const io = nodeIO();
+    expect(() => io.readFile('/tmp/bijou-nonexistent-file-xyz')).toThrow();
+  });
+
+  it('readDir() lists real directory contents', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bijou-test-'));
+    writeFileSync(join(tempDir, 'a.txt'), '');
+    writeFileSync(join(tempDir, 'b.txt'), '');
+
+    const io = nodeIO();
+    const entries = io.readDir(tempDir);
+    expect(entries).toContain('a.txt');
+    expect(entries).toContain('b.txt');
+  });
+
+  it('readDir() throws for missing directory', () => {
+    const io = nodeIO();
+    expect(() => io.readDir('/tmp/bijou-nonexistent-dir-xyz')).toThrow();
+  });
+
+  it('joinPath() joins segments', () => {
+    const io = nodeIO();
+    expect(io.joinPath('/foo', 'bar', 'baz.txt')).toBe('/foo/bar/baz.txt');
+  });
+
+  it('setInterval() returns a disposable handle', () => {
+    const io = nodeIO();
+    let count = 0;
+    const handle = io.setInterval(() => { count++; }, 10_000);
+    expect(handle.dispose).toBeTypeOf('function');
+    handle.dispose();
+  });
+});

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -14,9 +14,8 @@ describe('nodeIO()', () => {
     }
   });
 
-  it('write() calls process.stdout.write', () => {
+  it('write() does not throw', () => {
     const io = nodeIO();
-    // Just verify it doesn't throw — stdout.write in test runner is fine
     expect(() => io.write('')).not.toThrow();
   });
 

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -5,11 +5,12 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 describe('nodeIO()', () => {
-  let tempDir: string;
+  let tempDir: string | undefined;
 
   afterEach(() => {
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
     }
   });
 
@@ -30,7 +31,7 @@ describe('nodeIO()', () => {
 
   it('readFile() throws for missing file', () => {
     const io = nodeIO();
-    const missingFile = join(tmpdir(), `bijou-missing-${Date.now()}.txt`);
+    const missingFile = join(tmpdir(), `bijou-missing-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
     expect(() => io.readFile(missingFile)).toThrow();
   });
 
@@ -47,7 +48,7 @@ describe('nodeIO()', () => {
 
   it('readDir() throws for missing directory', () => {
     const io = nodeIO();
-    const missingDir = join(tmpdir(), `bijou-missing-${Date.now()}`);
+    const missingDir = join(tmpdir(), `bijou-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     expect(() => io.readDir(missingDir)).toThrow();
   });
 

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -62,4 +62,6 @@ describe('nodeIO()', () => {
     expect(handle.dispose).toBeTypeOf('function');
     handle.dispose();
   });
+
+  // question() and rawInput() require a TTY stdin and are not unit-testable.
 });

--- a/packages/bijou-node/src/runtime.test.ts
+++ b/packages/bijou-node/src/runtime.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { nodeRuntime } from './runtime.js';
 
 describe('nodeRuntime()', () => {
   const TEMP_KEY = '__BIJOU_TEST_RUNTIME__';
 
   afterEach(() => {
-    delete process.env[TEMP_KEY];
+    vi.unstubAllEnvs();
   });
 
   it('env() reads from process.env', () => {
-    process.env[TEMP_KEY] = 'hello';
+    vi.stubEnv(TEMP_KEY, 'hello');
     const rt = nodeRuntime();
     expect(rt.env(TEMP_KEY)).toBe('hello');
   });

--- a/packages/bijou-node/src/runtime.test.ts
+++ b/packages/bijou-node/src/runtime.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { nodeRuntime } from './runtime.js';
+
+describe('nodeRuntime()', () => {
+  const TEMP_KEY = '__BIJOU_TEST_RUNTIME__';
+
+  afterEach(() => {
+    delete process.env[TEMP_KEY];
+  });
+
+  it('env() reads from process.env', () => {
+    process.env[TEMP_KEY] = 'hello';
+    const rt = nodeRuntime();
+    expect(rt.env(TEMP_KEY)).toBe('hello');
+  });
+
+  it('env() returns undefined for missing keys', () => {
+    const rt = nodeRuntime();
+    expect(rt.env(TEMP_KEY)).toBeUndefined();
+  });
+
+  it('stdoutIsTTY returns a boolean', () => {
+    const rt = nodeRuntime();
+    expect(typeof rt.stdoutIsTTY).toBe('boolean');
+  });
+
+  it('stdinIsTTY returns a boolean', () => {
+    const rt = nodeRuntime();
+    expect(typeof rt.stdinIsTTY).toBe('boolean');
+  });
+
+  it('columns returns a number', () => {
+    const rt = nodeRuntime();
+    expect(typeof rt.columns).toBe('number');
+    expect(rt.columns).toBeGreaterThan(0);
+  });
+
+  it('rows returns a number', () => {
+    const rt = nodeRuntime();
+    expect(typeof rt.rows).toBe('number');
+    expect(rt.rows).toBeGreaterThan(0);
+  });
+});

--- a/packages/bijou-node/src/style.test.ts
+++ b/packages/bijou-node/src/style.test.ts
@@ -60,11 +60,10 @@ describe('chalkStyle()', () => {
       expect(style.hex('#ff0000', 'red')).toBe('red');
     });
 
-    it('styled() does not apply hex color', () => {
+    it('styled() passes text through without modification', () => {
       // In noColor mode, styled uses base chalk (no hex call),
-      // so without modifiers the text should pass through
-      const result = style.styled({ hex: '#ff0000' }, 'plain');
-      expect(result).toContain('plain');
+      // so without modifiers the text should pass through exactly
+      expect(style.styled({ hex: '#ff0000' }, 'plain')).toBe('plain');
     });
 
     it('bold() still applies (chalk.bold is not gated by noColor)', () => {

--- a/packages/bijou-node/src/style.test.ts
+++ b/packages/bijou-node/src/style.test.ts
@@ -15,8 +15,7 @@ describe('chalkStyle()', () => {
       expect(style.styled({ hex: '#ff0000' }, 'red')).toContain('red');
     });
 
-    it('styled() applies hex color when chalk supports it', () => {
-      if (!chalkEmitsColor) return; // skip in colorless env
+    it.runIf(chalkEmitsColor)('styled() applies hex color when chalk supports it', () => {
       expect(style.styled({ hex: '#ff0000' }, 'red')).toMatch(/\x1b\[/);
     });
 

--- a/packages/bijou-node/src/style.test.ts
+++ b/packages/bijou-node/src/style.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import chalk from 'chalk';
+import { chalkStyle } from './style.js';
+
+// Chalk may suppress color in non-TTY test environments.
+// We test behavior, not ANSI codes: colored mode should use chalk (may or may not emit ANSI),
+// noColor mode must return plain text.
+const chalkEmitsColor = chalk.hex('#ff0000')('x') !== 'x';
+
+describe('chalkStyle()', () => {
+  describe('with color', () => {
+    const style = chalkStyle(false);
+
+    it('styled() returns string containing the text', () => {
+      expect(style.styled({ hex: '#ff0000' }, 'red')).toContain('red');
+    });
+
+    it('styled() applies hex color when chalk supports it', () => {
+      if (!chalkEmitsColor) return; // skip in colorless env
+      expect(style.styled({ hex: '#ff0000' }, 'red')).toMatch(/\x1b\[/);
+    });
+
+    it('styled() applies bold modifier', () => {
+      const result = style.styled({ hex: '#ffffff', modifiers: ['bold'] }, 'text');
+      expect(result).toContain('text');
+    });
+
+    it('styled() applies dim modifier', () => {
+      expect(style.styled({ hex: '#808080', modifiers: ['dim'] }, 'muted')).toContain('muted');
+    });
+
+    it('styled() applies strikethrough modifier', () => {
+      expect(style.styled({ hex: '#ffffff', modifiers: ['strikethrough'] }, 'gone')).toContain('gone');
+    });
+
+    it('styled() applies inverse modifier', () => {
+      expect(style.styled({ hex: '#ffffff', modifiers: ['inverse'] }, 'inv')).toContain('inv');
+    });
+
+    it('rgb() returns string containing the text', () => {
+      expect(style.rgb(255, 0, 0, 'red')).toContain('red');
+    });
+
+    it('hex() returns string containing the text', () => {
+      expect(style.hex('#00ff00', 'green')).toContain('green');
+    });
+
+    it('bold() returns string containing the text', () => {
+      expect(style.bold('strong')).toContain('strong');
+    });
+  });
+
+  describe('noColor mode', () => {
+    const style = chalkStyle(true);
+
+    it('rgb() returns plain text', () => {
+      expect(style.rgb(255, 0, 0, 'red')).toBe('red');
+    });
+
+    it('hex() returns plain text', () => {
+      expect(style.hex('#ff0000', 'red')).toBe('red');
+    });
+
+    it('styled() does not apply hex color', () => {
+      // In noColor mode, styled uses base chalk (no hex call),
+      // so without modifiers the text should pass through
+      const result = style.styled({ hex: '#ff0000' }, 'plain');
+      expect(result).toContain('plain');
+    });
+
+    it('bold() still applies (chalk.bold is not gated by noColor)', () => {
+      expect(style.bold('text')).toContain('text');
+    });
+  });
+});

--- a/packages/bijou-node/src/style.test.ts
+++ b/packages/bijou-node/src/style.test.ts
@@ -16,7 +16,7 @@ describe('chalkStyle()', () => {
     });
 
     it.runIf(chalkEmitsColor)('styled() applies hex color when chalk supports it', () => {
-      expect(style.styled({ hex: '#ff0000' }, 'red')).toMatch(/\x1b\[/);
+      expect(style.styled({ hex: '#ff0000' }, 'red')).toMatch(new RegExp('\\x1b\\['));
     });
 
     it('styled() applies bold modifier', () => {

--- a/packages/bijou-node/src/style.test.ts
+++ b/packages/bijou-node/src/style.test.ts
@@ -36,6 +36,22 @@ describe('chalkStyle()', () => {
       expect(style.styled({ hex: '#ffffff', modifiers: ['inverse'] }, 'inv')).toContain('inv');
     });
 
+    it.runIf(chalkEmitsColor)('styled() emits ANSI for bold modifier', () => {
+      expect(style.styled({ hex: '#ffffff', modifiers: ['bold'] }, 'text')).toMatch(new RegExp('\\x1b\\['));
+    });
+
+    it.runIf(chalkEmitsColor)('styled() emits ANSI for dim modifier', () => {
+      expect(style.styled({ hex: '#808080', modifiers: ['dim'] }, 'muted')).toMatch(new RegExp('\\x1b\\['));
+    });
+
+    it.runIf(chalkEmitsColor)('styled() emits ANSI for strikethrough modifier', () => {
+      expect(style.styled({ hex: '#ffffff', modifiers: ['strikethrough'] }, 'gone')).toMatch(new RegExp('\\x1b\\['));
+    });
+
+    it.runIf(chalkEmitsColor)('styled() emits ANSI for inverse modifier', () => {
+      expect(style.styled({ hex: '#ffffff', modifiers: ['inverse'] }, 'inv')).toMatch(new RegExp('\\x1b\\['));
+    });
+
     it('rgb() returns string containing the text', () => {
       expect(style.rgb(255, 0, 0, 'red')).toContain('red');
     });

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -12,6 +12,7 @@ export type {
 export {
   getDefaultContext,
   setDefaultContext,
+  _resetDefaultContextForTesting,
 } from './context.js';
 
 // Factory


### PR DESCRIPTION
## Summary
30 tests covering all Node.js adapters:

- **chalkStyle** (13): styled with hex/modifiers (bold, dim, strikethrough, inverse), rgb, hex, bold; noColor passthrough
- **nodeRuntime** (6): env read/miss, stdoutIsTTY, stdinIsTTY, columns, rows
- **nodeIO** (7): write, readFile (real fs + missing throws), readDir (real fs + missing throws), joinPath, setInterval handle
- **createNodeContext** (4): all fields, resolved theme, valid mode, runtime reads process.env

Handles chalk's non-TTY color suppression gracefully (tests behavior, not ANSI codes).

Test count: 113 → 143

## Test plan
- `npm test` — 143 passing