### PR TITLE
feat: v0.6.0 — dag stats, wizard, TUI building blocks, test hardening

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -240,7 +240,9 @@ First public release.
 - **Screen control** — `enterScreen()`, `exitScreen()`, `clearAndHome()`, `renderFrame()`
 - **Layout helpers** — `vstack()`, `hstack()`
 
-[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/flyingrobots/bijou/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/flyingrobots/bijou/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/flyingrobots/bijou/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/flyingrobots/bijou/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/flyingrobots/bijou/releases/tag/v0.3.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,20 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`fpEnter()` / `fpBack()`** — directory traversal (enter child / go to parent)
 - **`filePickerKeyMap()`** — preconfigured vim-style keybindings (j/k, arrows, enter, backspace)
 
+### Fixed
+
+#### Node adapter (`@flyingrobots/bijou-node`)
+
+- **`nodeIO().readDir()` directory classification** — entries are now suffixed with `/` for directories (via `statSync`), matching the `IOPort` contract that `filePicker()` relies on; previously `readdirSync()` returned bare names causing all directories to be misclassified as files
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`filePicker()` unreadable directory crash** — `createFilePickerState()`, `fpEnter()`, and `fpBack()` now gracefully return empty entries instead of throwing when `readDir()` fails on an unreadable directory
+- **`filePicker()` / `browsableList()` / `navigableTable()` viewport height** — `height` is now clamped to a minimum of 1, preventing invalid scroll/paging behavior with zero or negative values
+- **`browsableList()` items mutation safety** — `createBrowsableListState()` now defensively copies items, consistent with navigable-table
+- **`navigableTable()` deep row copy** — `createNavigableTableState()` now deep-copies rows (inner arrays) to prevent external mutation leaking into state
+- **`fpBack()` cross-platform paths** — parent directory resolution now uses `io.joinPath()` instead of hardcoded `/` separator
+
 ### Tests
 
 - **Form edge-case hardening** — added confirm/input empty-answer tests in interactive mode, multiselect toggle-on-off and last-item navigation tests

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,16 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`filePicker()`** — directory browser building block with focus navigation, scroll windowing, and extension filtering. Uses `IOPort.readDir()` for synchronous directory listing
+- **`createFilePickerState()`** — initializes picker state from a directory path and IO port
+- **`fpFocusNext()` / `fpFocusPrev()`** — focus navigation with wrap-around and scroll adjustment
+- **`fpEnter()` / `fpBack()`** — directory traversal (enter child / go to parent)
+- **`filePickerKeyMap()`** — preconfigured vim-style keybindings (j/k, arrows, enter, backspace)
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### TUI runtime (`@flyingrobots/bijou-tui`)
+
+- **`browsableList()`** — navigable list building block with focus tracking, scroll-aware viewport clipping, page navigation, description support, and convenience keymap (`j/k` navigate, `d/u` page, `Enter` select, `q` quit)
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-02-27
+
 ### Added
 
 #### Core (`@flyingrobots/bijou`)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,16 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`navigableTable()`** — keyboard-navigable table wrapping core `table()` with focus management, vertical scrolling, and vim-style keybindings (`j`/`k`, `d`/`u`, page up/down)
+- **`createNavigableTableState()`** — factory for navigable table state with configurable viewport height
+- **`navTableFocusNext()` / `navTableFocusPrev()`** — row focus with wrap-around
+- **`navTablePageDown()` / `navTablePageUp()`** — page-sized jumps with clamping
+- **`navTableKeyMap()`** — preconfigured keybinding map for table navigation
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`wizard()`** — multi-step form orchestrator that runs steps sequentially, passes accumulated values to each step, and supports conditional skipping via `skip` predicates
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`dagStats()`** — pure graph statistics (nodes, edges, depth, width, roots, leaves) with cycle detection, ghost-node filtering, and `SlicedDagSource` support
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Tests
+
+- **Form edge-case hardening** — added confirm/input empty-answer tests in interactive mode, multiselect toggle-on-off and last-item navigation tests
+- **Environment integration matrix** — added form fallback tests for pipe and accessible modes, component × mode matrix, NO_COLOR × component matrix, and CI=true TTY detection variants
+
 ## [0.5.0] — 2026-02-27
 
 ### Added

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -27,7 +27,7 @@
     "chalk": "^5.6.2"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.5.1"
+    "@flyingrobots/bijou": "0.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { nodeIO } from './io.js';
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -43,6 +43,19 @@ describe('nodeIO()', () => {
     const entries = io.readDir(tempDir);
     expect(entries).toContain('a.txt');
     expect(entries).toContain('b.txt');
+  });
+
+  it('readDir() appends trailing / to directories', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bijou-test-'));
+    mkdirSync(join(tempDir, 'subdir'));
+    writeFileSync(join(tempDir, 'file.txt'), '');
+
+    const io = nodeIO();
+    const entries = io.readDir(tempDir);
+    expect(entries).toContain('subdir/');
+    expect(entries).not.toContain('subdir');
+    expect(entries).toContain('file.txt');
+    expect(entries).not.toContain('file.txt/');
   });
 
   it('readDir() throws for missing directory', () => {

--- a/packages/bijou-node/src/io.ts
+++ b/packages/bijou-node/src/io.ts
@@ -1,5 +1,5 @@
 import * as readline from 'readline';
-import { readFileSync, readdirSync } from 'fs';
+import { readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import type { IOPort, RawInputHandle, TimerHandle } from '@flyingrobots/bijou';
 
@@ -63,8 +63,14 @@ export function nodeIO(): IOPort {
       return readFileSync(path, 'utf8');
     },
 
-    readDir(path: string): string[] {
-      return readdirSync(path);
+    readDir(dirPath: string): string[] {
+      return readdirSync(dirPath).map((name) => {
+        try {
+          return statSync(join(dirPath, name)).isDirectory() ? name + '/' : name;
+        } catch {
+          return name;
+        }
+      });
     },
 
     joinPath(...segments: string[]): string {

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.5.1"
+    "@flyingrobots/bijou": "0.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/src/browsable-list.test.ts
+++ b/packages/bijou-tui/src/browsable-list.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createBrowsableListState,
+  listFocusNext,
+  listFocusPrev,
+  listPageDown,
+  listPageUp,
+  browsableList,
+  browsableListKeyMap,
+} from './browsable-list.js';
+
+describe('browsableList', () => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana', description: 'Yellow fruit' },
+    { label: 'Cherry', value: 'cherry' },
+    { label: 'Date', value: 'date' },
+    { label: 'Elderberry', value: 'elderberry' },
+  ];
+
+  describe('createBrowsableListState()', () => {
+    it('creates state with defaults', () => {
+      const state = createBrowsableListState({ items });
+      expect(state.focusIndex).toBe(0);
+      expect(state.scrollY).toBe(0);
+      expect(state.height).toBe(10);
+      expect(state.items).toBe(items);
+    });
+
+    it('accepts custom height', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      expect(state.height).toBe(3);
+    });
+  });
+
+  describe('focus navigation', () => {
+    it('focusNext moves to next item', () => {
+      const state = createBrowsableListState({ items });
+      const next = listFocusNext(state);
+      expect(next.focusIndex).toBe(1);
+    });
+
+    it('focusNext wraps around', () => {
+      let state = createBrowsableListState({ items });
+      for (let i = 0; i < items.length; i++) state = listFocusNext(state);
+      expect(state.focusIndex).toBe(0);
+    });
+
+    it('focusPrev moves to previous item', () => {
+      let state = createBrowsableListState({ items });
+      state = listFocusNext(state);
+      state = listFocusPrev(state);
+      expect(state.focusIndex).toBe(0);
+    });
+
+    it('focusPrev wraps around', () => {
+      const state = createBrowsableListState({ items });
+      const prev = listFocusPrev(state);
+      expect(prev.focusIndex).toBe(items.length - 1);
+    });
+
+    it('empty list is a no-op', () => {
+      const state = createBrowsableListState({ items: [] });
+      expect(listFocusNext(state)).toBe(state);
+      expect(listFocusPrev(state)).toBe(state);
+    });
+  });
+
+  describe('page navigation', () => {
+    it('pageDown moves by height', () => {
+      const state = createBrowsableListState({ items, height: 2 });
+      const paged = listPageDown(state);
+      expect(paged.focusIndex).toBe(2);
+    });
+
+    it('pageDown clamps to last item', () => {
+      const state = createBrowsableListState({ items, height: 10 });
+      const paged = listPageDown(state);
+      expect(paged.focusIndex).toBe(items.length - 1);
+    });
+
+    it('pageUp clamps to first item', () => {
+      const state = createBrowsableListState({ items, height: 10 });
+      const paged = listPageUp(state);
+      expect(paged.focusIndex).toBe(0);
+    });
+  });
+
+  describe('scroll follows focus', () => {
+    it('scrollY adjusts when focus goes below viewport', () => {
+      let state = createBrowsableListState({ items, height: 2 });
+      state = listFocusNext(state);
+      state = listFocusNext(state);
+      expect(state.scrollY).toBe(1);
+    });
+
+    it('scrollY adjusts when focus wraps to top', () => {
+      let state = createBrowsableListState({ items, height: 2 });
+      for (let i = 0; i < items.length; i++) state = listFocusNext(state);
+      expect(state.focusIndex).toBe(0);
+      expect(state.scrollY).toBe(0);
+    });
+  });
+
+  describe('render', () => {
+    it('shows focus indicator on focused item', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      const output = browsableList(state);
+      const lines = output.split('\n');
+      expect(lines[0]).toContain('\u25b8');
+      expect(lines[0]).toContain('Apple');
+      expect(lines[1]).toContain(' ');
+      expect(lines[1]).toContain('Banana');
+    });
+
+    it('renders description with em-dash', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      const output = browsableList(state);
+      expect(output).toContain('\u2014 Yellow fruit');
+    });
+
+    it('renders empty list as empty string', () => {
+      const state = createBrowsableListState({ items: [] });
+      const output = browsableList(state);
+      expect(output).toBe('');
+    });
+
+    it('custom focus indicator', () => {
+      const state = createBrowsableListState({ items, height: 3 });
+      const output = browsableList(state, { focusIndicator: '>' });
+      expect(output).toContain('>');
+    });
+
+    it('only shows items within viewport', () => {
+      const state = createBrowsableListState({ items, height: 2 });
+      const output = browsableList(state);
+      const lines = output.split('\n');
+      expect(lines).toHaveLength(2);
+      expect(output).toContain('Apple');
+      expect(output).toContain('Banana');
+      expect(output).not.toContain('Cherry');
+    });
+  });
+
+  describe('keymap', () => {
+    it('dispatches correct actions', () => {
+      const actions = {
+        focusNext: 'next',
+        focusPrev: 'prev',
+        pageDown: 'pd',
+        pageUp: 'pu',
+        select: 'sel',
+        quit: 'q',
+      };
+      const km = browsableListKeyMap(actions);
+      expect(km.handle({ key: 'j', ctrl: false, alt: false, shift: false })).toBe('next');
+      expect(km.handle({ key: 'k', ctrl: false, alt: false, shift: false })).toBe('prev');
+      expect(km.handle({ key: 'enter', ctrl: false, alt: false, shift: false })).toBe('sel');
+      expect(km.handle({ key: 'q', ctrl: false, alt: false, shift: false })).toBe('q');
+    });
+  });
+});

--- a/packages/bijou-tui/src/browsable-list.test.ts
+++ b/packages/bijou-tui/src/browsable-list.test.ts
@@ -24,12 +24,22 @@ describe('browsableList', () => {
       expect(state.focusIndex).toBe(0);
       expect(state.scrollY).toBe(0);
       expect(state.height).toBe(10);
-      expect(state.items).toBe(items);
+      expect(state.items).toEqual(items);
     });
 
     it('accepts custom height', () => {
       const state = createBrowsableListState({ items, height: 3 });
       expect(state.height).toBe(3);
+    });
+
+    it('clamps height to 1 when 0 is provided', () => {
+      const state = createBrowsableListState({ items, height: 0 });
+      expect(state.height).toBe(1);
+    });
+
+    it('clamps negative height to 1', () => {
+      const state = createBrowsableListState({ items, height: -5 });
+      expect(state.height).toBe(1);
     });
   });
 

--- a/packages/bijou-tui/src/browsable-list.ts
+++ b/packages/bijou-tui/src/browsable-list.ts
@@ -62,11 +62,12 @@ export interface BrowsableListRenderOptions {
 export function createBrowsableListState<T = string>(
   options: BrowsableListOptions<T>,
 ): BrowsableListState<T> {
+  const height = Math.max(1, options.height ?? 10);
   return {
-    items: options.items,
+    items: [...options.items],
     focusIndex: 0,
     scrollY: 0,
-    height: options.height ?? 10,
+    height,
   };
 }
 

--- a/packages/bijou-tui/src/browsable-list.ts
+++ b/packages/bijou-tui/src/browsable-list.ts
@@ -1,0 +1,194 @@
+/**
+ * Browsable list building block — a scrollable, navigable list with focus tracking.
+ *
+ * Provides state transformers for focus and page navigation, a pure render
+ * function with viewport clipping, and a convenience keymap for vim-style
+ * navigation.
+ *
+ * ```ts
+ * // In TEA init:
+ * const listState = createBrowsableListState({ items, height: 10 });
+ *
+ * // In TEA view:
+ * const output = browsableList(model.listState);
+ *
+ * // In TEA update:
+ * case 'focus-next':
+ *   return [{ ...model, listState: listFocusNext(model.listState) }, []];
+ * case 'select':
+ *   const selected = model.listState.items[model.listState.focusIndex];
+ *   // handle selection...
+ * ```
+ */
+
+import type { BijouContext } from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BrowsableListItem<T = string> {
+  label: string;
+  value: T;
+  description?: string;
+}
+
+export interface BrowsableListState<T = string> {
+  readonly items: readonly BrowsableListItem<T>[];
+  readonly focusIndex: number;
+  readonly scrollY: number;
+  readonly height: number;
+}
+
+export interface BrowsableListOptions<T = string> {
+  readonly items: readonly BrowsableListItem<T>[];
+  readonly height?: number;
+}
+
+export interface BrowsableListRenderOptions {
+  readonly focusIndicator?: string;
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial browsable list state from items and optional height.
+ * Focus starts at index 0 with scroll at the top.
+ */
+export function createBrowsableListState<T = string>(
+  options: BrowsableListOptions<T>,
+): BrowsableListState<T> {
+  return {
+    items: options.items,
+    focusIndex: 0,
+    scrollY: 0,
+    height: options.height ?? 10,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Move focus to the next item (wraps around). */
+export function listFocusNext<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = (state.focusIndex + 1) % state.items.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+/** Move focus to the previous item (wraps around). */
+export function listFocusPrev<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = (state.focusIndex - 1 + state.items.length) % state.items.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+/** Move focus down by one page (clamps to last item). */
+export function listPageDown<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = Math.min(state.focusIndex + state.height, state.items.length - 1);
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+/** Move focus up by one page (clamps to first item). */
+export function listPageUp<T>(state: BrowsableListState<T>): BrowsableListState<T> {
+  if (state.items.length === 0) return state;
+  const focusIndex = Math.max(state.focusIndex - state.height, 0);
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.items.length) };
+}
+
+// ---------------------------------------------------------------------------
+// Scroll helper
+// ---------------------------------------------------------------------------
+
+function adjustScroll(focusIndex: number, scrollY: number, height: number, totalItems: number): number {
+  let newScrollY = scrollY;
+  if (focusIndex < newScrollY) {
+    newScrollY = focusIndex;
+  } else if (focusIndex >= newScrollY + height) {
+    newScrollY = focusIndex - height + 1;
+  }
+  const maxScroll = Math.max(0, totalItems - height);
+  return Math.min(newScrollY, maxScroll);
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the browsable list — visible items within the viewport with a
+ * focus indicator on the currently focused item.
+ *
+ * Items with a `description` field render as `label — description`.
+ */
+export function browsableList<T>(
+  state: BrowsableListState<T>,
+  options?: BrowsableListRenderOptions,
+): string {
+  if (state.items.length === 0) return '';
+
+  const indicator = options?.focusIndicator ?? '\u25b8';
+  const pad = ' '.repeat(indicator.length);
+
+  const visibleItems = state.items.slice(state.scrollY, state.scrollY + state.height);
+  const lines: string[] = [];
+
+  for (let i = 0; i < visibleItems.length; i++) {
+    const item = visibleItems[i]!;
+    const globalIndex = state.scrollY + i;
+    const prefix = globalIndex === state.focusIndex ? indicator : pad;
+    const desc = item.description ? ` \u2014 ${item.description}` : '';
+    lines.push(`${prefix} ${item.label}${desc}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for browsable list navigation.
+ *
+ * The caller provides their own message types for each action:
+ * ```ts
+ * const keys = browsableListKeyMap({
+ *   focusNext: { type: 'next' },
+ *   focusPrev: { type: 'prev' },
+ *   pageDown: { type: 'page-down' },
+ *   pageUp: { type: 'page-up' },
+ *   select: { type: 'select' },
+ *   quit: { type: 'quit' },
+ * });
+ * ```
+ */
+export function browsableListKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  pageDown: Msg;
+  pageUp: Msg;
+  select: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next item', actions.focusNext)
+      .bind('down', 'Next item', actions.focusNext)
+      .bind('k', 'Previous item', actions.focusPrev)
+      .bind('up', 'Previous item', actions.focusPrev)
+      .bind('d', 'Page down', actions.pageDown)
+      .bind('pagedown', 'Page down', actions.pageDown)
+      .bind('u', 'Page up', actions.pageUp)
+      .bind('pageup', 'Page up', actions.pageUp),
+    )
+    .bind('enter', 'Select', actions.select)
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/file-picker.test.ts
+++ b/packages/bijou-tui/src/file-picker.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createFilePickerState,
+  fpFocusNext,
+  fpFocusPrev,
+  fpEnter,
+  fpBack,
+  filePicker,
+  filePickerKeyMap,
+} from './file-picker.js';
+import { mockIO } from '@flyingrobots/bijou/adapters/test';
+import type { KeyMsg } from './types.js';
+
+// NOTE: mockIO dirs entries use trailing '/' to indicate directories
+function createMockIO() {
+  return mockIO({
+    dirs: {
+      '/project': ['src/', 'README.md', 'package.json'],
+      '/project/src': ['index.ts', 'utils/'],
+      '/': ['project/', 'tmp/'],
+    },
+  });
+}
+
+function keyMsg(key: string, mods?: Partial<KeyMsg>): KeyMsg {
+  return { type: 'key', key, ctrl: false, alt: false, shift: false, ...mods };
+}
+
+// ── createFilePickerState ─────────────────────────────────────────
+
+describe('createFilePickerState', () => {
+  it('lists entries with dirs first', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    expect(state.entries[0]).toEqual({ name: 'src', isDirectory: true });
+    expect(state.entries[1]).toEqual({ name: 'package.json', isDirectory: false });
+    expect(state.entries[2]).toEqual({ name: 'README.md', isDirectory: false });
+  });
+
+  it('starts with focus at 0', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    expect(state.focusIndex).toBe(0);
+    expect(state.scrollY).toBe(0);
+  });
+
+  it('default height is 10', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    expect(state.height).toBe(10);
+  });
+});
+
+// ── focus navigation ──────────────────────────────────────────────
+
+describe('focus navigation', () => {
+  it('focusNext moves to next entry', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const next = fpFocusNext(state);
+    expect(next.focusIndex).toBe(1);
+  });
+
+  it('focusNext wraps around', () => {
+    const io = createMockIO();
+    let state = createFilePickerState({ cwd: '/project', io });
+    for (let i = 0; i < state.entries.length; i++) state = fpFocusNext(state);
+    expect(state.focusIndex).toBe(0);
+  });
+
+  it('focusPrev wraps around', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const prev = fpFocusPrev(state);
+    expect(prev.focusIndex).toBe(state.entries.length - 1);
+  });
+
+  it('focusNext is no-op on empty entries', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    expect(fpFocusNext(state).focusIndex).toBe(0);
+  });
+
+  it('focusPrev is no-op on empty entries', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    expect(fpFocusPrev(state).focusIndex).toBe(0);
+  });
+});
+
+// ── directory navigation ──────────────────────────────────────────
+
+describe('directory navigation', () => {
+  it('enter on directory changes cwd and refreshes entries', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    // First entry should be 'src' directory
+    const entered = fpEnter(state, io);
+    expect(entered.cwd).toBe('/project/src');
+    expect(entered.focusIndex).toBe(0);
+    expect(entered.entries.length).toBeGreaterThan(0);
+  });
+
+  it('enter on file is a no-op', () => {
+    const io = createMockIO();
+    let state = createFilePickerState({ cwd: '/project', io });
+    // Move to a file entry
+    state = fpFocusNext(state); // package.json (file)
+    const result = fpEnter(state, io);
+    expect(result.cwd).toBe('/project');
+  });
+
+  it('enter on empty entries is a no-op', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    const result = fpEnter(state, io);
+    expect(result.cwd).toBe('/empty');
+  });
+
+  it('back goes to parent directory', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project/src', io });
+    const backed = fpBack(state, io);
+    expect(backed.cwd).toBe('/project');
+  });
+
+  it('back at root is a no-op', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/', io });
+    const backed = fpBack(state, io);
+    expect(backed.cwd).toBe('/');
+  });
+});
+
+// ── extension filter ──────────────────────────────────────────────
+
+describe('extension filter', () => {
+  it('hides non-matching files', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io, filter: '.md' });
+    const fileEntries = state.entries.filter(e => !e.isDirectory);
+    expect(fileEntries.every(e => e.name.endsWith('.md'))).toBe(true);
+    expect(fileEntries.some(e => e.name === 'README.md')).toBe(true);
+  });
+
+  it('directories are always shown', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io, filter: '.md' });
+    const dirEntries = state.entries.filter(e => e.isDirectory);
+    expect(dirEntries.length).toBeGreaterThan(0);
+  });
+
+  it('filter is preserved across directory navigation', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io, filter: '.ts' });
+    const entered = fpEnter(state, io);
+    // /project/src has index.ts and utils/ — filter should keep .ts files
+    const fileEntries = entered.entries.filter(e => !e.isDirectory);
+    expect(fileEntries.every(e => e.name.endsWith('.ts'))).toBe(true);
+  });
+});
+
+// ── empty directory ───────────────────────────────────────────────
+
+describe('empty directory', () => {
+  it('renders empty message', () => {
+    const io = mockIO({ dirs: { '/empty': [] } });
+    const state = createFilePickerState({ cwd: '/empty', io });
+    expect(state.entries).toEqual([]);
+    const output = filePicker(state);
+    expect(output).toContain('(empty)');
+  });
+});
+
+// ── render ────────────────────────────────────────────────────────
+
+describe('render', () => {
+  it('shows cwd as header', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('/project');
+  });
+
+  it('shows focus indicator on focused entry', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('\u25b8');
+  });
+
+  it('shows directory indicator', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('d src/');
+  });
+
+  it('shows file indicator', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state);
+    expect(output).toContain('- package.json');
+  });
+
+  it('uses custom indicators', () => {
+    const io = createMockIO();
+    const state = createFilePickerState({ cwd: '/project', io });
+    const output = filePicker(state, {
+      focusIndicator: '>>',
+      dirIndicator: 'D',
+      fileIndicator: 'F',
+    });
+    expect(output).toContain('>> D src/');
+    expect(output).toContain('F package.json');
+  });
+
+  it('respects scroll window', () => {
+    const io = mockIO({
+      dirs: {
+        '/many': ['a/', 'b/', 'c/', 'd.txt', 'e.txt', 'f.txt'],
+      },
+    });
+    const state = createFilePickerState({ cwd: '/many', io, height: 3 });
+    const output = filePicker(state);
+    const lines = output.split('\n');
+    // header + 3 visible entries = 4 lines
+    expect(lines).toHaveLength(4);
+  });
+});
+
+// ── scroll adjustment ─────────────────────────────────────────────
+
+describe('scroll adjustment', () => {
+  it('scrolls down when focus moves past viewport', () => {
+    const io = mockIO({
+      dirs: {
+        '/many': ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'],
+      },
+    });
+    let state = createFilePickerState({ cwd: '/many', io, height: 2 });
+    state = fpFocusNext(state); // index 1
+    state = fpFocusNext(state); // index 2 — should trigger scroll
+    expect(state.scrollY).toBe(1);
+  });
+
+  it('scrolls up when focus wraps to top', () => {
+    const io = mockIO({
+      dirs: {
+        '/many': ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'],
+      },
+    });
+    let state = createFilePickerState({ cwd: '/many', io, height: 2 });
+    // Move to end
+    for (let i = 0; i < 5; i++) state = fpFocusNext(state);
+    // Now at index 0 (wrapped), scrollY should reset
+    expect(state.focusIndex).toBe(0);
+    expect(state.scrollY).toBe(0);
+  });
+});
+
+// ── keymap ────────────────────────────────────────────────────────
+
+describe('filePickerKeyMap', () => {
+  const actions = {
+    focusNext: 'next' as const,
+    focusPrev: 'prev' as const,
+    enter: 'enter' as const,
+    back: 'back' as const,
+    quit: 'quit' as const,
+  };
+
+  const km = filePickerKeyMap(actions);
+
+  it('handles j/k for navigation', () => {
+    expect(km.handle(keyMsg('j'))).toBe('next');
+    expect(km.handle(keyMsg('k'))).toBe('prev');
+  });
+
+  it('handles arrow keys', () => {
+    expect(km.handle(keyMsg('down'))).toBe('next');
+    expect(km.handle(keyMsg('up'))).toBe('prev');
+  });
+
+  it('handles enter for directory entry', () => {
+    expect(km.handle(keyMsg('enter'))).toBe('enter');
+  });
+
+  it('handles backspace and left for parent directory', () => {
+    expect(km.handle(keyMsg('backspace'))).toBe('back');
+    expect(km.handle(keyMsg('left'))).toBe('back');
+  });
+
+  it('handles quit', () => {
+    expect(km.handle(keyMsg('q'))).toBe('quit');
+    expect(km.handle(keyMsg('c', { ctrl: true }))).toBe('quit');
+  });
+
+  it('returns undefined for unbound keys', () => {
+    expect(km.handle(keyMsg('x'))).toBeUndefined();
+  });
+});

--- a/packages/bijou-tui/src/file-picker.ts
+++ b/packages/bijou-tui/src/file-picker.ts
@@ -58,6 +58,14 @@ export interface FilePickerRenderOptions {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Parse raw directory listing into sorted `FileEntry[]`.
+ *
+ * @param names  - Names returned by `IOPort.readDir()` (dirs have trailing `/`).
+ * @param filter - Optional extension suffix (e.g. `".ts"`) — only files whose
+ *                 name ends with this suffix are included. Directories are
+ *                 always included regardless of the filter.
+ */
 function parseEntries(names: string[], filter?: string): FileEntry[] {
   const dirs: FileEntry[] = [];
   const files: FileEntry[] = [];
@@ -142,11 +150,8 @@ export function fpEnter(state: FilePickerState, io: IOPort): FilePickerState {
 
 /** Navigate to the parent directory. No-op at filesystem root. */
 export function fpBack(state: FilePickerState, io: IOPort): FilePickerState {
-  // Go to parent directory
-  const parts = state.cwd.split('/').filter(Boolean);
-  if (parts.length === 0) return state;
-  parts.pop();
-  const newCwd = '/' + parts.join('/');
+  const newCwd = io.joinPath(state.cwd, '..');
+  if (newCwd === state.cwd) return state;
 
   const names = io.readDir(newCwd);
   const entries = parseEntries(names, state.filter);

--- a/packages/bijou-tui/src/file-picker.ts
+++ b/packages/bijou-tui/src/file-picker.ts
@@ -1,0 +1,255 @@
+/**
+ * File picker building block — a directory browser with focus navigation.
+ *
+ * Uses `IOPort.readDir()` to list directory contents and `IOPort.joinPath()`
+ * to navigate between directories. Follows the same state + pure transformers
+ * + sync render + convenience keymap pattern as pager and accordion.
+ *
+ * ```ts
+ * // In TEA init:
+ * const fpState = createFilePickerState({ cwd: '/project', io });
+ *
+ * // In TEA view:
+ * const output = filePicker(model.fpState);
+ *
+ * // In TEA update:
+ * case 'focus-next':
+ *   return [{ ...model, fpState: fpFocusNext(model.fpState) }, []];
+ * case 'enter':
+ *   return [{ ...model, fpState: fpEnter(model.fpState, io) }, []];
+ * ```
+ */
+
+import type { IOPort } from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FileEntry {
+  name: string;
+  isDirectory: boolean;
+}
+
+export interface FilePickerState {
+  readonly cwd: string;
+  readonly entries: readonly FileEntry[];
+  readonly focusIndex: number;
+  readonly scrollY: number;
+  readonly height: number;
+  readonly filter?: string;
+}
+
+export interface FilePickerOptions {
+  readonly cwd: string;
+  readonly io: IOPort;
+  readonly height?: number;
+  readonly filter?: string;
+}
+
+export interface FilePickerRenderOptions {
+  readonly focusIndicator?: string;
+  readonly dirIndicator?: string;
+  readonly fileIndicator?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseEntries(names: string[], filter?: string): FileEntry[] {
+  const dirs: FileEntry[] = [];
+  const files: FileEntry[] = [];
+
+  for (const name of names) {
+    if (name.endsWith('/')) {
+      dirs.push({ name: name.slice(0, -1), isDirectory: true });
+    } else {
+      if (filter && !name.endsWith(filter)) continue;
+      files.push({ name, isDirectory: false });
+    }
+  }
+
+  // Sort dirs first, then files, both alphabetically
+  dirs.sort((a, b) => a.name.localeCompare(b.name));
+  files.sort((a, b) => a.name.localeCompare(b.name));
+
+  return [...dirs, ...files];
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial file picker state for the given directory.
+ *
+ * Reads directory contents via `io.readDir()` and parses entries into
+ * directories (trailing `/`) and files. Directories are sorted first,
+ * then files, both alphabetically.
+ */
+export function createFilePickerState(options: FilePickerOptions): FilePickerState {
+  const names = options.io.readDir(options.cwd);
+  const entries = parseEntries(names, options.filter);
+
+  return {
+    cwd: options.cwd,
+    entries,
+    focusIndex: 0,
+    scrollY: 0,
+    height: options.height ?? 10,
+    filter: options.filter,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Move focus to the next entry (wraps around). */
+export function fpFocusNext(state: FilePickerState): FilePickerState {
+  if (state.entries.length === 0) return state;
+  const focusIndex = (state.focusIndex + 1) % state.entries.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.entries.length) };
+}
+
+/** Move focus to the previous entry (wraps around). */
+export function fpFocusPrev(state: FilePickerState): FilePickerState {
+  if (state.entries.length === 0) return state;
+  const focusIndex = (state.focusIndex - 1 + state.entries.length) % state.entries.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.entries.length) };
+}
+
+/** Enter the focused directory, refreshing the entry list. No-op on files. */
+export function fpEnter(state: FilePickerState, io: IOPort): FilePickerState {
+  if (state.entries.length === 0) return state;
+  const entry = state.entries[state.focusIndex];
+  if (!entry || !entry.isDirectory) return state;
+
+  const newCwd = io.joinPath(state.cwd, entry.name);
+  const names = io.readDir(newCwd);
+  const entries = parseEntries(names, state.filter);
+
+  return {
+    ...state,
+    cwd: newCwd,
+    entries,
+    focusIndex: 0,
+    scrollY: 0,
+  };
+}
+
+/** Navigate to the parent directory. No-op at filesystem root. */
+export function fpBack(state: FilePickerState, io: IOPort): FilePickerState {
+  // Go to parent directory
+  const parts = state.cwd.split('/').filter(Boolean);
+  if (parts.length === 0) return state;
+  parts.pop();
+  const newCwd = '/' + parts.join('/');
+
+  const names = io.readDir(newCwd);
+  const entries = parseEntries(names, state.filter);
+
+  return {
+    ...state,
+    cwd: newCwd,
+    entries,
+    focusIndex: 0,
+    scrollY: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scroll helper
+// ---------------------------------------------------------------------------
+
+function adjustScroll(focusIndex: number, scrollY: number, height: number, totalItems: number): number {
+  let newScrollY = scrollY;
+  if (focusIndex < newScrollY) {
+    newScrollY = focusIndex;
+  } else if (focusIndex >= newScrollY + height) {
+    newScrollY = focusIndex - height + 1;
+  }
+  const maxScroll = Math.max(0, totalItems - height);
+  return Math.min(newScrollY, maxScroll);
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the file picker — cwd header followed by the visible entry list.
+ *
+ * Each entry is prefixed with a focus indicator and a type indicator
+ * (directory or file). Directories are suffixed with `/`.
+ */
+export function filePicker(state: FilePickerState, options?: FilePickerRenderOptions): string {
+  const indicator = options?.focusIndicator ?? '\u25b8';
+  const dirIcon = options?.dirIndicator ?? 'd';
+  const fileIcon = options?.fileIndicator ?? '-';
+  const pad = ' '.repeat(indicator.length);
+
+  const lines: string[] = [];
+  lines.push(state.cwd);
+
+  if (state.entries.length === 0) {
+    lines.push('  (empty)');
+    return lines.join('\n');
+  }
+
+  const visibleEntries = state.entries.slice(state.scrollY, state.scrollY + state.height);
+
+  for (let i = 0; i < visibleEntries.length; i++) {
+    const entry = visibleEntries[i]!;
+    const globalIndex = state.scrollY + i;
+    const prefix = globalIndex === state.focusIndex ? indicator : pad;
+    const icon = entry.isDirectory ? dirIcon : fileIcon;
+    const suffix = entry.isDirectory ? '/' : '';
+    lines.push(`${prefix} ${icon} ${entry.name}${suffix}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for file picker navigation.
+ *
+ * The caller provides their own message types for each action:
+ * ```ts
+ * const keys = filePickerKeyMap({
+ *   focusNext: { type: 'next' },
+ *   focusPrev: { type: 'prev' },
+ *   enter: { type: 'enter' },
+ *   back: { type: 'back' },
+ *   quit: { type: 'quit' },
+ * });
+ * ```
+ */
+export function filePickerKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  enter: Msg;
+  back: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next entry', actions.focusNext)
+      .bind('down', 'Next entry', actions.focusNext)
+      .bind('k', 'Previous entry', actions.focusPrev)
+      .bind('up', 'Previous entry', actions.focusPrev),
+    )
+    .group('Actions', (g) => g
+      .bind('enter', 'Enter directory / select file', actions.enter)
+      .bind('backspace', 'Parent directory', actions.back)
+      .bind('left', 'Parent directory', actions.back),
+    )
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -185,3 +185,18 @@ export {
   collapseAll,
   accordionKeyMap,
 } from './accordion.js';
+
+// File picker
+export {
+  type FileEntry,
+  type FilePickerState,
+  type FilePickerOptions,
+  type FilePickerRenderOptions,
+  createFilePickerState,
+  filePicker,
+  fpFocusNext,
+  fpFocusPrev,
+  fpEnter,
+  fpBack,
+  filePickerKeyMap,
+} from './file-picker.js';

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -185,3 +185,18 @@ export {
   collapseAll,
   accordionKeyMap,
 } from './accordion.js';
+
+// Browsable list
+export {
+  type BrowsableListItem,
+  type BrowsableListState,
+  type BrowsableListOptions,
+  type BrowsableListRenderOptions,
+  createBrowsableListState,
+  browsableList,
+  listFocusNext,
+  listFocusPrev,
+  listPageDown,
+  listPageUp,
+  browsableListKeyMap,
+} from './browsable-list.js';

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -185,3 +185,17 @@ export {
   collapseAll,
   accordionKeyMap,
 } from './accordion.js';
+
+// Navigable table
+export {
+  type NavigableTableState,
+  type NavigableTableOptions,
+  type NavTableRenderOptions,
+  createNavigableTableState,
+  navigableTable,
+  navTableFocusNext,
+  navTableFocusPrev,
+  navTablePageDown,
+  navTablePageUp,
+  navTableKeyMap,
+} from './navigable-table.js';

--- a/packages/bijou-tui/src/navigable-table.test.ts
+++ b/packages/bijou-tui/src/navigable-table.test.ts
@@ -33,6 +33,16 @@ describe('navigableTable', () => {
       const state = createNavigableTableState({ columns, rows, height: 3 });
       expect(state.height).toBe(3);
     });
+
+    it('clamps height to 1 when 0 is provided', () => {
+      const state = createNavigableTableState({ columns, rows, height: 0 });
+      expect(state.height).toBe(1);
+    });
+
+    it('clamps negative height to 1', () => {
+      const state = createNavigableTableState({ columns, rows, height: -5 });
+      expect(state.height).toBe(1);
+    });
   });
 
   describe('focus navigation', () => {

--- a/packages/bijou-tui/src/navigable-table.test.ts
+++ b/packages/bijou-tui/src/navigable-table.test.ts
@@ -26,7 +26,7 @@ describe('navigableTable', () => {
       expect(state.focusRow).toBe(0);
       expect(state.scrollY).toBe(0);
       expect(state.height).toBe(10);
-      expect(state.rows).toBe(rows);
+      expect(state.rows).toEqual(rows);
     });
 
     it('accepts custom height', () => {

--- a/packages/bijou-tui/src/navigable-table.test.ts
+++ b/packages/bijou-tui/src/navigable-table.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createNavigableTableState,
+  navTableFocusNext,
+  navTableFocusPrev,
+  navTablePageDown,
+  navTablePageUp,
+  navigableTable,
+  navTableKeyMap,
+} from './navigable-table.js';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+
+describe('navigableTable', () => {
+  const columns = [{ header: 'Name' }, { header: 'Age' }];
+  const rows = [
+    ['Alice', '30'],
+    ['Bob', '25'],
+    ['Carol', '28'],
+    ['Dave', '35'],
+    ['Eve', '22'],
+  ];
+
+  describe('createNavigableTableState()', () => {
+    it('creates state with defaults', () => {
+      const state = createNavigableTableState({ columns, rows });
+      expect(state.focusRow).toBe(0);
+      expect(state.scrollY).toBe(0);
+      expect(state.height).toBe(10);
+      expect(state.rows).toBe(rows);
+    });
+
+    it('accepts custom height', () => {
+      const state = createNavigableTableState({ columns, rows, height: 3 });
+      expect(state.height).toBe(3);
+    });
+  });
+
+  describe('focus navigation', () => {
+    it('focusNext moves to next row', () => {
+      const state = createNavigableTableState({ columns, rows });
+      const next = navTableFocusNext(state);
+      expect(next.focusRow).toBe(1);
+    });
+
+    it('focusNext wraps around', () => {
+      let state = createNavigableTableState({ columns, rows });
+      for (let i = 0; i < rows.length; i++) state = navTableFocusNext(state);
+      expect(state.focusRow).toBe(0);
+    });
+
+    it('focusPrev moves to previous row', () => {
+      let state = createNavigableTableState({ columns, rows });
+      state = navTableFocusNext(state);
+      state = navTableFocusPrev(state);
+      expect(state.focusRow).toBe(0);
+    });
+
+    it('focusPrev wraps around', () => {
+      const state = createNavigableTableState({ columns, rows });
+      const prev = navTableFocusPrev(state);
+      expect(prev.focusRow).toBe(rows.length - 1);
+    });
+
+    it('empty rows are no-ops', () => {
+      const state = createNavigableTableState({ columns, rows: [] });
+      expect(navTableFocusNext(state)).toBe(state);
+      expect(navTableFocusPrev(state)).toBe(state);
+    });
+  });
+
+  describe('page navigation', () => {
+    it('pageDown moves by height', () => {
+      const state = createNavigableTableState({ columns, rows, height: 2 });
+      const paged = navTablePageDown(state);
+      expect(paged.focusRow).toBe(2);
+    });
+
+    it('pageDown clamps to last row', () => {
+      const state = createNavigableTableState({ columns, rows, height: 10 });
+      const paged = navTablePageDown(state);
+      expect(paged.focusRow).toBe(rows.length - 1);
+    });
+
+    it('pageUp moves up by height', () => {
+      let state = createNavigableTableState({ columns, rows, height: 2 });
+      state = navTablePageDown(navTablePageDown(state));
+      state = navTablePageUp(state);
+      expect(state.focusRow).toBe(2);
+    });
+
+    it('pageUp clamps to first row', () => {
+      const state = createNavigableTableState({ columns, rows, height: 10 });
+      const paged = navTablePageUp(state);
+      expect(paged.focusRow).toBe(0);
+    });
+  });
+
+  describe('scroll follows focus', () => {
+    it('scrollY adjusts when focus goes below viewport', () => {
+      let state = createNavigableTableState({ columns, rows, height: 2 });
+      state = navTableFocusNext(state);
+      state = navTableFocusNext(state);
+      expect(state.scrollY).toBe(1);
+    });
+
+    it('scrollY adjusts when focus goes above viewport', () => {
+      let state = createNavigableTableState({ columns, rows, height: 2 });
+      // Go to bottom, then wrap to 0
+      for (let i = 0; i < rows.length; i++) state = navTableFocusNext(state);
+      expect(state.focusRow).toBe(0);
+      expect(state.scrollY).toBe(0);
+    });
+  });
+
+  describe('render', () => {
+    it('shows focus indicator on focused row', () => {
+      const state = createNavigableTableState({ columns, rows, height: 3 });
+      const ctx = createTestContext({ mode: 'interactive' });
+      const output = navigableTable(state, { ctx });
+      expect(output).toContain('\u25b8');
+      expect(output).toContain('Alice');
+    });
+
+    it('renders empty table', () => {
+      const state = createNavigableTableState({ columns, rows: [] });
+      const ctx = createTestContext({ mode: 'interactive' });
+      const output = navigableTable(state, { ctx });
+      expect(output).toContain('Name');
+    });
+  });
+
+  describe('keymap', () => {
+    it('dispatches correct actions', () => {
+      const actions = {
+        focusNext: 'next',
+        focusPrev: 'prev',
+        pageDown: 'pd',
+        pageUp: 'pu',
+        quit: 'q',
+      };
+      const km = navTableKeyMap(actions);
+      expect(km.handle({ key: 'j', ctrl: false, alt: false, shift: false })).toBe('next');
+      expect(km.handle({ key: 'k', ctrl: false, alt: false, shift: false })).toBe('prev');
+      expect(km.handle({ key: 'q', ctrl: false, alt: false, shift: false })).toBe('q');
+    });
+  });
+});

--- a/packages/bijou-tui/src/navigable-table.ts
+++ b/packages/bijou-tui/src/navigable-table.ts
@@ -59,7 +59,7 @@ export interface NavTableRenderOptions {
 export function createNavigableTableState(options: NavigableTableOptions): NavigableTableState {
   return {
     columns: [...options.columns],
-    rows: options.rows,
+    rows: [...options.rows],
     focusRow: 0,
     scrollY: 0,
     height: options.height ?? 10,

--- a/packages/bijou-tui/src/navigable-table.ts
+++ b/packages/bijou-tui/src/navigable-table.ts
@@ -1,0 +1,190 @@
+/**
+ * Navigable table building block.
+ *
+ * Wraps the static `table()` from bijou core with focus management,
+ * keyboard navigation, and vertical scrolling.
+ *
+ * ```ts
+ * // In TEA init:
+ * const tableState = createNavigableTableState({ columns, rows, height: 10 });
+ *
+ * // In TEA view:
+ * const output = navigableTable(model.tableState, { ctx });
+ *
+ * // In TEA update:
+ * case 'focus-next':
+ *   return [{ ...model, tableState: navTableFocusNext(model.tableState) }, []];
+ * ```
+ */
+
+import {
+  table,
+  type TableColumn,
+  type BijouContext,
+} from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NavigableTableState {
+  readonly columns: TableColumn[];
+  readonly rows: readonly (readonly string[])[];
+  readonly focusRow: number;
+  readonly scrollY: number;
+  readonly height: number;
+}
+
+export interface NavigableTableOptions {
+  readonly columns: TableColumn[];
+  readonly rows: readonly (readonly string[])[];
+  readonly height?: number;
+}
+
+export interface NavTableRenderOptions {
+  readonly focusIndicator?: string;
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial navigable table state.
+ *
+ * `height` defaults to 10 rows when not provided.
+ */
+export function createNavigableTableState(options: NavigableTableOptions): NavigableTableState {
+  return {
+    columns: [...options.columns],
+    rows: options.rows,
+    focusRow: 0,
+    scrollY: 0,
+    height: options.height ?? 10,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/** Move focus to the next row (wraps around). */
+export function navTableFocusNext(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = (state.focusRow + 1) % state.rows.length;
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+/** Move focus to the previous row (wraps around). */
+export function navTableFocusPrev(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = (state.focusRow - 1 + state.rows.length) % state.rows.length;
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+/** Move focus down by one page (clamps to last row). */
+export function navTablePageDown(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = Math.min(state.focusRow + state.height, state.rows.length - 1);
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+/** Move focus up by one page (clamps to first row). */
+export function navTablePageUp(state: NavigableTableState): NavigableTableState {
+  if (state.rows.length === 0) return state;
+  const focusRow = Math.max(state.focusRow - state.height, 0);
+  return { ...state, focusRow, scrollY: adjustScroll(focusRow, state.scrollY, state.height, state.rows.length) };
+}
+
+// ---------------------------------------------------------------------------
+// Scroll helper
+// ---------------------------------------------------------------------------
+
+function adjustScroll(focusRow: number, scrollY: number, height: number, totalRows: number): number {
+  let newScrollY = scrollY;
+  if (focusRow < newScrollY) {
+    newScrollY = focusRow;
+  } else if (focusRow >= newScrollY + height) {
+    newScrollY = focusRow - height + 1;
+  }
+  const maxScroll = Math.max(0, totalRows - height);
+  return Math.min(newScrollY, maxScroll);
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the navigable table with a focus indicator on the focused row.
+ *
+ * Slices visible rows based on `scrollY` and `height`, prepends a focus
+ * indicator to the first column, then delegates to core `table()`.
+ */
+export function navigableTable(state: NavigableTableState, options?: NavTableRenderOptions): string {
+  if (state.rows.length === 0) {
+    return table({ columns: state.columns, rows: [], ctx: options?.ctx });
+  }
+
+  const indicator = options?.focusIndicator ?? '\u25b8';
+  const pad = ' '.repeat(indicator.length);
+
+  // Slice visible window
+  const visibleRows = state.rows.slice(state.scrollY, state.scrollY + state.height);
+
+  // Prepend focus indicator to first column
+  const decoratedRows = visibleRows.map((row, i) => {
+    const globalIndex = state.scrollY + i;
+    const prefix = globalIndex === state.focusRow ? indicator : pad;
+    const firstCol = `${prefix} ${row[0] ?? ''}`;
+    return [firstCol, ...row.slice(1)];
+  });
+
+  return table({
+    columns: state.columns,
+    rows: decoratedRows,
+    ctx: options?.ctx,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for navigable table navigation.
+ *
+ * The caller provides their own message types for each action:
+ * ```ts
+ * const keys = navTableKeyMap({
+ *   focusNext: { type: 'next-row' },
+ *   focusPrev: { type: 'prev-row' },
+ *   pageDown:  { type: 'page-down' },
+ *   pageUp:    { type: 'page-up' },
+ *   quit:      { type: 'quit' },
+ * });
+ * ```
+ */
+export function navTableKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  pageDown: Msg;
+  pageUp: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next row', actions.focusNext)
+      .bind('down', 'Next row', actions.focusNext)
+      .bind('k', 'Previous row', actions.focusPrev)
+      .bind('up', 'Previous row', actions.focusPrev)
+      .bind('d', 'Page down', actions.pageDown)
+      .bind('pagedown', 'Page down', actions.pageDown)
+      .bind('u', 'Page up', actions.pageUp)
+      .bind('pageup', 'Page up', actions.pageUp),
+    )
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/navigable-table.ts
+++ b/packages/bijou-tui/src/navigable-table.ts
@@ -57,12 +57,13 @@ export interface NavTableRenderOptions {
  * `height` defaults to 10 rows when not provided.
  */
 export function createNavigableTableState(options: NavigableTableOptions): NavigableTableState {
+  const height = Math.max(1, options.height ?? 10);
   return {
     columns: [...options.columns],
-    rows: [...options.rows],
+    rows: options.rows.map((row) => [...row]),
     focusRow: 0,
     scrollY: 0,
-    height: options.height ?? 10,
+    height,
   };
 }
 

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/src/core/components/dag-stats.test.ts
+++ b/packages/bijou/src/core/components/dag-stats.test.ts
@@ -62,6 +62,14 @@ describe('dagStats()', () => {
     expect(() => dagStats(nodes)).toThrow('cycle detected');
   });
 
+  it('duplicate node ids throws', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A' },
+      { id: 'a', label: 'A2' },
+    ];
+    expect(() => dagStats(nodes)).toThrow('duplicate node id "a"');
+  });
+
   it('self-loop throws', () => {
     const nodes: DagNode[] = [
       { id: 'a', label: 'A', edges: ['a'] },

--- a/packages/bijou/src/core/components/dag-stats.test.ts
+++ b/packages/bijou/src/core/components/dag-stats.test.ts
@@ -62,6 +62,13 @@ describe('dagStats()', () => {
     expect(() => dagStats(nodes)).toThrow('cycle detected');
   });
 
+  it('self-loop throws', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['a'] },
+    ];
+    expect(() => dagStats(nodes)).toThrow('cycle detected');
+  });
+
   it('ghost nodes are filtered out', () => {
     const nodes: DagNode[] = [
       { id: 'a', label: 'A', edges: ['b'] },
@@ -81,6 +88,19 @@ describe('dagStats()', () => {
     const source = arraySource(nodes);
     expect(dagStats(source)).toEqual({
       nodes: 2, edges: 1, depth: 2, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('disconnected components', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C', edges: ['d'] },
+      { id: 'd', label: 'D', edges: ['e'] },
+      { id: 'e', label: 'E' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 5, edges: 3, depth: 3, width: 2, roots: 2, leaves: 2,
     });
   });
 

--- a/packages/bijou/src/core/components/dag-stats.test.ts
+++ b/packages/bijou/src/core/components/dag-stats.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { dagStats } from './dag-stats.js';
+import type { DagNode } from './dag.js';
+import { arraySource } from './dag-source.js';
+
+describe('dagStats()', () => {
+  it('empty graph returns all zeros', () => {
+    expect(dagStats([])).toEqual({
+      nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0,
+    });
+  });
+
+  it('single node', () => {
+    const nodes: DagNode[] = [{ id: 'a', label: 'A' }];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 1, edges: 0, depth: 1, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('linear chain A→B→C', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B', edges: ['c'] },
+      { id: 'c', label: 'C' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 3, edges: 2, depth: 3, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('diamond A→B,C→D', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b', 'c'] },
+      { id: 'b', label: 'B', edges: ['d'] },
+      { id: 'c', label: 'C', edges: ['d'] },
+      { id: 'd', label: 'D' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 4, edges: 4, depth: 3, width: 2, roots: 1, leaves: 1,
+    });
+  });
+
+  it('wide fan-out', () => {
+    const nodes: DagNode[] = [
+      { id: 'root', label: 'Root', edges: ['a', 'b', 'c', 'd', 'e'] },
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+      { id: 'd', label: 'D' },
+      { id: 'e', label: 'E' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 6, edges: 5, depth: 2, width: 5, roots: 1, leaves: 5,
+    });
+  });
+
+  it('cycle throws', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B', edges: ['a'] },
+    ];
+    expect(() => dagStats(nodes)).toThrow('cycle detected');
+  });
+
+  it('ghost nodes are filtered out', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B' },
+      { id: 'ghost1', label: '... 3 ancestors', _ghost: true, edges: ['a'] },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 2, edges: 1, depth: 2, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('accepts SlicedDagSource', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'] },
+      { id: 'b', label: 'B' },
+    ];
+    const source = arraySource(nodes);
+    expect(dagStats(source)).toEqual({
+      nodes: 2, edges: 1, depth: 2, width: 1, roots: 1, leaves: 1,
+    });
+  });
+
+  it('multiple roots and leaves', () => {
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['c'] },
+      { id: 'b', label: 'B', edges: ['c'] },
+      { id: 'c', label: 'C', edges: ['d', 'e'] },
+      { id: 'd', label: 'D' },
+      { id: 'e', label: 'E' },
+    ];
+    expect(dagStats(nodes)).toEqual({
+      nodes: 5, edges: 4, depth: 3, width: 2, roots: 2, leaves: 2,
+    });
+  });
+});

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -1,0 +1,127 @@
+import type { DagNode } from './dag.js';
+import type { SlicedDagSource } from './dag-source.js';
+import { isSlicedDagSource } from './dag-source.js';
+import { materialize } from './dag-source.js';
+
+export interface DagStats {
+  nodes: number;
+  edges: number;
+  depth: number;        // number of layers (longest-path assignment)
+  width: number;        // max nodes on any single layer
+  roots: number;        // in-degree 0
+  leaves: number;       // out-degree 0
+}
+
+export function dagStats(nodes: DagNode[]): DagStats;
+export function dagStats(source: SlicedDagSource): DagStats;
+export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {
+  const nodes = isSlicedDagSource(input) ? materialize(input) : input;
+
+  if (nodes.length === 0) {
+    return { nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0 };
+  }
+
+  // Filter out ghost nodes
+  const realNodes = nodes.filter(n => !n._ghost);
+
+  if (realNodes.length === 0) {
+    return { nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0 };
+  }
+
+  const nodeIds = new Set(realNodes.map(n => n.id));
+  const children = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+  const parents = new Map<string, string[]>();
+
+  for (const n of realNodes) {
+    const validEdges = (n.edges ?? []).filter(e => nodeIds.has(e));
+    children.set(n.id, validEdges);
+    inDegree.set(n.id, 0);
+    if (!parents.has(n.id)) parents.set(n.id, []);
+  }
+
+  let totalEdges = 0;
+  for (const n of realNodes) {
+    for (const childId of children.get(n.id) ?? []) {
+      if (!parents.has(childId)) parents.set(childId, []);
+      parents.get(childId)!.push(n.id);
+      inDegree.set(childId, (inDegree.get(childId) ?? 0) + 1);
+      totalEdges++;
+    }
+  }
+
+  // Kahn's topological sort
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) queue.push(id);
+  }
+
+  const topoOrder: string[] = [];
+  const visited = new Set<string>();
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (visited.has(id)) continue;
+    visited.add(id);
+    topoOrder.push(id);
+    for (const childId of children.get(id) ?? []) {
+      const newDeg = (inDegree.get(childId) ?? 1) - 1;
+      inDegree.set(childId, newDeg);
+      if (newDeg === 0) queue.push(childId);
+    }
+  }
+
+  if (topoOrder.length !== realNodes.length) {
+    throw new Error('[bijou] dagStats(): cycle detected in graph');
+  }
+
+  // Longest-path layer assignment
+  const layerMap = new Map<string, number>();
+  for (const id of topoOrder) {
+    const pars = parents.get(id) ?? [];
+    if (pars.length === 0) {
+      layerMap.set(id, 0);
+    } else {
+      let maxParent = 0;
+      for (const p of pars) {
+        maxParent = Math.max(maxParent, layerMap.get(p) ?? 0);
+      }
+      layerMap.set(id, maxParent + 1);
+    }
+  }
+
+  // Compute stats
+  let maxLayer = 0;
+  for (const v of layerMap.values()) {
+    if (v > maxLayer) maxLayer = v;
+  }
+  const depth = maxLayer + 1;
+
+  // Width: count nodes per layer, find max
+  const layerCounts = new Map<number, number>();
+  for (const v of layerMap.values()) {
+    layerCounts.set(v, (layerCounts.get(v) ?? 0) + 1);
+  }
+  let maxWidth = 0;
+  for (const count of layerCounts.values()) {
+    if (count > maxWidth) maxWidth = count;
+  }
+
+  // Roots: in-degree 0 (already counted)
+  let rootCount = 0;
+  let leafCount = 0;
+  for (const n of realNodes) {
+    const pars = parents.get(n.id) ?? [];
+    if (pars.length === 0) rootCount++;
+    const ch = children.get(n.id) ?? [];
+    if (ch.length === 0) leafCount++;
+  }
+
+  return {
+    nodes: realNodes.length,
+    edges: totalEdges,
+    depth,
+    width: maxWidth,
+    roots: rootCount,
+    leaves: leafCount,
+  };
+}

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -50,21 +50,19 @@ export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {
     }
   }
 
-  // Kahn's topological sort
+  // Kahn's topological sort (index-based dequeue for O(n) total)
   const queue: string[] = [];
+  let head = 0;
   for (const [id, deg] of inDegree) {
     if (deg === 0) queue.push(id);
   }
 
   const topoOrder: string[] = [];
-  const visited = new Set<string>();
-  while (queue.length > 0) {
-    const id = queue.shift()!;
-    if (visited.has(id)) continue;
-    visited.add(id);
+  while (head < queue.length) {
+    const id = queue[head++]!;
     topoOrder.push(id);
     for (const childId of children.get(id) ?? []) {
-      const newDeg = (inDegree.get(childId) ?? 1) - 1;
+      const newDeg = inDegree.get(childId)! - 1;
       inDegree.set(childId, newDeg);
       if (newDeg === 0) queue.push(childId);
     }

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -28,7 +28,13 @@ export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {
     return { nodes: 0, edges: 0, depth: 0, width: 0, roots: 0, leaves: 0 };
   }
 
-  const nodeIds = new Set(realNodes.map(n => n.id));
+  const nodeIds = new Set<string>();
+  for (const n of realNodes) {
+    if (nodeIds.has(n.id)) {
+      throw new Error(`[bijou] dagStats(): duplicate node id "${n.id}"`);
+    }
+    nodeIds.add(n.id);
+  }
   const children = new Map<string, string[]>();
   const inDegree = new Map<string, number>();
   const parents = new Map<string, string[]>();

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -3,15 +3,41 @@ import type { SlicedDagSource } from './dag-source.js';
 import { isSlicedDagSource } from './dag-source.js';
 import { materialize } from './dag-source.js';
 
+/** Statistics computed from a directed acyclic graph. */
 export interface DagStats {
+  /** Total number of (non-ghost) nodes. */
   nodes: number;
+  /** Total number of edges between non-ghost nodes. */
   edges: number;
-  depth: number;        // number of layers (longest-path assignment)
-  width: number;        // max nodes on any single layer
-  roots: number;        // in-degree 0
-  leaves: number;       // out-degree 0
+  /** Number of layers in the longest-path layer assignment. */
+  depth: number;
+  /** Maximum number of nodes on any single layer. */
+  width: number;
+  /** Number of root nodes (in-degree 0). */
+  roots: number;
+  /** Number of leaf nodes (out-degree 0). */
+  leaves: number;
 }
 
+/**
+ * Compute statistics for a directed acyclic graph.
+ *
+ * Accepts either a `DagNode[]` array or a `SlicedDagSource`. Ghost nodes
+ * (internal boundary markers from `dagSlice()`) are filtered out automatically.
+ *
+ * @throws If the graph contains a cycle or duplicate node IDs.
+ *
+ * @example
+ * ```ts
+ * const stats = dagStats([
+ *   { id: 'a', label: 'A', edges: ['b', 'c'] },
+ *   { id: 'b', label: 'B', edges: ['d'] },
+ *   { id: 'c', label: 'C', edges: ['d'] },
+ *   { id: 'd', label: 'D' },
+ * ]);
+ * // => { nodes: 4, edges: 4, depth: 3, width: 2, roots: 1, leaves: 1 }
+ * ```
+ */
 export function dagStats(nodes: DagNode[]): DagStats;
 export function dagStats(source: SlicedDagSource): DagStats;
 export function dagStats(input: DagNode[] | SlicedDagSource): DagStats {

--- a/packages/bijou/src/core/components/dag-stats.ts
+++ b/packages/bijou/src/core/components/dag-stats.ts
@@ -1,7 +1,6 @@
 import type { DagNode } from './dag.js';
 import type { SlicedDagSource } from './dag-source.js';
-import { isSlicedDagSource } from './dag-source.js';
-import { materialize } from './dag-source.js';
+import { isSlicedDagSource, materialize } from './dag-source.js';
 
 /** Statistics computed from a directed acyclic graph. */
 export interface DagStats {

--- a/packages/bijou/src/core/components/index.ts
+++ b/packages/bijou/src/core/components/index.ts
@@ -54,3 +54,6 @@ export type { DagNode, DagOptions, DagNodePosition, DagLayout } from './dag.js';
 
 export { arraySource, isDagSource, isSlicedDagSource } from './dag-source.js';
 export type { DagSource, SlicedDagSource, DagSliceOptions } from './dag-source.js';
+
+export { dagStats } from './dag-stats.js';
+export type { DagStats } from './dag-stats.js';

--- a/packages/bijou/src/core/forms/confirm.test.ts
+++ b/packages/bijou/src/core/forms/confirm.test.ts
@@ -117,4 +117,16 @@ describe('confirm()', () => {
     expect(result).toBe(true);
     expect(ctx.io.written.length).toBeGreaterThan(0);
   });
+
+  describe('Ctrl+C / empty answer in interactive mode', () => {
+    it('empty answer in interactive mode returns default (true)', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { answers: [''] } });
+      expect(await confirm({ title: 'Continue?', ctx })).toBe(true);
+    });
+
+    it('empty answer in interactive mode returns default (false) when defaultValue is false', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { answers: [''] } });
+      expect(await confirm({ title: 'Continue?', defaultValue: false, ctx })).toBe(false);
+    });
+  });
 });

--- a/packages/bijou/src/core/forms/confirm.test.ts
+++ b/packages/bijou/src/core/forms/confirm.test.ts
@@ -118,7 +118,7 @@ describe('confirm()', () => {
     expect(ctx.io.written.length).toBeGreaterThan(0);
   });
 
-  describe('Ctrl+C / empty answer in interactive mode', () => {
+  describe('empty answer in interactive mode', () => {
     it('empty answer in interactive mode returns default (true)', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { answers: [''] } });
       expect(await confirm({ title: 'Continue?', ctx })).toBe(true);

--- a/packages/bijou/src/core/forms/index.ts
+++ b/packages/bijou/src/core/forms/index.ts
@@ -24,3 +24,6 @@ export type { TextareaOptions } from './textarea.js';
 
 export { filter } from './filter.js';
 export type { FilterOption, FilterOptions } from './filter.js';
+
+export { wizard } from './wizard.js';
+export type { WizardStep, WizardOptions } from './wizard.js';

--- a/packages/bijou/src/core/forms/input.test.ts
+++ b/packages/bijou/src/core/forms/input.test.ts
@@ -99,6 +99,20 @@ describe('input()', () => {
     });
   });
 
+  describe('empty / Ctrl+C behavior', () => {
+    it('empty input in interactive mode returns empty string', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { answers: [''] } });
+      const result = await input({ title: 'Name', ctx });
+      expect(result).toBe('');
+    });
+
+    it('empty input in interactive mode returns default when set', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { answers: [''] } });
+      const result = await input({ title: 'Name', defaultValue: 'fallback', ctx });
+      expect(result).toBe('fallback');
+    });
+  });
+
   describe('edge cases', () => {
     it('handles 1000+ character input', async () => {
       const longStr = 'a'.repeat(1500);

--- a/packages/bijou/src/core/forms/multiselect.test.ts
+++ b/packages/bijou/src/core/forms/multiselect.test.ts
@@ -91,6 +91,18 @@ describe('multiselect()', () => {
       const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
       expect(result).toEqual([]);
     });
+
+    it('toggle on and off deselects item', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: [' ', ' ', '\r'] } });
+      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      expect(result).toEqual([]);
+    });
+
+    it('navigate to last item and select', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[B', '\x1b[B', ' ', '\r'] } });
+      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      expect(result).toEqual(['blue']);
+    });
   });
 
   it('accepts ctx parameter', async () => {

--- a/packages/bijou/src/core/forms/wizard.test.ts
+++ b/packages/bijou/src/core/forms/wizard.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { wizard } from './wizard.js';
+
+describe('wizard()', () => {
+  it('runs all steps and collects values', async () => {
+    const result = await wizard<{ name: string; age: number; active: boolean }>({
+      steps: [
+        { key: 'name', field: async () => 'Alice' },
+        { key: 'age', field: async () => 30 },
+        { key: 'active', field: async () => true },
+      ],
+    });
+    expect(result).toEqual({
+      values: { name: 'Alice', age: 30, active: true },
+      cancelled: false,
+    });
+  });
+
+  it('skips step when skip predicate returns true', async () => {
+    const result = await wizard<{ mode: string; details: string }>({
+      steps: [
+        { key: 'mode', field: async () => 'simple' },
+        {
+          key: 'details',
+          field: async () => 'extra info',
+          skip: (values) => values.mode === 'simple',
+        },
+      ],
+    });
+    expect(result.values.mode).toBe('simple');
+    expect(result.values.details).toBeUndefined();
+    expect(result.cancelled).toBe(false);
+  });
+
+  it('does not skip when skip predicate returns false', async () => {
+    const result = await wizard<{ mode: string; details: string }>({
+      steps: [
+        { key: 'mode', field: async () => 'advanced' },
+        {
+          key: 'details',
+          field: async () => 'extra info',
+          skip: (values) => values.mode === 'simple',
+        },
+      ],
+    });
+    expect(result.values.mode).toBe('advanced');
+    expect(result.values.details).toBe('extra info');
+  });
+
+  it('empty steps returns empty values', async () => {
+    const result = await wizard<Record<string, never>>({
+      steps: [],
+    });
+    expect(result).toEqual({ values: {}, cancelled: false });
+  });
+
+  it('field receives accumulated values', async () => {
+    const received: Partial<{ a: string; b: string }>[] = [];
+    await wizard<{ a: string; b: string }>({
+      steps: [
+        {
+          key: 'a',
+          field: async (vals) => {
+            received.push({ ...vals });
+            return 'first';
+          },
+        },
+        {
+          key: 'b',
+          field: async (vals) => {
+            received.push({ ...vals });
+            return 'second';
+          },
+        },
+      ],
+    });
+    expect(received[0]).toEqual({});
+    expect(received[1]).toEqual({ a: 'first' });
+  });
+
+  it('steps run sequentially', async () => {
+    const order: number[] = [];
+    await wizard<{ a: string; b: string; c: string }>({
+      steps: [
+        {
+          key: 'a',
+          field: async () => {
+            order.push(1);
+            return 'a';
+          },
+        },
+        {
+          key: 'b',
+          field: async () => {
+            order.push(2);
+            return 'b';
+          },
+        },
+        {
+          key: 'c',
+          field: async () => {
+            order.push(3);
+            return 'c';
+          },
+        },
+      ],
+    });
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('skip predicate can depend on multiple prior values', async () => {
+    const result = await wizard<{ x: number; y: number; sum: number }>({
+      steps: [
+        { key: 'x', field: async () => 5 },
+        { key: 'y', field: async () => 10 },
+        {
+          key: 'sum',
+          field: async (vals) => (vals.x ?? 0) + (vals.y ?? 0),
+          skip: (vals) => (vals.x ?? 0) + (vals.y ?? 0) > 20,
+        },
+      ],
+    });
+    expect(result.values.sum).toBe(15);
+  });
+});

--- a/packages/bijou/src/core/forms/wizard.ts
+++ b/packages/bijou/src/core/forms/wizard.ts
@@ -1,0 +1,47 @@
+import type { GroupFieldResult } from './types.js';
+
+export interface WizardStep<T> {
+  key: keyof T;
+  field: (values: Partial<T>) => Promise<unknown>;
+  skip?: (values: Partial<T>) => boolean;
+}
+
+export interface WizardOptions<T extends Record<string, unknown>> {
+  steps: WizardStep<T>[];
+}
+
+/**
+ * Multi-step form wizard that runs steps sequentially, passing accumulated
+ * values to each step's `field` function. Steps can be conditionally skipped
+ * via the `skip` predicate.
+ *
+ * @example
+ * ```ts
+ * const result = await wizard<{ mode: string; details: string }>({
+ *   steps: [
+ *     { key: 'mode', field: () => select({ title: 'Mode', options: [...] }) },
+ *     {
+ *       key: 'details',
+ *       field: () => input({ title: 'Details' }),
+ *       skip: (vals) => vals.mode === 'simple',
+ *     },
+ *   ],
+ * });
+ * ```
+ */
+export async function wizard<T extends Record<string, unknown>>(
+  options: WizardOptions<T>,
+): Promise<GroupFieldResult<T>> {
+  const values = {} as T;
+
+  for (const step of options.steps) {
+    if (step.skip?.(values)) {
+      continue;
+    }
+
+    const result = await step.field(values);
+    (values as Record<string, unknown>)[step.key as string] = result;
+  }
+
+  return { values, cancelled: false };
+}

--- a/packages/bijou/src/core/forms/wizard.ts
+++ b/packages/bijou/src/core/forms/wizard.ts
@@ -1,8 +1,8 @@
 import type { GroupFieldResult } from './types.js';
 
-export interface WizardStep<T> {
-  key: keyof T;
-  field: (values: Partial<T>) => Promise<unknown>;
+export interface WizardStep<T, K extends keyof T = keyof T> {
+  key: K;
+  field: (values: Partial<T>) => Promise<T[K]>;
   skip?: (values: Partial<T>) => boolean;
 }
 

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -136,6 +136,8 @@ export {
   type DagSource,
   type SlicedDagSource,
   type DagSliceOptions,
+  dagStats,
+  type DagStats,
 } from './core/components/index.js';
 
 // Forms

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -158,4 +158,7 @@ export {
   filter,
   type FilterOption,
   type FilterOptions,
+  wizard,
+  type WizardStep,
+  type WizardOptions,
 } from './core/forms/index.js';

--- a/packages/bijou/src/ports/io.ts
+++ b/packages/bijou/src/ports/io.ts
@@ -13,6 +13,10 @@ export interface IOPort {
   onResize(callback: (cols: number, rows: number) => void): RawInputHandle;
   setInterval(callback: () => void, ms: number): TimerHandle;
   readFile(path: string): string;
+  /**
+   * List directory contents. Directory names MUST include a trailing `/`
+   * suffix (e.g. `"src/"`) so consumers can distinguish them from files.
+   */
   readDir(path: string): string[];
   joinPath(...segments: string[]): string;
 }


### PR DESCRIPTION
## Summary
Merges all 6 v0.6.0 workstreams into a single release PR.

### Core (`@flyingrobots/bijou`)
- **`dagStats()`** — pure graph statistics (nodes, edges, depth, width, roots, leaves)
- **`wizard()`** — multi-step form orchestration with conditional skip

### TUI (`@flyingrobots/bijou-tui`)
- **`navigableTable()`** — keyboard-navigable table with focus + scroll
- **`browsableList()`** — rich navigable list with descriptions
- **`filePicker()`** — directory browser using `IOPort.readDir()`

### Tests
- 26 new form edge-case and environment integration matrix tests

### Branches merged
- `feat/dag-stats` (#14)
- `feat/wizard` (#15)
- `feat/navigable-table` (#16)
- `feat/browsable-list` (#17)
- `feat/file-picker` (#18)
- `test/hardening` (#19)

## Test plan
- [x] `npm run build` passes
- [x] All 1010 tests pass (896 baseline + 114 new)
- [x] Version bumped to 0.6.0