### PR TITLE
feat(dag): add dagStats() for pure graph statistics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`dagStats()`** — pure graph statistics (nodes, edges, depth, width, roots, leaves) with cycle detection, ghost-node filtering, and `SlicedDagSource` support
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/packages/bijou/src/core/components/dag-stats.test.ts
+++ b/packages/bijou/src/core/components/dag-stats.test.ts
@@ -62,6 +62,14 @@ describe('dagStats()', () => {
     expect(() => dagStats(nodes)).toThrow('cycle detected');
   });
 
+  it('duplicate node ids throws', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A' },
+      { id: 'a', label: 'A2' },
+    ];
+    expect(() => dagStats(nodes)).toThrow('duplicate node id "a"');
+  });
+
   it('self-loop throws', () => {
     const nodes: DagNode[] = [
       { id: 'a', label: 'A', edges: ['a'] },

--- a/packages/bijou/src/core/components/dag-stats.test.ts
+++ b/packages/bijou/src/core/components/dag-stats.test.ts
@@ -62,6 +62,13 @@ describe('dagStats()', () => {
     expect(() => dagStats(nodes)).toThrow('cycle detected');
   });
 
+  it('self-loop throws', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['a'] },
+    ];
+    expect(() => dagStats(nodes)).toThrow('cycle detected');
+  });
+
   it('ghost nodes are filtered out', () => {
     const nodes: DagNode[] = [
       { id: 'a', label: 'A', edges: ['b'] },
@@ -81,6 +88,19 @@ describe('dagStats()', () => {
     const source = arraySource(nodes);
     expect(dagStats(source)).toEqual({
       nodes: 2, edges: 1, depth: 2, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('disconnected components', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C', edges: ['d'] },
+      { id: 'd', label: 'D', edges: ['e'] },
+      { id: 'e', label: 'E' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 5, edges: 3, depth: 3, width: 2, roots: 2, leaves: 2,
     });
   });
 

--- a/packages/bijou/src/core/components/dag-stats.test.ts
+++ b/packages/bijou/src/core/components/dag-stats.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { dagStats } from './dag-stats.js';
+import type { DagNode } from './dag.js';
+import { arraySource } from './dag-source.js';
+
+describe('dagStats()', () => {
+  it('empty graph returns all zeros', () => {
+    expect(dagStats([])).toEqual({
+      nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0,
+    });
+  });
+
+  it('single node', () => {
+    const nodes: DagNode[] = [{ id: 'a', label: 'A' }];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 1, edges: 0, depth: 1, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('linear chain A→B→C', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B', edges: ['c'] },
+      { id: 'c', label: 'C' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 3, edges: 2, depth: 3, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('diamond A→B,C→D', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b', 'c'] },
+      { id: 'b', label: 'B', edges: ['d'] },
+      { id: 'c', label: 'C', edges: ['d'] },
+      { id: 'd', label: 'D' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 4, edges: 4, depth: 3, width: 2, roots: 1, leaves: 1,
+    });
+  });
+
+  it('wide fan-out', () => {
+    const nodes: DagNode[] = [
+      { id: 'root', label: 'Root', edges: ['a', 'b', 'c', 'd', 'e'] },
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+      { id: 'd', label: 'D' },
+      { id: 'e', label: 'E' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 6, edges: 5, depth: 2, width: 5, roots: 1, leaves: 5,
+    });
+  });
+
+  it('cycle throws', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B', edges: ['a'] },
+    ];
+    expect(() => dagStats(nodes)).toThrow('cycle detected');
+  });
+
+  it('ghost nodes are filtered out', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B' },
+      { id: 'ghost1', label: '... 3 ancestors', _ghost: true, edges: ['a'] },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 2, edges: 1, depth: 2, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('accepts SlicedDagSource', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B' },
+    ];
+    const source = arraySource(nodes);
+    expect(dagStats(source)).toEqual({
+      nodes: 2, edges: 1, depth: 2, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('multiple roots and leaves', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['c'] },
+      { id: 'b', label: 'B', edges: ['c'] },
+      { id: 'c', label: 'C', edges: ['d', 'e'] },
+      { id: 'd', label: 'D' },
+      { id: 'e', label: 'E' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 5, edges: 4, depth: 3, width: 2, roots: 2, leaves: 2,
+    });
+  });
+});

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -1,0 +1,127 @@
+import type { DagNode } from './dag.js';
+import type { SlicedDagSource } from './dag-source.js';
+import { isSlicedDagSource } from './dag-source.js';
+import { materialize } from './dag-source.js';
+
+export interface DagStats {
+  nodes: number;
+  edges: number;
+  depth: number;        // number of layers (longest-path assignment)
+  width: number;        // max nodes on any single layer
+  roots: number;        // in-degree 0
+  leaves: number;       // out-degree 0
+}
+
+export function dagStats(nodes: DagNode[]): DagStats;
+export function dagStats(source: SlicedDagSource): DagStats;
+export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {
+  const nodes = isSlicedDagSource(input) ? materialize(input) : input;
+
+  if (nodes.length === 0) {
+    return { nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0 };
+  }
+
+  // Filter out ghost nodes
+  const realNodes = nodes.filter(n => !n._ghost);
+
+  if (realNodes.length === 0) {
+    return { nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0 };
+  }
+
+  const nodeIds = new Set(realNodes.map(n => n.id));
+  const children = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+  const parents = new Map<string, string[]>();
+
+  for (const n of realNodes) {
+    const validEdges = (n.edges ?? []).filter(e => nodeIds.has(e));
+    children.set(n.id, validEdges);
+    inDegree.set(n.id, 0);
+    if (!parents.has(n.id)) parents.set(n.id, []);
+  }
+
+  let totalEdges = 0;
+  for (const n of realNodes) {
+    for (const childId of children.get(n.id) ?? []) {
+      if (!parents.has(childId)) parents.set(childId, []);
+      parents.get(childId)!.push(n.id);
+      inDegree.set(childId, (inDegree.get(childId) ?? 0) + 1);
+      totalEdges++;
+    }
+  }
+
+  // Kahn's topological sort
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) queue.push(id);
+  }
+
+  const topoOrder: string[] = [];
+  const visited = new Set<string>();
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (visited.has(id)) continue;
+    visited.add(id);
+    topoOrder.push(id);
+    for (const childId of children.get(id) ?? []) {
+      const newDeg = (inDegree.get(childId) ?? 1) - 1;
+      inDegree.set(childId, newDeg);
+      if (newDeg === 0) queue.push(childId);
+    }
+  }
+
+  if (topoOrder.length !== realNodes.length) {
+    throw new Error('[bijou] dagStats(): cycle detected in graph');
+  }
+
+  // Longest-path layer assignment
+  const layerMap = new Map<string, number>();
+  for (const id of topoOrder) {
+    const pars = parents.get(id) ?? [];
+    if (pars.length === 0) {
+      layerMap.set(id, 0);
+    } else {
+      let maxParent = 0;
+      for (const p of pars) {
+        maxParent = Math.max(maxParent, layerMap.get(p) ?? 0);
+      }
+      layerMap.set(id, maxParent + 1);
+    }
+  }
+
+  // Compute stats
+  let maxLayer = 0;
+  for (const v of layerMap.values()) {
+    if (v > maxLayer) maxLayer = v;
+  }
+  const depth = maxLayer + 1;
+
+  // Width: count nodes per layer, find max
+  const layerCounts = new Map<number, number>();
+  for (const v of layerMap.values()) {
+    layerCounts.set(v, (layerCounts.get(v) ?? 0) + 1);
+  }
+  let maxWidth = 0;
+  for (const count of layerCounts.values()) {
+    if (count > maxWidth) maxWidth = count;
+  }
+
+  // Roots: in-degree 0 (already counted)
+  let rootCount = 0;
+  let leafCount = 0;
+  for (const n of realNodes) {
+    const pars = parents.get(n.id) ?? [];
+    if (pars.length === 0) rootCount++;
+    const ch = children.get(n.id) ?? [];
+    if (ch.length === 0) leafCount++;
+  }
+
+  return {
+    nodes: realNodes.length,
+    edges: totalEdges,
+    depth,
+    width: maxWidth,
+    roots: rootCount,
+    leaves: leafCount,
+  };
+}

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -50,21 +50,19 @@ export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {
     }
   }
 
-  // Kahn's topological sort
+  // Kahn's topological sort (index-based dequeue for O(n) total)
   const queue: string[] = [];
+  let head = 0;
   for (const [id, deg] of inDegree) {
     if (deg === 0) queue.push(id);
   }
 
   const topoOrder: string[] = [];
-  const visited = new Set<string>();
-  while (queue.length > 0) {
-    const id = queue.shift()!;
-    if (visited.has(id)) continue;
-    visited.add(id);
+  while (head < queue.length) {
+    const id = queue[head++]!;
     topoOrder.push(id);
     for (const childId of children.get(id) ?? []) {
-      const newDeg = (inDegree.get(childId) ?? 1) - 1;
+      const newDeg = inDegree.get(childId)! - 1;
       inDegree.set(childId, newDeg);
       if (newDeg === 0) queue.push(childId);
     }

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -28,7 +28,13 @@ export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {
     return { nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0 };
   }
 
-  const nodeIds = new Set(realNodes.map(n => n.id));
+  const nodeIds = new Set<string>();
+  for (const n of realNodes) {
+    if (nodeIds.has(n.id)) {
+      throw new Error(`[bijou] dagStats(): duplicate node id "${n.id}"`);
+    }
+    nodeIds.add(n.id);
+  }
   const children = new Map<string, string[]>();
   const inDegree = new Map<string, number>();
   const parents = new Map<string, string[]>();

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -3,15 +3,41 @@ import type { SlicedDagSource } from './dag-source.js';
 import { isSlicedDagSource } from './dag-source.js';
 import { materialize } from './dag-source.js';
 
+/** Statistics computed from a directed acyclic graph. */
 export interface DagStats {
+  /** Total number of (non-ghost) nodes. */
   nodes: number;
+  /** Total number of edges between non-ghost nodes. */
   edges: number;
-  depth: number;        // number of layers (longest-path assignment)
-  width: number;        // max nodes on any single layer
-  roots: number;        // in-degree 0
-  leaves: number;       // out-degree 0
+  /** Number of layers in the longest-path layer assignment. */
+  depth: number;
+  /** Maximum number of nodes on any single layer. */
+  width: number;
+  /** Number of root nodes (in-degree 0). */
+  roots: number;
+  /** Number of leaf nodes (out-degree 0). */
+  leaves: number;
 }
 
+/**
+ * Compute statistics for a directed acyclic graph.
+ *
+ * Accepts either a `DagNode[]` array or a `SlicedDagSource`. Ghost nodes
+ * (internal boundary markers from `dagSlice()`) are filtered out automatically.
+ *
+ * @throws If the graph contains a cycle or duplicate node IDs.
+ *
+ * @example
+ * ```ts
+ * const stats = dagStats([
+ *   { id: 'a', label: 'A', edges: ['b', 'c'] },
+ *   { id: 'b', label: 'B', edges: ['d'] },
+ *   { id: 'c', label: 'C', edges: ['d'] },
+ *   { id: 'd', label: 'D' },
+ * ]);
+ * // => { nodes: 4, edges: 4, depth: 3, width: 2, roots: 1, leaves: 1 }
+ * ```
+ */
 export function dagStats(nodes: DagNode[]): DagStats;
 export function dagStats(source: SlicedDagSource): DagStats;
 export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {

--- a/packages/bijou/src/core/components/index.ts
+++ b/packages/bijou/src/core/components/index.ts
@@ -54,3 +54,6 @@ export type { DagNode, DagOptions, DagNodePosition, DagLayout } from './dag.js';
 
 export { arraySource, isDagSource, isSlicedDagSource } from './dag-source.js';
 export type { DagSource, SlicedDagSource, DagSliceOptions } from './dag-source.js';
+
+export { dagStats } from './dag-stats.js';
+export type { DagStats } from './dag-stats.js';

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -136,6 +136,8 @@ export {
   type DagSource,
   type SlicedDagSource,
   type DagSliceOptions,
+  dagStats,
+  type DagStats,
 } from './core/components/index.js';
 
 // Forms


### PR DESCRIPTION
## Summary
- Adds `dagStats()` function that computes graph statistics (nodes, edges, depth, width, roots, leaves) from `DagNode[]` or `SlicedDagSource`
- Reuses Kahn's topo-sort + longest-path pattern from `assignLayers()` with cycle detection
- Ghost nodes are filtered out automatically

## Test plan
- [x] Empty graph → all zeros
- [x] Single node → correct stats
- [x] Linear chain (A→B→C) → depth=3, width=1
- [x] Diamond (A→B,C→D) → depth=3, width=2
- [x] Wide fan-out → width matches fan
- [x] Cycle → throws
- [x] Ghost nodes filtered out
- [x] SlicedDagSource overload works
- [x] Multiple roots and leaves
- [x] Full test suite passes (905 tests)