### PR TITLE
feat(tui): add navigableTable() keyboard-navigable table

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,16 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`navigableTable()`** — keyboard-navigable table wrapping core `table()` with focus management, vertical scrolling, and vim-style keybindings (`j`/`k`, `d`/`u`, page up/down)
+- **`createNavigableTableState()`** — factory for navigable table state with configurable viewport height
+- **`navTableFocusNext()` / `navTableFocusPrev()`** — row focus with wrap-around
+- **`navTablePageDown()` / `navTablePageUp()`** — page-sized jumps with clamping
+- **`navTableKeyMap()`** — preconfigured keybinding map for table navigation
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -185,3 +185,17 @@ export {
   collapseAll,
   accordionKeyMap,
 } from './accordion.js';
+
+// Navigable table
+export {
+  type NavigableTableState,
+  type NavigableTableOptions,
+  type NavTableRenderOptions,
+  createNavigableTableState,
+  navigableTable,
+  navTableFocusNext,
+  navTableFocusPrev,
+  navTablePageDown,
+  navTablePageUp,
+  navTableKeyMap,
+} from './navigable-table.js';

--- a/packages/bijou-tui/src/navigable-table.test.ts
+++ b/packages/bijou-tui/src/navigable-table.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createNavigableTableState,
+  navTableFocusNext,
+  navTableFocusPrev,
+  navTablePageDown,
+  navTablePageUp,
+  navigableTable,
+  navTableKeyMap,
+} from './navigable-table.js';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+
+describe('navigableTable', () => {
+  const columns = [{ header: 'Name' }, { header: 'Age' }];
+  const rows = [
+    ['Alice', '30'],
+    ['Bob', '25'],
+    ['Carol', '28'],
+    ['Dave', '35'],
+    ['Eve', '22'],
+  ];
+
+  describe('createNavigableTableState()', () => {
+    it('creates state with defaults', () => {
+      const state = createNavigableTableState({ columns, rows });
+      expect(state.focusRow).toBe(0);
+      expect(state.scrollY).toBe(0);
+      expect(state.height).toBe(10);
+      expect(state.rows).toBe(rows);
+    });
+
+    it('accepts custom height', () => {
+      const state = createNavigableTableState({ columns, rows, height: 3 });
+      expect(state.height).toBe(3);
+    });
+  });
+
+  describe('focus navigation', () => {
+    it('focusNext moves to next row', () => {
+      const state = createNavigableTableState({ columns, rows });
+      const next = navTableFocusNext(state);
+      expect(next.focusRow).toBe(1);
+    });
+
+    it('focusNext wraps around', () => {
+      let state = createNavigableTableState({ columns, rows });
+      for (let i = 0; i < rows.length; i++) state = navTableFocusNext(state);
+      expect(state.focusRow).toBe(0);
+    });
+
+    it('focusPrev moves to previous row', () => {
+      let state = createNavigableTableState({ columns, rows });
+      state = navTableFocusNext(state);
+      state = navTableFocusPrev(state);
+      expect(state.focusRow).toBe(0);
+    });
+
+    it('focusPrev wraps around', () => {
+      const state = createNavigableTableState({ columns, rows });
+      const prev = navTableFocusPrev(state);
+      expect(prev.focusRow).toBe(rows.length - 1);
+    });
+
+    it('empty rows are no-ops', () => {
+      const state = createNavigableTableState({ columns, rows: [] });
+      expect(navTableFocusNext(state)).toBe(state);
+      expect(navTableFocusPrev(state)).toBe(state);
+    });
+  });
+
+  describe('page navigation', () => {
+    it('pageDown moves by height', () => {
+      const state = createNavigableTableState({ columns, rows, height: 2 });
+      const paged = navTablePageDown(state);
+      expect(paged.focusRow).toBe(2);
+    });
+
+    it('pageDown clamps to last row', () => {
+      const state = createNavigableTableState({ columns, rows, height: 10 });
+      const paged = navTablePageDown(state);
+      expect(paged.focusRow).toBe(rows.length - 1);
+    });
+
+    it('pageUp moves up by height', () => {
+      let state = createNavigableTableState({ columns, rows, height: 2 });
+      state = navTablePageDown(navTablePageDown(state));
+      state = navTablePageUp(state);
+      expect(state.focusRow).toBe(2);
+    });
+
+    it('pageUp clamps to first row', () => {
+      const state = createNavigableTableState({ columns, rows, height: 10 });
+      const paged = navTablePageUp(state);
+      expect(paged.focusRow).toBe(0);
+    });
+  });
+
+  describe('scroll follows focus', () => {
+    it('scrollY adjusts when focus goes below viewport', () => {
+      let state = createNavigableTableState({ columns, rows, height: 2 });
+      state = navTableFocusNext(state);
+      state = navTableFocusNext(state);
+      expect(state.scrollY).toBe(1);
+    });
+
+    it('scrollY adjusts when focus goes above viewport', () => {
+      let state = createNavigableTableState({ columns, rows, height: 2 });
+      // Go to bottom, then wrap to 0
+      for (let i = 0; i < rows.length; i++) state = navTableFocusNext(state);
+      expect(state.focusRow).toBe(0);
+      expect(state.scrollY).toBe(0);
+    });
+  });
+
+  describe('render', () => {
+    it('shows focus indicator on focused row', () => {
+      const state = createNavigableTableState({ columns, rows, height: 3 });
+      const ctx = createTestContext({ mode: 'interactive' });
+      const output = navigableTable(state, { ctx });
+      expect(output).toContain('\u25b8');
+      expect(output).toContain('Alice');
+    });
+
+    it('renders empty table', () => {
+      const state = createNavigableTableState({ columns, rows: [] });
+      const ctx = createTestContext({ mode: 'interactive' });
+      const output = navigableTable(state, { ctx });
+      expect(output).toContain('Name');
+    });
+  });
+
+  describe('keymap', () => {
+    it('dispatches correct actions', () => {
+      const actions = {
+        focusNext: 'next',
+        focusPrev: 'prev',
+        pageDown: 'pd',
+        pageUp: 'pu',
+        quit: 'q',
+      };
+      const km = navTableKeyMap(actions);
+      expect(km.handle({ key: 'j', ctrl: false, alt: false, shift: false })).toBe('next');
+      expect(km.handle({ key: 'k', ctrl: false, alt: false, shift: false })).toBe('prev');
+      expect(km.handle({ key: 'q', ctrl: false, alt: false, shift: false })).toBe('q');
+    });
+  });
+});

--- a/packages/bijou-tui/src/navigable-table.ts
+++ b/packages/bijou-tui/src/navigable-table.ts
@@ -1,0 +1,190 @@
+/**
+ * Navigable table building block.
+ *
+ * Wraps the static `table()` from bijou core with focus management,
+ * keyboard navigation, and vertical scrolling.
+ *
+ * ```ts
+ * // In TEA init:
+ * const tableState = createNavigableTableState({ columns, rows, height: 10 });
+ *
+ * // In TEA view:
+ * const output = navigableTable(model.tableState, { ctx });
+ *
+ * // In TEA update:
+ * case 'focus-next':
+ *   return [{ ...model, tableState: navTableFocusNext(model.tableState) }, []];
+ * ```
+ */
+
+import {
+  table,
+  type TableColumn,
+  type BijouContext,
+} from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NavigableTableState {
+  readonly columns: TableColumn[];
+  readonly rows: readonly (readonly string[])[];
+  readonly focusRow: number;
+  readonly scrollY: number;
+  readonly height: number;
+}
+
+export interface NavigableTableOptions {
+  readonly columns: TableColumn[];
+  readonly rows: readonly (readonly string[])[];
+  readonly height?: number;
+}
+
+export interface NavTableRenderOptions {
+  readonly focusIndicator?: string;
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial navigable table state.
+ *
+ * `height` defaults to 10 rows when not provided.
+ */
+export function createNavigableTableState(options: NavigableTableOptions): NavigableTableState {
+  return {
+    columns: [...options.columns],
+    rows: options.rows,
+    focusRow: 0,
+    scrollY: 0,
+    height: options.height ?? 10,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Move focus to the next row (wraps around). */
+export function navTableFocusNext(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = (state.focusRow + 1) % state.rows.length;
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+/** Move focus to the previous row (wraps around). */
+export function navTableFocusPrev(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = (state.focusRow - 1 + state.rows.length) % state.rows.length;
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+/** Move focus down by one page (clamps to last row). */
+export function navTablePageDown(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = Math.min(state.focusRow + state.height, state.rows.length - 1);
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+/** Move focus up by one page (clamps to first row). */
+export function navTablePageUp(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = Math.max(state.focusRow - state.height, 0);
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+// ---------------------------------------------------------------------------
+// Scroll helper
+// ---------------------------------------------------------------------------
+
+function adjustScroll(focusRow: number, scrollY: number, height: number, totalRows: number): number {
+  let newScrollY = scrollY;
+  if (focusRow < newScrollY) {
+    newScrollY = focusRow;
+  } else if (focusRow >= newScrollY + height) {
+    newScrollY = focusRow - height + 1;
+  }
+  const maxScroll = Math.max(0, totalRows - height);
+  return Math.min(newScrollY, maxScroll);
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the navigable table with a focus indicator on the focused row.
+ *
+ * Slices visible rows based on `scrollY` and `height`, prepends a focus
+ * indicator to the first column, then delegates to core `table()`.
+ */
+export function navigableTable(state: NavigableTableState, options?: NavTableRenderOptions): string {
+  if (state.rows.length === 0) {
+    return table({ columns: state.columns, rows: [], ctx: options?.ctx });
+  }
+
+  const indicator = options?.focusIndicator ?? '\u25b8';
+  const pad = ' '.repeat(indicator.length);
+
+  // Slice visible window
+  const visibleRows = state.rows.slice(state.scrollY, state.scrollY + state.height);
+
+  // Prepend focus indicator to first column
+  const decoratedRows = visibleRows.map((row, i) => {
+    const globalIndex = state.scrollY + i;
+    const prefix = globalIndex === state.focusRow ? indicator : pad;
+    const firstCol = `${prefix} ${row[0] ?? ''}`;
+    return [firstCol, ...row.slice(1)];
+  });
+
+  return table({
+    columns: state.columns,
+    rows: decoratedRows,
+    ctx: options?.ctx,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for navigable table navigation.
+ *
+ * The caller provides their own message types for each action:
+ * ```ts
+ * const keys = navTableKeyMap({
+ *   focusNext: { type: 'next-row' },
+ *   focusPrev: { type: 'prev-row' },
+ *   pageDown:  { type: 'page-down' },
+ *   pageUp:    { type: 'page-up' },
+ *   quit:      { type: 'quit' },
+ * });
+ * ```
+ */
+export function navTableKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  pageDown: Msg;
+  pageUp: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next row', actions.focusNext)
+      .bind('down', 'Next row', actions.focusNext)
+      .bind('k', 'Previous row', actions.focusPrev)
+      .bind('up', 'Previous row', actions.focusPrev)
+      .bind('d', 'Page down', actions.pageDown)
+      .bind('pagedown', 'Page down', actions.pageDown)
+      .bind('u', 'Page up', actions.pageUp)
+      .bind('pageup', 'Page up', actions.pageUp),
+    )
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}


### PR DESCRIPTION
## Summary
- Adds `navigableTable()` TUI building block following the state + pure transformers + render + keymap pattern
- Wraps bijou core's static `table()` with focus management, viewport scrolling, and focus indicator
- Provides `navTableFocusNext/Prev`, `navTablePageDown/Up` transformers
- Includes `navTableKeyMap()` with vim-style bindings

## Test plan
- [x] State creation with defaults and custom height
- [x] Focus next/prev with wrap-around
- [x] Page down/up with clamping
- [x] Scroll follows focus (auto-scroll)
- [x] Empty rows are no-ops
- [x] Render shows focus indicator
- [x] Render empty table
- [x] Keymap dispatches correct actions
- [x] Full test suite passes (912 tests)