### PR TITLE
feat(tui): overlay primitives (composite, modal, toast)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Bijou is a growing ecosystem. Transparency is our baseline—here is the current
 | `timeline` | ✅ Stable | Vertical event visualization. |
 | `dag` / `dagSlice` | ✅ Stable | Directed acyclic graph with auto-layout, edge routing, and subgraph slicing. |
 | `skeleton` | ✅ Stable | Loading placeholders for data-heavy views. |
-| `textarea` | 🗓️ Roadmap | Multi-line, scrollable text entry. |
-| `filter` | 🗓️ Roadmap | Fuzzy type-to-filter list component. |
+| `textarea` | ✅ Stable | Multi-line, scrollable text entry. |
+| `filter` | ✅ Stable | Fuzzy type-to-filter list component. |
 
 ### Interactive Forms (`@flyingrobots/bijou`)
 
@@ -109,7 +109,7 @@ Bijou is a growing ecosystem. Transparency is our baseline—here is the current
 | `viewport` | ✅ Stable | Scrollable content pane with proportional scrollbars. |
 | `animate` / `timeline` | ✅ Stable | Physics-based springs and GSAP-style timelines. |
 | `KeyMap` / `InputStack` | ✅ Stable | Layered, declarative input dispatch for modal UIs. |
-| `modal` / `drawer` | ✅ Showcase | High-level patterns (see `demo-tui.ts`). |
+| `composite` / `modal` / `toast` | ✅ Stable | ANSI-safe overlay compositing, centered dialogs, anchored notifications. |
 | `commandPalette` | 🗓️ Roadmap | Unified global search and action interface. |
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`createPanelGroup()`** — multi-pane focus management with hotkey switching, per-panel KeyMap delegation, InputStack integration, and formatted labels
 - **`pager()`** — scrollable content viewer building block wrapping `viewport()` with a status line, position tracking, and convenience keymap (`j/k` scroll, `d/u` page, `g/G` top/bottom, `q` quit)
 - **`interactiveAccordion()`** — navigable accordion building block wrapping static `accordion()` with focus tracking, expand/collapse transformers, and convenience keymap (`j/k` navigate, `Enter/Space` toggle, `q` quit)
+- **`composite()`** — ANSI-safe overlay compositing with dim background support
+- **`modal()`** — centered dialog overlay with title, body, hint, and auto-centering
+- **`toast()`** — anchored notification overlay with success/error/info variants
 
 ## [0.3.0] — 2026-02-27
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 #### Core (`@flyingrobots/bijou`)
 
+- **`dag()` `selectedId`/`selectedToken`** — cursor-style node highlighting with highest priority over highlight path
 - **`textarea()`** — multi-line text input form with cursor navigation, line numbers, placeholder, maxLength, and Ctrl+D submit / Ctrl+C cancel
 - **`filter()`** — fuzzy-filter select form with real-time search by label and keywords, customizable match function, and configurable max visible items
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,13 +8,30 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Fixed
 
+#### Core (`@flyingrobots/bijou`)
+
+- **`filter()` empty-options crash** — guard against empty options array; throws descriptive error or returns `defaultValue` instead of crashing with modulo-by-zero / undefined dereference
+- **`filter()` cursor wrap** — cursor navigation now no-ops when the filtered list is empty, preventing `NaN` cursor index
+- **`textarea()` maxLength on Enter** — Enter key now respects `maxLength`, preventing newlines from exceeding the character limit
+- **`textarea()` width rendering** — the `width` option now clips line content to the specified width instead of being silently ignored
+- **`textarea()` placeholder line** — placeholder now renders on the first line (`lineIdx === 0`) instead of on lines beyond the buffer
+
 #### TUI runtime (`@flyingrobots/bijou-tui`)
 
 - **`composite()` dim predicate** — dim check now uses `visibleLength()` instead of raw `.length`, correctly skipping lines that contain only ANSI escape codes
+- **`createPanelGroup()` defaultFocus validation** — throws a descriptive error when `defaultFocus` refers to a non-existent panel ID, preventing silent `InputStack` routing failures
+- **`pager()` scroll clamp** — clamps scroll offset to the active viewport height, fixing overscroll artifact when `showStatus` is toggled off
+- **`interactiveAccordion()` focusIndex normalization** — normalizes stale/out-of-range focus index before rendering to prevent undefined focus behavior
+- **`interactiveAccordion()` continuation indentation** — continuation-line padding now matches the focus prefix width for custom `focusChar` values
+- **`sliceAnsi()` ANSI leak** — appends reset sequence when the source string ends with an active style, preventing style bleed into subsequent content
+- **viewport tests** — replaced inline ANSI-stripping regexes with the imported `stripAnsi()` utility
 
 ### Documentation
 
 - **textarea example** — fixed `box()` call with nonexistent `title` option; replaced with `headerBox()`
+- **textarea example** — use nullish check (`!= null`) instead of truthy check for cancellation detection
+- **pager example** — removed unused `kbd` import; preserve scroll position across terminal resize
+- **accordion example** — removed unused `separator` import
 - **ROADMAP P1.75** — clarified that `dagStats()` is deferred, not shipped with overlay primitives
 
 ## [0.4.0] — 2026-02-27

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-02-27
+
 ### Added
 
 #### Core (`@flyingrobots/bijou`)
@@ -150,7 +152,8 @@ First public release.
 - **Screen control** — `enterScreen()`, `exitScreen()`, `clearAndHome()`, `renderFrame()`
 - **Layout helpers** — `vstack()`, `hstack()`
 
-[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/flyingrobots/bijou/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.3.0
 [0.2.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.2.0
 [0.1.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.1.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Added
 
+#### Core (`@flyingrobots/bijou`)
+
+- **`textarea()`** — multi-line text input form with cursor navigation, line numbers, placeholder, maxLength, and Ctrl+D submit / Ctrl+C cancel
+- **`filter()`** — fuzzy-filter select form with real-time search by label and keywords, customizable match function, and configurable max visible items
+
 #### TUI runtime (`@flyingrobots/bijou-tui`)
 
 - **`pager()`** — scrollable content viewer building block wrapping `viewport()` with a status line, position tracking, and convenience keymap (`j/k` scroll, `d/u` page, `g/G` top/bottom, `q` quit)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 #### TUI runtime (`@flyingrobots/bijou-tui`)
 
+- **`stripAnsi()`**, **`visibleLength()`**, **`clipToWidth()`** — publicly exported ANSI utility functions from viewport module
 - **`pager()`** — scrollable content viewer building block wrapping `viewport()` with a status line, position tracking, and convenience keymap (`j/k` scroll, `d/u` page, `g/G` top/bottom, `q` quit)
 - **`interactiveAccordion()`** — navigable accordion building block wrapping static `accordion()` with focus tracking, expand/collapse transformers, and convenience keymap (`j/k` navigate, `Enter/Space` toggle, `q` quit)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 #### TUI runtime (`@flyingrobots/bijou-tui`)
 
 - **`stripAnsi()`**, **`visibleLength()`**, **`clipToWidth()`** — publicly exported ANSI utility functions from viewport module
+- **viewport `scrollX`** — horizontal scrolling support with `sliceAnsi()`, `scrollByX()`, `scrollToX()`
 - **`pager()`** — scrollable content viewer building block wrapping `viewport()` with a status line, position tracking, and convenience keymap (`j/k` scroll, `d/u` page, `g/G` top/bottom, `q` quit)
 - **`interactiveAccordion()`** — navigable accordion building block wrapping static `accordion()` with focus tracking, expand/collapse transformers, and convenience keymap (`j/k` navigate, `Enter/Space` toggle, `q` quit)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 #### Core (`@flyingrobots/bijou`)
 
 - **`dag()` `selectedId`/`selectedToken`** — cursor-style node highlighting with highest priority over highlight path
+- **`dagLayout()`** — returns node position map (`DagNodePosition`) and grid dimensions alongside rendered output, for interactive DAG navigation
 - **`textarea()`** — multi-line text input form with cursor navigation, line numbers, placeholder, maxLength, and Ctrl+D submit / Ctrl+C cancel
 - **`filter()`** — fuzzy-filter select form with real-time search by label and keywords, customizable match function, and configurable max visible items
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 - **`stripAnsi()`**, **`visibleLength()`**, **`clipToWidth()`** — publicly exported ANSI utility functions from viewport module
 - **viewport `scrollX`** — horizontal scrolling support with `sliceAnsi()`, `scrollByX()`, `scrollToX()`
+- **`createPanelGroup()`** — multi-pane focus management with hotkey switching, per-panel KeyMap delegation, InputStack integration, and formatted labels
 - **`pager()`** — scrollable content viewer building block wrapping `viewport()` with a status line, position tracking, and convenience keymap (`j/k` scroll, `d/u` page, `g/G` top/bottom, `q` quit)
 - **`interactiveAccordion()`** — navigable accordion building block wrapping static `accordion()` with focus tracking, expand/collapse transformers, and convenience keymap (`j/k` navigate, `Enter/Space` toggle, `q` quit)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,17 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Fixed
+
+#### TUI runtime (`@flyingrobots/bijou-tui`)
+
+- **`composite()` dim predicate** — dim check now uses `visibleLength()` instead of raw `.length`, correctly skipping lines that contain only ANSI escape codes
+
+### Documentation
+
+- **textarea example** — fixed `box()` call with nonexistent `title` option; replaced with `headerBox()`
+- **ROADMAP P1.75** — clarified that `dagStats()` is deferred, not shipped with overlay primitives
+
 ## [0.4.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### TUI runtime (`@flyingrobots/bijou-tui`)
+
+- **`pager()`** — scrollable content viewer building block wrapping `viewport()` with a status line, position tracking, and convenience keymap (`j/k` scroll, `d/u` page, `g/G` top/bottom, `q` quit)
+- **`interactiveAccordion()`** — navigable accordion building block wrapping static `accordion()` with focus tracking, expand/collapse transformers, and convenience keymap (`j/k` navigate, `Enter/Space` toggle, `q` quit)
+
 ## [0.3.0] — 2026-02-27
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -338,11 +338,11 @@ Growing toward a full terminal component library:
 | Category | Components |
 |----------|-----------|
 | **Element** | ~~`alert()`~~, ~~`badge()`~~, ~~`separator()`~~, ~~`skeleton()`~~, ~~`kbd()`~~ ✅ |
-| **Data** | ~~`accordion()`~~, ~~`tree()`~~, ~~`timeline()`~~, ~~`dag()`~~, ~~`dagSlice()`~~ ✅, `dagLayout()`, `dagStats()` |
+| **Data** | ~~`accordion()`~~, ~~`tree()`~~, ~~`timeline()`~~, ~~`dag()`~~, ~~`dagSlice()`~~, ~~`dagLayout()`~~ ✅, `dagStats()` |
 | **Forms** | ~~`input()`~~, ~~`select()`~~, ~~`multiselect()`~~, ~~`confirm()`~~, ~~`group()`~~ ✅, ~~`textarea()`~~, ~~`filter()`~~ ✅, `wizard()` |
 | **Navigation** | ~~`tabs()`~~, ~~`breadcrumb()`~~, ~~`paginator()`~~, ~~`stepper()`~~ ✅, `commandPalette()` |
-| **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~ ✅, `navigableTable()`, `browsableList()`, `filePicker()`, `createPanelGroup()` |
-| **Overlay** | `composite()`, `modal()`, `toast()`, `drawer()` |
+| **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~, ~~`createPanelGroup()`~~ ✅, `navigableTable()`, `browsableList()`, `filePicker()` |
+| **Overlay** | `composite()` ← P1.75, `modal()` ← P1.75, `toast()` ← P1.75, `drawer()` |
 | **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~ ✅, mouse events (`IOPort.onMouse()`) |
 | **App** | `statusBar()`, `splitPane()`, `tooltip()` |
 
@@ -379,28 +379,38 @@ Gaps identified from Charm ecosystem comparison (gum, bubbles, lipgloss, huh). P
 | **Form wizard** | bijou | Multi-page form orchestration — `stepper()` is visual only today, this adds the state machine. |
 | **`navigableTable()`** | bijou-tui | Keyboard-navigable table with row/column selection. Extends `table()`. |
 
-### P1.5 — Interactive DAG primitives (XYPH-driven)
+### ~~P1.5 — Interactive DAG primitives (XYPH-driven)~~ ✅ Shipped
 
 Specs from XYPH for building an interactive roadmap DAG view with 2D panning, node selection, and multi-panel input.
 
 | Feature | Package | Notes | Blocks XYPH? |
 |---------|---------|-------|:------------:|
-| **Export ANSI utilities** | bijou-tui | Export `stripAnsi()`, `visibleLength()`, `clipToWidth()` — already implemented, just not public | ✓ |
-| **`viewport()` scrollX** | bijou-tui | Horizontal scrolling for wide content. `scrollX` option, ANSI-aware left-edge slicing, `scrollByX()`/`scrollToX()` state transformers, `maxX` in `ScrollState` | ✓ |
-| **`dag()` `selectedId`** | bijou | `selectedId`/`selectedToken` options for visual node focus highlight. Selection styling on box border chars, distinct from `highlightPath` | ✓ |
-| **`dagLayout()`** | bijou | Returns rendered string + `Map<string, DagNodePosition>` with grid coordinates per node. Enables auto-scroll-to-selection and future click-to-select | |
-| **`createPanelGroup()`** | bijou-tui | Multi-panel focus management with per-panel keymaps. Integrates with `InputStack` — focus change pushes/pops keymap layers. `formatLabel()` for styled panel headers | |
-| **`dagStats()`** | bijou | Pure function: `{nodes, edges, depth, width, roots, leaves}` from node array | |
+| ~~**Export ANSI utilities**~~ | bijou-tui | ✅ `stripAnsi()`, `visibleLength()`, `clipToWidth()` publicly exported | ✓ |
+| ~~**`viewport()` scrollX**~~ | bijou-tui | ✅ `scrollX` option, `sliceAnsi()`, `scrollByX()`/`scrollToX()`, `maxX` in `ScrollState` | ✓ |
+| ~~**`dag()` `selectedId`**~~ | bijou | ✅ `selectedId`/`selectedToken` with highest priority over highlight path | ✓ |
+| ~~**`dagLayout()`**~~ | bijou | ✅ Returns rendered string + `Map<string, DagNodePosition>` with grid coordinates | |
+| ~~**`createPanelGroup()`**~~ | bijou-tui | ✅ Multi-panel focus with InputStack integration, hotkey switching, `formatLabel()` | |
+
+### P1.75 — XYPH Dashboard blockers
+
+Primitives needed for XYPH's interactive TUI dashboard (confirm dialogs, overlays, write operation flows). Promoted from P2/backlog based on XYPH Phase 1 requirements.
+
+| Feature | Package | Notes | Blocks XYPH? |
+|---------|---------|-------|:------------:|
+| **`composite()` overlay** | bijou-tui | Painter's algorithm compositing: base render + positioned overlays → final string. ANSI-aware, screen-edge clamping. Core primitive for modals, tooltips, toasts. | ✓ |
+| **`modal()`** | bijou-tui | Centered dialog overlay built on `composite()`. Confirm (y/n), input (text field), and info variants. Returns rendered overlay string. | ✓ |
+| **`toast()`** | bijou-tui | Anchored notification (top-right/bottom-right) built on `composite()`. Success/error/info variants with auto-dismiss timing. | ✓ |
+| **`dagStats()`** | bijou | Pure function: `{nodes, edges, depth, width, roots, leaves}` from node array. For overview dashboard counts. | |
 
 ### P2 — Layout, input & styling primitives
 
 | Feature | Package | Notes |
 |---------|---------|-------|
 | **Mouse input** | bijou + bijou-node + bijou-tui | `IOPort.onMouse()` with SGR mouse parsing, `MouseMsg` in TEA runtime. Breaking change (new port method). |
-| **`composite()` overlay** | bijou-tui | Painter's algorithm compositing: base render + positioned overlays → final string. ANSI-aware, screen-edge clamping. Enables tooltips, context menus, detail popups. |
 | **`DagNode` token expansion** | bijou | `labelToken` and `badgeToken` on `DagNode` for granular per-node styling beyond border color. |
-| **CLI/stdin component driver** | bijou-tui | Drive component state via CLI flags (`--accordion.open(3)`) or streaming stdin commands. Enables scripted demos, testing, and external control of running TUI apps. |
 | **`place()`** | bijou | 2D text placement with horizontal + vertical alignment. |
+| **`drawer()`** | bijou-tui | Slide-in side panel built on `composite()`. Left/right anchored, configurable width. |
+| **CLI/stdin component driver** | bijou-tui | Drive component state via CLI flags or streaming stdin commands. Enables scripted demos, testing, and external control. |
 | **`enumeratedList()`** | bijou | Ordered/unordered lists with bullet styles (arabic, alpha, roman, bullet). |
 | **Terminal hyperlinks** | bijou | Clickable OSC 8 links with graceful fallback. |
 | **Adaptive colors** | bijou | Runtime light/dark background detection, auto color switching. |
@@ -431,3 +441,12 @@ Once published:
 2. Create xyph-specific theme preset with custom status keys
 3. Replace inline rendering with bijou components
 4. Domain-specific views stay in xyph
+
+**XYPH TUI Dashboard dependency map:**
+
+| XYPH Phase | Bijou dependency | Status |
+|------------|-----------------|--------|
+| Phase 1 (views, selection, writes) | `selectedId`, ANSI utils, `InputStack` | ✅ Ready |
+| Phase 1h (confirm/input overlays) | `composite()`, `modal()` | P1.75 — next up |
+| Phase 2 (review actions, detail panel) | `selectedId`, ANSI utils | ✅ Ready |
+| Phase 3 (full DAG interactivity) | `scrollX`, `dagLayout()`, `createPanelGroup()` | ✅ Ready |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Tests ARE the Spec.** Every feature is defined by its tests. If it's not tested, it's not guaranteed. Acceptance criteria are written as test descriptions first, implementation second.
 
-Current: **v0.3.0** — DAG renderer, 47 examples with GIF demos
+Current: **v0.4.0** — Overlay compositing, interactive building blocks, forms
 
 ---
 
@@ -342,7 +342,7 @@ Growing toward a full terminal component library:
 | **Forms** | ~~`input()`~~, ~~`select()`~~, ~~`multiselect()`~~, ~~`confirm()`~~, ~~`group()`~~ ✅, ~~`textarea()`~~, ~~`filter()`~~ ✅, `wizard()` |
 | **Navigation** | ~~`tabs()`~~, ~~`breadcrumb()`~~, ~~`paginator()`~~, ~~`stepper()`~~ ✅, `commandPalette()` |
 | **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~, ~~`createPanelGroup()`~~ ✅, `navigableTable()`, `browsableList()`, `filePicker()` |
-| **Overlay** | `composite()` ← P1.75, `modal()` ← P1.75, `toast()` ← P1.75, `drawer()` |
+| **Overlay** | ~~`composite()`~~, ~~`modal()`~~, ~~`toast()`~~ ✅, `drawer()` |
 | **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~ ✅, mouse events (`IOPort.onMouse()`) |
 | **App** | `statusBar()`, `splitPane()`, `tooltip()` |
 
@@ -391,15 +391,13 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | ~~**`dagLayout()`**~~ | bijou | ✅ Returns rendered string + `Map<string, DagNodePosition>` with grid coordinates | |
 | ~~**`createPanelGroup()`**~~ | bijou-tui | ✅ Multi-panel focus with InputStack integration, hotkey switching, `formatLabel()` | |
 
-### P1.75 — XYPH Dashboard blockers
-
-Primitives needed for XYPH's interactive TUI dashboard (confirm dialogs, overlays, write operation flows). Promoted from P2/backlog based on XYPH Phase 1 requirements.
+### ~~P1.75 — XYPH Dashboard blockers~~ ✅ Shipped (overlay primitives)
 
 | Feature | Package | Notes | Blocks XYPH? |
 |---------|---------|-------|:------------:|
-| **`composite()` overlay** | bijou-tui | Painter's algorithm compositing: base render + positioned overlays → final string. ANSI-aware, screen-edge clamping. Core primitive for modals, tooltips, toasts. | ✓ |
-| **`modal()`** | bijou-tui | Centered dialog overlay built on `composite()`. Confirm (y/n), input (text field), and info variants. Returns rendered overlay string. | ✓ |
-| **`toast()`** | bijou-tui | Anchored notification (top-right/bottom-right) built on `composite()`. Success/error/info variants with auto-dismiss timing. | ✓ |
+| ~~**`composite()` overlay**~~ | bijou-tui | ✅ Painter's algorithm compositing with ANSI-safe splicing, dim background support | ✓ |
+| ~~**`modal()`**~~ | bijou-tui | ✅ Centered dialog overlay with title, body, hint, auto-centering, themed borders | ✓ |
+| ~~**`toast()`**~~ | bijou-tui | ✅ Anchored notification overlay with success/error/info variants, 4-corner anchoring | ✓ |
 | **`dagStats()`** | bijou | Pure function: `{nodes, edges, depth, width, roots, leaves}` from node array. For overview dashboard counts. | |
 
 ### P2 — Layout, input & styling primitives
@@ -447,6 +445,6 @@ Once published:
 | XYPH Phase | Bijou dependency | Status |
 |------------|-----------------|--------|
 | Phase 1 (views, selection, writes) | `selectedId`, ANSI utils, `InputStack` | ✅ Ready |
-| Phase 1h (confirm/input overlays) | `composite()`, `modal()` | P1.75 — next up |
+| Phase 1h (confirm/input overlays) | `composite()`, `modal()` | ✅ Ready |
 | Phase 2 (review actions, detail panel) | `selectedId`, ANSI utils | ✅ Ready |
 | Phase 3 (full DAG interactivity) | `scrollX`, `dagLayout()`, `createPanelGroup()` | ✅ Ready |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Tests ARE the Spec.** Every feature is defined by its tests. If it's not tested, it's not guaranteed. Acceptance criteria are written as test descriptions first, implementation second.
 
-Current: **v0.3.0** — DAG renderer, 43 examples with GIF demos
+Current: **v0.3.0** — DAG renderer, 47 examples with GIF demos
 
 ---
 
@@ -338,10 +338,13 @@ Growing toward a full terminal component library:
 | Category | Components |
 |----------|-----------|
 | **Element** | ~~`alert()`~~, ~~`badge()`~~, ~~`separator()`~~, ~~`skeleton()`~~, ~~`kbd()`~~ ✅ |
-| **Data** | ~~`accordion()`~~, ~~`tree()`~~, ~~`timeline()`~~, ~~`dag()`~~, ~~`dagSlice()`~~ ✅ |
+| **Data** | ~~`accordion()`~~, ~~`tree()`~~, ~~`timeline()`~~, ~~`dag()`~~, ~~`dagSlice()`~~ ✅, `dagLayout()`, `dagStats()` |
+| **Forms** | ~~`input()`~~, ~~`select()`~~, ~~`multiselect()`~~, ~~`confirm()`~~, ~~`group()`~~ ✅, ~~`textarea()`~~, ~~`filter()`~~ ✅, `wizard()` |
 | **Navigation** | ~~`tabs()`~~, ~~`breadcrumb()`~~, ~~`paginator()`~~, ~~`stepper()`~~ ✅, `commandPalette()` |
-| **Overlay** | `modal()`, `toast()`, `drawer()` |
-| **App** | `list()`, `statusBar()`, `splitPane()`, `tooltip()` |
+| **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~ ✅, `navigableTable()`, `browsableList()`, `filePicker()`, `createPanelGroup()` |
+| **Overlay** | `composite()`, `modal()`, `toast()`, `drawer()` |
+| **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~ ✅, mouse events (`IOPort.onMouse()`) |
+| **App** | `statusBar()`, `splitPane()`, `tooltip()` |
 
 Each new component should follow this template before implementation:
 1. Write user story and requirements
@@ -365,21 +368,37 @@ Gaps identified from Charm ecosystem comparison (gum, bubbles, lipgloss, huh). P
 
 ### P1 — Core components
 
-| Feature | Package | Notes |
-|---------|---------|-------|
-| **Interactive `accordion()`** | bijou-tui | TEA wrapper around static `accordion()` — `j`/`k` navigate, `Enter`/`Space` toggle fold, `q` quit. |
-| **`textarea()`** | bijou | Multi-line text input with scroll, line numbers, char limit. |
-| **`filter()`** | bijou | Fuzzy type-to-filter from a list. |
+| Feature | Package | Status |
+|---------|---------|--------|
+| ~~**Interactive `accordion()`**~~ | bijou-tui | ✅ Building block: `interactiveAccordion()`, `accordionKeyMap()`, state transformers |
+| ~~**`pager()`**~~ | bijou-tui | ✅ Building block wrapping `viewport()` with status line |
+| ~~**`textarea()`**~~ | bijou | ✅ Multi-line text input with cursor nav, line numbers, maxLength |
+| ~~**`filter()`**~~ | bijou | ✅ Fuzzy type-to-filter with keyword matching |
 | **`browsableList()`** | bijou-tui | Rich list with keyboard nav, filtering, pagination, status. Beyond `select()`. |
 | **`filePicker()`** | bijou-tui | Directory browser with extension filtering. |
-| **`pager()`** | bijou-tui | Read-only scrollable text viewer. Thin wrapper over viewport. |
 | **Form wizard** | bijou | Multi-page form orchestration — `stepper()` is visual only today, this adds the state machine. |
 | **`navigableTable()`** | bijou-tui | Keyboard-navigable table with row/column selection. Extends `table()`. |
 
-### P2 — Layout & styling primitives
+### P1.5 — Interactive DAG primitives (XYPH-driven)
+
+Specs from XYPH for building an interactive roadmap DAG view with 2D panning, node selection, and multi-panel input.
+
+| Feature | Package | Notes | Blocks XYPH? |
+|---------|---------|-------|:------------:|
+| **Export ANSI utilities** | bijou-tui | Export `stripAnsi()`, `visibleLength()`, `clipToWidth()` — already implemented, just not public | ✓ |
+| **`viewport()` scrollX** | bijou-tui | Horizontal scrolling for wide content. `scrollX` option, ANSI-aware left-edge slicing, `scrollByX()`/`scrollToX()` state transformers, `maxX` in `ScrollState` | ✓ |
+| **`dag()` `selectedId`** | bijou | `selectedId`/`selectedToken` options for visual node focus highlight. Selection styling on box border chars, distinct from `highlightPath` | ✓ |
+| **`dagLayout()`** | bijou | Returns rendered string + `Map<string, DagNodePosition>` with grid coordinates per node. Enables auto-scroll-to-selection and future click-to-select | |
+| **`createPanelGroup()`** | bijou-tui | Multi-panel focus management with per-panel keymaps. Integrates with `InputStack` — focus change pushes/pops keymap layers. `formatLabel()` for styled panel headers | |
+| **`dagStats()`** | bijou | Pure function: `{nodes, edges, depth, width, roots, leaves}` from node array | |
+
+### P2 — Layout, input & styling primitives
 
 | Feature | Package | Notes |
 |---------|---------|-------|
+| **Mouse input** | bijou + bijou-node + bijou-tui | `IOPort.onMouse()` with SGR mouse parsing, `MouseMsg` in TEA runtime. Breaking change (new port method). |
+| **`composite()` overlay** | bijou-tui | Painter's algorithm compositing: base render + positioned overlays → final string. ANSI-aware, screen-edge clamping. Enables tooltips, context menus, detail popups. |
+| **`DagNode` token expansion** | bijou | `labelToken` and `badgeToken` on `DagNode` for granular per-node styling beyond border color. |
 | **CLI/stdin component driver** | bijou-tui | Drive component state via CLI flags (`--accordion.open(3)`) or streaming stdin commands. Enables scripted demos, testing, and external control of running TUI apps. |
 | **`place()`** | bijou | 2D text placement with horizontal + vertical alignment. |
 | **`enumeratedList()`** | bijou | Ordered/unordered lists with bullet styles (arabic, alpha, roman, bullet). |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -398,6 +398,11 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | ~~**`composite()` overlay**~~ | bijou-tui | ✅ Painter's algorithm compositing with ANSI-safe splicing, dim background support | ✓ |
 | ~~**`modal()`**~~ | bijou-tui | ✅ Centered dialog overlay with title, body, hint, auto-centering, themed borders | ✓ |
 | ~~**`toast()`**~~ | bijou-tui | ✅ Anchored notification overlay with success/error/info variants, 4-corner anchoring | ✓ |
+
+Remaining from P1.75 (deferred — not an overlay primitive):
+
+| Feature | Package | Notes | Blocks XYPH? |
+|---------|---------|-------|:------------:|
 | **`dagStats()`** | bijou | Pure function: `{nodes, edges, depth, width, roots, leaves}` from node array. For overview dashboard counts. | |
 
 ### P2 — Layout, input & styling primitives

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-> 45 examples · Run any: `npx tsx examples/<name>/main.ts`  
+> 47 examples · Run any: `npx tsx examples/<name>/main.ts`  
 > Record all GIFs: `../scripts/record-gifs.sh`
 
 ## Static Components
@@ -36,6 +36,8 @@
 | [`select`](./select/) | `select()` | Single-select menu |
 | [`multiselect`](./multiselect/) | `multiselect()` | Checkbox multi-select |
 | [`confirm`](./confirm/) | `confirm()` | Yes/no confirmation prompt |
+| [`textarea`](./textarea/) | `textarea()` | Multi-line text input with cursor navigation |
+| [`filter`](./filter/) | `filter()` | Fuzzy-filter select with real-time search |
 | [`form-group`](./form-group/) | `group()` | Multi-field form wizard |
 
 ## TUI Apps

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-> 43 examples · Run any: `npx tsx examples/<name>/main.ts`  
+> 45 examples · Run any: `npx tsx examples/<name>/main.ts`  
 > Record all GIFs: `../scripts/record-gifs.sh`
 
 ## Static Components
@@ -57,6 +57,8 @@
 | [`stopwatch`](./stopwatch/) | `tick()`, view rendering | Stopwatch with laps, start/stop/reset |
 | [`chat`](./chat/) | `viewport()` + `input()` + `vstack()` + `flex()` | Chat UI with message input |
 | [`split-editors`](./split-editors/) | `flex()` + `hstack()` + `createInputStack()` | Dual-pane editor with focus switching |
+| [`pager`](./pager/) | `pager()`, `pagerKeyMap()` | Scrollable text viewer with status line |
+| [`interactive-accordion`](./interactive-accordion/) | `interactiveAccordion()`, `accordionKeyMap()` | Keyboard-navigable accordion with expand/collapse |
 | [`composable`](./composable/) | `composable` | Tabbed dashboard combining many components |
 | [`package-manager`](./package-manager/) | `package-manager` | Simulated `npm install` (resolve → download → link) |
 | [`splash`](./splash/) | `splash` | Animated splash screen |

--- a/examples/filter/README.md
+++ b/examples/filter/README.md
@@ -1,0 +1,45 @@
+# `filter()`
+
+Fuzzy-filter select with real-time search
+
+![demo](demo.gif)
+
+## Run
+
+```sh
+npx tsx examples/filter/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { filter, badge } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+async function main() {
+  const language = await filter({
+    title: 'Choose a programming language:',
+    placeholder: 'Type to filter...',
+    options: [
+      { label: 'TypeScript', value: 'ts', keywords: ['javascript', 'typed', 'web'] },
+      { label: 'Rust', value: 'rust', keywords: ['systems', 'memory', 'safe'] },
+      { label: 'Python', value: 'python', keywords: ['scripting', 'ml', 'data'] },
+      { label: 'Go', value: 'go', keywords: ['google', 'concurrent', 'fast'] },
+      { label: 'Zig', value: 'zig', keywords: ['systems', 'comptime', 'safe'] },
+      { label: 'Elixir', value: 'elixir', keywords: ['erlang', 'functional', 'beam'] },
+      { label: 'Haskell', value: 'haskell', keywords: ['functional', 'pure', 'lazy'] },
+      { label: 'OCaml', value: 'ocaml', keywords: ['functional', 'ml', 'typed'] },
+    ],
+    ctx,
+  });
+
+  console.log();
+  console.log('Selected:', badge(language.toUpperCase(), { variant: 'primary', ctx }));
+}
+
+main().catch(console.error);
+```
+
+[← Examples](../README.md)

--- a/examples/filter/demo.tape
+++ b/examples/filter/demo.tape
@@ -1,0 +1,21 @@
+Output examples/filter/demo.gif
+Set Shell zsh
+Set FontFamily "Monaspace Radon NF"
+Set FontSize 14
+Set Width 960
+Set Height 540
+Set Theme "Catppuccin Mocha"
+Set Padding 20
+
+Type "npx tsx examples/filter/main.ts"
+Enter
+Sleep 3s
+
+Type "fun"
+Sleep 1s
+Down
+Sleep 500ms
+Down
+Sleep 500ms
+Enter
+Sleep 2s

--- a/examples/filter/main.ts
+++ b/examples/filter/main.ts
@@ -1,0 +1,27 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { filter, badge } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+async function main() {
+  const language = await filter({
+    title: 'Choose a programming language:',
+    placeholder: 'Type to filter...',
+    options: [
+      { label: 'TypeScript', value: 'ts', keywords: ['javascript', 'typed', 'web'] },
+      { label: 'Rust', value: 'rust', keywords: ['systems', 'memory', 'safe'] },
+      { label: 'Python', value: 'python', keywords: ['scripting', 'ml', 'data'] },
+      { label: 'Go', value: 'go', keywords: ['google', 'concurrent', 'fast'] },
+      { label: 'Zig', value: 'zig', keywords: ['systems', 'comptime', 'safe'] },
+      { label: 'Elixir', value: 'elixir', keywords: ['erlang', 'functional', 'beam'] },
+      { label: 'Haskell', value: 'haskell', keywords: ['functional', 'pure', 'lazy'] },
+      { label: 'OCaml', value: 'ocaml', keywords: ['functional', 'ml', 'typed'] },
+    ],
+    ctx,
+  });
+
+  console.log();
+  console.log('Selected:', badge(language.toUpperCase(), { variant: 'primary', ctx }));
+}
+
+main().catch(console.error);

--- a/examples/interactive-accordion/README.md
+++ b/examples/interactive-accordion/README.md
@@ -14,7 +14,6 @@ npx tsx examples/interactive-accordion/main.ts
 
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
-import { separator } from '@flyingrobots/bijou';
 import {
   run, quit, type App, type KeyMsg,
   createAccordionState, interactiveAccordion,

--- a/examples/interactive-accordion/README.md
+++ b/examples/interactive-accordion/README.md
@@ -1,0 +1,69 @@
+# `interactiveAccordion()`
+
+Keyboard-navigable accordion with expand/collapse
+
+![demo](demo.gif)
+
+## Run
+
+```sh
+npx tsx examples/interactive-accordion/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { separator } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg,
+  createAccordionState, interactiveAccordion,
+  focusNext, focusPrev, toggleFocused,
+  accordionKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+
+const SECTIONS = [
+  { title: 'Section A', content: 'Content for A', expanded: true },
+  { title: 'Section B', content: 'Content for B', expanded: false },
+  { title: 'Section C', content: 'Content for C', expanded: false },
+];
+
+type Msg = { type: 'next' } | { type: 'prev' } | { type: 'toggle' } | { type: 'quit' };
+
+const keys = accordionKeyMap<Msg>({
+  focusNext: { type: 'next' },
+  focusPrev: { type: 'prev' },
+  toggle: { type: 'toggle' },
+  quit: { type: 'quit' },
+});
+
+interface Model { accordion: ReturnType<typeof createAccordionState> }
+
+const app: App<Model, Msg> = {
+  init: () => [{ accordion: createAccordionState(SECTIONS) }, []],
+
+  update: (msg, model) => {
+    if ('type' in msg && msg.type === 'key') {
+      const action = keys.handle(msg as KeyMsg);
+      if (!action) return [model, []];
+      switch (action.type) {
+        case 'quit': return [model, [quit()]];
+        case 'next': return [{ accordion: focusNext(model.accordion) }, []];
+        case 'prev': return [{ accordion: focusPrev(model.accordion) }, []];
+        case 'toggle': return [{ accordion: toggleFocused(model.accordion) }, []];
+      }
+    }
+    return [model, []];
+  },
+
+  view: (model) => vstack(
+    '', interactiveAccordion(model.accordion), '', `  ${helpShort(keys)}`, '',
+  ),
+};
+
+run(app);
+```
+
+[← Examples](../README.md)

--- a/examples/interactive-accordion/demo.tape
+++ b/examples/interactive-accordion/demo.tape
@@ -1,0 +1,30 @@
+Output examples/interactive-accordion/demo.gif
+Set Shell zsh
+Set FontFamily "Monaspace Radon NF"
+Set FontSize 14
+Set Width 1200
+Set Height 660
+Set Theme "Catppuccin Mocha"
+Set Padding 20
+
+Type "npx tsx examples/interactive-accordion/main.ts"
+Enter
+Sleep 3s
+Down
+Sleep 1s
+Enter
+Sleep 1s
+Down
+Sleep 1s
+Enter
+Sleep 1s
+Down
+Sleep 1s
+Enter
+Sleep 1s
+Up
+Sleep 1s
+Enter
+Sleep 2s
+Type "q"
+Sleep 1s

--- a/examples/interactive-accordion/main.ts
+++ b/examples/interactive-accordion/main.ts
@@ -1,0 +1,93 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { kbd, separator } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg,
+  createAccordionState, interactiveAccordion,
+  focusNext, focusPrev, toggleFocused, expandAll, collapseAll,
+  accordionKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+
+const SECTIONS = [
+  {
+    title: 'What is bijou?',
+    content: 'A physics-powered TUI engine for TypeScript.\nZero dependencies. Hexagonal architecture.',
+    expanded: true,
+  },
+  {
+    title: 'Components',
+    content: 'box, table, tree, accordion, tabs, badge, alert,\nseparator, skeleton, kbd, breadcrumb, stepper,\ntimeline, paginator, progress, spinner, dag.',
+    expanded: false,
+  },
+  {
+    title: 'TUI Runtime',
+    content: 'TEA architecture (Model → Update → View).\nSpring animations, flexbox layout, viewport,\nkeybindings, input stack, event bus.',
+    expanded: false,
+  },
+  {
+    title: 'Theme Engine',
+    content: 'DTCG interop with built-in presets:\ncyan-magenta, nord, catppuccin.\nCustom themes via BIJOU_THEME env var.',
+    expanded: false,
+  },
+  {
+    title: 'Getting Started',
+    content: 'npm install @flyingrobots/bijou @flyingrobots/bijou-node\nimport { initDefaultContext } from "@flyingrobots/bijou-node";\ninitDefaultContext();',
+    expanded: false,
+  },
+];
+
+type Msg =
+  | { type: 'next' }
+  | { type: 'prev' }
+  | { type: 'toggle' }
+  | { type: 'expand-all' }
+  | { type: 'collapse-all' }
+  | { type: 'quit' };
+
+const keys = accordionKeyMap<Msg>({
+  focusNext: { type: 'next' },
+  focusPrev: { type: 'prev' },
+  toggle: { type: 'toggle' },
+  quit: { type: 'quit' },
+});
+
+// Add extra bindings for expand/collapse all
+keys
+  .bind('e', 'Expand all', { type: 'expand-all' })
+  .bind('c', 'Collapse all', { type: 'collapse-all' });
+
+interface Model {
+  accordion: ReturnType<typeof createAccordionState>;
+}
+
+const app: App<Model, Msg> = {
+  init: () => [{ accordion: createAccordionState(SECTIONS) }, []],
+
+  update: (msg, model) => {
+    if ('type' in msg && msg.type === 'key') {
+      const action = keys.handle(msg as KeyMsg);
+      if (!action) return [model, []];
+
+      switch (action.type) {
+        case 'quit': return [model, [quit()]];
+        case 'next': return [{ accordion: focusNext(model.accordion) }, []];
+        case 'prev': return [{ accordion: focusPrev(model.accordion) }, []];
+        case 'toggle': return [{ accordion: toggleFocused(model.accordion) }, []];
+        case 'expand-all': return [{ accordion: expandAll(model.accordion) }, []];
+        case 'collapse-all': return [{ accordion: collapseAll(model.accordion) }, []];
+      }
+    }
+
+    return [model, []];
+  },
+
+  view: (model) => {
+    const header = separator({ label: 'interactive accordion' });
+    const body = interactiveAccordion(model.accordion);
+    const help = `  ${helpShort(keys)}`;
+    return vstack('', header, '', body, '', help, '');
+  },
+};
+
+run(app);

--- a/examples/pager/README.md
+++ b/examples/pager/README.md
@@ -1,0 +1,77 @@
+# `pager()`
+
+Scrollable text viewer with status line
+
+![demo](demo.gif)
+
+## Run
+
+```sh
+npx tsx examples/pager/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { kbd, separator } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg,
+  createPagerState, pager, pagerScrollBy, pagerPageDown, pagerPageUp,
+  pagerScrollToTop, pagerScrollToBottom, pagerKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+
+const CONTENT = Array.from({ length: 80 }, (_, i) => `  Line ${i + 1}`).join('\n');
+
+type Msg =
+  | { type: 'scroll'; dy: number }
+  | { type: 'page-up' }
+  | { type: 'page-down' }
+  | { type: 'top' }
+  | { type: 'bottom' }
+  | { type: 'quit' };
+
+const keys = pagerKeyMap<Msg>({
+  scrollUp: { type: 'scroll', dy: -1 },
+  scrollDown: { type: 'scroll', dy: 1 },
+  pageUp: { type: 'page-up' },
+  pageDown: { type: 'page-down' },
+  top: { type: 'top' },
+  bottom: { type: 'bottom' },
+  quit: { type: 'quit' },
+});
+
+interface Model {
+  pager: ReturnType<typeof createPagerState>;
+}
+
+const app: App<Model, Msg> = {
+  init: () => [{
+    pager: createPagerState({ content: CONTENT, width: 80, height: 20 }),
+  }, []],
+
+  update: (msg, model) => {
+    if ('type' in msg && msg.type === 'key') {
+      const action = keys.handle(msg as KeyMsg);
+      if (!action) return [model, []];
+      switch (action.type) {
+        case 'quit': return [model, [quit()]];
+        case 'scroll': return [{ pager: pagerScrollBy(model.pager, action.dy) }, []];
+        case 'page-up': return [{ pager: pagerPageUp(model.pager) }, []];
+        case 'page-down': return [{ pager: pagerPageDown(model.pager) }, []];
+        case 'top': return [{ pager: pagerScrollToTop(model.pager) }, []];
+        case 'bottom': return [{ pager: pagerScrollToBottom(model.pager) }, []];
+      }
+    }
+    return [model, []];
+  },
+
+  view: (model) => vstack(pager(model.pager), `  ${helpShort(keys)}`),
+};
+
+run(app);
+```
+
+[← Examples](../README.md)

--- a/examples/pager/README.md
+++ b/examples/pager/README.md
@@ -14,7 +14,7 @@ npx tsx examples/pager/main.ts
 
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
-import { kbd, separator } from '@flyingrobots/bijou';
+import { separator } from '@flyingrobots/bijou';
 import {
   run, quit, type App, type KeyMsg,
   createPagerState, pager, pagerScrollBy, pagerPageDown, pagerPageUp,

--- a/examples/pager/demo.tape
+++ b/examples/pager/demo.tape
@@ -1,0 +1,32 @@
+Output examples/pager/demo.gif
+Set Shell zsh
+Set FontFamily "Monaspace Radon NF"
+Set FontSize 14
+Set Width 1200
+Set Height 660
+Set Theme "Catppuccin Mocha"
+Set Padding 20
+
+Type "npx tsx examples/pager/main.ts"
+Enter
+Sleep 3s
+Down
+Sleep 500ms
+Down
+Sleep 500ms
+Down
+Sleep 500ms
+Down
+Sleep 500ms
+Down
+Sleep 2s
+Type "d"
+Sleep 2s
+Type "u"
+Sleep 2s
+Type "G"
+Sleep 2s
+Type "g"
+Sleep 2s
+Type "q"
+Sleep 1s

--- a/examples/pager/main.ts
+++ b/examples/pager/main.ts
@@ -1,5 +1,5 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
-import { kbd, separator } from '@flyingrobots/bijou';
+import { separator } from '@flyingrobots/bijou';
 import {
   run, quit, type App, type KeyMsg,
   createPagerState, pager, pagerScrollBy, pagerPageDown, pagerPageUp,
@@ -54,7 +54,9 @@ const app: App<Model, Msg> = {
     if ('type' in msg && msg.type === 'resize') {
       const r = msg as { columns: number; rows: number };
       const p = createPagerState({ content: CONTENT, width: r.columns, height: r.rows - 2 });
-      return [{ ...model, pager: p, cols: r.columns, rows: r.rows }, []];
+      // Preserve scroll position across resize
+      const clampedY = Math.min(model.pager.scroll.y, p.scroll.maxY);
+      return [{ ...model, pager: { ...p, scroll: { ...p.scroll, y: clampedY } }, cols: r.columns, rows: r.rows }, []];
     }
 
     if ('type' in msg && msg.type === 'key') {

--- a/examples/pager/main.ts
+++ b/examples/pager/main.ts
@@ -1,0 +1,85 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { kbd, separator } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg,
+  createPagerState, pager, pagerScrollBy, pagerPageDown, pagerPageUp,
+  pagerScrollToTop, pagerScrollToBottom, pagerKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+
+// Generate some content to page through
+const CONTENT = Array.from({ length: 80 }, (_, i) => {
+  if (i === 0) return '  Welcome to the bijou pager!';
+  if (i % 10 === 0) return `  ── Section ${i / 10} ──`;
+  return `  Line ${i}: ${'Lorem ipsum dolor sit amet'.repeat(Math.ceil(Math.random() * 2))}`;
+}).join('\n');
+
+type Msg =
+  | { type: 'scroll'; dy: number }
+  | { type: 'page-up' }
+  | { type: 'page-down' }
+  | { type: 'top' }
+  | { type: 'bottom' }
+  | { type: 'quit' };
+
+const keys = pagerKeyMap<Msg>({
+  scrollUp: { type: 'scroll', dy: -1 },
+  scrollDown: { type: 'scroll', dy: 1 },
+  pageUp: { type: 'page-up' },
+  pageDown: { type: 'page-down' },
+  top: { type: 'top' },
+  bottom: { type: 'bottom' },
+  quit: { type: 'quit' },
+});
+
+interface Model {
+  pager: ReturnType<typeof createPagerState>;
+  cols: number;
+  rows: number;
+}
+
+const app: App<Model, Msg> = {
+  init: () => {
+    const cols = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    return [{
+      pager: createPagerState({ content: CONTENT, width: cols, height: rows - 2 }),
+      cols,
+      rows,
+    }, []];
+  },
+
+  update: (msg, model) => {
+    if ('type' in msg && msg.type === 'resize') {
+      const r = msg as { columns: number; rows: number };
+      const p = createPagerState({ content: CONTENT, width: r.columns, height: r.rows - 2 });
+      return [{ ...model, pager: p, cols: r.columns, rows: r.rows }, []];
+    }
+
+    if ('type' in msg && msg.type === 'key') {
+      const action = keys.handle(msg as KeyMsg);
+      if (!action) return [model, []];
+
+      switch (action.type) {
+        case 'quit': return [model, [quit()]];
+        case 'scroll': return [{ ...model, pager: pagerScrollBy(model.pager, action.dy) }, []];
+        case 'page-up': return [{ ...model, pager: pagerPageUp(model.pager) }, []];
+        case 'page-down': return [{ ...model, pager: pagerPageDown(model.pager) }, []];
+        case 'top': return [{ ...model, pager: pagerScrollToTop(model.pager) }, []];
+        case 'bottom': return [{ ...model, pager: pagerScrollToBottom(model.pager) }, []];
+      }
+    }
+
+    return [model, []];
+  },
+
+  view: (model) => {
+    const header = separator({ label: 'pager', width: model.cols });
+    const body = pager(model.pager);
+    const help = `  ${helpShort(keys)}`;
+    return vstack(header, body, help);
+  },
+};
+
+run(app);

--- a/examples/textarea/README.md
+++ b/examples/textarea/README.md
@@ -27,7 +27,7 @@ async function main() {
     ctx,
   });
 
-  if (message) {
+  if (message != null) {
     console.log();
     console.log(headerBox('Commit Message', { detail: message, ctx }));
   } else {

--- a/examples/textarea/README.md
+++ b/examples/textarea/README.md
@@ -1,0 +1,41 @@
+# `textarea()`
+
+Multi-line text input with cursor navigation
+
+![demo](demo.gif)
+
+## Run
+
+```sh
+npx tsx examples/textarea/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { textarea, box } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+async function main() {
+  const message = await textarea({
+    title: 'Write a commit message:',
+    placeholder: 'Describe your changes...',
+    showLineNumbers: true,
+    height: 8,
+    ctx,
+  });
+
+  if (message) {
+    console.log();
+    console.log(box(message, { title: 'Commit Message', ctx }));
+  } else {
+    console.log('\nCancelled.');
+  }
+}
+
+main().catch(console.error);
+```
+
+[← Examples](../README.md)

--- a/examples/textarea/README.md
+++ b/examples/textarea/README.md
@@ -14,7 +14,7 @@ npx tsx examples/textarea/main.ts
 
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
-import { textarea, box } from '@flyingrobots/bijou';
+import { textarea, headerBox } from '@flyingrobots/bijou';
 
 const ctx = initDefaultContext();
 
@@ -29,7 +29,7 @@ async function main() {
 
   if (message) {
     console.log();
-    console.log(box(message, { title: 'Commit Message', ctx }));
+    console.log(headerBox('Commit Message', { detail: message, ctx }));
   } else {
     console.log('\nCancelled.');
   }

--- a/examples/textarea/demo.tape
+++ b/examples/textarea/demo.tape
@@ -1,0 +1,27 @@
+Output examples/textarea/demo.gif
+Set Shell zsh
+Set FontFamily "Monaspace Radon NF"
+Set FontSize 14
+Set Width 960
+Set Height 540
+Set Theme "Catppuccin Mocha"
+Set Padding 20
+
+Type "npx tsx examples/textarea/main.ts"
+Enter
+Sleep 3s
+
+Type "feat: add textarea component"
+Enter
+Sleep 300ms
+Enter
+Sleep 300ms
+Type "Multi-line text input with cursor"
+Enter
+Sleep 300ms
+Type "navigation and line numbers."
+Sleep 1s
+
+# Submit with Ctrl+D
+Ctrl+D
+Sleep 2s

--- a/examples/textarea/main.ts
+++ b/examples/textarea/main.ts
@@ -12,7 +12,7 @@ async function main() {
     ctx,
   });
 
-  if (message) {
+  if (message != null) {
     console.log();
     console.log(headerBox('Commit Message', { detail: message, ctx }));
   } else {

--- a/examples/textarea/main.ts
+++ b/examples/textarea/main.ts
@@ -1,0 +1,23 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { textarea, box } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+async function main() {
+  const message = await textarea({
+    title: 'Write a commit message:',
+    placeholder: 'Describe your changes...',
+    showLineNumbers: true,
+    height: 8,
+    ctx,
+  });
+
+  if (message) {
+    console.log();
+    console.log(box(message, { title: 'Commit Message', ctx }));
+  } else {
+    console.log('\nCancelled.');
+  }
+}
+
+main().catch(console.error);

--- a/examples/textarea/main.ts
+++ b/examples/textarea/main.ts
@@ -1,5 +1,5 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
-import { textarea, box } from '@flyingrobots/bijou';
+import { textarea, headerBox } from '@flyingrobots/bijou';
 
 const ctx = initDefaultContext();
 
@@ -14,7 +14,7 @@ async function main() {
 
   if (message) {
     console.log();
-    console.log(box(message, { title: 'Commit Message', ctx }));
+    console.log(headerBox('Commit Message', { detail: message, ctx }));
   } else {
     console.log('\nCancelled.');
   }

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "0.3.0",
+    "@flyingrobots/bijou": "0.4.0",
     "chalk": "^5.6.2"
   },
   "devDependencies": {

--- a/packages/bijou-tui/GUIDE.md
+++ b/packages/bijou-tui/GUIDE.md
@@ -490,6 +490,76 @@ for (const layer of stack.layers()) {
 }
 ```
 
+## Overlay Compositing
+
+### Modals
+
+Create centered dialog overlays for confirm prompts, info boxes, or text input:
+
+```typescript
+import { composite, modal } from '@flyingrobots/bijou-tui';
+
+// In view:
+let output = renderMainContent(model);
+
+if (model.showConfirm) {
+  const dialog = modal({
+    title: 'Delete Item',
+    body: `Are you sure you want to delete "${model.selectedName}"?`,
+    hint: 'y to confirm, n to cancel',
+    screenWidth: model.cols,
+    screenHeight: model.rows,
+    borderToken: ctx.theme.theme.border.warning,
+    ctx,
+  });
+  output = composite(output, [dialog], { dim: true });
+}
+
+return output;
+```
+
+The `width` option overrides auto-sizing. Without `ctx`, borders render as plain unicode.
+
+### Toasts
+
+Anchored notification overlays for operation feedback:
+
+```typescript
+import { composite, toast } from '@flyingrobots/bijou-tui';
+
+// In view:
+let output = renderMainContent(model);
+
+if (model.notification) {
+  const t = toast({
+    message: model.notification.text,
+    variant: model.notification.variant,  // 'success' | 'error' | 'info'
+    anchor: 'bottom-right',
+    margin: 2,
+    screenWidth: model.cols,
+    screenHeight: model.rows,
+    ctx,
+  });
+  output = composite(output, [t]);
+}
+
+return output;
+```
+
+### Stacking Overlays
+
+Multiple overlays compose with painter's algorithm — later overlays paint over earlier ones:
+
+```typescript
+const overlays = [];
+
+if (model.toast) overlays.push(toast({ ...model.toast, screenWidth, screenHeight }));
+if (model.modal) overlays.push(modal({ ...model.modal, screenWidth, screenHeight }));
+
+// Modal paints over toast if they overlap
+return composite(background, overlays, { dim: model.modal != null });
+```
+
 ## Pure Functions Everywhere
 
 The spring engine, tween engine, timeline, viewport, scroll state, keybinding matching, and help generation are all pure functions operating on immutable state. This means:

--- a/packages/bijou-tui/README.md
+++ b/packages/bijou-tui/README.md
@@ -4,9 +4,14 @@ TEA runtime for terminal UIs — model/update/view with physics-based animation,
 
 Inspired by [Bubble Tea](https://github.com/charmbracelet/bubbletea) (Go) and [GSAP](https://gsap.com/) animation.
 
-## What's New in 0.3.0?
+## What's New in 0.4.0?
 
-- Lock-step version bump with `@flyingrobots/bijou` v0.3.0 (DAG renderer)
+- **`composite()`** — ANSI-safe overlay compositing with dim background support
+- **`modal()`** — centered dialog overlay with title, body, hint, and auto-centering
+- **`toast()`** — anchored notification overlay with success/error/info variants
+- **`pager()`** — scrollable content viewer with status line and convenience keymap
+- **`interactiveAccordion()`** — navigable accordion with focus tracking and expand/collapse
+- **`createPanelGroup()`** — multi-pane focus management with hotkey switching
 
 See the [CHANGELOG](https://github.com/flyingrobots/bijou/blob/main/docs/CHANGELOG.md) for the full release history.
 
@@ -249,6 +254,37 @@ stack.remove(modalId);
 ```
 
 `KeyMap` implements `InputHandler`, so it plugs directly into the input stack.
+
+## Overlay Compositing
+
+Paint overlays (modals, toasts) on top of existing content:
+
+```typescript
+import { composite, modal, toast } from '@flyingrobots/bijou-tui';
+
+// Create a centered dialog
+const dialog = modal({
+  title: 'Confirm',
+  body: 'Delete this item?',
+  hint: 'y/n',
+  screenWidth: 80,
+  screenHeight: 24,
+});
+
+// Create a toast notification
+const notification = toast({
+  message: 'Saved successfully',
+  variant: 'success',        // 'success' | 'error' | 'info'
+  anchor: 'bottom-right',    // 'top-right' | 'bottom-right' | 'bottom-left' | 'top-left'
+  screenWidth: 80,
+  screenHeight: 24,
+});
+
+// Paint overlays onto background content
+const output = composite(backgroundView, [dialog, notification], { dim: true });
+```
+
+Each overlay is a `{ content, row, col }` object. `composite()` splices them onto the background using painter's algorithm (last overlay wins on overlap). The `dim` option fades the background with ANSI dim.
 
 ## Related Packages
 

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "0.3.0"
+    "@flyingrobots/bijou": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/src/accordion.test.ts
+++ b/packages/bijou-tui/src/accordion.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createAccordionState,
+  focusNext,
+  focusPrev,
+  toggleFocused,
+  expandAll,
+  collapseAll,
+  interactiveAccordion,
+  accordionKeyMap,
+} from './accordion.js';
+import type { AccordionSection } from '@flyingrobots/bijou';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import type { KeyMsg } from './types.js';
+
+// ── Test Data ──────────────────────────────────────────────────────
+
+const sections: AccordionSection[] = [
+  { title: 'Alpha', content: 'Content A', expanded: true },
+  { title: 'Beta', content: 'Content B', expanded: false },
+  { title: 'Gamma', content: 'Content C', expanded: false },
+];
+
+function keyMsg(key: string, mods?: Partial<KeyMsg>): KeyMsg {
+  return { type: 'key', key, ctrl: false, alt: false, shift: false, ...mods };
+}
+
+// ── createAccordionState ──────────────────────────────────────────
+
+describe('createAccordionState', () => {
+  it('initializes with focusIndex 0', () => {
+    const state = createAccordionState(sections);
+    expect(state.focusIndex).toBe(0);
+  });
+
+  it('preserves section expanded state', () => {
+    const state = createAccordionState(sections);
+    expect(state.sections[0]!.expanded).toBe(true);
+    expect(state.sections[1]!.expanded).toBe(false);
+  });
+
+  it('copies sections (no shared references)', () => {
+    const original = [{ title: 'A', content: 'a', expanded: false }];
+    const state = createAccordionState(original);
+    original[0]!.expanded = true;
+    expect(state.sections[0]!.expanded).toBe(false);
+  });
+});
+
+// ── focusNext / focusPrev ─────────────────────────────────────────
+
+describe('focusNext', () => {
+  it('advances focus by 1', () => {
+    const state = createAccordionState(sections);
+    expect(focusNext(state).focusIndex).toBe(1);
+  });
+
+  it('wraps around to 0', () => {
+    let state = createAccordionState(sections);
+    state = focusNext(state);
+    state = focusNext(state);
+    state = focusNext(state);
+    expect(state.focusIndex).toBe(0);
+  });
+
+  it('handles empty sections', () => {
+    const state = createAccordionState([]);
+    expect(focusNext(state).focusIndex).toBe(0);
+  });
+});
+
+describe('focusPrev', () => {
+  it('decrements focus by 1', () => {
+    let state = createAccordionState(sections);
+    state = focusNext(state); // now at 1
+    expect(focusPrev(state).focusIndex).toBe(0);
+  });
+
+  it('wraps around to last section', () => {
+    const state = createAccordionState(sections);
+    expect(focusPrev(state).focusIndex).toBe(2);
+  });
+});
+
+// ── toggleFocused ─────────────────────────────────────────────────
+
+describe('toggleFocused', () => {
+  it('toggles expanded state of focused section', () => {
+    const state = createAccordionState(sections);
+    // Section 0 starts expanded
+    const toggled = toggleFocused(state);
+    expect(toggled.sections[0]!.expanded).toBe(false);
+    expect(toggled.sections[1]!.expanded).toBe(false); // unchanged
+  });
+
+  it('expands a collapsed section', () => {
+    let state = createAccordionState(sections);
+    state = focusNext(state); // focus on section 1 (collapsed)
+    const toggled = toggleFocused(state);
+    expect(toggled.sections[1]!.expanded).toBe(true);
+  });
+
+  it('does not mutate other sections', () => {
+    const state = createAccordionState(sections);
+    const toggled = toggleFocused(state);
+    expect(toggled.sections[1]).toEqual(state.sections[1]);
+    expect(toggled.sections[2]).toEqual(state.sections[2]);
+  });
+
+  it('handles empty sections', () => {
+    const state = createAccordionState([]);
+    expect(toggleFocused(state).sections).toHaveLength(0);
+  });
+});
+
+// ── expandAll / collapseAll ───────────────────────────────────────
+
+describe('expandAll', () => {
+  it('expands all sections', () => {
+    const state = createAccordionState(sections);
+    const expanded = expandAll(state);
+    for (const s of expanded.sections) {
+      expect(s.expanded).toBe(true);
+    }
+  });
+});
+
+describe('collapseAll', () => {
+  it('collapses all sections', () => {
+    const state = createAccordionState(sections);
+    const collapsed = collapseAll(state);
+    for (const s of collapsed.sections) {
+      expect(s.expanded).toBe(false);
+    }
+  });
+});
+
+// ── interactiveAccordion ──────────────────────────────────────────
+
+describe('interactiveAccordion', () => {
+  it('renders with focus indicator on first section', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const state = createAccordionState(sections);
+    const output = interactiveAccordion(state, { ctx });
+    const lines = output.split('\n');
+    // First line should start with "> "
+    expect(lines[0]).toMatch(/^> /);
+  });
+
+  it('moves focus indicator with state', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const state = focusNext(createAccordionState(sections));
+    const output = interactiveAccordion(state, { ctx });
+    // The second section's header should have the focus indicator
+    // Find section blocks (separated by blank lines)
+    const blocks = output.split('\n\n');
+    expect(blocks[0]).toMatch(/^\s\s/); // first section: no focus (indented with spaces)
+    expect(blocks[1]).toMatch(/^> /);   // second section: focused
+  });
+
+  it('non-focused sections are indented with spaces', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const state = createAccordionState(sections);
+    const output = interactiveAccordion(state, { ctx });
+    const blocks = output.split('\n\n');
+    // Second section should start with "  " (not "> ")
+    expect(blocks[1]).toMatch(/^\s\s/);
+  });
+
+  it('renders empty string for empty sections', () => {
+    const state = createAccordionState([]);
+    expect(interactiveAccordion(state)).toBe('');
+  });
+
+  it('renders expanded content with indentation', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const state = createAccordionState(sections);
+    const output = interactiveAccordion(state, { ctx });
+    // Section 0 is expanded, its content should appear
+    expect(output).toContain('Content A');
+  });
+});
+
+// ── accordionKeyMap ───────────────────────────────────────────────
+
+describe('accordionKeyMap', () => {
+  type Msg = { type: string };
+
+  const km = accordionKeyMap<Msg>({
+    focusNext: { type: 'next' },
+    focusPrev: { type: 'prev' },
+    toggle: { type: 'toggle' },
+    quit: { type: 'quit' },
+  });
+
+  it('handles j/k for navigation', () => {
+    expect(km.handle(keyMsg('j'))).toEqual({ type: 'next' });
+    expect(km.handle(keyMsg('k'))).toEqual({ type: 'prev' });
+  });
+
+  it('handles arrow keys', () => {
+    expect(km.handle(keyMsg('down'))).toEqual({ type: 'next' });
+    expect(km.handle(keyMsg('up'))).toEqual({ type: 'prev' });
+  });
+
+  it('handles enter/space for toggle', () => {
+    expect(km.handle(keyMsg('enter'))).toEqual({ type: 'toggle' });
+    expect(km.handle(keyMsg('space'))).toEqual({ type: 'toggle' });
+  });
+
+  it('handles quit', () => {
+    expect(km.handle(keyMsg('q'))).toEqual({ type: 'quit' });
+    expect(km.handle(keyMsg('c', { ctrl: true }))).toEqual({ type: 'quit' });
+  });
+
+  it('returns undefined for unbound keys', () => {
+    expect(km.handle(keyMsg('x'))).toBeUndefined();
+  });
+});

--- a/packages/bijou-tui/src/accordion.ts
+++ b/packages/bijou-tui/src/accordion.ts
@@ -1,0 +1,173 @@
+/**
+ * Interactive accordion building block.
+ *
+ * Wraps the static `accordion()` from bijou core with focus management
+ * and expand/collapse state transformers.
+ *
+ * ```ts
+ * // In TEA init:
+ * const accState = createAccordionState(sections);
+ *
+ * // In TEA view:
+ * const output = interactiveAccordion(model.accordion);
+ *
+ * // In TEA update:
+ * case 'focus-next':
+ *   return [{ ...model, accordion: focusNext(model.accordion) }, []];
+ * case 'toggle':
+ *   return [{ ...model, accordion: toggleFocused(model.accordion) }, []];
+ * ```
+ */
+
+import {
+  accordion,
+  type AccordionSection,
+  type AccordionOptions,
+} from '@flyingrobots/bijou';
+import type { BijouContext } from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// Re-export AccordionSection for convenience
+export type { AccordionSection } from '@flyingrobots/bijou';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AccordionState {
+  readonly sections: readonly AccordionSection[];
+  readonly focusIndex: number;
+}
+
+export interface InteractiveAccordionOptions {
+  /** Token for the expand/collapse indicator. */
+  readonly indicatorToken?: AccordionOptions['indicatorToken'];
+  /** Token for section titles. */
+  readonly titleToken?: AccordionOptions['titleToken'];
+  /** Character for the focus indicator. Default: '>' */
+  readonly focusChar?: string;
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial accordion state from sections.
+ * Preserves existing `expanded` flags; focus starts at index 0.
+ */
+export function createAccordionState(sections: AccordionSection[]): AccordionState {
+  return {
+    sections: sections.map((s) => ({ ...s })),
+    focusIndex: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Move focus to the next section (wraps around). */
+export function focusNext(state: AccordionState): AccordionState {
+  if (state.sections.length === 0) return state;
+  return {
+    ...state,
+    focusIndex: (state.focusIndex + 1) % state.sections.length,
+  };
+}
+
+/** Move focus to the previous section (wraps around). */
+export function focusPrev(state: AccordionState): AccordionState {
+  if (state.sections.length === 0) return state;
+  return {
+    ...state,
+    focusIndex: (state.focusIndex - 1 + state.sections.length) % state.sections.length,
+  };
+}
+
+/** Toggle the expanded state of the focused section. */
+export function toggleFocused(state: AccordionState): AccordionState {
+  if (state.sections.length === 0) return state;
+  const sections = state.sections.map((s, i) =>
+    i === state.focusIndex ? { ...s, expanded: !s.expanded } : s,
+  );
+  return { ...state, sections };
+}
+
+/** Expand all sections. */
+export function expandAll(state: AccordionState): AccordionState {
+  return { ...state, sections: state.sections.map((s) => ({ ...s, expanded: true })) };
+}
+
+/** Collapse all sections. */
+export function collapseAll(state: AccordionState): AccordionState {
+  return { ...state, sections: state.sections.map((s) => ({ ...s, expanded: false })) };
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the interactive accordion with a focus indicator on the
+ * currently focused section.
+ *
+ * Delegates to the static `accordion()` for the actual rendering,
+ * then prepends a focus indicator to the focused section's line.
+ */
+export function interactiveAccordion(
+  state: AccordionState,
+  options?: InteractiveAccordionOptions,
+): string {
+  if (state.sections.length === 0) return '';
+
+  const focusChar = options?.focusChar ?? '>';
+
+  // Render each section individually so we can prepend the focus indicator
+  const renderedSections = state.sections.map((section, i) => {
+    const rendered = accordion([section], {
+      indicatorToken: options?.indicatorToken,
+      titleToken: options?.titleToken,
+      ctx: options?.ctx,
+    });
+
+    const prefix = i === state.focusIndex ? `${focusChar} ` : '  ';
+
+    // Prepend the focus indicator to each line of the rendered section
+    return rendered
+      .split('\n')
+      .map((line, lineIdx) => (lineIdx === 0 ? prefix + line : '  ' + line))
+      .join('\n');
+  });
+
+  return renderedSections.join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for accordion navigation.
+ */
+export function accordionKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  toggle: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next section', actions.focusNext)
+      .bind('down', 'Next section', actions.focusNext)
+      .bind('k', 'Previous section', actions.focusPrev)
+      .bind('up', 'Previous section', actions.focusPrev),
+    )
+    .group('Actions', (g) => g
+      .bind('enter', 'Toggle section', actions.toggle)
+      .bind('space', 'Toggle section', actions.toggle),
+    )
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/accordion.ts
+++ b/packages/bijou-tui/src/accordion.ts
@@ -23,8 +23,8 @@ import {
   accordion,
   type AccordionSection,
   type AccordionOptions,
+  type BijouContext,
 } from '@flyingrobots/bijou';
-import type { BijouContext } from '@flyingrobots/bijou';
 import { createKeyMap, type KeyMap } from './keybindings.js';
 
 // Re-export AccordionSection for convenience

--- a/packages/bijou-tui/src/accordion.ts
+++ b/packages/bijou-tui/src/accordion.ts
@@ -123,6 +123,11 @@ export function interactiveAccordion(
   if (state.sections.length === 0) return '';
 
   const focusChar = options?.focusChar ?? '>';
+  // Normalize focusIndex to avoid stale/out-of-range values
+  const focusIndex = ((state.focusIndex % state.sections.length) + state.sections.length) % state.sections.length;
+  // Continuation-line padding must match the focus prefix width
+  const padWidth = focusChar.length + 1; // focusChar + space
+  const continuationPad = ' '.repeat(padWidth);
 
   // Render each section individually so we can prepend the focus indicator
   const renderedSections = state.sections.map((section, i) => {
@@ -132,12 +137,12 @@ export function interactiveAccordion(
       ctx: options?.ctx,
     });
 
-    const prefix = i === state.focusIndex ? `${focusChar} ` : '  ';
+    const prefix = i === focusIndex ? `${focusChar} ` : continuationPad;
 
     // Prepend the focus indicator to each line of the rendered section
     return rendered
       .split('\n')
-      .map((line, lineIdx) => (lineIdx === 0 ? prefix + line : '  ' + line))
+      .map((line, lineIdx) => (lineIdx === 0 ? prefix + line : continuationPad + line))
       .join('\n');
   });
 

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -127,3 +127,34 @@ export {
   type InputStack,
   createInputStack,
 } from './inputstack.js';
+
+// Pager — scrollable text viewer
+export {
+  type PagerState,
+  type PagerOptions,
+  type PagerRenderOptions,
+  createPagerState,
+  pager,
+  pagerScrollBy,
+  pagerScrollTo,
+  pagerScrollToTop,
+  pagerScrollToBottom,
+  pagerPageDown,
+  pagerPageUp,
+  pagerSetContent,
+  pagerKeyMap,
+} from './pager.js';
+
+// Interactive accordion
+export {
+  type AccordionState,
+  type InteractiveAccordionOptions,
+  createAccordionState,
+  interactiveAccordion,
+  focusNext,
+  focusPrev,
+  toggleFocused,
+  expandAll,
+  collapseAll,
+  accordionKeyMap,
+} from './accordion.js';

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -81,6 +81,9 @@ export {
   stripAnsi,
   visibleLength,
   clipToWidth,
+  sliceAnsi,
+  scrollByX,
+  scrollToX,
 } from './viewport.js';
 
 // Timeline — GSAP-style animation orchestration

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -159,6 +159,19 @@ export {
   createPanelGroup,
 } from './panels.js';
 
+// Overlay compositing
+export {
+  type Overlay,
+  type CompositeOptions,
+  type ModalOptions,
+  type ToastVariant,
+  type ToastAnchor,
+  type ToastOptions,
+  composite,
+  modal,
+  toast,
+} from './overlay.js';
+
 // Interactive accordion
 export {
   type AccordionState,

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -78,6 +78,9 @@ export {
   scrollToBottom,
   pageDown,
   pageUp,
+  stripAnsi,
+  visibleLength,
+  clipToWidth,
 } from './viewport.js';
 
 // Timeline — GSAP-style animation orchestration

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -151,6 +151,14 @@ export {
   pagerKeyMap,
 } from './pager.js';
 
+// Panel group — multi-pane focus management
+export {
+  type PanelDef,
+  type PanelGroupOptions,
+  type PanelGroup,
+  createPanelGroup,
+} from './panels.js';
+
 // Interactive accordion
 export {
   type AccordionState,

--- a/packages/bijou-tui/src/overlay.test.ts
+++ b/packages/bijou-tui/src/overlay.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { composite, modal, toast } from './overlay.js';
+import type { Overlay } from './overlay.js';
+import { visibleLength, stripAnsi } from './viewport.js';
+
+// ---------------------------------------------------------------------------
+// composite()
+// ---------------------------------------------------------------------------
+
+describe('composite', () => {
+  it('paints single overlay at (0,0)', () => {
+    const bg = 'AAAA\nBBBB\nCCCC';
+    const ov: Overlay = { content: 'XX', row: 0, col: 0 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    expect(stripAnsi(lines[0]!)).toBe('XXAA');
+    expect(stripAnsi(lines[1]!)).toBe('BBBB');
+  });
+
+  it('paints single overlay at arbitrary offset', () => {
+    const bg = 'AAAA\nBBBB\nCCCC';
+    const ov: Overlay = { content: 'XX', row: 1, col: 2 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    expect(stripAnsi(lines[0]!)).toBe('AAAA');
+    expect(stripAnsi(lines[1]!)).toBe('BBXX');
+    expect(stripAnsi(lines[2]!)).toBe('CCCC');
+  });
+
+  it('multi-line overlay replaces correct rows', () => {
+    const bg = 'AAAA\nBBBB\nCCCC\nDDDD';
+    const ov: Overlay = { content: 'XX\nYY', row: 1, col: 1 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    expect(stripAnsi(lines[1]!)).toBe('BXXB');
+    expect(stripAnsi(lines[2]!)).toBe('CYYC');
+  });
+
+  it('multiple overlays, last wins on overlap', () => {
+    const bg = 'AAAA\nBBBB';
+    const ov1: Overlay = { content: 'XX', row: 0, col: 0 };
+    const ov2: Overlay = { content: 'YY', row: 0, col: 0 };
+    const result = composite(bg, [ov1, ov2]);
+    const lines = result.split('\n');
+    expect(stripAnsi(lines[0]!)).toBe('YYAA');
+  });
+
+  it('empty overlays returns background unchanged', () => {
+    const bg = 'AAAA\nBBBB';
+    const result = composite(bg, []);
+    expect(stripAnsi(result)).toBe(bg);
+  });
+
+  it('overlay beyond bottom edge is clipped', () => {
+    const bg = 'AAAA\nBBBB';
+    const ov: Overlay = { content: 'XX\nYY\nZZ', row: 1, col: 0 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(stripAnsi(lines[1]!)).toBe('XXBB');
+  });
+
+  it('overlay beyond right edge extends the line', () => {
+    const bg = 'AA\nBB';
+    const ov: Overlay = { content: 'XXXX', row: 0, col: 1 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    expect(stripAnsi(lines[0]!)).toBe('AXXXX');
+  });
+
+  it('short background lines padded with spaces to reach col', () => {
+    const bg = 'AB\nCD';
+    const ov: Overlay = { content: 'X', row: 0, col: 5 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    expect(stripAnsi(lines[0]!)).toBe('AB   X');
+  });
+
+  it('dim wraps background lines', () => {
+    const bg = 'AAAA\nBBBB';
+    const ov: Overlay = { content: 'XX', row: 0, col: 1 };
+    const result = composite(bg, [ov], { dim: true });
+    const lines = result.split('\n');
+    // background line 1 (row 1) should be dimmed
+    expect(lines[1]!).toContain('\x1b[2m');
+    // overlay content should NOT be dimmed
+    expect(stripAnsi(lines[0]!)).toBe('AXXA');
+  });
+
+  it('styled background: non-overlaid regions preserve ANSI', () => {
+    const bg = '\x1b[31mAAAA\x1b[0m\nBBBB';
+    const ov: Overlay = { content: 'X', row: 0, col: 2 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    // Left portion should still contain red escape
+    expect(lines[0]!).toContain('\x1b[31m');
+    expect(stripAnsi(lines[0]!)).toBe('AAXA');
+  });
+
+  it('styled overlay on styled background: no cross-bleed', () => {
+    const bg = '\x1b[31mAAAA\x1b[0m\n\x1b[32mBBBB\x1b[0m';
+    const ov: Overlay = { content: '\x1b[34mXX\x1b[0m', row: 0, col: 1 };
+    const result = composite(bg, [ov]);
+    const lines = result.split('\n');
+    // Resets should separate regions
+    expect(lines[0]!).toContain('\x1b[0m');
+    expect(stripAnsi(lines[0]!)).toBe('AXXA');
+    // Second line untouched
+    expect(stripAnsi(lines[1]!)).toBe('BBBB');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// modal()
+// ---------------------------------------------------------------------------
+
+describe('modal', () => {
+  it('body-only modal renders bordered box', () => {
+    const { content } = modal({ body: 'Hello', screenWidth: 40, screenHeight: 20 });
+    const lines = content.split('\n');
+    expect(lines[0]!).toContain('\u250c'); // ┌
+    expect(lines[lines.length - 1]!).toContain('\u2514'); // └
+    expect(stripAnsi(lines[1]!)).toContain('Hello');
+  });
+
+  it('title renders bold above body with separator', () => {
+    const { content } = modal({ title: 'Title', body: 'Body', screenWidth: 40, screenHeight: 20 });
+    const lines = content.split('\n');
+    // line 0: top border, line 1: title, line 2: blank separator, line 3: body, line 4: bottom
+    expect(stripAnsi(lines[1]!)).toContain('Title');
+    // separator line is bordered but inner content is blank
+    const sep = stripAnsi(lines[2]!).replace(/[│]/g, '').trim();
+    expect(sep).toBe('');
+    expect(stripAnsi(lines[3]!)).toContain('Body');
+  });
+
+  it('hint renders below body with separator', () => {
+    const { content } = modal({ body: 'Body', hint: 'Press q', screenWidth: 40, screenHeight: 20 });
+    const lines = content.split('\n');
+    // line 0: top border, line 1: body, line 2: blank, line 3: hint, line 4: bottom
+    expect(stripAnsi(lines[1]!)).toContain('Body');
+    const sep = stripAnsi(lines[2]!).replace(/[│]/g, '').trim();
+    expect(sep).toBe('');
+    expect(stripAnsi(lines[3]!)).toContain('Press q');
+  });
+
+  it('all three (title + body + hint) together', () => {
+    const { content } = modal({
+      title: 'T',
+      body: 'B',
+      hint: 'H',
+      screenWidth: 40,
+      screenHeight: 20,
+    });
+    const lines = content.split('\n');
+    expect(stripAnsi(lines[1]!)).toContain('T');
+    expect(stripAnsi(lines[3]!)).toContain('B');
+    expect(stripAnsi(lines[5]!)).toContain('H');
+  });
+
+  it('centers on screen', () => {
+    const { row, col, content } = modal({ body: 'Hi', screenWidth: 80, screenHeight: 24 });
+    const boxLines = content.split('\n');
+    const boxH = boxLines.length;
+    const boxW = visibleLength(boxLines[0]!);
+    expect(row).toBe(Math.floor((24 - boxH) / 2));
+    expect(col).toBe(Math.floor((80 - boxW) / 2));
+  });
+
+  it('clamps to (0,0) when modal exceeds screen', () => {
+    const { row, col } = modal({
+      body: 'A very long line of text that is wider than the screen for sure!!!!',
+      screenWidth: 5,
+      screenHeight: 2,
+    });
+    expect(row).toBe(0);
+    expect(col).toBe(0);
+  });
+
+  it('width override respected', () => {
+    const { content } = modal({ body: 'Hi', screenWidth: 80, screenHeight: 24, width: 30 });
+    const lines = content.split('\n');
+    expect(visibleLength(lines[0]!)).toBe(30);
+  });
+
+  it('works without ctx (plain text, still has borders)', () => {
+    const { content } = modal({ body: 'No ctx', screenWidth: 40, screenHeight: 20 });
+    expect(content).toContain('\u2502');
+    expect(stripAnsi(content)).toContain('No ctx');
+  });
+
+  it('works with ctx (themed)', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const { content } = modal({
+      body: 'Themed',
+      title: 'Title',
+      hint: 'hint',
+      screenWidth: 40,
+      screenHeight: 20,
+      borderToken: ctx.theme.theme.border.primary,
+      ctx,
+    });
+    expect(stripAnsi(content)).toContain('Themed');
+    expect(stripAnsi(content)).toContain('Title');
+    expect(stripAnsi(content)).toContain('hint');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toast()
+// ---------------------------------------------------------------------------
+
+describe('toast', () => {
+  it('success variant has ✔ icon', () => {
+    const { content } = toast({ message: 'ok', variant: 'success', screenWidth: 80, screenHeight: 24 });
+    expect(stripAnsi(content)).toContain('\u2714');
+  });
+
+  it('error variant has ✘ icon', () => {
+    const { content } = toast({ message: 'fail', variant: 'error', screenWidth: 80, screenHeight: 24 });
+    expect(stripAnsi(content)).toContain('\u2718');
+  });
+
+  it('info variant has ℹ icon', () => {
+    const { content } = toast({ message: 'note', variant: 'info', screenWidth: 80, screenHeight: 24 });
+    expect(stripAnsi(content)).toContain('\u2139');
+  });
+
+  it('default variant is info', () => {
+    const { content } = toast({ message: 'note', screenWidth: 80, screenHeight: 24 });
+    expect(stripAnsi(content)).toContain('\u2139');
+  });
+
+  it('four anchors produce correct row/col', () => {
+    const base = { message: 'msg', screenWidth: 80, screenHeight: 24, margin: 1 };
+
+    const tr = toast({ ...base, anchor: 'top-right' });
+    const br = toast({ ...base, anchor: 'bottom-right' });
+    const bl = toast({ ...base, anchor: 'bottom-left' });
+    const tl = toast({ ...base, anchor: 'top-left' });
+
+    const boxH = tr.content.split('\n').length;
+    const boxW = visibleLength(tr.content.split('\n')[0]!);
+
+    expect(tr.row).toBe(1);
+    expect(tr.col).toBe(80 - boxW - 1);
+
+    expect(br.row).toBe(24 - boxH - 1);
+    expect(br.col).toBe(80 - boxW - 1);
+
+    expect(bl.row).toBe(24 - boxH - 1);
+    expect(bl.col).toBe(1);
+
+    expect(tl.row).toBe(1);
+    expect(tl.col).toBe(1);
+  });
+
+  it('default anchor is bottom-right', () => {
+    const { row, col, content } = toast({ message: 'x', screenWidth: 80, screenHeight: 24 });
+    const boxH = content.split('\n').length;
+    const boxW = visibleLength(content.split('\n')[0]!);
+    expect(row).toBe(24 - boxH - 1);
+    expect(col).toBe(80 - boxW - 1);
+  });
+
+  it('margin is respected', () => {
+    const m3 = toast({ message: 'x', anchor: 'top-left', screenWidth: 80, screenHeight: 24, margin: 3 });
+    expect(m3.row).toBe(3);
+    expect(m3.col).toBe(3);
+  });
+
+  it('works without ctx', () => {
+    const { content } = toast({ message: 'plain', screenWidth: 80, screenHeight: 24 });
+    expect(content).toContain('\u2502');
+    expect(stripAnsi(content)).toContain('plain');
+  });
+
+  it('works with ctx (themed)', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const { content } = toast({ message: 'themed', variant: 'success', screenWidth: 80, screenHeight: 24, ctx });
+    expect(stripAnsi(content)).toContain('\u2714');
+    expect(stripAnsi(content)).toContain('themed');
+  });
+
+  it('composites correctly with a background', () => {
+    const bg = Array.from({ length: 24 }, () => '.'.repeat(80)).join('\n');
+    const t = toast({ message: 'saved', variant: 'success', screenWidth: 80, screenHeight: 24 });
+    const result = composite(bg, [t]);
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(24);
+    // Toast should appear near bottom-right
+    expect(stripAnsi(lines[t.row]!)).toContain('\u250c');
+  });
+});

--- a/packages/bijou-tui/src/overlay.test.ts
+++ b/packages/bijou-tui/src/overlay.test.ts
@@ -86,6 +86,10 @@ describe('composite', () => {
     expect(lines[1]!).toContain('\x1b[2m');
     // overlay content should NOT be dimmed
     expect(stripAnsi(lines[0]!)).toBe('AXXA');
+    // verify overlay portion between resets lacks dim code
+    const overlayRegion = lines[0]!.split('\x1b[0m').find(s => s.includes('XX'));
+    expect(overlayRegion).toBeDefined();
+    expect(overlayRegion).not.toContain('\x1b[2m');
   });
 
   it('styled background: non-overlaid regions preserve ANSI', () => {

--- a/packages/bijou-tui/src/overlay.ts
+++ b/packages/bijou-tui/src/overlay.ts
@@ -93,7 +93,7 @@ export function composite(
 
   if (options?.dim) {
     for (let i = 0; i < bgLines.length; i++) {
-      if (bgLines[i]!.length > 0) {
+      if (visibleLength(bgLines[i]!) > 0) {
         bgLines[i] = '\x1b[2m' + bgLines[i] + '\x1b[0m';
       }
     }
@@ -190,12 +190,6 @@ const TOAST_ICONS: Record<ToastVariant, string> = {
   info: '\u2139',    // ℹ
 };
 
-const TOAST_SEMANTIC: Record<ToastVariant, 'success' | 'error' | 'info'> = {
-  success: 'success',
-  error: 'error',
-  info: 'info',
-};
-
 const TOAST_BORDER: Record<ToastVariant, 'success' | 'error' | 'primary'> = {
   success: 'success',
   error: 'error',
@@ -216,10 +210,8 @@ export function toast(options: ToastOptions): Overlay {
   const icon = TOAST_ICONS[variant];
   let line = icon + ' ' + message;
 
-  const semanticKey = TOAST_SEMANTIC[variant];
   if (ctx) {
-    const token = ctx.theme.theme.semantic[semanticKey];
-    line = ctx.style.styled(token, line);
+    line = ctx.style.styled(ctx.theme.theme.semantic[variant], line);
   }
 
   const borderKey = TOAST_BORDER[variant];

--- a/packages/bijou-tui/src/overlay.ts
+++ b/packages/bijou-tui/src/overlay.ts
@@ -1,0 +1,261 @@
+/**
+ * Overlay compositing primitives for TUI apps.
+ *
+ * - `composite()` — paint overlays onto a background string (ANSI-safe)
+ * - `modal()` — centered dialog overlay with title, body, hint
+ * - `toast()` — anchored notification overlay with variant icons
+ */
+
+import type { BijouContext, TokenValue } from '@flyingrobots/bijou';
+import { sliceAnsi, visibleLength } from './viewport.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Overlay {
+  readonly content: string;
+  readonly row: number;
+  readonly col: number;
+}
+
+export interface CompositeOptions {
+  /** Wrap background lines in dim (ANSI 2m). */
+  readonly dim?: boolean;
+}
+
+export interface ModalOptions {
+  readonly title?: string;
+  readonly body: string;
+  readonly hint?: string;
+  readonly screenWidth: number;
+  readonly screenHeight: number;
+  /** Override box width (default: auto from content). */
+  readonly width?: number;
+  readonly borderToken?: TokenValue;
+  readonly ctx?: BijouContext;
+}
+
+export type ToastVariant = 'success' | 'error' | 'info';
+export type ToastAnchor = 'top-right' | 'bottom-right' | 'bottom-left' | 'top-left';
+
+export interface ToastOptions {
+  readonly message: string;
+  readonly variant?: ToastVariant;
+  readonly anchor?: ToastAnchor;
+  readonly screenWidth: number;
+  readonly screenHeight: number;
+  /** Rows/cols from edge. Default: 1. */
+  readonly margin?: number;
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// Border characters (same as core box.ts)
+// ---------------------------------------------------------------------------
+
+const BORDER = {
+  tl: '\u250c', // ┌
+  tr: '\u2510', // ┐
+  bl: '\u2514', // └
+  br: '\u2518', // ┘
+  h: '\u2500',  // ─
+  v: '\u2502',  // │
+};
+
+// ---------------------------------------------------------------------------
+// spliceLine (internal)
+// ---------------------------------------------------------------------------
+
+function spliceLine(bgLine: string, overlayLine: string, col: number): string {
+  const overlayVis = visibleLength(overlayLine);
+  const bgVis = visibleLength(bgLine);
+
+  const left = bgVis <= col
+    ? bgLine + ' '.repeat(col - bgVis)
+    : sliceAnsi(bgLine, 0, col);
+
+  const right = sliceAnsi(bgLine, col + overlayVis, bgVis);
+
+  return left + '\x1b[0m' + overlayLine + '\x1b[0m' + right;
+}
+
+// ---------------------------------------------------------------------------
+// composite()
+// ---------------------------------------------------------------------------
+
+export function composite(
+  background: string,
+  overlays: readonly Overlay[],
+  options?: CompositeOptions,
+): string {
+  const bgLines = background.split('\n');
+
+  if (options?.dim) {
+    for (let i = 0; i < bgLines.length; i++) {
+      if (bgLines[i]!.length > 0) {
+        bgLines[i] = '\x1b[2m' + bgLines[i] + '\x1b[0m';
+      }
+    }
+  }
+
+  for (const overlay of overlays) {
+    const oLines = overlay.content.split('\n');
+    for (let i = 0; i < oLines.length; i++) {
+      const targetRow = overlay.row + i;
+      if (targetRow < 0 || targetRow >= bgLines.length) continue;
+      bgLines[targetRow] = spliceLine(bgLines[targetRow]!, oLines[i]!, overlay.col);
+    }
+  }
+
+  return bgLines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// renderBox (shared between modal and toast)
+// ---------------------------------------------------------------------------
+
+function renderBox(
+  lines: string[],
+  borderColor: (s: string) => string,
+): string {
+  const innerWidth = lines.reduce((max, l) => Math.max(max, visibleLength(l)), 0);
+  const top = borderColor(BORDER.tl + BORDER.h.repeat(innerWidth + 2) + BORDER.tr);
+  const bottom = borderColor(BORDER.bl + BORDER.h.repeat(innerWidth + 2) + BORDER.br);
+  const body = lines.map((l) => {
+    const pad = innerWidth - visibleLength(l);
+    return borderColor(BORDER.v) + ' ' + l + ' '.repeat(pad) + ' ' + borderColor(BORDER.v);
+  });
+  return [top, ...body, bottom].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// modal()
+// ---------------------------------------------------------------------------
+
+export function modal(options: ModalOptions): Overlay {
+  const { title, body, hint, screenWidth, screenHeight, ctx } = options;
+
+  const contentLines: string[] = [];
+
+  if (title != null) {
+    const titleText = ctx ? ctx.style.bold(title) : title;
+    contentLines.push(titleText, '');
+  }
+
+  contentLines.push(...body.split('\n'));
+
+  if (hint != null) {
+    contentLines.push('');
+    const hintText = ctx
+      ? ctx.style.styled(ctx.theme.theme.semantic.muted, hint)
+      : hint;
+    contentLines.push(hintText);
+  }
+
+  // If width override, constrain inner width
+  if (options.width != null) {
+    const targetInner = options.width - 4; // border + padding
+    // Pad short lines, but don't truncate (user controls width)
+    for (let i = 0; i < contentLines.length; i++) {
+      const vis = visibleLength(contentLines[i]!);
+      if (vis < targetInner) {
+        contentLines[i] = contentLines[i]! + ' '.repeat(targetInner - vis);
+      }
+    }
+  }
+
+  const borderColor = ctx && options.borderToken
+    ? (s: string) => ctx.style.styled(options.borderToken!, s)
+    : (s: string) => s;
+
+  const boxStr = renderBox(contentLines, borderColor);
+  const boxLines = boxStr.split('\n');
+  const boxHeight = boxLines.length;
+  const boxWidth = visibleLength(boxLines[0]!);
+
+  const row = Math.max(0, Math.floor((screenHeight - boxHeight) / 2));
+  const col = Math.max(0, Math.floor((screenWidth - boxWidth) / 2));
+
+  return { content: boxStr, row, col };
+}
+
+// ---------------------------------------------------------------------------
+// toast()
+// ---------------------------------------------------------------------------
+
+const TOAST_ICONS: Record<ToastVariant, string> = {
+  success: '\u2714', // ✔
+  error: '\u2718',   // ✘
+  info: '\u2139',    // ℹ
+};
+
+const TOAST_SEMANTIC: Record<ToastVariant, 'success' | 'error' | 'info'> = {
+  success: 'success',
+  error: 'error',
+  info: 'info',
+};
+
+const TOAST_BORDER: Record<ToastVariant, 'success' | 'error' | 'primary'> = {
+  success: 'success',
+  error: 'error',
+  info: 'primary',
+};
+
+export function toast(options: ToastOptions): Overlay {
+  const {
+    message,
+    variant = 'info',
+    anchor = 'bottom-right',
+    screenWidth,
+    screenHeight,
+    margin = 1,
+    ctx,
+  } = options;
+
+  const icon = TOAST_ICONS[variant];
+  let line = icon + ' ' + message;
+
+  const semanticKey = TOAST_SEMANTIC[variant];
+  if (ctx) {
+    const token = ctx.theme.theme.semantic[semanticKey];
+    line = ctx.style.styled(token, line);
+  }
+
+  const borderKey = TOAST_BORDER[variant];
+  const borderColor = ctx
+    ? (s: string) => ctx.style.styled(ctx.theme.theme.border[borderKey], s)
+    : (s: string) => s;
+
+  const boxStr = renderBox([line], borderColor);
+  const boxLines = boxStr.split('\n');
+  const boxHeight = boxLines.length;
+  const boxWidth = visibleLength(boxLines[0]!);
+
+  let row: number;
+  let col: number;
+
+  switch (anchor) {
+    case 'top-right':
+      row = margin;
+      col = screenWidth - boxWidth - margin;
+      break;
+    case 'bottom-right':
+      row = screenHeight - boxHeight - margin;
+      col = screenWidth - boxWidth - margin;
+      break;
+    case 'bottom-left':
+      row = screenHeight - boxHeight - margin;
+      col = margin;
+      break;
+    case 'top-left':
+      row = margin;
+      col = margin;
+      break;
+  }
+
+  row = Math.max(0, row);
+  col = Math.max(0, col);
+
+  return { content: boxStr, row, col };
+}

--- a/packages/bijou-tui/src/pager.test.ts
+++ b/packages/bijou-tui/src/pager.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createPagerState,
+  pager,
+  pagerScrollBy,
+  pagerScrollTo,
+  pagerScrollToTop,
+  pagerScrollToBottom,
+  pagerPageDown,
+  pagerPageUp,
+  pagerSetContent,
+  pagerKeyMap,
+} from './pager.js';
+import type { KeyMsg } from './types.js';
+
+// ── Test Data ──────────────────────────────────────────────────────
+
+const SHORT_CONTENT = 'line 1\nline 2\nline 3';
+const LONG_CONTENT = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n');
+
+function keyMsg(key: string, mods?: Partial<KeyMsg>): KeyMsg {
+  return { type: 'key', key, ctrl: false, alt: false, shift: false, ...mods };
+}
+
+// ── createPagerState ──────────────────────────────────────────────
+
+describe('createPagerState', () => {
+  it('creates state with scroll at 0', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    expect(state.scroll.y).toBe(0);
+    expect(state.width).toBe(40);
+    expect(state.height).toBe(10);
+  });
+
+  it('reserves 1 line for status (viewport height = height - 1)', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    // 50 lines of content, viewport of 9 lines → maxY = 50 - 9 = 41
+    expect(state.scroll.visibleLines).toBe(9);
+    expect(state.scroll.maxY).toBe(41);
+  });
+
+  it('handles content shorter than viewport', () => {
+    const state = createPagerState({ content: SHORT_CONTENT, width: 40, height: 10 });
+    expect(state.scroll.maxY).toBe(0);
+    expect(state.scroll.totalLines).toBe(3);
+  });
+
+  it('handles height of 1 (minimum viewport of 1 line)', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 1 });
+    expect(state.scroll.visibleLines).toBe(1);
+  });
+});
+
+// ── State transformers ────────────────────────────────────────────
+
+describe('pagerScrollBy', () => {
+  it('scrolls down', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = pagerScrollBy(state, 5);
+    expect(next.scroll.y).toBe(5);
+  });
+
+  it('clamps to maxY', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = pagerScrollBy(state, 999);
+    expect(next.scroll.y).toBe(state.scroll.maxY);
+  });
+
+  it('clamps to 0', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = pagerScrollBy(state, -5);
+    expect(next.scroll.y).toBe(0);
+  });
+});
+
+describe('pagerScrollTo', () => {
+  it('scrolls to absolute position', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = pagerScrollTo(state, 10);
+    expect(next.scroll.y).toBe(10);
+  });
+});
+
+describe('pagerScrollToTop / pagerScrollToBottom', () => {
+  it('scrolls to top', () => {
+    const state = pagerScrollBy(
+      createPagerState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      20,
+    );
+    expect(pagerScrollToTop(state).scroll.y).toBe(0);
+  });
+
+  it('scrolls to bottom', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = pagerScrollToBottom(state);
+    expect(next.scroll.y).toBe(state.scroll.maxY);
+  });
+});
+
+describe('pagerPageDown / pagerPageUp', () => {
+  it('pages down by viewport height', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = pagerPageDown(state);
+    expect(next.scroll.y).toBe(9); // viewportHeight = 9
+  });
+
+  it('pages up by viewport height', () => {
+    const state = pagerScrollBy(
+      createPagerState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      20,
+    );
+    const next = pagerPageUp(state);
+    expect(next.scroll.y).toBe(11); // 20 - 9
+  });
+});
+
+describe('pagerSetContent', () => {
+  it('updates content and preserves scroll position', () => {
+    const state = pagerScrollBy(
+      createPagerState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      5,
+    );
+    const newContent = Array.from({ length: 60 }, (_, i) => `new ${i}`).join('\n');
+    const next = pagerSetContent(state, newContent);
+    expect(next.scroll.y).toBe(5);
+    expect(next.scroll.totalLines).toBe(60);
+    expect(next.content).toBe(newContent);
+  });
+
+  it('clamps scroll when new content is shorter', () => {
+    const state = pagerScrollBy(
+      createPagerState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      40,
+    );
+    const next = pagerSetContent(state, SHORT_CONTENT);
+    expect(next.scroll.y).toBe(0); // 3 lines < viewport, maxY = 0
+  });
+});
+
+// ── Render ─────────────────────────────────────────────────────────
+
+describe('pager', () => {
+  it('renders viewport with status line', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 20, height: 5 });
+    const output = pager(state);
+    const lines = output.split('\n');
+    // 4 viewport lines + 1 status line = 5
+    expect(lines).toHaveLength(5);
+    expect(lines[4]).toContain('Line 1/50');
+  });
+
+  it('status line updates with scroll position', () => {
+    const state = pagerScrollBy(
+      createPagerState({ content: LONG_CONTENT, width: 20, height: 5 }),
+      10,
+    );
+    const output = pager(state);
+    const lines = output.split('\n');
+    expect(lines[4]).toContain('Line 11/50');
+  });
+
+  it('renders without status line when showStatus is false', () => {
+    const state = createPagerState({ content: LONG_CONTENT, width: 20, height: 5 });
+    const output = pager(state, { showStatus: false });
+    const lines = output.split('\n');
+    // Full viewport height, no status
+    expect(lines).toHaveLength(5);
+    expect(output).not.toContain('Line');
+  });
+
+  it('first visible line matches scroll position', () => {
+    const state = pagerScrollBy(
+      createPagerState({ content: LONG_CONTENT, width: 20, height: 5 }),
+      3,
+    );
+    const output = pager(state);
+    const lines = output.split('\n');
+    expect(lines[0]).toContain('line 4');
+  });
+});
+
+// ── Keymap ──────────────────────────────────────────────────────────
+
+describe('pagerKeyMap', () => {
+  type Msg = { type: string };
+
+  const km = pagerKeyMap<Msg>({
+    scrollUp: { type: 'up' },
+    scrollDown: { type: 'down' },
+    pageUp: { type: 'pu' },
+    pageDown: { type: 'pd' },
+    top: { type: 'top' },
+    bottom: { type: 'bot' },
+    quit: { type: 'quit' },
+  });
+
+  it('handles j/k for scroll', () => {
+    expect(km.handle(keyMsg('j'))).toEqual({ type: 'down' });
+    expect(km.handle(keyMsg('k'))).toEqual({ type: 'up' });
+  });
+
+  it('handles arrow keys', () => {
+    expect(km.handle(keyMsg('down'))).toEqual({ type: 'down' });
+    expect(km.handle(keyMsg('up'))).toEqual({ type: 'up' });
+  });
+
+  it('handles page keys', () => {
+    expect(km.handle(keyMsg('d'))).toEqual({ type: 'pd' });
+    expect(km.handle(keyMsg('u'))).toEqual({ type: 'pu' });
+  });
+
+  it('handles top/bottom', () => {
+    expect(km.handle(keyMsg('g'))).toEqual({ type: 'top' });
+    expect(km.handle(keyMsg('g', { shift: true }))).toEqual({ type: 'bot' });
+  });
+
+  it('handles quit', () => {
+    expect(km.handle(keyMsg('q'))).toEqual({ type: 'quit' });
+    expect(km.handle(keyMsg('c', { ctrl: true }))).toEqual({ type: 'quit' });
+  });
+
+  it('returns undefined for unbound keys', () => {
+    expect(km.handle(keyMsg('x'))).toBeUndefined();
+  });
+});

--- a/packages/bijou-tui/src/pager.ts
+++ b/packages/bijou-tui/src/pager.ts
@@ -1,0 +1,200 @@
+/**
+ * Pager building block — a scrollable text viewer with status line.
+ *
+ * Wraps `viewport()` with a "Line N/M" status indicator and provides
+ * a convenience keymap for vim-style scroll navigation.
+ *
+ * ```ts
+ * // In TEA init:
+ * const pagerState = createPagerState({ content, width: 80, height: 20 });
+ *
+ * // In TEA view:
+ * const output = pager(model.pagerState);
+ *
+ * // In TEA update:
+ * case 'scroll-down':
+ *   return [{ ...model, pagerState: pagerScrollBy(model.pagerState, 1) }, []];
+ * ```
+ */
+
+import {
+  type ScrollState,
+  viewport,
+  createScrollState,
+  scrollBy,
+  scrollTo,
+  scrollToTop,
+  scrollToBottom,
+  pageDown,
+  pageUp,
+} from './viewport.js';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PagerState {
+  readonly scroll: ScrollState;
+  readonly content: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface PagerOptions {
+  readonly content: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface PagerRenderOptions {
+  /** Show a scrollbar track on the right edge. Default: true. */
+  readonly showScrollbar?: boolean;
+  /** Show a "Line N/M" status line below the viewport. Default: true. */
+  readonly showStatus?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial pager state for the given content and dimensions.
+ *
+ * The viewport height is `height - 1` when status is shown (the default),
+ * reserving one line for the status indicator.
+ */
+export function createPagerState(options: PagerOptions): PagerState {
+  const { content, width, height } = options;
+  const viewportHeight = Math.max(1, height - 1); // reserve 1 for status
+  return {
+    scroll: createScrollState(content, viewportHeight),
+    content,
+    width,
+    height,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Scroll by a relative number of lines. */
+export function pagerScrollBy(state: PagerState, dy: number): PagerState {
+  return { ...state, scroll: scrollBy(state.scroll, dy) };
+}
+
+/** Scroll to an absolute line. */
+export function pagerScrollTo(state: PagerState, y: number): PagerState {
+  return { ...state, scroll: scrollTo(state.scroll, y) };
+}
+
+/** Scroll to the first line. */
+export function pagerScrollToTop(state: PagerState): PagerState {
+  return { ...state, scroll: scrollToTop(state.scroll) };
+}
+
+/** Scroll to the last line. */
+export function pagerScrollToBottom(state: PagerState): PagerState {
+  return { ...state, scroll: scrollToBottom(state.scroll) };
+}
+
+/** Page down (one viewport height). */
+export function pagerPageDown(state: PagerState): PagerState {
+  return { ...state, scroll: pageDown(state.scroll) };
+}
+
+/** Page up (one viewport height). */
+export function pagerPageUp(state: PagerState): PagerState {
+  return { ...state, scroll: pageUp(state.scroll) };
+}
+
+/** Update content while preserving scroll position (clamped). */
+export function pagerSetContent(state: PagerState, content: string): PagerState {
+  const viewportHeight = Math.max(1, state.height - 1);
+  const newScroll = createScrollState(content, viewportHeight);
+  const clampedY = Math.min(state.scroll.y, newScroll.maxY);
+  return {
+    ...state,
+    content,
+    scroll: { ...newScroll, y: clampedY },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the pager — viewport content plus optional status line.
+ */
+export function pager(state: PagerState, options?: PagerRenderOptions): string {
+  const showScrollbar = options?.showScrollbar ?? true;
+  const showStatus = options?.showStatus ?? true;
+
+  const viewportHeight = showStatus
+    ? Math.max(1, state.height - 1)
+    : state.height;
+
+  const body = viewport({
+    width: state.width,
+    height: viewportHeight,
+    content: state.content,
+    scrollY: state.scroll.y,
+    showScrollbar,
+  });
+
+  if (!showStatus) return body;
+
+  const currentLine = state.scroll.y + 1;
+  const totalLines = state.scroll.totalLines;
+  const status = `  Line ${currentLine}/${totalLines}`;
+
+  return body + '\n' + status;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for pager navigation.
+ *
+ * The caller provides their own message types for each action:
+ * ```ts
+ * const keys = pagerKeyMap({
+ *   scrollUp: { type: 'scroll', dy: -1 },
+ *   scrollDown: { type: 'scroll', dy: 1 },
+ *   pageUp: { type: 'page-up' },
+ *   pageDown: { type: 'page-down' },
+ *   top: { type: 'top' },
+ *   bottom: { type: 'bottom' },
+ *   quit: { type: 'quit' },
+ * });
+ * ```
+ */
+export function pagerKeyMap<Msg>(actions: {
+  scrollUp: Msg;
+  scrollDown: Msg;
+  pageUp: Msg;
+  pageDown: Msg;
+  top: Msg;
+  bottom: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Scroll', (g) => g
+      .bind('k', 'Up', actions.scrollUp)
+      .bind('up', 'Up', actions.scrollUp)
+      .bind('j', 'Down', actions.scrollDown)
+      .bind('down', 'Down', actions.scrollDown)
+      .bind('u', 'Page up', actions.pageUp)
+      .bind('pageup', 'Page up', actions.pageUp)
+      .bind('d', 'Page down', actions.pageDown)
+      .bind('pagedown', 'Page down', actions.pageDown)
+      .bind('g', 'Top', actions.top)
+      .bind('shift+g', 'Bottom', actions.bottom),
+    )
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/pager.ts
+++ b/packages/bijou-tui/src/pager.ts
@@ -136,17 +136,22 @@ export function pager(state: PagerState, options?: PagerRenderOptions): string {
     ? Math.max(1, state.height - 1)
     : state.height;
 
+  // Clamp scroll to the active viewport height (which may differ from
+  // the height used when creating state if showStatus changed).
+  const maxY = Math.max(0, state.scroll.totalLines - viewportHeight);
+  const clampedY = Math.max(0, Math.min(state.scroll.y, maxY));
+
   const body = viewport({
     width: state.width,
     height: viewportHeight,
     content: state.content,
-    scrollY: state.scroll.y,
+    scrollY: clampedY,
     showScrollbar,
   });
 
   if (!showStatus) return body;
 
-  const currentLine = state.scroll.y + 1;
+  const currentLine = clampedY + 1;
   const totalLines = state.scroll.totalLines;
   const status = `  Line ${currentLine}/${totalLines}`;
 

--- a/packages/bijou-tui/src/panels.test.ts
+++ b/packages/bijou-tui/src/panels.test.ts
@@ -39,6 +39,14 @@ function makePanels(): readonly PanelDef<Msg>[] {
 // Focus
 // ---------------------------------------------------------------------------
 
+describe('PanelGroup validation', () => {
+  it('throws when defaultFocus refers to non-existent panel', () => {
+    expect(() =>
+      createPanelGroup({ panels: makePanels(), defaultFocus: 'nonexistent' }),
+    ).toThrow('defaultFocus "nonexistent"');
+  });
+});
+
 describe('PanelGroup focus', () => {
   it('starts with defaultFocus', () => {
     const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });

--- a/packages/bijou-tui/src/panels.test.ts
+++ b/packages/bijou-tui/src/panels.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { createPanelGroup } from './panels.js';
+import type { PanelDef } from './panels.js';
+import type { KeyMsg } from './types.js';
+import { createKeyMap } from './keybindings.js';
+import { createInputStack } from './inputstack.js';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Msg = { type: string };
+
+function key(k: string): KeyMsg {
+  return { type: 'key', key: k, ctrl: false, alt: false, shift: false };
+}
+
+function ctrlKey(k: string): KeyMsg {
+  return { type: 'key', key: k, ctrl: true, alt: false, shift: false };
+}
+
+function makePanels(): readonly PanelDef<Msg>[] {
+  const navMap = createKeyMap<Msg>()
+    .bind('j', 'Down', { type: 'nav-down' })
+    .bind('k', 'Up', { type: 'nav-up' });
+
+  const detailMap = createKeyMap<Msg>()
+    .bind('j', 'Scroll down', { type: 'detail-down' })
+    .bind('enter', 'Select', { type: 'detail-select' });
+
+  return [
+    { id: 'nav', hotkey: '1', label: 'Navigation', keyMap: navMap },
+    { id: 'detail', hotkey: '2', label: 'Details', keyMap: detailMap },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Focus
+// ---------------------------------------------------------------------------
+
+describe('PanelGroup focus', () => {
+  it('starts with defaultFocus', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    expect(group.focused).toBe('nav');
+  });
+
+  it('switches via hotkey', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    group.handle(key('2'));
+    expect(group.focused).toBe('detail');
+  });
+
+  it('switches back', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    group.handle(key('2'));
+    group.handle(key('1'));
+    expect(group.focused).toBe('nav');
+  });
+
+  it('ignores unknown hotkey', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    group.handle(key('9'));
+    expect(group.focused).toBe('nav');
+  });
+
+  it('no-ops on same panel hotkey', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    group.handle(key('1'));
+    expect(group.focused).toBe('nav');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delegation
+// ---------------------------------------------------------------------------
+
+describe('PanelGroup delegation', () => {
+  it('delegates to focused panel keyMap', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    const result = group.handle(key('j'));
+    expect(result).toEqual({ type: 'nav-down' });
+  });
+
+  it('delegates after switch', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    group.handle(key('2')); // switch to detail
+    const result = group.handle(key('j'));
+    expect(result).toEqual({ type: 'detail-down' });
+  });
+
+  it('unfocused panel does not fire', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    // 'enter' is only bound in detail panel
+    const result = group.handle(key('enter'));
+    expect(result).toBeUndefined();
+  });
+
+  it('unbound keys return undefined', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    const result = group.handle(key('x'));
+    expect(result).toBeUndefined();
+  });
+
+  it('hotkey returns undefined (side effect only)', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    const result = group.handle(key('2'));
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLabel
+// ---------------------------------------------------------------------------
+
+describe('PanelGroup formatLabel', () => {
+  it('contains hotkey prefix without ctx', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    const label = group.formatLabel('nav');
+    expect(label).toContain('[1]');
+    expect(label).toContain('Navigation');
+  });
+
+  it('returns empty for unknown panel', () => {
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    expect(group.formatLabel('unknown')).toBe('');
+  });
+
+  it('runs with ctx without error', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav' });
+    const focused = group.formatLabel('nav', ctx);
+    const unfocused = group.formatLabel('detail', ctx);
+    expect(focused).toContain('Navigation');
+    expect(unfocused).toContain('Details');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// InputStack integration
+// ---------------------------------------------------------------------------
+
+describe('PanelGroup with InputStack', () => {
+  it('pushes 2 layers on creation', () => {
+    const stack = createInputStack<KeyMsg, Msg>();
+    createPanelGroup({ panels: makePanels(), defaultFocus: 'nav', inputStack: stack });
+    expect(stack.size).toBe(2);
+  });
+
+  it('swaps panel layer on focus change', () => {
+    const stack = createInputStack<KeyMsg, Msg>();
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav', inputStack: stack });
+    const layersBefore = stack.layers().map(l => l.name);
+    expect(layersBefore).toContain('panel:nav');
+
+    group.focus('detail');
+    const layersAfter = stack.layers().map(l => l.name);
+    expect(layersAfter).not.toContain('panel:nav');
+    expect(layersAfter).toContain('panel:detail');
+    // Still 2 layers total
+    expect(stack.size).toBe(2);
+  });
+
+  it('dispose removes all layers', () => {
+    const stack = createInputStack<KeyMsg, Msg>();
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav', inputStack: stack });
+    expect(stack.size).toBe(2);
+    group.dispose();
+    expect(stack.size).toBe(0);
+  });
+
+  it('dispatch through stack reaches focused panel', () => {
+    const stack = createInputStack<KeyMsg, Msg>();
+    createPanelGroup({ panels: makePanels(), defaultFocus: 'nav', inputStack: stack });
+    // Dispatch j → should reach nav panel's keymap via stack
+    const result = stack.dispatch(key('j'));
+    expect(result).toEqual({ type: 'nav-down' });
+  });
+
+  it('dispatch routes to new panel after hotkey-triggered switch', () => {
+    const stack = createInputStack<KeyMsg, Msg>();
+    const group = createPanelGroup({ panels: makePanels(), defaultFocus: 'nav', inputStack: stack });
+    // Hotkey '2' triggers focus switch via the hotkey layer in the stack
+    stack.dispatch(key('2'));
+    // Now focused should be detail
+    expect(group.focused).toBe('detail');
+    // j should now dispatch to detail panel
+    const result = stack.dispatch(key('j'));
+    expect(result).toEqual({ type: 'detail-down' });
+  });
+});

--- a/packages/bijou-tui/src/panels.ts
+++ b/packages/bijou-tui/src/panels.ts
@@ -49,6 +49,13 @@ export function createPanelGroup<A>(options: PanelGroupOptions<A>): PanelGroup<A
     hotkeyMap.set(panel.hotkey, panel.id);
   }
 
+  if (!panelMap.has(options.defaultFocus)) {
+    throw new Error(
+      `createPanelGroup: defaultFocus "${options.defaultFocus}" does not match any panel id. ` +
+      `Available: ${[...panelMap.keys()].join(', ')}`,
+    );
+  }
+
   let focusedId = options.defaultFocus;
   const { inputStack } = options;
 

--- a/packages/bijou-tui/src/panels.ts
+++ b/packages/bijou-tui/src/panels.ts
@@ -1,0 +1,155 @@
+/**
+ * Multi-pane focus management for TUI applications.
+ *
+ * Each panel has a hotkey, label, and its own KeyMap. The group tracks
+ * which panel is focused, routes input to the active panel's keymap,
+ * and switches focus on hotkey press.
+ */
+
+import type { KeyMsg } from './types.js';
+import type { KeyMap } from './keybindings.js';
+import type { InputStack } from './inputstack.js';
+import type { BijouContext } from '@flyingrobots/bijou';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PanelDef<A> {
+  readonly id: string;
+  readonly hotkey: string;
+  readonly label: string;
+  readonly keyMap: KeyMap<A>;
+}
+
+export interface PanelGroupOptions<A> {
+  readonly panels: readonly PanelDef<A>[];
+  readonly defaultFocus: string;
+  readonly inputStack?: InputStack<KeyMsg, A>;
+}
+
+export interface PanelGroup<A> {
+  readonly focused: string;
+  focus(id: string): void;
+  handle(msg: KeyMsg): A | undefined;
+  formatLabel(id: string, ctx?: BijouContext): string;
+  dispose(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export function createPanelGroup<A>(options: PanelGroupOptions<A>): PanelGroup<A> {
+  const panelMap = new Map<string, PanelDef<A>>();
+  const hotkeyMap = new Map<string, string>();
+
+  for (const panel of options.panels) {
+    panelMap.set(panel.id, panel);
+    hotkeyMap.set(panel.hotkey, panel.id);
+  }
+
+  let focusedId = options.defaultFocus;
+  const { inputStack } = options;
+
+  let hotkeyLayerId: number | undefined;
+  let panelLayerId: number | undefined;
+
+  if (inputStack) {
+    // Hotkey layer: passthrough, handles hotkey presses
+    hotkeyLayerId = inputStack.push(
+      {
+        handle(msg: KeyMsg): A | undefined {
+          if (!msg.ctrl && !msg.alt && !msg.shift) {
+            const targetId = hotkeyMap.get(msg.key);
+            if (targetId !== undefined && targetId !== focusedId) {
+              group.focus(targetId);
+            }
+          }
+          return undefined;
+        },
+      },
+      { passthrough: true, name: 'panel-group:hotkeys' },
+    );
+
+    // Focused panel keymap layer
+    const focusedPanel = panelMap.get(focusedId);
+    if (focusedPanel) {
+      panelLayerId = inputStack.push(focusedPanel.keyMap, {
+        passthrough: true,
+        name: `panel:${focusedId}`,
+      });
+    }
+  }
+
+  const group: PanelGroup<A> = {
+    get focused(): string {
+      return focusedId;
+    },
+
+    focus(id: string): void {
+      if (!panelMap.has(id) || id === focusedId) return;
+
+      focusedId = id;
+
+      if (inputStack && panelLayerId !== undefined) {
+        inputStack.remove(panelLayerId);
+        const panel = panelMap.get(id)!;
+        panelLayerId = inputStack.push(panel.keyMap, {
+          passthrough: true,
+          name: `panel:${id}`,
+        });
+      }
+    },
+
+    handle(msg: KeyMsg): A | undefined {
+      // Check hotkeys first (only plain keys, no modifiers)
+      if (!msg.ctrl && !msg.alt && !msg.shift) {
+        const targetId = hotkeyMap.get(msg.key);
+        if (targetId !== undefined && targetId !== focusedId) {
+          group.focus(targetId);
+          return undefined;
+        }
+      }
+
+      // Delegate to focused panel's keymap
+      const panel = panelMap.get(focusedId);
+      if (panel) {
+        return panel.keyMap.handle(msg);
+      }
+      return undefined;
+    },
+
+    formatLabel(id: string, ctx?: BijouContext): string {
+      const panel = panelMap.get(id);
+      if (!panel) return '';
+
+      if (!ctx) {
+        return `[${panel.hotkey}] ${panel.label}`;
+      }
+
+      const style = ctx.style;
+      const semantic = ctx.theme.theme.semantic;
+
+      if (id === focusedId) {
+        return style.bold(style.styled(semantic.primary, panel.label));
+      }
+      return style.styled(semantic.muted, panel.label);
+    },
+
+    dispose(): void {
+      if (inputStack) {
+        if (panelLayerId !== undefined) {
+          inputStack.remove(panelLayerId);
+          panelLayerId = undefined;
+        }
+        if (hotkeyLayerId !== undefined) {
+          inputStack.remove(hotkeyLayerId);
+          hotkeyLayerId = undefined;
+        }
+      }
+    },
+  };
+
+  return group;
+}

--- a/packages/bijou-tui/src/viewport.test.ts
+++ b/packages/bijou-tui/src/viewport.test.ts
@@ -90,9 +90,8 @@ describe('viewport', () => {
       showScrollbar: false,
     });
     const line = result.split('\n')[0]!;
-    // After stripping any ANSI reset, visible length should be ≤ 10
-    const visible = line.replace(/\x1b\[[0-9;]*m/g, '');
-    expect(visible.length).toBeLessThanOrEqual(10);
+    // After stripping ANSI, visible length should be ≤ 10
+    expect(stripAnsi(line).length).toBeLessThanOrEqual(10);
   });
 
   it('shows scrollbar when content exceeds viewport', () => {
@@ -105,7 +104,7 @@ describe('viewport', () => {
     const lines = result.split('\n');
     // Each line should include a scrollbar character at the end
     for (const line of lines) {
-      const lastChar = line.replace(/\x1b\[[0-9;]*m/g, '').trimEnd().slice(-1);
+      const lastChar = stripAnsi(line).trimEnd().slice(-1);
       expect(['█', '│']).toContain(lastChar);
     }
   });
@@ -121,7 +120,7 @@ describe('viewport', () => {
     const lines = result.split('\n');
     // No scrollbar chars — content fits entirely
     for (const line of lines) {
-      const stripped = line.replace(/\x1b\[[0-9;]*m/g, '').trimEnd();
+      const stripped = stripAnsi(line).trimEnd();
       expect(stripped).not.toContain('█');
       expect(stripped).not.toContain('│');
     }
@@ -136,7 +135,7 @@ describe('viewport', () => {
     });
     const lines = result.split('\n');
     for (const line of lines) {
-      const stripped = line.replace(/\x1b\[[0-9;]*m/g, '').trimEnd();
+      const stripped = stripAnsi(line).trimEnd();
       expect(stripped).not.toContain('█');
       expect(stripped).not.toContain('│');
     }
@@ -350,7 +349,7 @@ describe('viewport with scrollX', () => {
       scrollX: 3,
       showScrollbar: false,
     });
-    const visible = result.replace(/\x1b\[[0-9;]*m/g, '').trimEnd();
+    const visible = stripAnsi(result).trimEnd();
     expect(visible).toBe('defgh');
   });
 

--- a/packages/bijou-tui/src/viewport.test.ts
+++ b/packages/bijou-tui/src/viewport.test.ts
@@ -8,6 +8,11 @@ import {
   scrollToBottom,
   pageDown,
   pageUp,
+  sliceAnsi,
+  scrollByX,
+  scrollToX,
+  stripAnsi,
+  visibleLength,
 } from './viewport.js';
 
 // ---------------------------------------------------------------------------
@@ -225,5 +230,145 @@ describe('pageDown / pageUp', () => {
     const state = createScrollState('a\nb\nc', 3);
     const next = pageDown(state);
     expect(next.y).toBe(0); // content fits, maxY = 0
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sliceAnsi
+// ---------------------------------------------------------------------------
+
+describe('sliceAnsi', () => {
+  it('slices plain text', () => {
+    expect(sliceAnsi('hello world', 3, 8)).toBe('lo wo');
+  });
+
+  it('returns empty for empty string', () => {
+    expect(sliceAnsi('', 0, 5)).toBe('');
+  });
+
+  it('returns empty when startCol beyond length', () => {
+    expect(sliceAnsi('short', 10, 20)).toBe('');
+  });
+
+  it('preserves ANSI style crossing startCol', () => {
+    const styled = '\x1b[31mhello world\x1b[0m';
+    const result = sliceAnsi(styled, 3, 8);
+    // Should include the red style prefix
+    expect(result).toContain('\x1b[31m');
+    const visible = stripAnsi(result);
+    expect(visible).toBe('lo wo');
+  });
+
+  it('appends reset when clipped at endCol mid-style', () => {
+    const styled = '\x1b[31mhello world\x1b[0m';
+    const result = sliceAnsi(styled, 0, 5);
+    expect(result).toContain('\x1b[0m');
+    const visible = stripAnsi(result);
+    expect(visible).toBe('hello');
+  });
+
+  it('startCol=0 equivalence to clipToWidth for plain text', () => {
+    const text = 'abcdefghij';
+    const sliced = sliceAnsi(text, 0, 5);
+    expect(sliced).toBe('abcde');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scrollByX / scrollToX
+// ---------------------------------------------------------------------------
+
+describe('scrollByX', () => {
+  it('scrolls right', () => {
+    const state = createScrollState('a long line here!!!', 1, 5);
+    const next = scrollByX(state, 3);
+    expect(next.x).toBe(3);
+  });
+
+  it('clamps to maxX', () => {
+    const state = createScrollState('1234567890', 1, 5);
+    // maxX = 10 - 5 = 5
+    const next = scrollByX(state, 999);
+    expect(next.x).toBe(5);
+  });
+
+  it('clamps to 0', () => {
+    const state = createScrollState('1234567890', 1, 5);
+    const next = scrollByX(state, -5);
+    expect(next.x).toBe(0);
+  });
+});
+
+describe('scrollToX', () => {
+  it('scrolls to absolute X', () => {
+    const state = createScrollState('1234567890', 1, 5);
+    const next = scrollToX(state, 3);
+    expect(next.x).toBe(3);
+  });
+
+  it('clamps to valid range', () => {
+    const state = createScrollState('1234567890', 1, 5);
+    expect(scrollToX(state, -1).x).toBe(0);
+    expect(scrollToX(state, 999).x).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createScrollState with viewportWidth
+// ---------------------------------------------------------------------------
+
+describe('createScrollState with viewportWidth', () => {
+  it('computes maxX from widest line', () => {
+    const content = 'short\na much longer line here\nmed';
+    const state = createScrollState(content, 3, 10);
+    expect(state.maxX).toBe(visibleLength('a much longer line here') - 10);
+  });
+
+  it('sets maxX=0 when all lines fit', () => {
+    const state = createScrollState('hi\nbye', 2, 20);
+    expect(state.maxX).toBe(0);
+  });
+
+  it('backward compat without viewportWidth', () => {
+    const state = createScrollState('hello', 1);
+    expect(state.x).toBe(0);
+    expect(state.maxX).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// viewport with scrollX
+// ---------------------------------------------------------------------------
+
+describe('viewport with scrollX', () => {
+  it('shifts content right', () => {
+    const wideContent = 'abcdefghijklmnop';
+    const result = viewport({
+      width: 5,
+      height: 1,
+      content: wideContent,
+      scrollX: 3,
+      showScrollbar: false,
+    });
+    const visible = result.replace(/\x1b\[[0-9;]*m/g, '').trimEnd();
+    expect(visible).toBe('defgh');
+  });
+
+  it('scrollX=0 matches default behavior', () => {
+    const content = 'abcdefghij';
+    const withoutX = viewport({
+      width: 5,
+      height: 1,
+      content,
+      scrollX: 0,
+      showScrollbar: false,
+    });
+    const withDefault = viewport({
+      width: 5,
+      height: 1,
+      content,
+      showScrollbar: false,
+    });
+    expect(withoutX).toBe(withDefault);
   });
 });

--- a/packages/bijou-tui/src/viewport.ts
+++ b/packages/bijou-tui/src/viewport.ts
@@ -39,11 +39,11 @@ export interface ScrollState {
 
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 
-function stripAnsi(str: string): string {
+export function stripAnsi(str: string): string {
   return str.replace(ANSI_RE, '');
 }
 
-function visibleLength(str: string): number {
+export function visibleLength(str: string): number {
   return stripAnsi(str).length;
 }
 
@@ -51,7 +51,7 @@ function visibleLength(str: string): number {
  * Clip a string to a maximum visible width, preserving ANSI escapes.
  * Appends a reset sequence if the string was clipped mid-style.
  */
-function clipToWidth(str: string, maxWidth: number): string {
+export function clipToWidth(str: string, maxWidth: number): string {
   let visible = 0;
   let result = '';
   let inEscape = false;

--- a/packages/bijou-tui/src/viewport.ts
+++ b/packages/bijou-tui/src/viewport.ts
@@ -144,6 +144,9 @@ export function sliceAnsi(str: string, startCol: number, endCol: number): string
     visible++;
   }
 
+  // Append reset if we reached end of string with an active style
+  if (collecting && hasStyle) result += '\x1b[0m';
+
   return result;
 }
 

--- a/packages/bijou-tui/src/viewport.ts
+++ b/packages/bijou-tui/src/viewport.ts
@@ -18,6 +18,8 @@ export interface ViewportOptions {
   readonly content: string;
   /** Vertical scroll offset (0-based line index). Default: 0. */
   readonly scrollY?: number;
+  /** Horizontal scroll offset (0-based column index). Default: 0. */
+  readonly scrollX?: number;
   /** Show a scrollbar track on the right edge. Default: true. */
   readonly showScrollbar?: boolean;
 }
@@ -27,6 +29,10 @@ export interface ScrollState {
   readonly y: number;
   /** Maximum vertical scroll offset. */
   readonly maxY: number;
+  /** Current horizontal scroll offset. */
+  readonly x: number;
+  /** Maximum horizontal scroll offset. */
+  readonly maxX: number;
   /** Total number of content lines. */
   readonly totalLines: number;
   /** Number of visible lines (viewport height). */
@@ -84,6 +90,63 @@ export function clipToWidth(str: string, maxWidth: number): string {
   return result;
 }
 
+/**
+ * Extract a visible-column substring from an ANSI-styled string.
+ * Returns characters between visible columns [startCol, endCol).
+ * Preserves any active ANSI styles seen before startCol.
+ */
+export function sliceAnsi(str: string, startCol: number, endCol: number): string {
+  let visible = 0;
+  let inEscape = false;
+  let activeAnsi = '';
+  let result = '';
+  let collecting = false;
+  let hasStyle = false;
+
+  for (let i = 0; i < str.length; i++) {
+    const ch = str[i]!;
+
+    if (ch === '\x1b') {
+      inEscape = true;
+      if (collecting) {
+        result += ch;
+        hasStyle = true;
+      } else {
+        activeAnsi += ch;
+      }
+      continue;
+    }
+
+    if (inEscape) {
+      if (collecting) {
+        result += ch;
+      } else {
+        activeAnsi += ch;
+      }
+      if (ch === 'm') inEscape = false;
+      continue;
+    }
+
+    if (visible >= endCol) {
+      if (hasStyle) result += '\x1b[0m';
+      break;
+    }
+
+    if (visible >= startCol) {
+      if (!collecting) {
+        collecting = true;
+        result = activeAnsi;
+        if (activeAnsi.length > 0) hasStyle = true;
+      }
+      result += ch;
+    }
+
+    visible++;
+  }
+
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Scrollbar rendering
 // ---------------------------------------------------------------------------
@@ -132,6 +195,7 @@ export function viewport(options: ViewportOptions): string {
     height,
     content,
     scrollY = 0,
+    scrollX = 0,
     showScrollbar = true,
   } = options;
 
@@ -154,12 +218,15 @@ export function viewport(options: ViewportOptions): string {
 
   // Clip/pad each line to content width
   const rendered = visibleSlice.map((line) => {
-    const vis = visibleLength(line);
-    if (vis > contentWidth) {
-      return clipToWidth(line, contentWidth);
+    let sliced: string;
+    if (scrollX > 0) {
+      sliced = sliceAnsi(line, scrollX, scrollX + contentWidth);
+    } else {
+      const vis = visibleLength(line);
+      sliced = vis > contentWidth ? clipToWidth(line, contentWidth) : line;
     }
-    // Right-pad with spaces to fill width
-    return line + ' '.repeat(contentWidth - vis);
+    const slicedVis = visibleLength(sliced);
+    return slicedVis < contentWidth ? sliced + ' '.repeat(contentWidth - slicedVis) : sliced;
   });
 
   // Append scrollbar
@@ -181,11 +248,26 @@ export function viewport(options: ViewportOptions): string {
 export function createScrollState(
   content: string,
   viewportHeight: number,
+  viewportWidth?: number,
 ): ScrollState {
-  const totalLines = content.split('\n').length;
+  const lines = content.split('\n');
+  const totalLines = lines.length;
+
+  let maxX = 0;
+  if (viewportWidth !== undefined) {
+    let widest = 0;
+    for (const line of lines) {
+      const w = visibleLength(line);
+      if (w > widest) widest = w;
+    }
+    maxX = Math.max(0, widest - viewportWidth);
+  }
+
   return {
     y: 0,
     maxY: Math.max(0, totalLines - viewportHeight),
+    x: 0,
+    maxX,
     totalLines,
     visibleLines: viewportHeight,
   };
@@ -204,6 +286,20 @@ export function scrollBy(state: ScrollState, dy: number): ScrollState {
  */
 export function scrollTo(state: ScrollState, y: number): ScrollState {
   return { ...state, y: Math.max(0, Math.min(y, state.maxY)) };
+}
+
+/**
+ * Scroll horizontally by a relative amount. Clamps to valid range.
+ */
+export function scrollByX(state: ScrollState, dx: number): ScrollState {
+  return { ...state, x: Math.max(0, Math.min(state.x + dx, state.maxX)) };
+}
+
+/**
+ * Scroll horizontally to an absolute position. Clamps to valid range.
+ */
+export function scrollToX(state: ScrollState, x: number): ScrollState {
+  return { ...state, x: Math.max(0, Math.min(x, state.maxX)) };
 }
 
 /**

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -4,10 +4,12 @@ Themed terminal components for CLIs, loggers, and scripts — graceful degradati
 
 **Zero dependencies. Hexagonal architecture. Works everywhere.**
 
-## What's New in 0.3.0?
+## What's New in 0.4.0?
 
-- **`dag()`** — ASCII DAG renderer with auto-layout (Sugiyama-Lite), edge routing, badges, per-node tokens, path highlighting, and graceful degradation
-- **`dagSlice()`** — extract subgraphs (ancestors/descendants/neighborhood) with ghost boundary nodes
+- **`textarea()`** — multi-line text input form with cursor navigation, line numbers, placeholder, maxLength
+- **`filter()`** — fuzzy-filter select form with real-time search by label and keywords
+- **`dagLayout()`** — returns node position map alongside rendered output, for interactive DAG navigation
+- **`dag()` `selectedId`** — cursor-style node highlighting with highest priority over highlight path
 
 See the [CHANGELOG](https://github.com/flyingrobots/bijou/blob/main/docs/CHANGELOG.md) for the full release history.
 

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/src/core/components/dag.test.ts
+++ b/packages/bijou/src/core/components/dag.test.ts
@@ -317,6 +317,45 @@ describe('dag', () => {
       expect(result).not.toContain('missing');
     });
   });
+
+  // ── selectedId ──────────────────────────────────────────────────
+
+  describe('selectedId', () => {
+    it('renders with selectedId without error', () => {
+      const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+      const result = dag(twoNodes, { selectedId: 'a', ctx });
+      expect(result).toContain('Alpha');
+      expect(result).toContain('Beta');
+    });
+
+    it('selectedId takes precedence over highlightPath', () => {
+      const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+      // Both highlight and select node 'a' — should not crash
+      const result = dag(diamond, {
+        selectedId: 'a',
+        highlightPath: ['a', 'b', 'd'],
+        highlightToken: { hex: '#ff0000' },
+        ctx,
+      });
+      expect(result).toContain('Start');
+    });
+
+    it('non-selected nodes are unaffected', () => {
+      const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+      const withSelected = dag(twoNodes, { selectedId: 'a', ctx });
+      const without = dag(twoNodes, { ctx });
+      // Both should contain Beta — it is not selected
+      expect(withSelected).toContain('Beta');
+      expect(without).toContain('Beta');
+    });
+
+    it('defaults to ui.cursor token when selectedToken omitted', () => {
+      const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+      // Should not throw — uses default cursor token
+      const result = dag(twoNodes, { selectedId: 'a', ctx });
+      expect(result).toContain('Alpha');
+    });
+  });
 });
 
 // ── dagSlice Tests ─────────────────────────────────────────────────

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -20,6 +20,8 @@ export interface DagOptions {
   edgeToken?: TokenValue;
   highlightPath?: string[];
   highlightToken?: TokenValue;
+  selectedId?: string;
+  selectedToken?: TokenValue;
   nodeWidth?: number;
   maxWidth?: number;
   direction?: 'down' | 'right';
@@ -449,7 +451,9 @@ function renderInteractive(
     const boxLines = renderNodeBox(n.label, n.badge, nodeWidth, n._ghost === true);
 
     let nToken: TokenValue;
-    if (highlightSet.has(n.id) && options.highlightToken) {
+    if (options.selectedId === n.id) {
+      nToken = options.selectedToken ?? ctx.theme.theme.ui.cursor;
+    } else if (highlightSet.has(n.id) && options.highlightToken) {
       nToken = options.highlightToken;
     } else if (n.token) {
       nToken = n.token;

--- a/packages/bijou/src/core/components/index.ts
+++ b/packages/bijou/src/core/components/index.ts
@@ -49,5 +49,5 @@ export type { PaginatorOptions } from './paginator.js';
 export { stepper } from './stepper.js';
 export type { StepperStep, StepperOptions } from './stepper.js';
 
-export { dag, dagSlice } from './dag.js';
-export type { DagNode, DagOptions } from './dag.js';
+export { dag, dagSlice, dagLayout } from './dag.js';
+export type { DagNode, DagOptions, DagNodePosition, DagLayout } from './dag.js';

--- a/packages/bijou/src/core/forms/filter.test.ts
+++ b/packages/bijou/src/core/forms/filter.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { filter } from './filter.js';
+import { createTestContext } from '../../adapters/test/index.js';
+
+const OPTIONS = [
+  { label: 'Apple', value: 'apple', keywords: ['fruit', 'red'] },
+  { label: 'Banana', value: 'banana', keywords: ['fruit', 'yellow'] },
+  { label: 'Carrot', value: 'carrot', keywords: ['vegetable', 'orange'] },
+];
+
+describe('filter()', () => {
+  describe('numbered fallback (non-interactive)', () => {
+    it('renders numbered list', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['1'] } });
+      await filter({ title: 'Food', options: OPTIONS, ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('1.');
+      expect(output).toContain('Apple');
+      expect(output).toContain('2.');
+      expect(output).toContain('Banana');
+      expect(output).toContain('3.');
+      expect(output).toContain('Carrot');
+    });
+
+    it('accepts number and returns corresponding value', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['2'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('banana');
+    });
+
+    it('matches by text when number is invalid', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['ban'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('banana');
+    });
+
+    it('matches by keyword', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['vegetable'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('carrot');
+    });
+
+    it('returns first option when no match', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['xyz'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('apple');
+    });
+
+    it('returns defaultValue when no match and default is set', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['xyz'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, defaultValue: 'carrot', ctx });
+      expect(result).toBe('carrot');
+    });
+
+    it('empty input returns first option', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: [''] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('apple');
+    });
+  });
+
+  describe('pipe mode', () => {
+    it('accepts number from stdin', async () => {
+      const ctx = createTestContext({ mode: 'pipe', io: { answers: ['3'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('carrot');
+    });
+
+    it('accepts text from stdin', async () => {
+      const ctx = createTestContext({ mode: 'pipe', io: { answers: ['apple'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('apple');
+    });
+  });
+
+  describe('accessible mode', () => {
+    it('prompt says "Enter number or search"', async () => {
+      const ctx = createTestContext({ mode: 'accessible', io: { answers: ['1'] } });
+      await filter({ title: 'Food', options: OPTIONS, ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('Enter number or search');
+    });
+  });
+
+  describe('interactive mode', () => {
+    it('renders list with cursor', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\r'] } });
+      await filter({ title: 'Food', options: OPTIONS, ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('❯');
+      expect(output).toContain('Apple');
+      expect(output).toContain('Banana');
+      expect(output).toContain('Carrot');
+    });
+
+    it('Enter selects first item by default', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\r'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('apple');
+    });
+
+    it('arrow down + Enter selects second item', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[B', '\r'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('banana');
+    });
+
+    it('arrow up wraps to last item', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[A', '\r'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('carrot');
+    });
+
+    it('typing filters options', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['c', 'a', 'r', '\r'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('carrot');
+    });
+
+    it('typing narrows list then Enter selects', async () => {
+      // Type "ban" — only Banana matches — Enter selects it
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['b', 'a', 'n', '\r'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('banana');
+    });
+
+    it('backspace removes filter character', async () => {
+      // Type "cx" (matches nothing), backspace "c" (matches Carrot), Enter
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['c', 'x', '\x7f', '\r'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      // After backspace: query="c", Carrot matches
+      expect(result).toBe('carrot');
+    });
+
+    it('Ctrl+C cancels and returns default/first value', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x03'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('apple');
+    });
+
+    it('Ctrl+C returns defaultValue when set', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x03'] } });
+      const result = await filter({ title: 'Food', options: OPTIONS, defaultValue: 'banana', ctx });
+      expect(result).toBe('banana');
+    });
+
+    it('shows item count status', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\r'] } });
+      await filter({ title: 'Food', options: OPTIONS, ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('3/3 items');
+    });
+
+    it('filter updates item count', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['a', '\r'] } });
+      await filter({ title: 'Food', options: OPTIONS, ctx });
+      const output = ctx.io.written.join('');
+      // "a" matches Apple, Banana, Carrot (all contain 'a')
+      // Check that status shows filtered count
+      expect(output).toContain('/3 items');
+    });
+
+    it('custom match function is used', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['x', '\r'] },
+      });
+      const result = await filter({
+        title: 'Food',
+        options: OPTIONS,
+        match: (_query, opt) => opt.label === 'Banana',
+        ctx,
+      });
+      expect(result).toBe('banana');
+    });
+
+    it('no matches returns default/first on Enter', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['z', 'z', 'z', '\r'] },
+      });
+      const result = await filter({ title: 'Food', options: OPTIONS, ctx });
+      expect(result).toBe('apple');
+    });
+  });
+});

--- a/packages/bijou/src/core/forms/filter.test.ts
+++ b/packages/bijou/src/core/forms/filter.test.ts
@@ -9,6 +9,24 @@ const OPTIONS = [
 ];
 
 describe('filter()', () => {
+  describe('empty options guard', () => {
+    it('throws when options is empty and no defaultValue', async () => {
+      await expect(
+        filter({ title: 'Pick', options: [], ctx: createTestContext({ mode: 'static', io: { answers: [''] } }) }),
+      ).rejects.toThrow('at least one option');
+    });
+
+    it('returns defaultValue when options is empty', async () => {
+      const result = await filter({
+        title: 'Pick',
+        options: [],
+        defaultValue: 'fallback' as string,
+        ctx: createTestContext({ mode: 'static', io: { answers: [''] } }),
+      });
+      expect(result).toBe('fallback');
+    });
+  });
+
   describe('numbered fallback (non-interactive)', () => {
     it('renders numbered list', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['1'] } });

--- a/packages/bijou/src/core/forms/filter.ts
+++ b/packages/bijou/src/core/forms/filter.ts
@@ -1,0 +1,229 @@
+import type { FieldOptions } from './types.js';
+import type { BijouContext } from '../../ports/context.js';
+import type { TokenValue } from '../theme/tokens.js';
+import type { OutputMode } from '../detect/tty.js';
+import { getDefaultContext } from '../../context.js';
+
+export interface FilterOption<T> {
+  label: string;
+  value: T;
+  keywords?: string[];
+}
+
+export interface FilterOptions<T> extends FieldOptions<T> {
+  options: FilterOption<T>[];
+  placeholder?: string;
+  maxVisible?: number;
+  match?: (query: string, option: FilterOption<T>) => boolean;
+  ctx?: BijouContext;
+}
+
+function defaultMatch<T>(query: string, option: FilterOption<T>): boolean {
+  const q = query.toLowerCase();
+  if (option.label.toLowerCase().includes(q)) return true;
+  if (option.keywords) {
+    return option.keywords.some((kw) => kw.toLowerCase().includes(q));
+  }
+  return false;
+}
+
+export async function filter<T>(options: FilterOptions<T>): Promise<T> {
+  const ctx = options.ctx ?? getDefaultContext();
+  const mode = ctx.mode;
+
+  if (mode === 'interactive' && ctx.runtime.stdinIsTTY) {
+    return interactiveFilter(options, ctx);
+  }
+
+  return fallbackFilter(options, mode, ctx);
+}
+
+async function fallbackFilter<T>(options: FilterOptions<T>, mode: OutputMode, ctx: BijouContext): Promise<T> {
+  const noColor = ctx.theme.noColor;
+  const styledFn = (token: TokenValue, text: string) => ctx.style.styled(token, text);
+
+  if (noColor || mode === 'accessible') {
+    ctx.io.write(`${options.title}\n`);
+  } else {
+    ctx.io.write(styledFn(ctx.theme.theme.semantic.info, '? ') + ctx.style.bold(options.title) + '\n');
+  }
+
+  for (let i = 0; i < options.options.length; i++) {
+    const opt = options.options[i]!;
+    ctx.io.write(`  ${i + 1}. ${opt.label}\n`);
+  }
+
+  const prompt = mode === 'accessible' ? 'Enter number or search: ' : '> ';
+  const answer = await ctx.io.question(prompt);
+  const trimmed = answer.trim();
+
+  // Try numeric selection first
+  const idx = parseInt(trimmed, 10) - 1;
+  if (idx >= 0 && idx < options.options.length) {
+    return options.options[idx]!.value;
+  }
+
+  // Try matching by text
+  if (trimmed) {
+    const matchFn = options.match ?? defaultMatch;
+    const matched = options.options.find((opt) => matchFn(trimmed, opt));
+    if (matched) return matched.value;
+  }
+
+  return options.defaultValue ?? options.options[0]!.value;
+}
+
+async function interactiveFilter<T>(options: FilterOptions<T>, ctx: BijouContext): Promise<T> {
+  const noColor = ctx.theme.noColor;
+  const t = ctx.theme;
+  const styledFn = (token: TokenValue, text: string) => ctx.style.styled(token, text);
+  const matchFn = options.match ?? defaultMatch;
+  const maxVisible = options.maxVisible ?? 7;
+
+  let query = '';
+  let cursor = 0;
+  let filtered = [...options.options];
+
+  function applyFilter(): void {
+    if (query === '') {
+      filtered = [...options.options];
+    } else {
+      filtered = options.options.filter((opt) => matchFn(query, opt));
+    }
+    cursor = Math.min(cursor, Math.max(0, filtered.length - 1));
+  }
+
+  function visibleItems(): FilterOption<T>[] {
+    return filtered.slice(0, maxVisible);
+  }
+
+  function renderLineCount(): number {
+    return 2 + Math.min(filtered.length, maxVisible) + 1; // header + filter input + items + status
+  }
+
+  function render(): void {
+    const label = noColor
+      ? `? ${options.title}`
+      : styledFn(t.theme.semantic.info, '? ') + ctx.style.bold(options.title);
+    ctx.io.write(`\x1b[?25l`);
+    ctx.io.write(`\r\x1b[K${label}\n`);
+
+    // Filter input
+    const filterDisplay = query || (options.placeholder ? styledFn(t.theme.semantic.muted, options.placeholder) : '');
+    ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.info, '/')} ${filterDisplay}\n`);
+
+    // Visible items
+    const vis = visibleItems();
+    for (let i = 0; i < vis.length; i++) {
+      const opt = vis[i]!;
+      const isCurrent = i === cursor;
+      const prefix = isCurrent ? '❯' : ' ';
+      if (isCurrent && !noColor) {
+        ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.info, prefix)} ${ctx.style.bold(opt.label)}\n`);
+      } else {
+        ctx.io.write(`\x1b[K  ${prefix} ${opt.label}\n`);
+      }
+    }
+
+    // Status
+    const status = `${filtered.length}/${options.options.length} items`;
+    ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.muted, status)}\n`);
+  }
+
+  function clearRender(): void {
+    const total = renderLineCount();
+    ctx.io.write(`\x1b[${total}A`);
+  }
+
+  function cleanup(): void {
+    const total = renderLineCount();
+    // Move up and clear all rendered lines
+    clearRender();
+    for (let i = 0; i < total; i++) ctx.io.write(`\x1b[K\n`);
+    ctx.io.write(`\x1b[${total}A`);
+
+    const selected = filtered[cursor];
+    const selectedLabel = selected ? selected.label : '(none)';
+    const label = noColor
+      ? `? ${options.title} ${selectedLabel}`
+      : styledFn(t.theme.semantic.info, '? ') + ctx.style.bold(options.title) + ' ' + styledFn(t.theme.semantic.info, selectedLabel);
+    ctx.io.write(`\x1b[K${label}\n`);
+    ctx.io.write(`\x1b[?25h`);
+  }
+
+  render();
+
+  return new Promise<T>((resolve) => {
+    const handle = ctx.io.rawInput((key: string) => {
+      if (key === '\r' || key === '\n') {
+        // Enter — select
+        handle.dispose();
+        cleanup();
+        resolve(filtered[cursor]?.value ?? options.defaultValue ?? options.options[0]!.value);
+        return;
+      }
+
+      if (key === '\x03') {
+        // Ctrl+C — cancel
+        handle.dispose();
+        cleanup();
+        resolve(options.defaultValue ?? options.options[0]!.value);
+        return;
+      }
+
+      if (key === '\x1b[A' || key === 'k') {
+        // Up
+        cursor = (cursor - 1 + filtered.length) % filtered.length;
+        clearRender();
+        render();
+        return;
+      }
+
+      if (key === '\x1b[B' || key === 'j') {
+        // Down — but only when query is empty (j is a printable char for filtering)
+        if (key === 'j' && query === '') {
+          // Start filtering with 'j'
+          query += key;
+          applyFilter();
+          clearRender();
+          render();
+          return;
+        }
+        if (key === '\x1b[B') {
+          cursor = (cursor + 1) % filtered.length;
+          clearRender();
+          render();
+          return;
+        }
+        // j when query is non-empty — fall through to printable handler
+      }
+
+      if (key === '\x7f' || key === '\b') {
+        // Backspace
+        if (query.length > 0) {
+          const prevLineCount = renderLineCount();
+          query = query.slice(0, -1);
+          applyFilter();
+          // Clear the old render (use the larger count to avoid leftover lines)
+          ctx.io.write(`\x1b[${prevLineCount}A`);
+          for (let i = 0; i < prevLineCount; i++) ctx.io.write(`\x1b[K\n`);
+          ctx.io.write(`\x1b[${prevLineCount}A`);
+          render();
+        }
+        return;
+      }
+
+      // Printable character (filter input)
+      if (key.length === 1 && key >= ' ') {
+        const prevLineCount = renderLineCount();
+        query += key;
+        applyFilter();
+        // Clear the old render
+        ctx.io.write(`\x1b[${prevLineCount}A`);
+        for (let i = 0; i < prevLineCount; i++) ctx.io.write(`\x1b[K\n`);
+        ctx.io.write(`\x1b[${prevLineCount}A`);
+        render();
+      }
+    });
+  });
+}

--- a/packages/bijou/src/core/forms/filter.ts
+++ b/packages/bijou/src/core/forms/filter.ts
@@ -28,6 +28,11 @@ function defaultMatch<T>(query: string, option: FilterOption<T>): boolean {
 }
 
 export async function filter<T>(options: FilterOptions<T>): Promise<T> {
+  if (options.options.length === 0) {
+    if (options.defaultValue !== undefined) return options.defaultValue;
+    throw new Error('filter() requires at least one option, or a defaultValue');
+  }
+
   const ctx = options.ctx ?? getDefaultContext();
   const mode = ctx.mode;
 
@@ -173,6 +178,7 @@ async function interactiveFilter<T>(options: FilterOptions<T>, ctx: BijouContext
 
       if (key === '\x1b[A' || key === 'k') {
         // Up
+        if (filtered.length === 0) return;
         cursor = (cursor - 1 + filtered.length) % filtered.length;
         clearRender();
         render();
@@ -190,6 +196,7 @@ async function interactiveFilter<T>(options: FilterOptions<T>, ctx: BijouContext
           return;
         }
         if (key === '\x1b[B') {
+          if (filtered.length === 0) return;
           cursor = (cursor + 1) % filtered.length;
           clearRender();
           render();

--- a/packages/bijou/src/core/forms/index.ts
+++ b/packages/bijou/src/core/forms/index.ts
@@ -18,3 +18,9 @@ export { multiselect } from './multiselect.js';
 export { confirm } from './confirm.js';
 
 export { group } from './group.js';
+
+export { textarea } from './textarea.js';
+export type { TextareaOptions } from './textarea.js';
+
+export { filter } from './filter.js';
+export type { FilterOption, FilterOptions } from './filter.js';

--- a/packages/bijou/src/core/forms/textarea.test.ts
+++ b/packages/bijou/src/core/forms/textarea.test.ts
@@ -185,6 +185,16 @@ describe('textarea()', () => {
       expect(result).toBe('abc');
     });
 
+    it('maxLength prevents Enter newline when at limit', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', 'b', 'c', '\r', 'd', '\x04'] },
+      });
+      // maxLength=3: "abc" is 3 chars, Enter would add \n (4th char) — blocked
+      const result = await textarea({ title: 'Msg', maxLength: 3, ctx });
+      expect(result).toBe('abc');
+    });
+
     it('cleanup shows line count for multiline', async () => {
       const ctx = createTestContext({
         mode: 'interactive',

--- a/packages/bijou/src/core/forms/textarea.test.ts
+++ b/packages/bijou/src/core/forms/textarea.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import { textarea } from './textarea.js';
+import { createTestContext } from '../../adapters/test/index.js';
+
+describe('textarea()', () => {
+  describe('fallback (non-interactive)', () => {
+    it('renders title and prompt', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['hello'] } });
+      await textarea({ title: 'Message', ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('Message');
+    });
+
+    it('returns trimmed answer', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['  hello world  '] } });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('hello world');
+    });
+
+    it('returns default when input is empty', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: [''] } });
+      const result = await textarea({ title: 'Msg', defaultValue: 'fallback', ctx });
+      expect(result).toBe('fallback');
+    });
+
+    it('returns empty string when no input and no default', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: [''] } });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('');
+    });
+
+    it('required: true writes error for empty input', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: [''] } });
+      await textarea({ title: 'Msg', required: true, ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('required');
+    });
+
+    it('custom validator error is written', async () => {
+      const ctx = createTestContext({ mode: 'static', io: { answers: ['ab'] } });
+      await textarea({
+        title: 'Msg',
+        validate: (v) => v.length < 3
+          ? { valid: false, message: 'Too short' }
+          : { valid: true },
+        ctx,
+      });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('Too short');
+    });
+  });
+
+  describe('pipe mode', () => {
+    it('accepts text from stdin', async () => {
+      const ctx = createTestContext({ mode: 'pipe', io: { answers: ['some text'] } });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('some text');
+    });
+  });
+
+  describe('accessible mode', () => {
+    it('prompt says "Enter text"', async () => {
+      const ctx = createTestContext({ mode: 'accessible', io: { answers: ['text'] } });
+      await textarea({ title: 'Msg', ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('Enter text');
+    });
+  });
+
+  describe('interactive mode', () => {
+    it('typing characters and submitting with Ctrl+D', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['h', 'i', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('hi');
+    });
+
+    it('Enter creates a new line', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', '\r', 'b', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('a\nb');
+    });
+
+    it('Ctrl+C cancels and returns default or empty', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['h', 'i', '\x03'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('');
+    });
+
+    it('Ctrl+C returns defaultValue when set', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['\x03'] },
+      });
+      const result = await textarea({ title: 'Msg', defaultValue: 'fallback', ctx });
+      expect(result).toBe('fallback');
+    });
+
+    it('Backspace deletes character', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', 'b', 'c', '\x7f', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('ab');
+    });
+
+    it('Backspace at start of line merges with previous', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        // type "a", Enter (new line), type "b", backspace (deletes "b"), backspace (merges empty line)
+        io: { keys: ['a', '\r', 'b', '\x7f', '\x7f', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('a');
+    });
+
+    it('Backspace at start of first line does nothing', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['\x7f', 'a', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('a');
+    });
+
+    it('arrow keys move cursor', async () => {
+      // Type "ab", left, left, type "c" → "cab"
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', 'b', '\x1b[D', '\x1b[D', 'c', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('cab');
+    });
+
+    it('right arrow at end of line wraps to next line', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        // type "a", Enter, type "b", Up (→ end of "a"), Right (wraps to start of "b"), type "x"
+        io: { keys: ['a', '\r', 'b', '\x1b[A', '\x1b[C', 'x', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('a\nxb');
+    });
+
+    it('left arrow at start of line wraps to previous line', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', '\r', '\x1b[D', 'x', '\x04'] },
+      });
+      // Start: lines=["a",""], cursor at (1,0)
+      // Left → wraps to (0,1) (end of "a")
+      // Type "x" → lines=["ax",""]
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('ax\n');
+    });
+
+    it('up/down arrow navigation clamps cursor column', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', 'b', 'c', '\r', 'x', '\x1b[A', '\x04'] },
+      });
+      // Lines: ["abc", "x"], cursor starts at (1,1) after typing "x"
+      // Up → (0, min(1, 3)) = (0,1)
+      // Submit → "abc\nx"
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('abc\nx');
+    });
+
+    it('maxLength prevents insertion beyond limit', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', 'b', 'c', 'd', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', maxLength: 3, ctx });
+      expect(result).toBe('abc');
+    });
+
+    it('cleanup shows line count for multiline', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', '\r', 'b', '\r', 'c', '\x04'] },
+      });
+      await textarea({ title: 'Msg', ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('3 lines');
+    });
+
+    it('cleanup shows (cancelled) on Ctrl+C', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['\x03'] },
+      });
+      await textarea({ title: 'Msg', ctx });
+      const output = ctx.io.written.join('');
+      expect(output).toContain('(cancelled)');
+    });
+
+    it('down arrow beyond last line does nothing', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', '\x1b[B', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('a');
+    });
+
+    it('up arrow at first line does nothing', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['a', '\x1b[A', '\x04'] },
+      });
+      const result = await textarea({ title: 'Msg', ctx });
+      expect(result).toBe('a');
+    });
+  });
+});

--- a/packages/bijou/src/core/forms/textarea.ts
+++ b/packages/bijou/src/core/forms/textarea.ts
@@ -1,0 +1,255 @@
+import type { FieldOptions } from './types.js';
+import type { BijouContext } from '../../ports/context.js';
+import type { TokenValue } from '../theme/tokens.js';
+import type { OutputMode } from '../detect/tty.js';
+import { getDefaultContext } from '../../context.js';
+
+export interface TextareaOptions extends FieldOptions<string> {
+  placeholder?: string;
+  maxLength?: number;
+  showLineNumbers?: boolean;
+  height?: number;
+  width?: number;
+  ctx?: BijouContext;
+}
+
+export async function textarea(options: TextareaOptions): Promise<string> {
+  const ctx = options.ctx ?? getDefaultContext();
+  const mode = ctx.mode;
+
+  if (mode === 'interactive' && ctx.runtime.stdinIsTTY) {
+    return interactiveTextarea(options, ctx);
+  }
+
+  return fallbackTextarea(options, mode, ctx);
+}
+
+async function fallbackTextarea(options: TextareaOptions, mode: OutputMode, ctx: BijouContext): Promise<string> {
+  const noColor = ctx.theme.noColor;
+  const styledFn = (token: TokenValue, text: string) => ctx.style.styled(token, text);
+
+  if (noColor || mode === 'accessible') {
+    ctx.io.write(`${options.title}\n`);
+  } else {
+    ctx.io.write(styledFn(ctx.theme.theme.semantic.info, '? ') + ctx.style.bold(options.title) + '\n');
+  }
+
+  const prompt = mode === 'accessible'
+    ? 'Enter text (multi-line, empty line to finish): '
+    : '> ';
+  const answer = await ctx.io.question(prompt);
+  const value = answer.trim() || options.defaultValue || '';
+
+  if (options.required && value === '') {
+    const msg = 'This field is required.';
+    if (noColor || mode === 'accessible') {
+      ctx.io.write(msg + '\n');
+    } else {
+      ctx.io.write(styledFn(ctx.theme.theme.semantic.error, msg) + '\n');
+    }
+  }
+
+  if (options.validate) {
+    const result = options.validate(value);
+    if (!result.valid && result.message) {
+      if (noColor) {
+        ctx.io.write(result.message + '\n');
+      } else {
+        ctx.io.write(styledFn(ctx.theme.theme.semantic.error, result.message) + '\n');
+      }
+    }
+  }
+
+  return value;
+}
+
+async function interactiveTextarea(options: TextareaOptions, ctx: BijouContext): Promise<string> {
+  const noColor = ctx.theme.noColor;
+  const t = ctx.theme;
+  const styledFn = (token: TokenValue, text: string) => ctx.style.styled(token, text);
+  const height = options.height ?? 6;
+  const showLineNumbers = options.showLineNumbers ?? false;
+
+  let lines: string[] = [''];
+  let cursorRow = 0;
+  let cursorCol = 0;
+  let scrollY = 0;
+
+  function visibleLines(): string[] {
+    return lines.slice(scrollY, scrollY + height);
+  }
+
+  function ensureCursorVisible(): void {
+    if (cursorRow < scrollY) scrollY = cursorRow;
+    if (cursorRow >= scrollY + height) scrollY = cursorRow - height + 1;
+  }
+
+  function render(): void {
+    const label = noColor
+      ? `? ${options.title}`
+      : styledFn(t.theme.semantic.info, '? ') + ctx.style.bold(options.title);
+    const hint = styledFn(t.theme.semantic.muted, ' (Ctrl+D to submit, Ctrl+C to cancel)');
+    ctx.io.write(`\x1b[?25l`);
+    ctx.io.write(`\r\x1b[K${label}${hint}\n`);
+
+    const vis = visibleLines();
+    for (let i = 0; i < height; i++) {
+      const lineIdx = scrollY + i;
+      const line = vis[i] ?? '';
+      const prefix = showLineNumbers
+        ? styledFn(t.theme.semantic.muted, `${String(lineIdx + 1).padStart(3)} │ `)
+        : '  ';
+
+      if (line === '' && lineIdx >= lines.length && options.placeholder && lines.length === 1 && lines[0] === '') {
+        ctx.io.write(`\x1b[K${prefix}${styledFn(t.theme.semantic.muted, options.placeholder)}\n`);
+      } else {
+        ctx.io.write(`\x1b[K${prefix}${line}\n`);
+      }
+    }
+
+    // Status line
+    const pos = `Ln ${cursorRow + 1}, Col ${cursorCol + 1}`;
+    const lenInfo = options.maxLength ? ` | ${currentLength()}/${options.maxLength}` : '';
+    ctx.io.write(`\x1b[K${styledFn(t.theme.semantic.muted, pos + lenInfo)}\n`);
+  }
+
+  function currentLength(): number {
+    return lines.join('\n').length;
+  }
+
+  function clearRender(): void {
+    const totalLines = height + 2; // header + visible lines + status
+    ctx.io.write(`\x1b[${totalLines}A`);
+  }
+
+  function cleanup(submitted: boolean): void {
+    clearRender();
+    const totalLines = height + 2;
+    for (let i = 0; i < totalLines; i++) ctx.io.write(`\x1b[K\n`);
+    ctx.io.write(`\x1b[${totalLines}A`);
+
+    const value = submitted ? lines.join('\n') : '';
+    const summary = value
+      ? (value.includes('\n') ? `${value.split('\n').length} lines` : value)
+      : '(cancelled)';
+    const label = noColor
+      ? `? ${options.title} ${summary}`
+      : styledFn(t.theme.semantic.info, '? ') + ctx.style.bold(options.title) + ' ' + styledFn(t.theme.semantic.info, summary);
+    ctx.io.write(`\x1b[K${label}\n`);
+    ctx.io.write(`\x1b[?25h`);
+  }
+
+  render();
+
+  return new Promise<string>((resolve) => {
+    const handle = ctx.io.rawInput((key: string) => {
+      if (key === '\x04') {
+        // Ctrl+D — submit
+        handle.dispose();
+        cleanup(true);
+        resolve(lines.join('\n'));
+        return;
+      }
+
+      if (key === '\x03') {
+        // Ctrl+C — cancel
+        handle.dispose();
+        cleanup(false);
+        resolve(options.defaultValue ?? '');
+        return;
+      }
+
+      if (key === '\r' || key === '\n') {
+        // Enter — newline
+        const currentLine = lines[cursorRow]!;
+        const before = currentLine.slice(0, cursorCol);
+        const after = currentLine.slice(cursorCol);
+        lines[cursorRow] = before;
+        lines.splice(cursorRow + 1, 0, after);
+        cursorRow++;
+        cursorCol = 0;
+        ensureCursorVisible();
+        clearRender();
+        render();
+        return;
+      }
+
+      if (key === '\x7f' || key === '\b') {
+        // Backspace
+        if (cursorCol > 0) {
+          const line = lines[cursorRow]!;
+          lines[cursorRow] = line.slice(0, cursorCol - 1) + line.slice(cursorCol);
+          cursorCol--;
+        } else if (cursorRow > 0) {
+          // Merge with previous line
+          const prevLine = lines[cursorRow - 1]!;
+          const currentLine = lines[cursorRow]!;
+          cursorCol = prevLine.length;
+          lines[cursorRow - 1] = prevLine + currentLine;
+          lines.splice(cursorRow, 1);
+          cursorRow--;
+          ensureCursorVisible();
+        }
+        clearRender();
+        render();
+        return;
+      }
+
+      // Arrow keys
+      if (key === '\x1b[A') { // Up
+        if (cursorRow > 0) {
+          cursorRow--;
+          cursorCol = Math.min(cursorCol, lines[cursorRow]!.length);
+          ensureCursorVisible();
+        }
+        clearRender();
+        render();
+        return;
+      }
+      if (key === '\x1b[B') { // Down
+        if (cursorRow < lines.length - 1) {
+          cursorRow++;
+          cursorCol = Math.min(cursorCol, lines[cursorRow]!.length);
+          ensureCursorVisible();
+        }
+        clearRender();
+        render();
+        return;
+      }
+      if (key === '\x1b[C') { // Right
+        if (cursorCol < lines[cursorRow]!.length) {
+          cursorCol++;
+        } else if (cursorRow < lines.length - 1) {
+          cursorRow++;
+          cursorCol = 0;
+          ensureCursorVisible();
+        }
+        clearRender();
+        render();
+        return;
+      }
+      if (key === '\x1b[D') { // Left
+        if (cursorCol > 0) {
+          cursorCol--;
+        } else if (cursorRow > 0) {
+          cursorRow--;
+          cursorCol = lines[cursorRow]!.length;
+          ensureCursorVisible();
+        }
+        clearRender();
+        render();
+        return;
+      }
+
+      // Printable character
+      if (key.length === 1 && key >= ' ') {
+        if (options.maxLength && currentLength() >= options.maxLength) return;
+        const line = lines[cursorRow]!;
+        lines[cursorRow] = line.slice(0, cursorCol) + key + line.slice(cursorCol);
+        cursorCol++;
+        clearRender();
+        render();
+      }
+    });
+  });
+}

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -125,8 +125,11 @@ export {
   type StepperOptions,
   dag,
   dagSlice,
+  dagLayout,
   type DagNode,
   type DagOptions,
+  type DagNodePosition,
+  type DagLayout,
 } from './core/components/index.js';
 
 // Forms

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -144,4 +144,9 @@ export {
   multiselect,
   confirm,
   group,
+  textarea,
+  type TextareaOptions,
+  filter,
+  type FilterOption,
+  type FilterOptions,
 } from './core/forms/index.js';


### PR DESCRIPTION
## Summary

- **`composite()`** — ANSI-safe overlay compositing with painter's algorithm ordering, dim background support, and `spliceLine()` internal helper using `sliceAnsi()`/`visibleLength()` from viewport.ts
- **`modal()`** — centered dialog overlay with optional title (bold), body, and hint (muted) sections, width override, themed borders via `BijouContext`
- **`toast()`** — anchored notification overlay with variant icons (✔ success, ✘ error, ℹ info), 4-corner anchoring with configurable margin, themed styling

All three primitives live in `packages/bijou-tui/src/overlay.ts`. No dependency on `box()` from bijou core — overlays always need borders regardless of output mode, so border rendering is self-contained.

Bumps all packages to **v0.4.0**.

## Test plan

- [x] 30 new tests in `overlay.test.ts` covering all three functions
- [x] Full test suite passes (846/846)
- [x] `tsc --noEmit` clean
- [x] CHANGELOG, ROADMAP, all READMEs updated
- [x] P1.75 marked shipped in roadmap, XYPH Phase 1h marked ready