### PR TITLE
chore: add CLAUDE.md with git rules and end-of-turn checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Git Rules
+
+- NEVER push to main without explicit permission
+- ALWAYS make changes in feature branches
+- ALWAYS PR to main
+- NEVER deploy locally or publish locally
+- NEVER amend commits
+- NEVER rebase
+- NEVER force any git operation
+
+# End of Turn Checklist
+
+At the end of every turn that alters files, ALWAYS:
+
+1. Update CHANGELOG.md if necessary
+2. Bump version if necessary
+3. Update documentation as needed
+4. `git add -A`
+5. `git commit` with a conventional commit message


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with git workflow rules (no direct pushes to main, always PR, no force/rebase/amend)
- Adds end-of-turn checklist requiring changelog, version, docs updates, and conventional commits

## Test plan
- [x] Verify CLAUDE.md contents are correct