### PR TITLE
fix: move bijou to peerDependencies in bijou-node and bijou-tui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ npm-debug.log*
 
 # Misc
 *.tgz
+.claude/worktrees/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@flyingrobots/bijou-node` and `@flyingrobots/bijou-tui` dual-package hazard** — moved `@flyingrobots/bijou` from `dependencies` to `peerDependencies` so downstream consumers get a single shared instance, preventing split `setDefaultContext()` state
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,7 +1569,7 @@
     },
     "packages/bijou": {
       "name": "@flyingrobots/bijou",
-      "version": "0.2.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1582,10 +1582,9 @@
     },
     "packages/bijou-node": {
       "name": "@flyingrobots/bijou-node",
-      "version": "0.2.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@flyingrobots/bijou": "0.2.0",
         "chalk": "^5.6.2"
       },
       "devDependencies": {
@@ -1594,15 +1593,15 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@flyingrobots/bijou": "^0.5.0"
       }
     },
     "packages/bijou-tui": {
       "name": "@flyingrobots/bijou-tui",
-      "version": "0.2.0",
+      "version": "0.5.0",
       "license": "MIT",
-      "dependencies": {
-        "@flyingrobots/bijou": "0.2.0"
-      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.9.3",
@@ -1610,6 +1609,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@flyingrobots/bijou": "^0.5.0"
       }
     }
   }

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -24,8 +24,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "0.5.0",
     "chalk": "^5.6.2"
+  },
+  "peerDependencies": {
+    "@flyingrobots/bijou": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -23,8 +23,8 @@
     "prepack": "tsc -b",
     "lint": "tsc --noEmit"
   },
-  "dependencies": {
-    "@flyingrobots/bijou": "0.5.0"
+  "peerDependencies": {
+    "@flyingrobots/bijou": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- Moves `@flyingrobots/bijou` from `dependencies` to `peerDependencies` in both `bijou-node` and `bijou-tui`
- Prevents the dual-package hazard where npm installs separate copies, causing `setDefaultContext()` to only configure one instance while the other package uses an unconfigured default
- Uses `^0.5.0` range to allow patch/minor updates without forcing exact version match

## Test plan
- [x] `npm install` resolves correctly in the workspace
- [x] `npm run build` passes
- [x] All 896 tests pass