### PR TITLE
feat(tui): add filePicker() directory browser

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,16 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`filePicker()`** — directory browser building block with focus navigation, scroll windowing, and extension filtering. Uses `IOPort.readDir()` for synchronous directory listing
+- **`createFilePickerState()`** — initializes picker state from a directory path and IO port
+- **`fpFocusNext()` / `fpFocusPrev()`** — focus navigation with wrap-around and scroll adjustment
+- **`fpEnter()` / `fpBack()`** — directory traversal (enter child / go to parent)
+- **`filePickerKeyMap()`** — preconfigured vim-style keybindings (j/k, arrows, enter, backspace)
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/packages/bijou-tui/src/file-picker.test.ts
+++ b/packages/bijou-tui/src/file-picker.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createFilePickerState,
+  fpFocusNext,
+  fpFocusPrev,
+  fpEnter,
+  fpBack,
+  filePicker,
+  filePickerKeyMap,
+} from './file-picker.js';
+import { mockIO } from '@flyingrobots/bijou/adapters/test';
+import type { KeyMsg } from './types.js';
+
+// NOTE: mockIO dirs entries use trailing '/' to indicate directories
+function createMockIO() {
+  return mockIO({
+    dirs: {
+      '/project': ['src/', 'README.md', 'package.json'],
+      '/project/src': ['index.ts', 'utils/'],
+      '/': ['project/', 'tmp/'],
+    },
+  });
+}
+
+function keyMsg(key: string, mods?: Partial<KeyMsg>): KeyMsg {
+  return { type: 'key', key, ctrl: false, alt: false, shift: false, ...mods };
+}
+
+// ── createFilePickerState ─────────────────────────────────────────
+
+describe('createFilePickerState', () => {
+  it('lists entries with dirs first', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    expect(state.entries[0]).toEqual({ name: 'src', isDirectory: true });
+    expect(state.entries[1]).toEqual({ name: 'package.json', isDirectory: false });
+    expect(state.entries[2]).toEqual({ name: 'README.md', isDirectory: false });
+  });
+
+  it('starts with focus at 0', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    expect(state.focusIndex).toBe(0);
+    expect(state.scrollY).toBe(0);
+  });
+
+  it('default height is 10', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    expect(state.height).toBe(10);
+  });
+});
+
+// ── focus navigation ──────────────────────────────────────────────
+
+describe('focus navigation', () => {
+  it('focusNext moves to next entry', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const next = fpFocusNext(state);
+    expect(next.focusIndex).toBe(1);
+  });
+
+  it('focusNext wraps around', () => {
+    const io = createMockIO();
+    let state = createFilePickerState({ cwd: '/project', io });
+    for (let i = 0; i < state.entries.length; i++) state = fpFocusNext(state);
+    expect(state.focusIndex).toBe(0);
+  });
+
+  it('focusPrev wraps around', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const prev = fpFocusPrev(state);
+    expect(prev.focusIndex).toBe(state.entries.length - 1);
+  });
+
+  it('focusNext is no-op on empty entries', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    expect(fpFocusNext(state).focusIndex).toBe(0);
+  });
+
+  it('focusPrev is no-op on empty entries', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    expect(fpFocusPrev(state).focusIndex).toBe(0);
+  });
+});
+
+// ── directory navigation ──────────────────────────────────────────
+
+describe('directory navigation', () => {
+  it('enter on directory changes cwd and refreshes entries', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    // First entry should be 'src' directory
+    const entered = fpEnter(state, io);
+    expect(entered.cwd).toBe('/project/src');
+    expect(entered.focusIndex).toBe(0);
+    expect(entered.entries.length).toBeGreaterThan(0);
+  });
+
+  it('enter on file is a no-op', () => {
+    const io = createMockIO();
+    let state = createFilePickerState({ cwd: '/project', io });
+    // Move to a file entry
+    state = fpFocusNext(state); // package.json (file)
+    const result = fpEnter(state, io);
+    expect(result.cwd).toBe('/project');
+  });
+
+  it('enter on empty entries is a no-op', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    const result = fpEnter(state, io);
+    expect(result.cwd).toBe('/empty');
+  });
+
+  it('back goes to parent directory', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project/src', io });
+    const backed = fpBack(state, io);
+    expect(backed.cwd).toBe('/project');
+  });
+
+  it('back at root is a no-op', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/', io });
+    const backed = fpBack(state, io);
+    expect(backed.cwd).toBe('/');
+  });
+});
+
+// ── extension filter ──────────────────────────────────────────────
+
+describe('extension filter', () => {
+  it('hides non-matching files', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io, filter: '.md' });
+    const fileEntries = state.entries.filter(e => !e.isDirectory);
+    expect(fileEntries.every(e => e.name.endsWith('.md'))).toBe(true);
+    expect(fileEntries.some(e => e.name === 'README.md')).toBe(true);
+  });
+
+  it('directories are always shown', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io, filter: '.md' });
+    const dirEntries = state.entries.filter(e => e.isDirectory);
+    expect(dirEntries.length).toBeGreaterThan(0);
+  });
+
+  it('filter is preserved across directory navigation', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io, filter: '.ts' });
+    const entered = fpEnter(state, io);
+    // /project/src has index.ts and utils/ — filter should keep .ts files
+    const fileEntries = entered.entries.filter(e => !e.isDirectory);
+    expect(fileEntries.every(e => e.name.endsWith('.ts'))).toBe(true);
+  });
+});
+
+// ── empty directory ───────────────────────────────────────────────
+
+describe('empty directory', () => {
+  it('renders empty message', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    expect(state.entries).toEqual([]);
+    const output = filePicker(state);
+    expect(output).toContain('(empty)');
+  });
+});
+
+// ── render ────────────────────────────────────────────────────────
+
+describe('render', () => {
+  it('shows cwd as header', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('/project');
+  });
+
+  it('shows focus indicator on focused entry', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('\u25b8');
+  });
+
+  it('shows directory indicator', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('d src/');
+  });
+
+  it('shows file indicator', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('- package.json');
+  });
+
+  it('uses custom indicators', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state, {
+      focusIndicator: '>>',
+      dirIndicator: 'D',
+      fileIndicator: 'F',
+    });
+    expect(output).toContain('>> D src/');
+    expect(output).toContain('F package.json');
+  });
+
+  it('respects scroll window', () => {
+    const io = mockIO({
+      dirs: {
+        '/many': ['a/', 'b/', 'c/', 'd.txt', 'e.txt', 'f.txt'],
+      },
+    });
+    const state = createFilePickerState({ cwd: '/many', io, height: 3 });
+    const output = filePicker(state);
+    const lines = output.split('\n');
+    // header + 3 visible entries = 4 lines
+    expect(lines).toHaveLength(4);
+  });
+});
+
+// ── scroll adjustment ─────────────────────────────────────────────
+
+describe('scroll adjustment', () => {
+  it('scrolls down when focus moves past viewport', () => {
+    const io = mockIO({
+      dirs: {
+        '/many': ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'],
+      },
+    });
+    let state = createFilePickerState({ cwd: '/many', io, height: 2 });
+    state = fpFocusNext(state); // index 1
+    state = fpFocusNext(state); // index 2 — should trigger scroll
+    expect(state.scrollY).toBe(1);
+  });
+
+  it('scrolls up when focus wraps to top', () => {
+    const io = mockIO({
+      dirs: {
+        '/many': ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'],
+      },
+    });
+    let state = createFilePickerState({ cwd: '/many', io, height: 2 });
+    // Move to end
+    for (let i = 0; i < 5; i++) state = fpFocusNext(state);
+    // Now at index 0 (wrapped), scrollY should reset
+    expect(state.focusIndex).toBe(0);
+    expect(state.scrollY).toBe(0);
+  });
+});
+
+// ── keymap ────────────────────────────────────────────────────────
+
+describe('filePickerKeyMap', () => {
+  const actions = {
+    focusNext: 'next' as const,
+    focusPrev: 'prev' as const,
+    enter: 'enter' as const,
+    back: 'back' as const,
+    quit: 'quit' as const,
+  };
+
+  const km = filePickerKeyMap(actions);
+
+  it('handles j/k for navigation', () => {
+    expect(km.handle(keyMsg('j'))).toBe('next');
+    expect(km.handle(keyMsg('k'))).toBe('prev');
+  });
+
+  it('handles arrow keys', () => {
+    expect(km.handle(keyMsg('down'))).toBe('next');
+    expect(km.handle(keyMsg('up'))).toBe('prev');
+  });
+
+  it('handles enter for directory entry', () => {
+    expect(km.handle(keyMsg('enter'))).toBe('enter');
+  });
+
+  it('handles backspace and left for parent directory', () => {
+    expect(km.handle(keyMsg('backspace'))).toBe('back');
+    expect(km.handle(keyMsg('left'))).toBe('back');
+  });
+
+  it('handles quit', () => {
+    expect(km.handle(keyMsg('q'))).toBe('quit');
+    expect(km.handle(keyMsg('c', { ctrl: true }))).toBe('quit');
+  });
+
+  it('returns undefined for unbound keys', () => {
+    expect(km.handle(keyMsg('x'))).toBeUndefined();
+  });
+});

--- a/packages/bijou-tui/src/file-picker.ts
+++ b/packages/bijou-tui/src/file-picker.ts
@@ -1,0 +1,255 @@
+/**
+ * File picker building block — a directory browser with focus navigation.
+ *
+ * Uses `IOPort.readDir()` to list directory contents and `IOPort.joinPath()`
+ * to navigate between directories. Follows the same state + pure transformers
+ * + sync render + convenience keymap pattern as pager and accordion.
+ *
+ * ```ts
+ * // In TEA init:
+ * const fpState = createFilePickerState({ cwd: '/project', io });
+ *
+ * // In TEA view:
+ * const output = filePicker(model.fpState);
+ *
+ * // In TEA update:
+ * case 'focus-next':
+ *   return [{ ...model, fpState: fpFocusNext(model.fpState) }, []];
+ * case 'enter':
+ *   return [{ ...model, fpState: fpEnter(model.fpState, io) }, []];
+ * ```
+ */
+
+import type { IOPort } from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FileEntry {
+  name: string;
+  isDirectory: boolean;
+}
+
+export interface FilePickerState {
+  readonly cwd: string;
+  readonly entries: readonly FileEntry[];
+  readonly focusIndex: number;
+  readonly scrollY: number;
+  readonly height: number;
+  readonly filter?: string;
+}
+
+export interface FilePickerOptions {
+  readonly cwd: string;
+  readonly io: IOPort;
+  readonly height?: number;
+  readonly filter?: string;
+}
+
+export interface FilePickerRenderOptions {
+  readonly focusIndicator?: string;
+  readonly dirIndicator?: string;
+  readonly fileIndicator?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseEntries(names: string[], filter?: string): FileEntry[] {
+  const dirs: FileEntry[] = [];
+  const files: FileEntry[] = [];
+
+  for (const name of names) {
+    if (name.endsWith('/')) {
+      dirs.push({ name: name.slice(0, -1), isDirectory: true });
+    } else {
+      if (filter && !name.endsWith(filter)) continue;
+      files.push({ name, isDirectory: false });
+    }
+  }
+
+  // Sort dirs first, then files, both alphabetically
+  dirs.sort((a, b) => a.name.localeCompare(b.name));
+  files.sort((a, b) => a.name.localeCompare(b.name));
+
+  return [...dirs, ...files];
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial file picker state for the given directory.
+ *
+ * Reads directory contents via `io.readDir()` and parses entries into
+ * directories (trailing `/`) and files. Directories are sorted first,
+ * then files, both alphabetically.
+ */
+export function createFilePickerState(options: FilePickerOptions): FilePickerState {
+  const names = options.io.readDir(options.cwd);
+  const entries = parseEntries(names, options.filter);
+
+  return {
+    cwd: options.cwd,
+    entries,
+    focusIndex: 0,
+    scrollY: 0,
+    height: options.height ?? 10,
+    filter: options.filter,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Move focus to the next entry (wraps around). */
+export function fpFocusNext(state: FilePickerState): FilePickerState {
+  if (state.entries.length === 0) return state;
+  const focusIndex = (state.focusIndex + 1) % state.entries.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.entries.length) };
+}
+
+/** Move focus to the previous entry (wraps around). */
+export function fpFocusPrev(state: FilePickerState): FilePickerState {
+  if (state.entries.length === 0) return state;
+  const focusIndex = (state.focusIndex - 1 + state.entries.length) % state.entries.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.entries.length) };
+}
+
+/** Enter the focused directory, refreshing the entry list. No-op on files. */
+export function fpEnter(state: FilePickerState, io: IOPort): FilePickerState {
+  if (state.entries.length === 0) return state;
+  const entry = state.entries[state.focusIndex];
+  if (!entry || !entry.isDirectory) return state;
+
+  const newCwd = io.joinPath(state.cwd, entry.name);
+  const names = io.readDir(newCwd);
+  const entries = parseEntries(names, state.filter);
+
+  return {
+    ...state,
+    cwd: newCwd,
+    entries,
+    focusIndex: 0,
+    scrollY: 0,
+  };
+}
+
+/** Navigate to the parent directory. No-op at filesystem root. */
+export function fpBack(state: FilePickerState, io: IOPort): FilePickerState {
+  // Go to parent directory
+  const parts = state.cwd.split('/').filter(Boolean);
+  if (parts.length === 0) return state;
+  parts.pop();
+  const newCwd = '/' + parts.join('/');
+
+  const names = io.readDir(newCwd);
+  const entries = parseEntries(names, state.filter);
+
+  return {
+    ...state,
+    cwd: newCwd,
+    entries,
+    focusIndex: 0,
+    scrollY: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scroll helper
+// ---------------------------------------------------------------------------
+
+function adjustScroll(focusIndex: number, scrollY: number, height: number, totalItems: number): number {
+  let newScrollY = scrollY;
+  if (focusIndex < newScrollY) {
+    newScrollY = focusIndex;
+  } else if (focusIndex >= newScrollY + height) {
+    newScrollY = focusIndex - height + 1;
+  }
+  const maxScroll = Math.max(0, totalItems - height);
+  return Math.min(newScrollY, maxScroll);
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the file picker — cwd header followed by the visible entry list.
+ *
+ * Each entry is prefixed with a focus indicator and a type indicator
+ * (directory or file). Directories are suffixed with `/`.
+ */
+export function filePicker(state: FilePickerState, options?: FilePickerRenderOptions): string {
+  const indicator = options?.focusIndicator ?? '\u25b8';
+  const dirIcon = options?.dirIndicator ?? 'd';
+  const fileIcon = options?.fileIndicator ?? '-';
+  const pad = ' '.repeat(indicator.length);
+
+  const lines: string[] = [];
+  lines.push(state.cwd);
+
+  if (state.entries.length === 0) {
+    lines.push('  (empty)');
+    return lines.join('\n');
+  }
+
+  const visibleEntries = state.entries.slice(state.scrollY, state.scrollY + state.height);
+
+  for (let i = 0; i < visibleEntries.length; i++) {
+    const entry = visibleEntries[i]!;
+    const globalIndex = state.scrollY + i;
+    const prefix = globalIndex === state.focusIndex ? indicator : pad;
+    const icon = entry.isDirectory ? dirIcon : fileIcon;
+    const suffix = entry.isDirectory ? '/' : '';
+    lines.push(`${prefix} ${icon} ${entry.name}${suffix}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for file picker navigation.
+ *
+ * The caller provides their own message types for each action:
+ * ```ts
+ * const keys = filePickerKeyMap({
+ *   focusNext: { type: 'next' },
+ *   focusPrev: { type: 'prev' },
+ *   enter: { type: 'enter' },
+ *   back: { type: 'back' },
+ *   quit: { type: 'quit' },
+ * });
+ * ```
+ */
+export function filePickerKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  enter: Msg;
+  back: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next entry', actions.focusNext)
+      .bind('down', 'Next entry', actions.focusNext)
+      .bind('k', 'Previous entry', actions.focusPrev)
+      .bind('up', 'Previous entry', actions.focusPrev),
+    )
+    .group('Actions', (g) => g
+      .bind('enter', 'Enter directory / select file', actions.enter)
+      .bind('backspace', 'Parent directory', actions.back)
+      .bind('left', 'Parent directory', actions.back),
+    )
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -185,3 +185,18 @@ export {
   collapseAll,
   accordionKeyMap,
 } from './accordion.js';
+
+// File picker
+export {
+  type FileEntry,
+  type FilePickerState,
+  type FilePickerOptions,
+  type FilePickerRenderOptions,
+  createFilePickerState,
+  filePicker,
+  fpFocusNext,
+  fpFocusPrev,
+  fpEnter,
+  fpBack,
+  filePickerKeyMap,
+} from './file-picker.js';


### PR DESCRIPTION
## Summary
- Adds `filePicker()` TUI building block following the state + pure transformers + render + keymap pattern
- Uses `IOPort.readDir()` to list directory contents, sorts dirs-first then alphabetical
- `fpEnter()` navigates into directories, `fpBack()` goes to parent
- Optional extension filter hides non-matching files while preserving directories
- Includes `filePickerKeyMap()` with vim-style nav, enter/backspace for dir traversal

## Test plan
- [x] State creation lists entries (dirs first, alphabetical)
- [x] Focus navigation with wrap-around
- [x] Enter on directory → cwd changes, entries refresh
- [x] Enter on file → no-op
- [x] Back → parent directory
- [x] Back at root → no-op
- [x] Extension filter hides non-matching files, preserves dirs
- [x] Empty directory renders "(empty)" message
- [x] Render shows cwd header, focus/type indicators
- [x] Scroll follows focus
- [x] Keymap dispatches correct actions
- [x] Full test suite passes (927 tests)