### PR TITLE
feat(dag): DagSource adapter for external graph representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Bijou is a growing ecosystem. Transparency is our baseline—here is the current
 | `badge` / `alert` / `kbd` | ✅ Stable | Semantic status and keyboard indicators. |
 | `progress` / `spinner` | ✅ Stable | Visual feedback for long-running tasks. |
 | `timeline` | ✅ Stable | Vertical event visualization. |
-| `dag` / `dagSlice` | ✅ Stable | Directed acyclic graph with auto-layout, edge routing, and subgraph slicing. |
+| `dag` / `dagSlice` | ✅ Stable | Directed acyclic graph with auto-layout, edge routing, subgraph slicing, and `DagSource` adapter for external graphs. |
 | `skeleton` | ✅ Stable | Loading placeholders for data-heavy views. |
 | `textarea` | ✅ Stable | Multi-line, scrollable text entry. |
 | `filter` | ✅ Stable | Fuzzy type-to-filter list component. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,7 +93,7 @@ interface BijouContext {
 |----------|----------|
 | **Layout** | `box()`, `headerBox()`, `separator()` |
 | **Elements** | `badge()`, `alert()`, `kbd()`, `skeleton()` |
-| **Data** | `table()`, `tree()`, `accordion()`, `timeline()` |
+| **Data** | `table()`, `tree()`, `accordion()`, `timeline()`, `dag()`, `dagSlice()`, `dagLayout()` + `DagSource` adapter |
 | **Navigation** | `tabs()`, `breadcrumb()`, `stepper()`, `paginator()` |
 | **Animation** | `spinner()`, `progressBar()`, `gradientText()` |
 | **Forms** | `input()`, `select()`, `multiselect()`, `confirm()`, `group()` |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,18 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`dag()`, `dagSlice()`, `dagLayout()` overloads** — accept `SlicedDagSource` or `DagNode[]`; existing callers are unaffected
 - **`dagSlice()` returns `SlicedDagSource`** when given `DagSource` input, enabling composable slice-of-slice chains; purely traversal-based (no full-graph enumeration)
 
+### Fixed
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`arraySource()` mutable reference leak** — `children()` and `parents()` now return defensive copies instead of exposing internal mutable arrays
+- **`sliceSource()` ghost children leak** — ghost boundary `children()` now returns a copy instead of the internal edges array
+- **`isSlicedDagSource()` incomplete guard** — now checks for `ghostLabel` method in addition to `ids` and `ghost`
+- **`dagSlice()` default direction crash** — silently downgrades `'both'` to `'descendants'` when `parents()` is missing (only throws if `'ancestors'` was explicitly requested)
+- **`dag()`/`dagLayout()` unbounded source guard** — throws a clear error if passed an unbounded `DagSource` directly
+- **Inherited ghost preservation** — slice-of-slice now preserves ghost status from the input slice, preventing ghost nodes from rendering with solid borders
+- **`sliceSource()` parent fallback performance** — replaced O(n×m) scan with precomputed parent map built during BFS
+
 ## [0.4.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,34 +20,6 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`dag()`, `dagSlice()`, `dagLayout()` overloads** — accept `SlicedDagSource` or `DagNode[]`; existing callers are unaffected
 - **`dagSlice()` returns `SlicedDagSource`** when given `DagSource` input, enabling composable slice-of-slice chains; purely traversal-based (no full-graph enumeration)
 
-#### Examples
-
-```typescript
-// Wrap an external graph (database, API, etc.) — no DagNode[] conversion
-const graph: DagSource = {
-  has: (id) => db.exists(id),
-  label: (id) => db.getTitle(id),
-  children: (id) => db.getDependencies(id),
-  parents: (id) => db.getDependents(id),
-  badge: (id) => db.getStatus(id),
-};
-
-// BFS-walk only the ~20 nodes you need — never loads the full graph
-const slice = dagSlice(graph, 'TASK-42', { depth: 2, direction: 'both' });
-
-// Render the bounded slice
-console.log(dag(slice, { ctx }));
-
-// Composable: slice a slice
-const narrower = dagSlice(slice, 'TASK-42', { depth: 1, direction: 'descendants' });
-
-// Existing DagNode[] API is unchanged
-dag([
-  { id: 'a', label: 'Build', edges: ['b'] },
-  { id: 'b', label: 'Test' },
-]);
-```
-
 ## [0.4.0] — 2026-02-27
 
 ### Added
@@ -222,7 +194,8 @@ First public release.
 - **Screen control** — `enterScreen()`, `exitScreen()`, `clearAndHome()`, `renderFrame()`
 - **Layout helpers** — `vstack()`, `hstack()`
 
-[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/flyingrobots/bijou/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/flyingrobots/bijou/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.3.0
 [0.2.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.2.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-02-27
+
 ### Added
 
 #### Core (`@flyingrobots/bijou`)
@@ -17,6 +19,34 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`DagSliceOptions`** — extracted named type for `dagSlice()` options
 - **`dag()`, `dagSlice()`, `dagLayout()` overloads** — accept `SlicedDagSource` or `DagNode[]`; existing callers are unaffected
 - **`dagSlice()` returns `SlicedDagSource`** when given `DagSource` input, enabling composable slice-of-slice chains; purely traversal-based (no full-graph enumeration)
+
+#### Examples
+
+```typescript
+// Wrap an external graph (database, API, etc.) — no DagNode[] conversion
+const graph: DagSource = {
+  has: (id) => db.exists(id),
+  label: (id) => db.getTitle(id),
+  children: (id) => db.getDependencies(id),
+  parents: (id) => db.getDependents(id),
+  badge: (id) => db.getStatus(id),
+};
+
+// BFS-walk only the ~20 nodes you need — never loads the full graph
+const slice = dagSlice(graph, 'TASK-42', { depth: 2, direction: 'both' });
+
+// Render the bounded slice
+console.log(dag(slice, { ctx }));
+
+// Composable: slice a slice
+const narrower = dagSlice(slice, 'TASK-42', { depth: 1, direction: 'descendants' });
+
+// Existing DagNode[] API is unchanged
+dag([
+  { id: 'a', label: 'Build', edges: ['b'] },
+  { id: 'b', label: 'Test' },
+]);
+```
 
 ## [0.4.0] — 2026-02-27
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,17 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`DagSource` adapter interface** — decouple DAG rendering from in-memory `DagNode[]` arrays; bring your own graph representation (database, API, adjacency matrix, etc.)
+- **`arraySource()`** — wraps `DagNode[]` as a `DagSource` for backward compatibility
+- **`isDagSource()`** — type guard for `DagSource` vs `DagNode[]`
+- **`DagSliceOptions`** — extracted named type for `dagSlice()` options
+- **`dag()`, `dagSlice()`, `dagLayout()` overloads** — all three functions now accept either `DagSource` or `DagNode[]`; existing `DagNode[]` callers are unaffected
+- **`dagSlice()` returns `DagSource`** when given `DagSource` input, enabling composable slice-of-slice chains
+
 ## [0.4.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,12 +10,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 #### Core (`@flyingrobots/bijou`)
 
-- **`DagSource` adapter interface** — decouple DAG rendering from in-memory `DagNode[]` arrays; bring your own graph representation (database, API, adjacency matrix, etc.)
-- **`arraySource()`** — wraps `DagNode[]` as a `DagSource` for backward compatibility
-- **`isDagSource()`** — type guard for `DagSource` vs `DagNode[]`
+- **`DagSource` adapter interface** — decouple DAG rendering from in-memory `DagNode[]` arrays; bring your own graph representation (database, API, adjacency matrix, etc.). Uses `has()`/`children()`/`parents()` traversal — never enumerates the full graph
+- **`SlicedDagSource`** — bounded subtype of `DagSource` with `ids()` for rendering; produced by `dagSlice()` or `arraySource()`
+- **`arraySource()`** — wraps `DagNode[]` as a `SlicedDagSource` for backward compatibility
+- **`isDagSource()`** / **`isSlicedDagSource()`** — type guards
 - **`DagSliceOptions`** — extracted named type for `dagSlice()` options
-- **`dag()`, `dagSlice()`, `dagLayout()` overloads** — all three functions now accept either `DagSource` or `DagNode[]`; existing `DagNode[]` callers are unaffected
-- **`dagSlice()` returns `DagSource`** when given `DagSource` input, enabling composable slice-of-slice chains
+- **`dag()`, `dagSlice()`, `dagLayout()` overloads** — accept `SlicedDagSource` or `DagNode[]`; existing callers are unaffected
+- **`dagSlice()` returns `SlicedDagSource`** when given `DagSource` input, enabling composable slice-of-slice chains; purely traversal-based (no full-graph enumeration)
 
 ## [0.4.0] — 2026-02-27
 

--- a/docs/dag.md
+++ b/docs/dag.md
@@ -66,13 +66,74 @@ export interface DagOptions {
   edgeToken?: TokenValue;     // Edge/connector color
   highlightPath?: string[];   // Node IDs to highlight (e.g., critical path) — renders with a distinct token
   highlightToken?: TokenValue;// Token for highlighted path
+  selectedId?: string;        // Single node drawn with cursor-style highlighting
+  selectedToken?: TokenValue; // Override token for selectedId
   nodeWidth?: number;         // Fixed node box width (default: auto from longest label)
   maxWidth?: number;          // Terminal width constraint (default: ctx.runtime.columns)
   direction?: 'down' | 'right'; // Layout direction (default: 'down')
   ctx?: BijouContext;
 }
 
+// Accepts DagNode[] (small graphs) or SlicedDagSource (adapter-driven)
 export function dag(nodes: DagNode[], options?: DagOptions): string;
+export function dag(source: SlicedDagSource, options?: DagOptions): string;
+```
+
+### DagSource Adapter (v0.5.0)
+
+Decouple DAG rendering from any specific in-memory representation. A `DagSource` represents a potentially unbounded graph — it has no enumeration method. Use `dagSlice()` to BFS-walk from a focus node and produce a bounded `SlicedDagSource` that the renderer can consume.
+
+```typescript
+// Unbounded graph adapter — can wrap a database, API, etc.
+export interface DagSource {
+  has(id: string): boolean;                   // existence check (not enumeration)
+  label(id: string): string;                  // display label
+  children(id: string): readonly string[];    // outgoing edges
+  parents?(id: string): readonly string[];    // incoming edges (required for ancestor traversal)
+  badge?(id: string): string | undefined;     // optional badge text
+  token?(id: string): TokenValue | undefined; // optional per-node color
+}
+
+// Bounded slice — extends DagSource with enumerable IDs
+export interface SlicedDagSource extends DagSource {
+  ids(): readonly string[];                   // all node IDs in the slice
+  ghost(id: string): boolean;                 // is this a boundary placeholder?
+  ghostLabel(id: string): string | undefined; // e.g., "... 3 ancestors"
+}
+```
+
+**The flow: Source → Slice → Render**
+
+```
+DagSource          dagSlice()              dag()
+(your graph,  →  (BFS bounded walk,  →  (Sugiyama on the
+ unbounded)       ghost boundaries)       bounded result)
+```
+
+```typescript
+// External graph (never fully loaded)
+const graph: DagSource = {
+  has: (id) => db.exists(id),
+  label: (id) => db.getTitle(id),
+  children: (id) => db.getDeps(id),
+  parents: (id) => db.getDependents(id),
+};
+
+// BFS touches ~20 nodes, not the whole graph
+const slice = dagSlice(graph, 'TASK-42', { depth: 2 });
+dag(slice, { ctx });
+
+// Composable: slice a slice
+const narrower = dagSlice(slice, 'TASK-42', { depth: 1, direction: 'descendants' });
+```
+
+**`arraySource()`** wraps `DagNode[]` as a `SlicedDagSource` for backward compatibility:
+
+```typescript
+import { arraySource } from '@flyingrobots/bijou';
+
+const src = arraySource(myNodes);  // SlicedDagSource
+dag(src, { ctx });                 // equivalent to dag(myNodes, { ctx })
 ```
 
 ### Fragment Rendering
@@ -80,21 +141,16 @@ export function dag(nodes: DagNode[], options?: DagOptions): string;
 Render a subgraph instead of the full DAG. This is critical for large graphs — show ancestry of a single node, the critical path, or a neighborhood.
 
 ```typescript
-export interface DagFragmentOptions extends DagOptions {
-  // The full node set is still passed in, but only the fragment is rendered.
-  // Nodes outside the fragment are omitted; edges crossing the boundary
-  // render with a "..." or "→ (N more)" indicator.
+export interface DagSliceOptions {
+  direction?: 'ancestors' | 'descendants' | 'both';  // default: 'both'
+  depth?: number;                                      // max hops from focus (default: Infinity)
 }
 
-// Convenience: extract a subgraph before passing to dag()
-export function dagSlice(
-  nodes: DagNode[],
-  focus: string,                           // Center node ID
-  opts?: {
-    direction?: 'ancestors' | 'descendants' | 'both';  // default: 'both'
-    depth?: number;                        // Max hops from focus (default: Infinity)
-  },
-): DagNode[];
+// DagSource in → SlicedDagSource out (composable)
+export function dagSlice(source: DagSource, focus: string, opts?: DagSliceOptions): SlicedDagSource;
+
+// DagNode[] in → DagNode[] out (backward compatible)
+export function dagSlice(nodes: DagNode[], focus: string, opts?: DagSliceOptions): DagNode[];
 ```
 
 **Usage:**
@@ -380,30 +436,32 @@ Apply colors only when writing content into the grid — never during layout mat
 
 ## XYPH Integration: `status --view deps`
 
-Once `dag()` exists, XYPH's deps view becomes:
+With the `DagSource` adapter, XYPH's quest graph is never duplicated — bijou reads directly from the quest store:
 
 ```typescript
-import { dag, dagSlice } from '@flyingrobots/bijou';
+import { dag, dagSlice, type DagSource } from '@flyingrobots/bijou';
 
-// Full dependency graph
-const nodes = snapshot.quests.map(q => ({
-  id: q.id,
-  label: q.title.slice(0, 20),
-  edges: q.dependsOn ?? [],
-  badge: `${q.hours}h`,
-  token: q.status === 'DONE' ? theme.semantic.success
-       : frontierSet.has(q.id) ? theme.semantic.primary
-       : theme.semantic.muted,
-}));
+// Wrap the quest store as a DagSource — no DagNode[] copy
+const questGraph: DagSource = {
+  has: (id) => snapshot.quests.has(id),
+  label: (id) => snapshot.quests.get(id)!.title.slice(0, 20),
+  children: (id) => snapshot.quests.get(id)!.dependsOn ?? [],
+  parents: (id) => snapshot.quests.get(id)!.dependents ?? [],
+  badge: (id) => `${snapshot.quests.get(id)!.hours}h`,
+  token: (id) => {
+    const q = snapshot.quests.get(id)!;
+    return q.status === 'DONE' ? theme.semantic.success
+         : frontierSet.has(id) ? theme.semantic.primary
+         : theme.semantic.muted;
+  },
+};
 
-// Full graph with critical path highlighted
-console.log(dag(nodes, {
+// Render a 3-hop neighborhood — never loads the full graph
+const slice = dagSlice(questGraph, 'task:BJU-007', { depth: 3, direction: 'ancestors' });
+console.log(dag(slice, {
   highlightPath: criticalResult.path,
   highlightToken: theme.semantic.error,
 }));
-
-// Or: just show what task:BJU-007 is waiting on
-console.log(dag(dagSlice(nodes, 'task:BJU-007', { direction: 'ancestors' })));
 ```
 
 ### Reactive DAG in TUI

--- a/docs/dag.md
+++ b/docs/dag.md
@@ -74,9 +74,9 @@ export interface DagOptions {
   ctx?: BijouContext;
 }
 
-// Accepts DagNode[] (small graphs) or SlicedDagSource (adapter-driven)
-export function dag(nodes: DagNode[], options?: DagOptions): string;
+// Accepts SlicedDagSource (adapter-driven) or DagNode[] (small graphs)
 export function dag(source: SlicedDagSource, options?: DagOptions): string;
+export function dag(nodes: DagNode[], options?: DagOptions): string;
 ```
 
 ### DagSource Adapter (v0.5.0)

--- a/docs/dag.md
+++ b/docs/dag.md
@@ -104,7 +104,7 @@ export interface SlicedDagSource extends DagSource {
 
 **The flow: Source → Slice → Render**
 
-```
+```text
 DagSource          dagSlice()              dag()
 (your graph,  →  (BFS bounded walk,  →  (Sugiyama on the
  unbounded)       ghost boundaries)       bounded result)

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "0.4.0",
+    "@flyingrobots/bijou": "0.5.0",
     "chalk": "^5.6.2"
   },
   "devDependencies": {

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "0.4.0"
+    "@flyingrobots/bijou": "0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -4,12 +4,11 @@ Themed terminal components for CLIs, loggers, and scripts — graceful degradati
 
 **Zero dependencies. Hexagonal architecture. Works everywhere.**
 
-## What's New in 0.4.0?
+## What's New in 0.5.0?
 
-- **`textarea()`** — multi-line text input form with cursor navigation, line numbers, placeholder, maxLength
-- **`filter()`** — fuzzy-filter select form with real-time search by label and keywords
-- **`dagLayout()`** — returns node position map alongside rendered output, for interactive DAG navigation
-- **`dag()` `selectedId`** — cursor-style node highlighting with highest priority over highlight path
+- **`DagSource` adapter** — bring your own graph representation (database, API, adjacency matrix). DAG rendering no longer requires `DagNode[]`
+- **Traversal-based slicing** — `dagSlice()` BFS-walks via `has()`/`children()`/`parents()`, never enumerates the full graph
+- **Composable slices** — `dagSlice()` returns a `SlicedDagSource` when given `DagSource`, enabling slice-of-slice chains
 
 See the [CHANGELOG](https://github.com/flyingrobots/bijou/blob/main/docs/CHANGELOG.md) for the full release history.
 
@@ -42,7 +41,7 @@ console.log(box('Hello, world!'));
 `badge()`, `alert()`, `kbd()`, `skeleton()` — status indicators and UI primitives.
 
 ### Data
-`table()`, `tree()`, `accordion()`, `timeline()` — structured data display.
+`table()`, `tree()`, `accordion()`, `timeline()`, `dag()`, `dagSlice()`, `dagLayout()` — structured data display and DAG rendering with `DagSource` adapter for external graphs.
 
 ### Navigation
 `tabs()`, `breadcrumb()`, `stepper()`, `paginator()` — wayfinding components.

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/src/core/components/dag-source.ts
+++ b/packages/bijou/src/core/components/dag-source.ts
@@ -1,0 +1,267 @@
+import type { TokenValue } from '../theme/tokens.js';
+import type { DagNode } from './dag.js';
+
+// ── DagSource Interface ─────────────────────────────────────────────
+
+/**
+ * Adapter interface for accessing graph data. Decouples DAG rendering
+ * from any specific in-memory representation. Implementations can wrap
+ * arrays, databases, APIs, or any other graph store.
+ *
+ * Every render is a bounded slice — `dagSlice()` walks a `DagSource`
+ * to produce a new (bounded) `DagSource` that the renderer consumes.
+ */
+export interface DagSource {
+  /** All node IDs in this source (must be finite and enumerable). */
+  ids(): readonly string[];
+
+  /** Human-readable label for a node. */
+  label(id: string): string;
+
+  /** Child node IDs (outgoing edges). */
+  children(id: string): readonly string[];
+
+  /**
+   * Parent node IDs (incoming edges). Optional — enables efficient
+   * ancestor traversal in `dagSlice()`. When omitted, parents are
+   * derived by scanning `children()` of all known IDs.
+   */
+  parents?(id: string): readonly string[];
+
+  /** Optional badge text for a node. */
+  badge?(id: string): string | undefined;
+
+  /** Optional per-node color/style token. */
+  token?(id: string): TokenValue | undefined;
+
+  /** Whether this node is a ghost (boundary placeholder). */
+  ghost?(id: string): boolean;
+
+  /** Ghost label override (e.g., "... 3 ancestors"). */
+  ghostLabel?(id: string): string | undefined;
+}
+
+/** Options for `dagSlice()`. */
+export interface DagSliceOptions {
+  direction?: 'ancestors' | 'descendants' | 'both';
+  depth?: number;
+}
+
+// ── Type Guard ──────────────────────────────────────────────────────
+
+/** Returns true if the value implements the `DagSource` interface. */
+export function isDagSource(value: unknown): value is DagSource {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as DagSource).ids === 'function' &&
+    typeof (value as DagSource).label === 'function' &&
+    typeof (value as DagSource).children === 'function'
+  );
+}
+
+// ── arraySource ─────────────────────────────────────────────────────
+
+/** Wraps a `DagNode[]` as a `DagSource`. Zero-copy read-only view. */
+export function arraySource(nodes: DagNode[]): DagSource {
+  const map = new Map<string, DagNode>();
+  for (const n of nodes) map.set(n.id, n);
+
+  // Pre-compute parent map
+  const parentMap = new Map<string, string[]>();
+  for (const n of nodes) {
+    if (!parentMap.has(n.id)) parentMap.set(n.id, []);
+    for (const c of n.edges ?? []) {
+      if (!parentMap.has(c)) parentMap.set(c, []);
+      parentMap.get(c)!.push(n.id);
+    }
+  }
+
+  const idList = Object.freeze(nodes.map(n => n.id));
+
+  return {
+    ids: () => idList,
+    label: (id) => map.get(id)?.label ?? id,
+    children: (id) => map.get(id)?.edges ?? [],
+    parents: (id) => parentMap.get(id) ?? [],
+    badge: (id) => map.get(id)?.badge,
+    token: (id) => map.get(id)?.token,
+    ghost: (id) => map.get(id)?._ghost ?? false,
+    ghostLabel: (id) => map.get(id)?._ghostLabel,
+  };
+}
+
+// ── materialize ─────────────────────────────────────────────────────
+
+/** Converts a `DagSource` to `DagNode[]` for internal renderers. */
+export function materialize(source: DagSource): DagNode[] {
+  const ids = source.ids();
+  const nodes: DagNode[] = [];
+  for (const id of ids) {
+    const children = source.children(id);
+    const node: DagNode = {
+      id,
+      label: source.label(id),
+      edges: children.length > 0 ? [...children] : undefined,
+    };
+    const badge = source.badge?.(id);
+    if (badge !== undefined) node.badge = badge;
+    const token = source.token?.(id);
+    if (token !== undefined) node.token = token;
+    if (source.ghost?.(id)) {
+      node._ghost = true;
+      node._ghostLabel = source.ghostLabel?.(id);
+    }
+    nodes.push(node);
+  }
+  return nodes;
+}
+
+// ── emptySource ─────────────────────────────────────────────────────
+
+function emptySource(): DagSource {
+  const empty: readonly string[] = Object.freeze([]);
+  return {
+    ids: () => empty,
+    label: () => '',
+    children: () => empty,
+  };
+}
+
+// ── sliceSource ─────────────────────────────────────────────────────
+
+/**
+ * BFS-walks a `DagSource` from a focus node and returns a new bounded
+ * `DagSource` containing only the neighborhood. Ghost nodes are
+ * injected at depth boundaries.
+ */
+export function sliceSource(
+  source: DagSource,
+  focus: string,
+  opts?: DagSliceOptions,
+): DagSource {
+  const direction = opts?.direction ?? 'both';
+  const maxDepth = opts?.depth ?? Infinity;
+
+  const allIds = new Set(source.ids());
+  if (!allIds.has(focus)) return emptySource();
+
+  const included = new Set<string>();
+  const ghostNodes = new Map<string, { label: string; edges: string[] }>();
+
+  // Resolve parents — use source.parents if available, else derive
+  const getParents = source.parents
+    ? (id: string) => source.parents!(id)
+    : (id: string) => {
+        const parents: string[] = [];
+        for (const candidate of allIds) {
+          if (source.children(candidate).includes(id)) {
+            parents.push(candidate);
+          }
+        }
+        return parents;
+      };
+
+  // BFS ancestors
+  if (direction === 'ancestors' || direction === 'both') {
+    const queue: [string, number][] = [[focus, 0]];
+    const visited = new Set<string>();
+    while (queue.length > 0) {
+      const [id, depth] = queue.shift()!;
+      if (visited.has(id)) continue;
+      visited.add(id);
+      included.add(id);
+      if (depth < maxDepth) {
+        for (const p of getParents(id)) {
+          if (!visited.has(p) && allIds.has(p)) queue.push([p, depth + 1]);
+        }
+      } else {
+        const boundaryParents = [...getParents(id)].filter(
+          p => !visited.has(p) && allIds.has(p),
+        );
+        if (boundaryParents.length > 0) {
+          const ghostId = `__ghost_ancestors_${id}`;
+          included.add(ghostId);
+          const count = boundaryParents.length;
+          ghostNodes.set(ghostId, {
+            label: `... ${count} ancestor${count !== 1 ? 's' : ''}`,
+            edges: [id],
+          });
+        }
+      }
+    }
+  }
+
+  // BFS descendants
+  if (direction === 'descendants' || direction === 'both') {
+    const queue: [string, number][] = [[focus, 0]];
+    const visited = new Set<string>();
+    while (queue.length > 0) {
+      const [id, depth] = queue.shift()!;
+      if (visited.has(id)) continue;
+      visited.add(id);
+      included.add(id);
+      const ch = [...source.children(id)].filter(c => allIds.has(c));
+      if (depth < maxDepth) {
+        for (const c of ch) {
+          if (!visited.has(c)) queue.push([c, depth + 1]);
+        }
+      } else {
+        const boundaryChildren = ch.filter(c => !visited.has(c));
+        if (boundaryChildren.length > 0) {
+          const ghostId = `__ghost_descendants_${id}`;
+          included.add(ghostId);
+          const count = boundaryChildren.length;
+          ghostNodes.set(ghostId, {
+            label: `... ${count} descendant${count !== 1 ? 's' : ''}`,
+            edges: [],
+          });
+        }
+      }
+    }
+  }
+
+  // Build the sliced DagSource
+  const slicedIds = Object.freeze([...included]);
+
+  return {
+    ids: () => slicedIds,
+
+    label: (id) => {
+      const ghost = ghostNodes.get(id);
+      if (ghost) return ghost.label;
+      return source.label(id);
+    },
+
+    children: (id) => {
+      const ghost = ghostNodes.get(id);
+      if (ghost) return ghost.edges;
+      // Filter to included IDs, plus any descendant ghost for this node
+      const ch = [...source.children(id)].filter(c => included.has(c));
+      const descGhostId = `__ghost_descendants_${id}`;
+      if (ghostNodes.has(descGhostId)) ch.push(descGhostId);
+      return ch;
+    },
+
+    parents: (id) => {
+      if (ghostNodes.has(id)) {
+        // Ghost ancestor nodes point down — they have no parents in the slice
+        // Ghost descendant nodes also have no parents tracked
+        if (id.startsWith('__ghost_ancestors_')) return [];
+        // Descendant ghosts: parent is the boundary node
+        const boundaryId = id.replace('__ghost_descendants_', '');
+        return included.has(boundaryId) ? [boundaryId] : [];
+      }
+      return [...getParents(id)].filter(p => included.has(p));
+    },
+
+    badge: (id) => ghostNodes.has(id) ? undefined : source.badge?.(id),
+
+    token: (id) => ghostNodes.has(id) ? undefined : source.token?.(id),
+
+    ghost: (id) => ghostNodes.has(id),
+
+    ghostLabel: (id) => ghostNodes.get(id)?.label,
+  };
+}

--- a/packages/bijou/src/core/components/dag.test.ts
+++ b/packages/bijou/src/core/components/dag.test.ts
@@ -823,19 +823,23 @@ describe('DagSource adapter', () => {
 
     it('works with a simulated large graph via DagSource', () => {
       // Simulate a graph with 1000 nodes but only render a 3-node slice
+      const nodeIndex = (id: string): number => {
+        const n = parseInt(id.split('-')[1] ?? '', 10);
+        if (Number.isNaN(n)) throw new Error(`Invalid node ID: ${id}`);
+        return n;
+      };
       const custom: DagSource = {
-        has: (id) => id.startsWith('node-') && parseInt(id.split('-')[1]!) < 1000,
-        label: (id) => `Node ${id.split('-')[1]}`,
+        has: (id) => id.startsWith('node-') && nodeIndex(id) < 1000,
+        label: (id) => `Node ${nodeIndex(id)}`,
         children: (id) => {
-          const n = parseInt(id.split('-')[1]!);
-          // Each node points to the next two
+          const n = nodeIndex(id);
           const ch: string[] = [];
           if (n * 2 + 1 < 1000) ch.push(`node-${n * 2 + 1}`);
           if (n * 2 + 2 < 1000) ch.push(`node-${n * 2 + 2}`);
           return ch;
         },
         parents: (id) => {
-          const n = parseInt(id.split('-')[1]!);
+          const n = nodeIndex(id);
           if (n === 0) return [];
           return [`node-${Math.floor((n - 1) / 2)}`];
         },

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -1,8 +1,8 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { getDefaultContext } from '../../context.js';
-import { isDagSource, arraySource, materialize, sliceSource } from './dag-source.js';
-import type { DagSource, DagSliceOptions } from './dag-source.js';
+import { isDagSource, isSlicedDagSource, arraySource, materialize, sliceSource } from './dag-source.js';
+import type { DagSource, SlicedDagSource, DagSliceOptions } from './dag-source.js';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -591,7 +591,7 @@ export function dagSlice(
   source: DagSource,
   focus: string,
   opts?: DagSliceOptions,
-): DagSource;
+): SlicedDagSource;
 export function dagSlice(
   nodes: DagNode[],
   focus: string,
@@ -601,7 +601,7 @@ export function dagSlice(
   input: DagNode[] | DagSource,
   focus: string,
   opts?: DagSliceOptions,
-): DagNode[] | DagSource {
+): DagNode[] | SlicedDagSource {
   if (isDagSource(input)) {
     return sliceSource(input, focus, opts);
   }
@@ -612,14 +612,14 @@ export function dagSlice(
 
 // ── dagLayout ──────────────────────────────────────────────────────
 
-export function dagLayout(source: DagSource, options?: DagOptions): DagLayout;
+export function dagLayout(source: SlicedDagSource, options?: DagOptions): DagLayout;
 export function dagLayout(nodes: DagNode[], options?: DagOptions): DagLayout;
 export function dagLayout(
-  input: DagNode[] | DagSource,
+  input: DagNode[] | SlicedDagSource,
   options: DagOptions = {},
 ): DagLayout {
   const ctx = resolveCtx(options.ctx);
-  const nodes = isDagSource(input) ? materialize(input) : input;
+  const nodes = isSlicedDagSource(input) ? materialize(input) : input;
   if (nodes.length === 0) return { output: '', nodes: new Map(), width: 0, height: 0 };
   const result = renderInteractiveLayout(nodes, options, ctx);
   return { output: result.output, nodes: result.nodes, width: result.width, height: result.height };
@@ -627,15 +627,15 @@ export function dagLayout(
 
 // ── Main Entry Point ───────────────────────────────────────────────
 
-export function dag(source: DagSource, options?: DagOptions): string;
+export function dag(source: SlicedDagSource, options?: DagOptions): string;
 export function dag(nodes: DagNode[], options?: DagOptions): string;
 export function dag(
-  input: DagNode[] | DagSource,
+  input: DagNode[] | SlicedDagSource,
   options: DagOptions = {},
 ): string {
   const ctx = resolveCtx(options.ctx);
   const mode = ctx.mode;
-  const nodes = isDagSource(input) ? materialize(input) : input;
+  const nodes = isSlicedDagSource(input) ? materialize(input) : input;
 
   if (nodes.length === 0) return '';
 

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -618,6 +618,11 @@ export function dagLayout(
   input: DagNode[] | SlicedDagSource,
   options: DagOptions = {},
 ): DagLayout {
+  if (isDagSource(input) && !isSlicedDagSource(input)) {
+    throw new Error(
+      '[bijou] dagLayout(): received an unbounded DagSource. Use dagSlice() to produce a SlicedDagSource first.',
+    );
+  }
   const ctx = resolveCtx(options.ctx);
   const nodes = isSlicedDagSource(input) ? materialize(input) : input;
   if (nodes.length === 0) return { output: '', nodes: new Map(), width: 0, height: 0 };
@@ -633,6 +638,11 @@ export function dag(
   input: DagNode[] | SlicedDagSource,
   options: DagOptions = {},
 ): string {
+  if (isDagSource(input) && !isSlicedDagSource(input)) {
+    throw new Error(
+      '[bijou] dag(): received an unbounded DagSource. Use dagSlice() to produce a SlicedDagSource first.',
+    );
+  }
   const ctx = resolveCtx(options.ctx);
   const mode = ctx.mode;
   const nodes = isSlicedDagSource(input) ? materialize(input) : input;

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -1,6 +1,8 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { getDefaultContext } from '../../context.js';
+import { isDagSource, arraySource, materialize, sliceSource } from './dag-source.js';
+import type { DagSource, DagSliceOptions } from './dag-source.js';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -586,137 +588,38 @@ function renderAccessible(nodes: DagNode[], layerMap: Map<string, number>): stri
 // ── dagSlice ───────────────────────────────────────────────────────
 
 export function dagSlice(
+  source: DagSource,
+  focus: string,
+  opts?: DagSliceOptions,
+): DagSource;
+export function dagSlice(
   nodes: DagNode[],
   focus: string,
-  opts?: {
-    direction?: 'ancestors' | 'descendants' | 'both';
-    depth?: number;
-  },
-): DagNode[] {
-  const direction = opts?.direction ?? 'both';
-  const maxDepth = opts?.depth ?? Infinity;
-
-  const nodeMap = new Map<string, DagNode>();
-  for (const n of nodes) nodeMap.set(n.id, n);
-
-  if (!nodeMap.has(focus)) return [];
-
-  const included = new Set<string>();
-  const ghostIds = new Set<string>();
-
-  // Build parent map
-  const parentsMap = new Map<string, string[]>();
-  for (const n of nodes) {
-    if (!parentsMap.has(n.id)) parentsMap.set(n.id, []);
-    for (const c of n.edges ?? []) {
-      if (!parentsMap.has(c)) parentsMap.set(c, []);
-      parentsMap.get(c)!.push(n.id);
-    }
+  opts?: DagSliceOptions,
+): DagNode[];
+export function dagSlice(
+  input: DagNode[] | DagSource,
+  focus: string,
+  opts?: DagSliceOptions,
+): DagNode[] | DagSource {
+  if (isDagSource(input)) {
+    return sliceSource(input, focus, opts);
   }
-
-  // BFS ancestors
-  if (direction === 'ancestors' || direction === 'both') {
-    const queue: [string, number][] = [[focus, 0]];
-    const visited = new Set<string>();
-    while (queue.length > 0) {
-      const entry = queue.shift()!;
-      const id = entry[0];
-      const depth = entry[1];
-      if (visited.has(id)) continue;
-      visited.add(id);
-      included.add(id);
-      if (depth < maxDepth) {
-        for (const p of parentsMap.get(id) ?? []) {
-          if (!visited.has(p)) queue.push([p, depth + 1]);
-        }
-      } else {
-        const boundaryParents = (parentsMap.get(id) ?? []).filter(p => !visited.has(p));
-        if (boundaryParents.length > 0) {
-          const ghostId = `__ghost_ancestors_${id}`;
-          ghostIds.add(ghostId);
-          included.add(ghostId);
-        }
-      }
-    }
-  }
-
-  // BFS descendants
-  if (direction === 'descendants' || direction === 'both') {
-    const queue: [string, number][] = [[focus, 0]];
-    const visited = new Set<string>();
-    while (queue.length > 0) {
-      const entry = queue.shift()!;
-      const id = entry[0];
-      const depth = entry[1];
-      if (visited.has(id)) continue;
-      visited.add(id);
-      included.add(id);
-      const ch = nodeMap.get(id)?.edges ?? [];
-      if (depth < maxDepth) {
-        for (const c of ch) {
-          if (!visited.has(c) && nodeMap.has(c)) queue.push([c, depth + 1]);
-        }
-      } else {
-        const boundaryChildren = ch.filter(c => !visited.has(c) && nodeMap.has(c));
-        if (boundaryChildren.length > 0) {
-          const ghostId = `__ghost_descendants_${id}`;
-          ghostIds.add(ghostId);
-          included.add(ghostId);
-        }
-      }
-    }
-  }
-
-  // Build result
-  const result: DagNode[] = [];
-
-  for (const gid of ghostIds) {
-    if (gid.startsWith('__ghost_ancestors_')) {
-      const boundaryId = gid.replace('__ghost_ancestors_', '');
-      const allParents = (parentsMap.get(boundaryId) ?? []).filter(p => !included.has(p));
-      const count = allParents.length;
-      result.push({
-        id: gid,
-        label: `... ${count} ancestor${count !== 1 ? 's' : ''}`,
-        edges: [boundaryId],
-        _ghost: true,
-        _ghostLabel: `... ${count} ancestor${count !== 1 ? 's' : ''}`,
-      });
-    }
-  }
-
-  for (const n of nodes) {
-    if (!included.has(n.id)) continue;
-    const filteredEdges = (n.edges ?? []).filter(e => included.has(e));
-    const descGhostId = `__ghost_descendants_${n.id}`;
-    if (ghostIds.has(descGhostId)) {
-      filteredEdges.push(descGhostId);
-    }
-    result.push({ ...n, edges: filteredEdges.length > 0 ? filteredEdges : undefined });
-  }
-
-  for (const gid of ghostIds) {
-    if (gid.startsWith('__ghost_descendants_')) {
-      const boundaryId = gid.replace('__ghost_descendants_', '');
-      const boundaryNode = nodeMap.get(boundaryId);
-      const allChildren = (boundaryNode?.edges ?? []).filter(c => !included.has(c) && nodeMap.has(c));
-      const count = allChildren.length;
-      result.push({
-        id: gid,
-        label: `... ${count} descendant${count !== 1 ? 's' : ''}`,
-        _ghost: true,
-        _ghostLabel: `... ${count} descendant${count !== 1 ? 's' : ''}`,
-      });
-    }
-  }
-
-  return result;
+  // Array path: wrap, slice, materialize back for backward compat
+  const source = arraySource(input);
+  return materialize(sliceSource(source, focus, opts));
 }
 
 // ── dagLayout ──────────────────────────────────────────────────────
 
-export function dagLayout(nodes: DagNode[], options: DagOptions = {}): DagLayout {
+export function dagLayout(source: DagSource, options?: DagOptions): DagLayout;
+export function dagLayout(nodes: DagNode[], options?: DagOptions): DagLayout;
+export function dagLayout(
+  input: DagNode[] | DagSource,
+  options: DagOptions = {},
+): DagLayout {
   const ctx = resolveCtx(options.ctx);
+  const nodes = isDagSource(input) ? materialize(input) : input;
   if (nodes.length === 0) return { output: '', nodes: new Map(), width: 0, height: 0 };
   const result = renderInteractiveLayout(nodes, options, ctx);
   return { output: result.output, nodes: result.nodes, width: result.width, height: result.height };
@@ -724,9 +627,15 @@ export function dagLayout(nodes: DagNode[], options: DagOptions = {}): DagLayout
 
 // ── Main Entry Point ───────────────────────────────────────────────
 
-export function dag(nodes: DagNode[], options: DagOptions = {}): string {
+export function dag(source: DagSource, options?: DagOptions): string;
+export function dag(nodes: DagNode[], options?: DagOptions): string;
+export function dag(
+  input: DagNode[] | DagSource,
+  options: DagOptions = {},
+): string {
   const ctx = resolveCtx(options.ctx);
   const mode = ctx.mode;
+  const nodes = isDagSource(input) ? materialize(input) : input;
 
   if (nodes.length === 0) return '';
 

--- a/packages/bijou/src/core/components/index.ts
+++ b/packages/bijou/src/core/components/index.ts
@@ -52,5 +52,5 @@ export type { StepperStep, StepperOptions } from './stepper.js';
 export { dag, dagSlice, dagLayout } from './dag.js';
 export type { DagNode, DagOptions, DagNodePosition, DagLayout } from './dag.js';
 
-export { arraySource, isDagSource } from './dag-source.js';
-export type { DagSource, DagSliceOptions } from './dag-source.js';
+export { arraySource, isDagSource, isSlicedDagSource } from './dag-source.js';
+export type { DagSource, SlicedDagSource, DagSliceOptions } from './dag-source.js';

--- a/packages/bijou/src/core/components/index.ts
+++ b/packages/bijou/src/core/components/index.ts
@@ -51,3 +51,6 @@ export type { StepperStep, StepperOptions } from './stepper.js';
 
 export { dag, dagSlice, dagLayout } from './dag.js';
 export type { DagNode, DagOptions, DagNodePosition, DagLayout } from './dag.js';
+
+export { arraySource, isDagSource } from './dag-source.js';
+export type { DagSource, DagSliceOptions } from './dag-source.js';

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -130,6 +130,10 @@ export {
   type DagOptions,
   type DagNodePosition,
   type DagLayout,
+  arraySource,
+  isDagSource,
+  type DagSource,
+  type DagSliceOptions,
 } from './core/components/index.js';
 
 // Forms

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -132,7 +132,9 @@ export {
   type DagLayout,
   arraySource,
   isDagSource,
+  isSlicedDagSource,
   type DagSource,
+  type SlicedDagSource,
   type DagSliceOptions,
 } from './core/components/index.js';
 


### PR DESCRIPTION
## Summary

- Introduce `DagSource` interface that decouples DAG rendering from `DagNode[]` arrays — users can wrap databases, APIs, or any graph store
- `DagSource` is traversal-based (`has()`/`children()`/`parents()`) — never enumerates the full graph, enabling unbounded external graphs
- `dagSlice()` BFS-walks from a focus node to produce a bounded `SlicedDagSource`, which the renderer consumes
- Composable: slice a slice for progressive narrowing
- Fully backward compatible: `dag(nodes: DagNode[])` unchanged, 48 original tests unmodified
- Bumps all packages to v0.5.0

## New public API

| Export | Type | Description |
|--------|------|-------------|
| `DagSource` | interface | Unbounded graph adapter with `has()`, `label()`, `children()`, `parents?()` |
| `SlicedDagSource` | interface | Bounded slice extending `DagSource` with `ids()`, `ghost()` |
| `arraySource()` | function | Wraps `DagNode[]` as `SlicedDagSource` |
| `isDagSource()` | function | Type guard |
| `isSlicedDagSource()` | function | Type guard |
| `DagSliceOptions` | type | Extracted named type for `dagSlice()` options |

## Review fixes (b026d23)

- **C1**: `dagSlice()` silently downgrades `'both'` → `'descendants'` when `parents()` is missing (only throws if `'ancestors'` was explicitly requested)
- **M4**: `dag()`/`dagLayout()` throw a clear error if passed an unbounded `DagSource` directly
- **L2**: `emptySource()` replaced with module-level `EMPTY_SOURCE` singleton
- **M1**: Fixed overload order in `dag.md` to match actual code
- **M2**: Removed inline code example from CHANGELOG (non-standard format)
- **M3**: Marked `materialize()` as `@internal`
- **L1**: Fixed CHANGELOG footer links for v0.5.0

## Test plan

- [x] All 48 original DAG tests pass unchanged (backward compat)
- [x] 41 new tests for DagSource adapter, slicing, composability, equivalence
- [x] Simulated 1000-node graph test confirms only ~5 nodes touched for depth-1 slice
- [x] Test verifying `ids()` is never called on unbounded DagSource
- [x] Full suite: 891 tests pass, build clean