### PR TITLE
feat(tui): add browsableList() rich navigable list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### TUI runtime (`@flyingrobots/bijou-tui`)
+
+- **`browsableList()`** — navigable list building block with focus tracking, scroll-aware viewport clipping, page navigation, description support, and convenience keymap (`j/k` navigate, `d/u` page, `Enter` select, `q` quit)
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/packages/bijou-tui/src/browsable-list.test.ts
+++ b/packages/bijou-tui/src/browsable-list.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createBrowsableListState,
+  listFocusNext,
+  listFocusPrev,
+  listPageDown,
+  listPageUp,
+  browsableList,
+  browsableListKeyMap,
+} from './browsable-list.js';
+
+describe('browsableList', () => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana', description: 'Yellow fruit' },
+    { label: 'Cherry', value: 'cherry' },
+    { label: 'Date', value: 'date' },
+    { label: 'Elderberry', value: 'elderberry' },
+  ];
+
+  describe('createBrowsableListState()', () => {
+    it('creates state with defaults', () => {
+      const state = createBrowsableListState({ items });
+      expect(state.focusIndex).toBe(0);
+      expect(state.scrollY).toBe(0);
+      expect(state.height).toBe(10);
+      expect(state.items).toBe(items);
+    });
+
+    it('accepts custom height', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      expect(state.height).toBe(3);
+    });
+  });
+
+  describe('focus navigation', () => {
+    it('focusNext moves to next item', () => {
+      const state = createBrowsableListState({ items });
+      const next = listFocusNext(state);
+      expect(next.focusIndex).toBe(1);
+    });
+
+    it('focusNext wraps around', () => {
+      let state = createBrowsableListState({ items });
+      for (let i = 0; i < items.length; i++) state = listFocusNext(state);
+      expect(state.focusIndex).toBe(0);
+    });
+
+    it('focusPrev moves to previous item', () => {
+      let state = createBrowsableListState({ items });
+      state = listFocusNext(state);
+      state = listFocusPrev(state);
+      expect(state.focusIndex).toBe(0);
+    });
+
+    it('focusPrev wraps around', () => {
+      const state = createBrowsableListState({ items });
+      const prev = listFocusPrev(state);
+      expect(prev.focusIndex).toBe(items.length - 1);
+    });
+
+    it('empty list is a no-op', () => {
+      const state = createBrowsableListState({ items: [] });
+      expect(listFocusNext(state)).toBe(state);
+      expect(listFocusPrev(state)).toBe(state);
+    });
+  });
+
+  describe('page navigation', () => {
+    it('pageDown moves by height', () => {
+      const state = createBrowsableListState({ items, height: 2 });
+      const paged = listPageDown(state);
+      expect(paged.focusIndex).toBe(2);
+    });
+
+    it('pageDown clamps to last item', () => {
+      const state = createBrowsableListState({ items, height: 10 });
+      const paged = listPageDown(state);
+      expect(paged.focusIndex).toBe(items.length - 1);
+    });
+
+    it('pageUp clamps to first item', () => {
+      const state = createBrowsableListState({ items, height: 10 });
+      const paged = listPageUp(state);
+      expect(paged.focusIndex).toBe(0);
+    });
+  });
+
+  describe('scroll follows focus', () => {
+    it('scrollY adjusts when focus goes below viewport', () => {
+      let state = createBrowsableListState({ items, height: 2 });
+      state = listFocusNext(state);
+      state = listFocusNext(state);
+      expect(state.scrollY).toBe(1);
+    });
+
+    it('scrollY adjusts when focus wraps to top', () => {
+      let state = createBrowsableListState({ items, height: 2 });
+      for (let i = 0; i < items.length; i++) state = listFocusNext(state);
+      expect(state.focusIndex).toBe(0);
+      expect(state.scrollY).toBe(0);
+    });
+  });
+
+  describe('render', () => {
+    it('shows focus indicator on focused item', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      const output = browsableList(state);
+      const lines = output.split('\n');
+      expect(lines[0]).toContain('\u25b8');
+      expect(lines[0]).toContain('Apple');
+      expect(lines[1]).toContain(' ');
+      expect(lines[1]).toContain('Banana');
+    });
+
+    it('renders description with em-dash', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      const output = browsableList(state);
+      expect(output).toContain('\u2014 Yellow fruit');
+    });
+
+    it('renders empty list as empty string', () => {
+      const state = createBrowsableListState({ items: [] });
+      const output = browsableList(state);
+      expect(output).toBe('');
+    });
+
+    it('custom focus indicator', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      const output = browsableList(state, { focusIndicator: '>' });
+      expect(output).toContain('>');
+    });
+
+    it('only shows items within viewport', () => {
+      const state = createBrowsableListState({ items, height: 2 });
+      const output = browsableList(state);
+      const lines = output.split('\n');
+      expect(lines).toHaveLength(2);
+      expect(output).toContain('Apple');
+      expect(output).toContain('Banana');
+      expect(output).not.toContain('Cherry');
+    });
+  });
+
+  describe('keymap', () => {
+    it('dispatches correct actions', () => {
+      const actions = {
+        focusNext: 'next',
+        focusPrev: 'prev',
+        pageDown: 'pd',
+        pageUp: 'pu',
+        select: 'sel',
+        quit: 'q',
+      };
+      const km = browsableListKeyMap(actions);
+      expect(km.handle({ key: 'j', ctrl: false, alt: false, shift: false })).toBe('next');
+      expect(km.handle({ key: 'k', ctrl: false, alt: false, shift: false })).toBe('prev');
+      expect(km.handle({ key: 'enter', ctrl: false, alt: false, shift: false })).toBe('sel');
+      expect(km.handle({ key: 'q', ctrl: false, alt: false, shift: false })).toBe('q');
+    });
+  });
+});

--- a/packages/bijou-tui/src/browsable-list.ts
+++ b/packages/bijou-tui/src/browsable-list.ts
@@ -1,0 +1,194 @@
+/**
+ * Browsable list building block — a scrollable, navigable list with focus tracking.
+ *
+ * Provides state transformers for focus and page navigation, a pure render
+ * function with viewport clipping, and a convenience keymap for vim-style
+ * navigation.
+ *
+ * ```ts
+ * // In TEA init:
+ * const listState = createBrowsableListState({ items, height: 10 });
+ *
+ * // In TEA view:
+ * const output = browsableList(model.listState);
+ *
+ * // In TEA update:
+ * case 'focus-next':
+ *   return [{ ...model, listState: listFocusNext(model.listState) }, []];
+ * case 'select':
+ *   const selected = model.listState.items[model.listState.focusIndex];
+ *   // handle selection...
+ * ```
+ */
+
+import type { BijouContext } from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BrowsableListItem<T = string> {
+  label: string;
+  value: T;
+  description?: string;
+}
+
+export interface BrowsableListState<T = string> {
+  readonly items: readonly BrowsableListItem<T>[];
+  readonly focusIndex: number;
+  readonly scrollY: number;
+  readonly height: number;
+}
+
+export interface BrowsableListOptions<T = string> {
+  readonly items: readonly BrowsableListItem<T>[];
+  readonly height?: number;
+}
+
+export interface BrowsableListRenderOptions {
+  readonly focusIndicator?: string;
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial browsable list state from items and optional height.
+ * Focus starts at index 0 with scroll at the top.
+ */
+export function createBrowsableListState<T = string>(
+  options: BrowsableListOptions<T>,
+): BrowsableListState<T> {
+  return {
+    items: options.items,
+    focusIndex: 0,
+    scrollY: 0,
+    height: options.height ?? 10,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Move focus to the next item (wraps around). */
+export function listFocusNext<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = (state.focusIndex + 1) % state.items.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+/** Move focus to the previous item (wraps around). */
+export function listFocusPrev<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = (state.focusIndex - 1 + state.items.length) % state.items.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+/** Move focus down by one page (clamps to last item). */
+export function listPageDown<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = Math.min(state.focusIndex + state.height, state.items.length - 1);
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+/** Move focus up by one page (clamps to first item). */
+export function listPageUp<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = Math.max(state.focusIndex - state.height, 0);
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+// ---------------------------------------------------------------------------
+// Scroll helper
+// ---------------------------------------------------------------------------
+
+function adjustScroll(focusIndex: number, scrollY: number, height: number, totalItems: number): number {
+  let newScrollY = scrollY;
+  if (focusIndex < newScrollY) {
+    newScrollY = focusIndex;
+  } else if (focusIndex >= newScrollY + height) {
+    newScrollY = focusIndex - height + 1;
+  }
+  const maxScroll = Math.max(0, totalItems - height);
+  return Math.min(newScrollY, maxScroll);
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the browsable list — visible items within the viewport with a
+ * focus indicator on the currently focused item.
+ *
+ * Items with a `description` field render as `label — description`.
+ */
+export function browsableList<T>(
+  state: BrowsableListState<T>,
+  options?: BrowsableListRenderOptions,
+): string {
+  if (state.items.length === 0) return '';
+
+  const indicator = options?.focusIndicator ?? '\u25b8';
+  const pad = ' '.repeat(indicator.length);
+
+  const visibleItems = state.items.slice(state.scrollY, state.scrollY + state.height);
+  const lines: string[] = [];
+
+  for (let i = 0; i < visibleItems.length; i++) {
+    const item = visibleItems[i]!;
+    const globalIndex = state.scrollY + i;
+    const prefix = globalIndex === state.focusIndex ? indicator : pad;
+    const desc = item.description ? ` \u2014 ${item.description}` : '';
+    lines.push(`${prefix} ${item.label}${desc}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for browsable list navigation.
+ *
+ * The caller provides their own message types for each action:
+ * ```ts
+ * const keys = browsableListKeyMap({
+ *   focusNext: { type: 'next' },
+ *   focusPrev: { type: 'prev' },
+ *   pageDown: { type: 'page-down' },
+ *   pageUp: { type: 'page-up' },
+ *   select: { type: 'select' },
+ *   quit: { type: 'quit' },
+ * });
+ * ```
+ */
+export function browsableListKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  pageDown: Msg;
+  pageUp: Msg;
+  select: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next item', actions.focusNext)
+      .bind('down', 'Next item', actions.focusNext)
+      .bind('k', 'Previous item', actions.focusPrev)
+      .bind('up', 'Previous item', actions.focusPrev)
+      .bind('d', 'Page down', actions.pageDown)
+      .bind('pagedown', 'Page down', actions.pageDown)
+      .bind('u', 'Page up', actions.pageUp)
+      .bind('pageup', 'Page up', actions.pageUp),
+    )
+    .bind('enter', 'Select', actions.select)
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -185,3 +185,18 @@ export {
   collapseAll,
   accordionKeyMap,
 } from './accordion.js';
+
+// Browsable list
+export {
+  type BrowsableListItem,
+  type BrowsableListState,
+  type BrowsableListOptions,
+  type BrowsableListRenderOptions,
+  createBrowsableListState,
+  browsableList,
+  listFocusNext,
+  listFocusPrev,
+  listPageDown,
+  listPageUp,
+  browsableListKeyMap,
+} from './browsable-list.js';


### PR DESCRIPTION
## Summary
- Adds `browsableList()` TUI building block following the state + pure transformers + render + keymap pattern
- Generic `BrowsableListItem<T>` with label, value, and optional description
- Focus navigation with wrap-around, page jumps, viewport scrolling
- Renders items with focus indicator and em-dash descriptions
- Includes `browsableListKeyMap()` with vim-style bindings plus enter-to-select

## Test plan
- [x] State creation with defaults and custom height
- [x] Focus next/prev with wrap-around
- [x] Page down/up with clamping
- [x] Empty list is a no-op
- [x] Scroll follows focus
- [x] Render with focus indicator and descriptions
- [x] Empty list renders empty string
- [x] Custom focus indicator
- [x] Viewport clipping (only visible items shown)
- [x] Keymap dispatches correct actions
- [x] Full test suite passes (914 tests)