### PR TITLE
feat(forms): add wizard() for multi-step form orchestration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`wizard()`** — multi-step form orchestrator that runs steps sequentially, passes accumulated values to each step, and supports conditional skipping via `skip` predicates
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/packages/bijou/src/core/forms/index.ts
+++ b/packages/bijou/src/core/forms/index.ts
@@ -24,3 +24,6 @@ export type { TextareaOptions } from './textarea.js';
 
 export { filter } from './filter.js';
 export type { FilterOption, FilterOptions } from './filter.js';
+
+export { wizard } from './wizard.js';
+export type { WizardStep, WizardOptions } from './wizard.js';

--- a/packages/bijou/src/core/forms/wizard.test.ts
+++ b/packages/bijou/src/core/forms/wizard.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { wizard } from './wizard.js';
+
+describe('wizard()', () => {
+  it('runs all steps and collects values', async () => {
+    const result = await wizard<{ name: string; age: number; active: boolean }>({
+      steps: [
+        { key: 'name', field: async () => 'Alice' },
+        { key: 'age', field: async () => 30 },
+        { key: 'active', field: async () => true },
+      ],
+    });
+    expect(result).toEqual({
+      values: { name: 'Alice', age: 30, active: true },
+      cancelled: false,
+    });
+  });
+
+  it('skips step when skip predicate returns true', async () => {
+    const result = await wizard<{ mode: string; details: string }>({
+      steps: [
+        { key: 'mode', field: async () => 'simple' },
+        {
+          key: 'details',
+          field: async () => 'extra info',
+          skip: (values) => values.mode === 'simple',
+        },
+      ],
+    });
+    expect(result.values.mode).toBe('simple');
+    expect(result.values.details).toBeUndefined();
+    expect(result.cancelled).toBe(false);
+  });
+
+  it('does not skip when skip predicate returns false', async () => {
+    const result = await wizard<{ mode: string; details: string }>({
+      steps: [
+        { key: 'mode', field: async () => 'advanced' },
+        {
+          key: 'details',
+          field: async () => 'extra info',
+          skip: (values) => values.mode === 'simple',
+        },
+      ],
+    });
+    expect(result.values.mode).toBe('advanced');
+    expect(result.values.details).toBe('extra info');
+  });
+
+  it('empty steps returns empty values', async () => {
+    const result = await wizard<Record<string, never>>({
+      steps: [],
+    });
+    expect(result).toEqual({ values: {}, cancelled: false });
+  });
+
+  it('field receives accumulated values', async () => {
+    const received: Partial<{ a: string; b: string }>[] = [];
+    await wizard<{ a: string; b: string }>({
+      steps: [
+        {
+          key: 'a',
+          field: async (vals) => {
+            received.push({ ...vals });
+            return 'first';
+          },
+        },
+        {
+          key: 'b',
+          field: async (vals) => {
+            received.push({ ...vals });
+            return 'second';
+          },
+        },
+      ],
+    });
+    expect(received[0]).toEqual({});
+    expect(received[1]).toEqual({ a: 'first' });
+  });
+
+  it('steps run sequentially', async () => {
+    const order: number[] = [];
+    await wizard<{ a: string; b: string; c: string }>({
+      steps: [
+        {
+          key: 'a',
+          field: async () => {
+            order.push(1);
+            return 'a';
+          },
+        },
+        {
+          key: 'b',
+          field: async () => {
+            order.push(2);
+            return 'b';
+          },
+        },
+        {
+          key: 'c',
+          field: async () => {
+            order.push(3);
+            return 'c';
+          },
+        },
+      ],
+    });
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('skip predicate can depend on multiple prior values', async () => {
+    const result = await wizard<{ x: number; y: number; sum: number }>({
+      steps: [
+        { key: 'x', field: async () => 5 },
+        { key: 'y', field: async () => 10 },
+        {
+          key: 'sum',
+          field: async (vals) => (vals.x ?? 0) + (vals.y ?? 0),
+          skip: (vals) => (vals.x ?? 0) + (vals.y ?? 0) > 20,
+        },
+      ],
+    });
+    expect(result.values.sum).toBe(15);
+  });
+});

--- a/packages/bijou/src/core/forms/wizard.ts
+++ b/packages/bijou/src/core/forms/wizard.ts
@@ -1,0 +1,47 @@
+import type { GroupFieldResult } from './types.js';
+
+export interface WizardStep<T> {
+  key: keyof T;
+  field: (values: Partial<T>) => Promise<unknown>;
+  skip?: (values: Partial<T>) => boolean;
+}
+
+export interface WizardOptions<T extends Record<string, unknown>> {
+  steps: WizardStep<T>[];
+}
+
+/**
+ * Multi-step form wizard that runs steps sequentially, passing accumulated
+ * values to each step's `field` function. Steps can be conditionally skipped
+ * via the `skip` predicate.
+ *
+ * @example
+ * ```ts
+ * const result = await wizard<{ mode: string; details: string }>({
+ *   steps: [
+ *     { key: 'mode', field: () => select({ title: 'Mode', options: [...] }) },
+ *     {
+ *       key: 'details',
+ *       field: () => input({ title: 'Details' }),
+ *       skip: (vals) => vals.mode === 'simple',
+ *     },
+ *   ],
+ * });
+ * ```
+ */
+export async function wizard<T extends Record<string, unknown>>(
+  options: WizardOptions<T>,
+): Promise<GroupFieldResult<T>> {
+  const values = {} as T;
+
+  for (const step of options.steps) {
+    if (step.skip?.(values)) {
+      continue;
+    }
+
+    const result = await step.field(values);
+    (values as Record<string, unknown>)[step.key as string] = result;
+  }
+
+  return { values, cancelled: false };
+}

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -158,4 +158,7 @@ export {
   filter,
   type FilterOption,
   type FilterOptions,
+  wizard,
+  type WizardStep,
+  type WizardOptions,
 } from './core/forms/index.js';


### PR DESCRIPTION
## Summary
- Adds `wizard()` function that orchestrates sequential multi-step forms with conditional skip logic
- Each step receives accumulated `Partial<T>` values, enabling dependent branching
- Returns `GroupFieldResult<T>` (same pattern as `group()`)
- Exports `WizardStep<T>` and `WizardOptions<T>` types

## Test plan
- [x] Runs all steps and collects values
- [x] Skips step when skip predicate returns true
- [x] Does not skip when skip returns false
- [x] Empty steps returns empty values
- [x] Field receives accumulated values from prior steps
- [x] Sequential execution order verified
- [x] Skip predicate depending on multiple prior values
- [x] Full test suite passes (903 tests)