### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,14 @@ Stop building brittle CLIs that break in CI or look like garbage on a server. Bi
 
 ---
 
-## What's New in v0.7.0
+## What's New in v0.8.0
 
-**Layout, Core Components & Overlays** — new primitives for building polished terminal interfaces:
+**Command Palette, Tooltip, Color Utils & DAG Tokens** — four high-value non-breaking features:
 
-- **`place()`** — 2D text alignment with horizontal and vertical positioning
-- **`statusBar()`** — segmented header/footer with left, center, and right sections
-- **`enumeratedList()`** — ordered/unordered lists with 6 bullet styles
-- **`hyperlink()`** — OSC 8 clickable terminal links with graceful fallback
-- **`log()`** — leveled styled output (debug/info/warn/error/fatal)
-- **`drawer()`** — slide-in side panel overlay with `composite()` integration
+- **`commandPalette()`** — filterable action list with case-insensitive search, viewport scrolling, and vim-style keymap
+- **`tooltip()`** — positioned overlay with top/bottom/left/right direction and screen-edge clamping
+- **Color manipulation** — `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` on theme tokens
+- **`DagNode` token expansion** — `labelToken` and `badgeToken` for granular per-node text styling
 
 See the [full changelog](./docs/CHANGELOG.md) for the complete technical breakdown.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Bijou is a growing ecosystem. Transparency is our baseline—here is the current
 | `navigableTable` | ✅ Stable | Keyboard-navigable data table with focus, scrolling, and vim keybindings. |
 | `browsableList` | ✅ Stable | Scrollable list with focus tracking, descriptions, and page navigation. |
 | `filePicker` | ✅ Stable | Directory browser with IOPort integration and extension filtering. |
-| `commandPalette` | 🗓️ Roadmap | Unified global search and action interface. |
+| `commandPalette` | ✅ Stable | Filterable action list with search and keyboard navigation. |
+| `tooltip` | ✅ Stable | Positioned overlay with directional placement and screen clamping. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Stop building brittle CLIs that break in CI or look like garbage on a server. Bi
 
 **Command Palette, Tooltip, Color Utils & DAG Tokens** — four high-value non-breaking features:
 
-- **`commandPalette()`** — filterable action list with case-insensitive search, viewport scrolling, and vim-style keymap
+- **`commandPalette()`** — filterable action list with case-insensitive search, viewport scrolling, and keyboard navigation
 - **`tooltip()`** — positioned overlay with top/bottom/left/right direction and screen-edge clamping
 - **Color manipulation** — `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` on theme tokens
 - **`DagNode` token expansion** — `labelToken` and `badgeToken` for granular per-node text styling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,9 +20,17 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`commandPalette()`** — filterable action list building block with case-insensitive substring matching on label/description/category/id/shortcut, focus and page navigation with wrap-around, viewport-clipped rendering, and preconfigured keymap
 - **`tooltip()`** — positioned overlay relative to a target element with top/bottom/left/right direction and screen-edge clamping. Reuses existing `renderBox()` helper
 
+### 🐛 Fixes
+
+- **`dag()`** — fix charTypes/chars length mismatch on non-BMP characters (emoji) by using code-point count instead of UTF-16 `.length`
+- **`cpPageDown()`/`cpPageUp()`** — change to half-page scroll (`floor(height/2)`) to match vim Ctrl+D/Ctrl+U conventions described in JSDoc
+- **`tooltip()`** — clip content lines to screen width before rendering box to prevent overflow
+- **`hexToRgb()`** — throw on invalid hex length (e.g. 2, 4, 5, 7+ digit strings)
+- **command-palette example** — remove unused `cpSelectedItem` import
+
 ### 🧪 Tests
 
-- 93 new tests across 2 new test files (1198 total)
+- 103 new tests across 4 test files (2 new, 2 expanded) (1208 total)
 
 ### 📝 Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,12 +17,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 #### TUI (`@flyingrobots/bijou-tui`)
 
-- **`commandPalette()`** — filterable action list building block with case-insensitive substring matching on label/description/category/id, focus and page navigation with wrap-around, viewport-clipped rendering, and preconfigured keymap
+- **`commandPalette()`** — filterable action list building block with case-insensitive substring matching on label/description/category/id/shortcut, focus and page navigation with wrap-around, viewport-clipped rendering, and preconfigured keymap
 - **`tooltip()`** — positioned overlay relative to a target element with top/bottom/left/right direction and screen-edge clamping. Reuses existing `renderBox()` helper
 
 ### 🧪 Tests
 
-- 87 new tests across 4 new test files (1192 total)
+- 88 new tests across 4 new test files (1193 total)
 
 ### 📝 Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,28 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-02-28
+
+### 🚀 Features
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`DagNode` `labelToken`/`badgeToken`** — optional per-node label and badge text color tokens for granular styling beyond border color. Propagated through `arraySource()`, `materialize()`, and `sliceSource()`
+- **Color manipulation utilities** — `hexToRgb()`, `rgbToHex()`, `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` for manipulating theme token colors. All functions preserve token modifiers and clamp amounts to [0,1]
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`commandPalette()`** — filterable action list building block with case-insensitive substring matching on label/description/category/id, focus and page navigation with wrap-around, viewport-clipped rendering, and preconfigured keymap
+- **`tooltip()`** — positioned overlay relative to a target element with top/bottom/left/right direction and screen-edge clamping. Reuses existing `renderBox()` helper
+
+### 🧪 Tests
+
+- 87 new tests across 4 new test files (1192 total)
+
+### 📝 Documentation
+
+- **2 new examples** — `command-palette`, `tooltip`
+
 ## [0.7.0] — 2026-02-28
 
 ### 🚀 Features
@@ -282,7 +304,8 @@ First public release.
 - **Screen control** — `enterScreen()`, `exitScreen()`, `clearAndHome()`, `renderFrame()`
 - **Layout helpers** — `vstack()`, `hstack()`
 
-[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/flyingrobots/bijou/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/flyingrobots/bijou/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/flyingrobots/bijou/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/flyingrobots/bijou/compare/v0.5.0...v0.5.1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧪 Tests
 
-- 91 new tests across 2 new test files (1196 total)
+- 93 new tests across 2 new test files (1198 total)
 
 ### 📝 Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧪 Tests
 
-- 88 new tests across 4 new test files (1193 total)
+- 90 new tests across 2 new test files (1195 total)
 
 ### 📝 Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧪 Tests
 
-- 103 new tests across 4 test files (2 new, 2 expanded) (1208 total)
+- 104 new tests across 4 test files (2 new, 2 expanded) (1209 total)
 
 ### 📝 Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧪 Tests
 
-- 90 new tests across 2 new test files (1195 total)
+- 91 new tests across 2 new test files (1196 total)
 
 ### 📝 Documentation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -422,6 +422,14 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | **`markdown()`** | bijou | Render markdown with syntax highlighting. |
 | ~~**`log()`**~~ | bijou | ✅ v0.7.0 — Leveled styled log output (debug/info/warn/error/fatal). |
 
+### P2.5 — Code quality & DX
+
+| Feature | Package | Notes |
+|---------|---------|-------|
+| **Eliminate `as KeyMsg` casts in examples** | examples | All 20+ examples use `'type' in msg && msg.type === 'key'` with an unsafe `as KeyMsg` cast. Refactor Msg unions to include `KeyMsg` for proper type narrowing. |
+| **`StyleAuditPort` test adapter** | bijou | Current `plainStyle()` is a no-op — can't verify token application in tests. Add an adapter that records styled calls for assertion. |
+| **Grapheme cluster support** | bijou-tui | `[...str]` splits by code points, not grapheme clusters. Multi-codepoint emoji (flags, skin tones) misalign charType mapping in dag renderer and width calculations in viewport/layout. Consider `Intl.Segmenter`. |
+
 ### P3 — Nice to have
 
 | Feature | Package | Notes |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Tests ARE the Spec.** Every feature is defined by its tests. If it's not tested, it's not guaranteed. Acceptance criteria are written as test descriptions first, implementation second.
 
-Current: **v0.7.0** — Layout primitives, core components, overlays
+Current: **v0.8.0** — Command palette, tooltip, color utils, DAG token expansion
 
 ---
 
@@ -340,11 +340,11 @@ Growing toward a full terminal component library:
 | **Element** | ~~`alert()`~~, ~~`badge()`~~, ~~`separator()`~~, ~~`skeleton()`~~, ~~`kbd()`~~ ✅ |
 | **Data** | ~~`accordion()`~~, ~~`tree()`~~, ~~`timeline()`~~, ~~`dag()`~~, ~~`dagSlice()`~~, ~~`dagLayout()`~~, ~~`dagStats()`~~ ✅ |
 | **Forms** | ~~`input()`~~, ~~`select()`~~, ~~`multiselect()`~~, ~~`confirm()`~~, ~~`group()`~~, ~~`textarea()`~~, ~~`filter()`~~, ~~`wizard()`~~ ✅ |
-| **Navigation** | ~~`tabs()`~~, ~~`breadcrumb()`~~, ~~`paginator()`~~, ~~`stepper()`~~ ✅, `commandPalette()` |
+| **Navigation** | ~~`tabs()`~~, ~~`breadcrumb()`~~, ~~`paginator()`~~, ~~`stepper()`~~, ~~`commandPalette()`~~ ✅ |
 | **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~, ~~`createPanelGroup()`~~, ~~`navigableTable()`~~, ~~`browsableList()`~~, ~~`filePicker()`~~ ✅ |
 | **Overlay** | ~~`composite()`~~, ~~`modal()`~~, ~~`toast()`~~, ~~`drawer()`~~ ✅ |
 | **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~ ✅, mouse events (`IOPort.onMouse()`) |
-| **App** | ~~`statusBar()`~~ ✅, `splitPane()`, `tooltip()` |
+| **App** | ~~`statusBar()`~~, ~~`tooltip()`~~ ✅, `splitPane()` |
 
 Each new component should follow this template before implementation:
 1. Write user story and requirements
@@ -410,7 +410,7 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | Feature | Package | Notes |
 |---------|---------|-------|
 | **Mouse input** | bijou + bijou-node + bijou-tui | `IOPort.onMouse()` with SGR mouse parsing, `MouseMsg` in TEA runtime. Breaking change (new port method). |
-| **`DagNode` token expansion** | bijou | `labelToken` and `badgeToken` on `DagNode` for granular per-node styling beyond border color. |
+| ~~**`DagNode` token expansion**~~ | bijou | ✅ v0.8.0 — `labelToken` and `badgeToken` on `DagNode` for granular per-node styling beyond border color. |
 | ~~**`place()`**~~ | bijou-tui | ✅ v0.7.0 — 2D text placement with horizontal + vertical alignment. |
 | ~~**`drawer()`**~~ | bijou-tui | ✅ v0.7.0 — Slide-in side panel built on `composite()`. Left/right anchored, configurable width. |
 | **CLI/stdin component driver** | bijou-tui | Drive component state via CLI flags or streaming stdin commands. Enables scripted demos, testing, and external control. |
@@ -418,7 +418,7 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | ~~**Terminal hyperlinks**~~ | bijou | ✅ v0.7.0 — Clickable OSC 8 links with graceful fallback. |
 | **Adaptive colors** | bijou | Runtime light/dark background detection, auto color switching. |
 | **Color downsampling** | bijou | Truecolor → ANSI256 → ANSI graceful fallback chain. |
-| **Color manipulation** | bijou | `darken()`, `lighten()`, `complementary()`, `alpha()` on theme tokens. |
+| ~~**Color manipulation**~~ | bijou | ✅ v0.8.0 — `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` on theme tokens. |
 | **`markdown()`** | bijou | Render markdown with syntax highlighting. |
 | ~~**`log()`**~~ | bijou | ✅ v0.7.0 — Leveled styled log output (debug/info/warn/error/fatal). |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-> 57 examples · Run any: `npx tsx examples/<name>/main.ts`
+> 59 examples · Run any: `npx tsx examples/<name>/main.ts`
 > Record all GIFs: `../scripts/record-gifs.sh`
 
 ## Static Components
@@ -73,4 +73,6 @@
 | [`package-manager`](./package-manager/) | `package-manager` | Simulated `npm install` (resolve → download → link) |
 | [`status-bar`](./status-bar/) | `statusBar()` | Segmented header/footer with fill characters |
 | [`drawer`](./drawer/) | `drawer()`, `composite()` | Togglable slide-in side panel overlay |
+| [`command-palette`](./command-palette/) | `commandPalette()`, `commandPaletteKeyMap()` | Filterable action list with live search |
+| [`tooltip`](./tooltip/) | `tooltip()`, `composite()` | Positioned overlay with directional placement |
 | [`splash`](./splash/) | `splash` | Animated splash screen |

--- a/examples/command-palette/main.ts
+++ b/examples/command-palette/main.ts
@@ -3,7 +3,7 @@ import { separator } from '@flyingrobots/bijou';
 import {
   run, quit, type App, type KeyMsg,
   createCommandPaletteState, commandPalette,
-  cpFilter, cpFocusNext, cpFocusPrev, cpPageDown, cpPageUp, cpSelectedItem,
+  cpFilter, cpFocusNext, cpFocusPrev, cpPageDown, cpPageUp,
   commandPaletteKeyMap, helpShort, vstack,
   type CommandPaletteItem,
 } from '@flyingrobots/bijou-tui';

--- a/examples/command-palette/main.ts
+++ b/examples/command-palette/main.ts
@@ -11,7 +11,7 @@ import {
 const ctx = initDefaultContext();
 
 const items: CommandPaletteItem[] = [
-  { id: 'box', label: 'box()', description: 'Bordered containers', category: 'Display', shortcut: '' },
+  { id: 'box', label: 'box()', description: 'Bordered containers', category: 'Display' },
   { id: 'table', label: 'table()', description: 'Auto-spacing data grids', category: 'Display' },
   { id: 'dag', label: 'dag()', description: 'Directed acyclic graph', category: 'Display' },
   { id: 'spinner', label: 'spinner()', description: 'Loading indicator', category: 'Feedback' },
@@ -19,7 +19,7 @@ const items: CommandPaletteItem[] = [
   { id: 'select', label: 'select()', description: 'Single-select menu', category: 'Forms' },
   { id: 'input', label: 'input()', description: 'Text input prompt', category: 'Forms' },
   { id: 'confirm', label: 'confirm()', description: 'Yes/no prompt', category: 'Forms' },
-  { id: 'wizard', label: 'wizard()', description: 'Multi-step form', category: 'Forms', shortcut: '' },
+  { id: 'wizard', label: 'wizard()', description: 'Multi-step form', category: 'Forms' },
   { id: 'accordion', label: 'accordion()', description: 'Expandable sections', category: 'Layout' },
   { id: 'tabs', label: 'tabs()', description: 'Tab bar navigation', category: 'Navigation' },
   { id: 'tree', label: 'tree()', description: 'Hierarchical tree', category: 'Display' },

--- a/examples/command-palette/main.ts
+++ b/examples/command-palette/main.ts
@@ -31,8 +31,7 @@ type Msg =
   | { type: 'page-down' }
   | { type: 'page-up' }
   | { type: 'select' }
-  | { type: 'close' }
-  | { type: 'char'; char: string };
+  | { type: 'close' };
 
 const keys = commandPaletteKeyMap<Msg>({
   focusNext: { type: 'next' },

--- a/examples/command-palette/main.ts
+++ b/examples/command-palette/main.ts
@@ -1,0 +1,98 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { separator } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg,
+  createCommandPaletteState, commandPalette,
+  cpFilter, cpFocusNext, cpFocusPrev, cpPageDown, cpPageUp, cpSelectedItem,
+  commandPaletteKeyMap, helpShort, vstack,
+  type CommandPaletteItem,
+} from '@flyingrobots/bijou-tui';
+
+const ctx = initDefaultContext();
+
+const items: CommandPaletteItem[] = [
+  { id: 'box', label: 'box()', description: 'Bordered containers', category: 'Display', shortcut: '' },
+  { id: 'table', label: 'table()', description: 'Auto-spacing data grids', category: 'Display' },
+  { id: 'dag', label: 'dag()', description: 'Directed acyclic graph', category: 'Display' },
+  { id: 'spinner', label: 'spinner()', description: 'Loading indicator', category: 'Feedback' },
+  { id: 'progress', label: 'progressBar()', description: 'Visual progress', category: 'Feedback' },
+  { id: 'select', label: 'select()', description: 'Single-select menu', category: 'Forms' },
+  { id: 'input', label: 'input()', description: 'Text input prompt', category: 'Forms' },
+  { id: 'confirm', label: 'confirm()', description: 'Yes/no prompt', category: 'Forms' },
+  { id: 'wizard', label: 'wizard()', description: 'Multi-step form', category: 'Forms', shortcut: '' },
+  { id: 'accordion', label: 'accordion()', description: 'Expandable sections', category: 'Layout' },
+  { id: 'tabs', label: 'tabs()', description: 'Tab bar navigation', category: 'Navigation' },
+  { id: 'tree', label: 'tree()', description: 'Hierarchical tree', category: 'Display' },
+];
+
+type Msg =
+  | { type: 'next' }
+  | { type: 'prev' }
+  | { type: 'page-down' }
+  | { type: 'page-up' }
+  | { type: 'select' }
+  | { type: 'close' }
+  | { type: 'char'; char: string };
+
+const keys = commandPaletteKeyMap<Msg>({
+  focusNext: { type: 'next' },
+  focusPrev: { type: 'prev' },
+  pageDown: { type: 'page-down' },
+  pageUp: { type: 'page-up' },
+  select: { type: 'select' },
+  close: { type: 'close' },
+});
+
+interface Model {
+  cp: ReturnType<typeof createCommandPaletteState>;
+  selected?: string;
+}
+
+const app: App<Model, Msg> = {
+  init: () => [{ cp: createCommandPaletteState(items, 8) }, []],
+
+  update: (msg, model) => {
+    if ('type' in msg && msg.type === 'key') {
+      const keyMsg = msg as KeyMsg;
+
+      // Let keymap handle navigation keys first
+      const action = keys.handle(keyMsg);
+      if (action) {
+        switch (action.type) {
+          case 'close': return [model, [quit()]];
+          case 'select': {
+            const item = cpSelectedItem(model.cp);
+            return [{ ...model, selected: item?.label }, [quit()]];
+          }
+          case 'next': return [{ ...model, cp: cpFocusNext(model.cp) }, []];
+          case 'prev': return [{ ...model, cp: cpFocusPrev(model.cp) }, []];
+          case 'page-down': return [{ ...model, cp: cpPageDown(model.cp) }, []];
+          case 'page-up': return [{ ...model, cp: cpPageUp(model.cp) }, []];
+        }
+      }
+
+      // Printable character → update filter
+      if (keyMsg.key.length === 1 && !keyMsg.ctrl && !keyMsg.alt) {
+        const newQuery = model.cp.query + keyMsg.key;
+        return [{ ...model, cp: cpFilter(model.cp, newQuery) }, []];
+      }
+
+      // Backspace → remove last char from query
+      if (keyMsg.key === 'backspace') {
+        const newQuery = model.cp.query.slice(0, -1);
+        return [{ ...model, cp: cpFilter(model.cp, newQuery) }, []];
+      }
+    }
+
+    return [model, []];
+  },
+
+  view: (model) => {
+    const header = separator({ label: 'command palette', ctx });
+    const body = commandPalette(model.cp, { width: 60, ctx });
+    const help = `  ${helpShort(keys)}`;
+    return vstack('', header, '', body, '', help, '');
+  },
+};
+
+run(app);

--- a/examples/tooltip/main.ts
+++ b/examples/tooltip/main.ts
@@ -34,6 +34,7 @@ const app: App<Model, Msg> = {
       switch (msg.key) {
         case 'q': return [model, [quit()]];
         case 'd': return [{ ...model, dirIndex: (model.dirIndex + 1) % directions.length }, []];
+        // Keep target within screen, leaving margin for tooltip overflow
         case 'up': return [{ ...model, selectedRow: Math.max(2, model.selectedRow - 1) }, []];
         case 'down': return [{ ...model, selectedRow: Math.min(model.rows - 3, model.selectedRow + 1) }, []];
         case 'left': return [{ ...model, selectedCol: Math.max(2, model.selectedCol - 1) }, []];

--- a/examples/tooltip/main.ts
+++ b/examples/tooltip/main.ts
@@ -33,7 +33,7 @@ const app: App<Model, Msg> = {
     if (msg.type === 'key') {
       switch (msg.key) {
         case 'q': return [model, [quit()]];
-        case 'd': return [{ ...model, dirIndex: (model.dirIndex + 1) % 4 }, []];
+        case 'd': return [{ ...model, dirIndex: (model.dirIndex + 1) % directions.length }, []];
         case 'up': return [{ ...model, selectedRow: Math.max(2, model.selectedRow - 1) }, []];
         case 'down': return [{ ...model, selectedRow: Math.min(model.rows - 3, model.selectedRow + 1) }, []];
         case 'left': return [{ ...model, selectedCol: Math.max(2, model.selectedCol - 1) }, []];
@@ -53,7 +53,11 @@ const app: App<Model, Msg> = {
     while (bgLines.length < rows) bgLines.push('');
 
     // Place a marker at the target position
-    bgLines[selectedRow] = bgLines[selectedRow]!.substring(0, selectedCol) + '◆' + bgLines[selectedRow]!.substring(selectedCol + 1);
+    let markerLine = bgLines[selectedRow]!;
+    if (markerLine.length < selectedCol + 1) {
+      markerLine = markerLine.padEnd(selectedCol + 1, ' ');
+    }
+    bgLines[selectedRow] = markerLine.substring(0, selectedCol) + '◆' + markerLine.substring(selectedCol + 1);
     const bg = bgLines.join('\n');
 
     const tip = tooltip({

--- a/examples/tooltip/main.ts
+++ b/examples/tooltip/main.ts
@@ -1,0 +1,74 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { separator, badge } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg, type ResizeMsg,
+  vstack, composite, tooltip, type TooltipDirection,
+} from '@flyingrobots/bijou-tui';
+
+const ctx = initDefaultContext();
+
+type Msg = KeyMsg | ResizeMsg;
+
+const directions: TooltipDirection[] = ['top', 'bottom', 'left', 'right'];
+
+interface Model {
+  selectedRow: number;
+  selectedCol: number;
+  dirIndex: number;
+  cols: number;
+  rows: number;
+}
+
+const app: App<Model, Msg> = {
+  init: () => {
+    const cols = ctx.runtime.columns();
+    const rows = ctx.runtime.rows();
+    return [{ selectedRow: 10, selectedCol: 20, dirIndex: 0, cols, rows }, []];
+  },
+
+  update: (msg, model) => {
+    if (msg.type === 'resize') {
+      return [{ ...model, cols: msg.cols, rows: msg.rows }, []];
+    }
+    if (msg.type === 'key') {
+      switch (msg.key) {
+        case 'q': return [model, [quit()]];
+        case 'd': return [{ ...model, dirIndex: (model.dirIndex + 1) % 4 }, []];
+        case 'up': return [{ ...model, selectedRow: Math.max(2, model.selectedRow - 1) }, []];
+        case 'down': return [{ ...model, selectedRow: Math.min(model.rows - 3, model.selectedRow + 1) }, []];
+        case 'left': return [{ ...model, selectedCol: Math.max(2, model.selectedCol - 1) }, []];
+        case 'right': return [{ ...model, selectedCol: Math.min(model.cols - 3, model.selectedCol + 1) }, []];
+      }
+    }
+    return [model, []];
+  },
+
+  view: (model) => {
+    const { cols, rows, selectedRow, selectedCol, dirIndex } = model;
+    const dir = directions[dirIndex]!;
+
+    const header = separator({ label: 'tooltip demo', width: cols, ctx });
+    const help = `  Arrows: move target · ${badge('d', { ctx })}: cycle direction (${dir}) · ${badge('q', { ctx })}: quit`;
+    const bgLines = [header, '', help];
+    while (bgLines.length < rows) bgLines.push('');
+
+    // Place a marker at the target position
+    bgLines[selectedRow] = bgLines[selectedRow]!.substring(0, selectedCol) + '◆' + bgLines[selectedRow]!.substring(selectedCol + 1);
+    const bg = bgLines.join('\n');
+
+    const tip = tooltip({
+      content: `Direction: ${dir}\nRow: ${selectedRow} Col: ${selectedCol}`,
+      row: selectedRow,
+      col: selectedCol,
+      direction: dir,
+      screenWidth: cols,
+      screenHeight: rows,
+      borderToken: ctx.theme.theme.border.primary,
+      ctx,
+    });
+
+    return composite(bg, [tip]);
+  },
+};
+
+run(app);

--- a/examples/tooltip/main.ts
+++ b/examples/tooltip/main.ts
@@ -2,7 +2,7 @@ import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { separator, badge } from '@flyingrobots/bijou';
 import {
   run, quit, type App, type KeyMsg, type ResizeMsg,
-  vstack, composite, tooltip, type TooltipDirection,
+  composite, tooltip, type TooltipDirection,
 } from '@flyingrobots/bijou-tui';
 
 const ctx = initDefaultContext();

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -27,7 +27,7 @@
     "chalk": "^5.6.2"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.7.0"
+    "@flyingrobots/bijou": "0.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.7.0"
+    "@flyingrobots/bijou": "0.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/src/command-palette.test.ts
+++ b/packages/bijou-tui/src/command-palette.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import {
+  createCommandPaletteState,
+  cpFilter,
+  cpFocusNext,
+  cpFocusPrev,
+  cpPageDown,
+  cpPageUp,
+  cpSelectedItem,
+  commandPalette,
+  commandPaletteKeyMap,
+} from './command-palette.js';
+import type { CommandPaletteItem } from './command-palette.js';
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const items: CommandPaletteItem[] = [
+  { id: 'open', label: 'Open File', description: 'Open a file from disk', category: 'File', shortcut: 'Ctrl+O' },
+  { id: 'save', label: 'Save', description: 'Save current file', category: 'File', shortcut: 'Ctrl+S' },
+  { id: 'close', label: 'Close Tab', description: 'Close the active tab', category: 'Tab' },
+  { id: 'split', label: 'Split Editor', category: 'View' },
+  { id: 'theme', label: 'Change Theme', description: 'Switch color theme', category: 'Preferences' },
+];
+
+// ---------------------------------------------------------------------------
+// createCommandPaletteState
+// ---------------------------------------------------------------------------
+
+describe('createCommandPaletteState', () => {
+  it('creates state with defaults', () => {
+    const state = createCommandPaletteState(items);
+    expect(state.focusIndex).toBe(0);
+    expect(state.scrollY).toBe(0);
+    expect(state.height).toBe(10);
+    expect(state.query).toBe('');
+    expect(state.items).toHaveLength(items.length);
+    expect(state.filteredItems).toHaveLength(items.length);
+  });
+
+  it('accepts custom height', () => {
+    const state = createCommandPaletteState(items, 3);
+    expect(state.height).toBe(3);
+  });
+
+  it('clamps height to 1', () => {
+    expect(createCommandPaletteState(items, 0).height).toBe(1);
+    expect(createCommandPaletteState(items, -5).height).toBe(1);
+  });
+
+  it('makes a defensive copy of items', () => {
+    const mutable = [...items];
+    const state = createCommandPaletteState(mutable);
+    mutable.push({ id: 'new', label: 'New' });
+    expect(state.items).toHaveLength(items.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cpFilter
+// ---------------------------------------------------------------------------
+
+describe('cpFilter', () => {
+  it('matches by label', () => {
+    const state = createCommandPaletteState(items);
+    const filtered = cpFilter(state, 'save');
+    expect(filtered.filteredItems).toHaveLength(1);
+    expect(filtered.filteredItems[0]!.id).toBe('save');
+  });
+
+  it('matches by description', () => {
+    const state = createCommandPaletteState(items);
+    const filtered = cpFilter(state, 'disk');
+    expect(filtered.filteredItems).toHaveLength(1);
+    expect(filtered.filteredItems[0]!.id).toBe('open');
+  });
+
+  it('matches by category', () => {
+    const state = createCommandPaletteState(items);
+    const filtered = cpFilter(state, 'file');
+    expect(filtered.filteredItems).toHaveLength(2);
+  });
+
+  it('matches by id', () => {
+    const state = createCommandPaletteState(items);
+    const filtered = cpFilter(state, 'split');
+    expect(filtered.filteredItems).toHaveLength(1);
+    expect(filtered.filteredItems[0]!.id).toBe('split');
+  });
+
+  it('is case-insensitive', () => {
+    const state = createCommandPaletteState(items);
+    const filtered = cpFilter(state, 'SAVE');
+    expect(filtered.filteredItems).toHaveLength(1);
+  });
+
+  it('resets focus to 0', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFocusNext(cpFocusNext(state)); // focus at 2
+    const filtered = cpFilter(state, 'file');
+    expect(filtered.focusIndex).toBe(0);
+    expect(filtered.scrollY).toBe(0);
+  });
+
+  it('empty query shows all items', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFilter(state, 'save');
+    expect(state.filteredItems).toHaveLength(1);
+    state = cpFilter(state, '');
+    expect(state.filteredItems).toHaveLength(items.length);
+  });
+
+  it('no matches returns empty filteredItems', () => {
+    const state = createCommandPaletteState(items);
+    const filtered = cpFilter(state, 'zzzzz');
+    expect(filtered.filteredItems).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus navigation
+// ---------------------------------------------------------------------------
+
+describe('focus navigation', () => {
+  it('focusNext moves forward', () => {
+    const state = createCommandPaletteState(items);
+    const next = cpFocusNext(state);
+    expect(next.focusIndex).toBe(1);
+  });
+
+  it('focusNext wraps around', () => {
+    let state = createCommandPaletteState(items);
+    for (let i = 0; i < items.length; i++) state = cpFocusNext(state);
+    expect(state.focusIndex).toBe(0);
+  });
+
+  it('focusPrev moves backward', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFocusNext(state);
+    state = cpFocusPrev(state);
+    expect(state.focusIndex).toBe(0);
+  });
+
+  it('focusPrev wraps around', () => {
+    const state = createCommandPaletteState(items);
+    const prev = cpFocusPrev(state);
+    expect(prev.focusIndex).toBe(items.length - 1);
+  });
+
+  it('empty list is a no-op', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFilter(state, 'zzzzz');
+    expect(cpFocusNext(state)).toBe(state);
+    expect(cpFocusPrev(state)).toBe(state);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Page navigation
+// ---------------------------------------------------------------------------
+
+describe('page navigation', () => {
+  it('pageDown moves by height', () => {
+    const state = createCommandPaletteState(items, 2);
+    const paged = cpPageDown(state);
+    expect(paged.focusIndex).toBe(2);
+  });
+
+  it('pageDown clamps to last item', () => {
+    const state = createCommandPaletteState(items, 10);
+    const paged = cpPageDown(state);
+    expect(paged.focusIndex).toBe(items.length - 1);
+  });
+
+  it('pageUp clamps to first item', () => {
+    const state = createCommandPaletteState(items, 10);
+    const paged = cpPageUp(state);
+    expect(paged.focusIndex).toBe(0);
+  });
+
+  it('empty list is a no-op', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFilter(state, 'zzzzz');
+    expect(cpPageDown(state)).toBe(state);
+    expect(cpPageUp(state)).toBe(state);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cpSelectedItem
+// ---------------------------------------------------------------------------
+
+describe('cpSelectedItem', () => {
+  it('returns focused item', () => {
+    const state = createCommandPaletteState(items);
+    expect(cpSelectedItem(state)?.id).toBe('open');
+  });
+
+  it('returns undefined when no matches', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFilter(state, 'zzzzz');
+    expect(cpSelectedItem(state)).toBeUndefined();
+  });
+
+  it('returns correct item after navigation', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFocusNext(state);
+    state = cpFocusNext(state);
+    expect(cpSelectedItem(state)?.id).toBe('close');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+describe('commandPalette render', () => {
+  it('renders search line', () => {
+    const state = createCommandPaletteState(items);
+    const output = commandPalette(state, { width: 60 });
+    expect(output).toContain('> ');
+  });
+
+  it('renders query in search line', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFilter(state, 'save');
+    const output = commandPalette(state, { width: 60 });
+    expect(output.split('\n')[0]).toContain('> save');
+  });
+
+  it('shows focus indicator on focused item', () => {
+    const state = createCommandPaletteState(items);
+    const output = commandPalette(state, { width: 60 });
+    const lines = output.split('\n');
+    expect(lines[1]).toContain('\u25b8');
+  });
+
+  it('shows category when enabled', () => {
+    const state = createCommandPaletteState(items);
+    const output = commandPalette(state, { width: 60, showCategory: true });
+    expect(output).toContain('[File]');
+  });
+
+  it('hides category when disabled', () => {
+    const state = createCommandPaletteState(items);
+    const output = commandPalette(state, { width: 60, showCategory: false });
+    expect(output).not.toContain('[File]');
+  });
+
+  it('shows shortcut when enabled', () => {
+    const state = createCommandPaletteState(items);
+    const output = commandPalette(state, { width: 60, showShortcut: true });
+    expect(output).toContain('Ctrl+O');
+  });
+
+  it('hides shortcut when disabled', () => {
+    const state = createCommandPaletteState(items);
+    const output = commandPalette(state, { width: 60, showShortcut: false });
+    expect(output).not.toContain('Ctrl+O');
+  });
+
+  it('shows "No matches" when empty', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFilter(state, 'zzzzz');
+    const output = commandPalette(state, { width: 60 });
+    expect(output).toContain('No matches');
+  });
+
+  it('respects viewport clipping (only shows items in viewport)', () => {
+    const state = createCommandPaletteState(items, 2);
+    const output = commandPalette(state, { width: 60 });
+    const lines = output.split('\n');
+    // 1 search line + 2 item lines = 3
+    expect(lines).toHaveLength(3);
+  });
+
+  it('works with ctx (themed)', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const state = createCommandPaletteState(items);
+    const output = commandPalette(state, { width: 60, ctx });
+    expect(output).toContain('Open File');
+    expect(output).toContain('[File]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keymap
+// ---------------------------------------------------------------------------
+
+describe('commandPaletteKeyMap', () => {
+  const actions = {
+    focusNext: 'next',
+    focusPrev: 'prev',
+    pageDown: 'pd',
+    pageUp: 'pu',
+    select: 'sel',
+    close: 'close',
+  };
+  const km = commandPaletteKeyMap(actions);
+
+  it('dispatches down/j to focusNext', () => {
+    expect(km.handle({ key: 'j', ctrl: false, alt: false, shift: false })).toBe('next');
+    expect(km.handle({ key: 'down', ctrl: false, alt: false, shift: false })).toBe('next');
+  });
+
+  it('dispatches up/k to focusPrev', () => {
+    expect(km.handle({ key: 'k', ctrl: false, alt: false, shift: false })).toBe('prev');
+    expect(km.handle({ key: 'up', ctrl: false, alt: false, shift: false })).toBe('prev');
+  });
+
+  it('dispatches enter to select', () => {
+    expect(km.handle({ key: 'enter', ctrl: false, alt: false, shift: false })).toBe('sel');
+  });
+
+  it('dispatches escape to close', () => {
+    expect(km.handle({ key: 'escape', ctrl: false, alt: false, shift: false })).toBe('close');
+  });
+});

--- a/packages/bijou-tui/src/command-palette.test.ts
+++ b/packages/bijou-tui/src/command-palette.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { visibleLength, stripAnsi } from './viewport.js';
 import {
   createCommandPaletteState,
   cpFilter,
@@ -273,6 +274,16 @@ describe('commandPalette render', () => {
     state = cpFilter(state, 'zzzzz');
     const output = commandPalette(state, { width: 60 });
     expect(output).toContain('No matches');
+  });
+
+  it('clips "No matches" to width', () => {
+    let state = createCommandPaletteState(items);
+    state = cpFilter(state, 'zzzzz');
+    const output = commandPalette(state, { width: 8 });
+    const lines = output.split('\n');
+    for (const line of lines) {
+      expect(visibleLength(stripAnsi(line))).toBeLessThanOrEqual(8);
+    }
   });
 
   it('respects viewport clipping (only shows items in viewport)', () => {

--- a/packages/bijou-tui/src/command-palette.test.ts
+++ b/packages/bijou-tui/src/command-palette.test.ts
@@ -317,6 +317,16 @@ describe('commandPaletteKeyMap', () => {
     expect(km.handle({ key: 'up', ctrl: false, alt: false, shift: false })).toBe('prev');
   });
 
+  it('dispatches pagedown/ctrl+d to pageDown', () => {
+    expect(km.handle({ key: 'd', ctrl: true, alt: false, shift: false })).toBe('pd');
+    expect(km.handle({ key: 'pagedown', ctrl: false, alt: false, shift: false })).toBe('pd');
+  });
+
+  it('dispatches pageup/ctrl+u to pageUp', () => {
+    expect(km.handle({ key: 'u', ctrl: true, alt: false, shift: false })).toBe('pu');
+    expect(km.handle({ key: 'pageup', ctrl: false, alt: false, shift: false })).toBe('pu');
+  });
+
   it('dispatches enter to select', () => {
     expect(km.handle({ key: 'enter', ctrl: false, alt: false, shift: false })).toBe('sel');
   });

--- a/packages/bijou-tui/src/command-palette.test.ts
+++ b/packages/bijou-tui/src/command-palette.test.ts
@@ -169,17 +169,41 @@ describe('focus navigation', () => {
 // Page navigation
 // ---------------------------------------------------------------------------
 
-describe('page navigation', () => {
-  it('pageDown moves by height', () => {
-    const state = createCommandPaletteState(items, 2);
+describe('page navigation (half-page)', () => {
+  it('pageDown moves by half height', () => {
+    const state = createCommandPaletteState(items, 4);
+    const paged = cpPageDown(state);
+    // half = floor(4 / 2) = 2
+    expect(paged.focusIndex).toBe(2);
+  });
+
+  it('pageDown with odd height uses floor(height/2)', () => {
+    // 5 items, height 5 → half = floor(5/2) = 2
+    const state = createCommandPaletteState(items, 5);
     const paged = cpPageDown(state);
     expect(paged.focusIndex).toBe(2);
+  });
+
+  it('pageDown with height 1 moves by 1', () => {
+    const state = createCommandPaletteState(items, 1);
+    const paged = cpPageDown(state);
+    // half = max(1, floor(1/2)) = max(1, 0) = 1
+    expect(paged.focusIndex).toBe(1);
   });
 
   it('pageDown clamps to last item', () => {
     const state = createCommandPaletteState(items, 10);
     const paged = cpPageDown(state);
     expect(paged.focusIndex).toBe(items.length - 1);
+  });
+
+  it('pageUp moves by half height', () => {
+    let state = createCommandPaletteState(items, 4);
+    // Move to index 4 first
+    for (let i = 0; i < 4; i++) state = cpFocusNext(state);
+    const paged = cpPageUp(state);
+    // half = floor(4 / 2) = 2, so 4 - 2 = 2
+    expect(paged.focusIndex).toBe(2);
   });
 
   it('pageUp clamps to first item', () => {

--- a/packages/bijou-tui/src/command-palette.test.ts
+++ b/packages/bijou-tui/src/command-palette.test.ts
@@ -90,6 +90,13 @@ describe('cpFilter', () => {
     expect(filtered.filteredItems[0]!.id).toBe('split');
   });
 
+  it('matches by shortcut', () => {
+    const state = createCommandPaletteState(items);
+    const filtered = cpFilter(state, 'ctrl+o');
+    expect(filtered.filteredItems).toHaveLength(1);
+    expect(filtered.filteredItems[0]!.id).toBe('open');
+  });
+
   it('is case-insensitive', () => {
     const state = createCommandPaletteState(items);
     const filtered = cpFilter(state, 'SAVE');
@@ -300,13 +307,13 @@ describe('commandPaletteKeyMap', () => {
   };
   const km = commandPaletteKeyMap(actions);
 
-  it('dispatches down/j to focusNext', () => {
-    expect(km.handle({ key: 'j', ctrl: false, alt: false, shift: false })).toBe('next');
+  it('dispatches down/ctrl+n to focusNext', () => {
+    expect(km.handle({ key: 'n', ctrl: true, alt: false, shift: false })).toBe('next');
     expect(km.handle({ key: 'down', ctrl: false, alt: false, shift: false })).toBe('next');
   });
 
-  it('dispatches up/k to focusPrev', () => {
-    expect(km.handle({ key: 'k', ctrl: false, alt: false, shift: false })).toBe('prev');
+  it('dispatches up/ctrl+p to focusPrev', () => {
+    expect(km.handle({ key: 'p', ctrl: true, alt: false, shift: false })).toBe('prev');
     expect(km.handle({ key: 'up', ctrl: false, alt: false, shift: false })).toBe('prev');
   });
 

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -136,17 +136,19 @@ export function cpFocusPrev(state: CommandPaletteState): CommandPaletteState {
   return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.filteredItems.length) };
 }
 
-/** Move focus down by one page (clamps to last item). */
+/** Move focus down by half a page (vim Ctrl+D convention, clamps to last item). */
 export function cpPageDown(state: CommandPaletteState): CommandPaletteState {
   if (state.filteredItems.length === 0) return state;
-  const focusIndex = Math.min(state.focusIndex + state.height, state.filteredItems.length - 1);
+  const half = Math.max(1, Math.floor(state.height / 2));
+  const focusIndex = Math.min(state.focusIndex + half, state.filteredItems.length - 1);
   return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.filteredItems.length) };
 }
 
-/** Move focus up by one page (clamps to first item). */
+/** Move focus up by half a page (vim Ctrl+U convention, clamps to first item). */
 export function cpPageUp(state: CommandPaletteState): CommandPaletteState {
   if (state.filteredItems.length === 0) return state;
-  const focusIndex = Math.max(state.focusIndex - state.height, 0);
+  const half = Math.max(1, Math.floor(state.height / 2));
+  const focusIndex = Math.max(state.focusIndex - half, 0);
   return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.filteredItems.length) };
 }
 
@@ -261,10 +263,10 @@ export function commandPaletteKeyMap<Msg>(actions: {
       .bind('down', 'Next item', actions.focusNext)
       .bind('ctrl+p', 'Previous item', actions.focusPrev)
       .bind('up', 'Previous item', actions.focusPrev)
-      .bind('ctrl+d', 'Page down', actions.pageDown)
-      .bind('pagedown', 'Page down', actions.pageDown)
-      .bind('ctrl+u', 'Page up', actions.pageUp)
-      .bind('pageup', 'Page up', actions.pageUp),
+      .bind('ctrl+d', 'Half page down', actions.pageDown)
+      .bind('pagedown', 'Half page down', actions.pageDown)
+      .bind('ctrl+u', 'Half page up', actions.pageUp)
+      .bind('pageup', 'Half page up', actions.pageUp),
     )
     .bind('enter', 'Select', actions.select)
     .bind('escape', 'Close', actions.close);

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -191,6 +191,8 @@ export function commandPalette(
 
   const indicator = '\u25b8'; // ▸
   const pad = ' ';
+  const muted = (text: string) =>
+    ctx ? ctx.style.styled(ctx.theme.theme.semantic.muted, text) : text;
 
   for (let i = 0; i < visible.length; i++) {
     const item = visible[i]!;
@@ -200,26 +202,17 @@ export function commandPalette(
     const parts: string[] = [];
 
     if (showCategory && item.category) {
-      const catText = ctx
-        ? ctx.style.styled(ctx.theme.theme.semantic.muted, `[${item.category}]`)
-        : `[${item.category}]`;
-      parts.push(catText);
+      parts.push(muted(`[${item.category}]`));
     }
 
     parts.push(item.label);
 
     if (item.description) {
-      const descText = ctx
-        ? ctx.style.styled(ctx.theme.theme.semantic.muted, item.description)
-        : item.description;
-      parts.push(descText);
+      parts.push(muted(item.description));
     }
 
     if (showShortcut && item.shortcut) {
-      const shortcutText = ctx
-        ? ctx.style.styled(ctx.theme.theme.semantic.muted, item.shortcut)
-        : item.shortcut;
-      parts.push(shortcutText);
+      parts.push(muted(item.shortcut));
     }
 
     const content = parts.join('  ');

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -22,7 +22,7 @@
 
 import type { BijouContext } from '@flyingrobots/bijou';
 import { createKeyMap, type KeyMap } from './keybindings.js';
-import { visibleLength, clipToWidth } from './viewport.js';
+import { clipToWidth } from './viewport.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -1,0 +1,271 @@
+/**
+ * Command palette building block — a filterable, navigable action list.
+ *
+ * Provides state transformers for filtering, focus, and page navigation,
+ * a pure render function with viewport clipping, and a convenience keymap.
+ *
+ * ```ts
+ * // In TEA init:
+ * const cpState = createCommandPaletteState(items);
+ *
+ * // In TEA view:
+ * const output = commandPalette(model.cpState, { width: 60 });
+ *
+ * // In TEA update:
+ * case 'filter':
+ *   return [{ ...model, cpState: cpFilter(model.cpState, msg.query) }, []];
+ * case 'select':
+ *   const selected = cpSelectedItem(model.cpState);
+ *   // handle selection...
+ * ```
+ */
+
+import type { BijouContext } from '@flyingrobots/bijou';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+import { visibleLength, clipToWidth } from './viewport.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CommandPaletteItem {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly category?: string;
+  readonly shortcut?: string;
+}
+
+export interface CommandPaletteState {
+  readonly items: readonly CommandPaletteItem[];
+  readonly filteredItems: readonly CommandPaletteItem[];
+  readonly query: string;
+  readonly focusIndex: number;
+  readonly scrollY: number;
+  readonly height: number;
+}
+
+export interface CommandPaletteOptions {
+  readonly width: number;
+  readonly showCategory?: boolean;
+  readonly showShortcut?: boolean;
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial command palette state from items and optional height.
+ * Focus starts at index 0 with empty query showing all items.
+ */
+export function createCommandPaletteState(
+  items: readonly CommandPaletteItem[],
+  height = 10,
+): CommandPaletteState {
+  const h = Math.max(1, height);
+  const copied = [...items];
+  return {
+    items: copied,
+    filteredItems: copied,
+    query: '',
+    focusIndex: 0,
+    scrollY: 0,
+    height: h,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+function matchesQuery(item: CommandPaletteItem, query: string): boolean {
+  const q = query.toLowerCase();
+  if (item.label.toLowerCase().includes(q)) return true;
+  if (item.description?.toLowerCase().includes(q)) return true;
+  if (item.category?.toLowerCase().includes(q)) return true;
+  if (item.id.toLowerCase().includes(q)) return true;
+  return false;
+}
+
+/** Filter items by case-insensitive substring match. Resets focus to 0. */
+export function cpFilter(state: CommandPaletteState, query: string): CommandPaletteState {
+  if (query === '') {
+    return {
+      ...state,
+      query: '',
+      filteredItems: [...state.items],
+      focusIndex: 0,
+      scrollY: 0,
+    };
+  }
+  const filtered = state.items.filter(item => matchesQuery(item, query));
+  return {
+    ...state,
+    query,
+    filteredItems: filtered,
+    focusIndex: 0,
+    scrollY: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Focus navigation
+// ---------------------------------------------------------------------------
+
+function adjustScroll(focusIndex: number, scrollY: number, height: number, total: number): number {
+  let s = scrollY;
+  if (focusIndex < s) s = focusIndex;
+  else if (focusIndex >= s + height) s = focusIndex - height + 1;
+  return Math.min(s, Math.max(0, total - height));
+}
+
+/** Move focus to the next item (wraps around on filteredItems). */
+export function cpFocusNext(state: CommandPaletteState): CommandPaletteState {
+  if (state.filteredItems.length === 0) return state;
+  const focusIndex = (state.focusIndex + 1) % state.filteredItems.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.filteredItems.length) };
+}
+
+/** Move focus to the previous item (wraps around on filteredItems). */
+export function cpFocusPrev(state: CommandPaletteState): CommandPaletteState {
+  if (state.filteredItems.length === 0) return state;
+  const focusIndex = (state.focusIndex - 1 + state.filteredItems.length) % state.filteredItems.length;
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.filteredItems.length) };
+}
+
+/** Move focus down by one page (clamps to last item). */
+export function cpPageDown(state: CommandPaletteState): CommandPaletteState {
+  if (state.filteredItems.length === 0) return state;
+  const focusIndex = Math.min(state.focusIndex + state.height, state.filteredItems.length - 1);
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.filteredItems.length) };
+}
+
+/** Move focus up by one page (clamps to first item). */
+export function cpPageUp(state: CommandPaletteState): CommandPaletteState {
+  if (state.filteredItems.length === 0) return state;
+  const focusIndex = Math.max(state.focusIndex - state.height, 0);
+  return { ...state, focusIndex, scrollY: adjustScroll(focusIndex, state.scrollY, state.height, state.filteredItems.length) };
+}
+
+/** Get the currently focused item, or undefined if no items match. */
+export function cpSelectedItem(state: CommandPaletteState): CommandPaletteItem | undefined {
+  return state.filteredItems[state.focusIndex];
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the command palette — a search line followed by filtered items
+ * in the viewport with a focus indicator.
+ *
+ * Layout:
+ * - Line 1: `> {query}` search input
+ * - Lines 2+: filtered items in viewport
+ * - Each item: `[category] label  description  shortcut`
+ * - Focus indicator: `▸` on focused item
+ */
+export function commandPalette(
+  state: CommandPaletteState,
+  options: CommandPaletteOptions,
+): string {
+  const { width, showCategory = true, showShortcut = true, ctx } = options;
+  const lines: string[] = [];
+
+  // Search line
+  const searchPrefix = '> ';
+  const queryLine = searchPrefix + state.query;
+  lines.push(clipToWidth(queryLine, width));
+
+  if (state.filteredItems.length === 0) {
+    lines.push('  No matches');
+    return lines.join('\n');
+  }
+
+  // Visible items in viewport
+  const visible = state.filteredItems.slice(state.scrollY, state.scrollY + state.height);
+
+  const indicator = '\u25b8'; // ▸
+  const pad = ' ';
+
+  for (let i = 0; i < visible.length; i++) {
+    const item = visible[i]!;
+    const globalIndex = state.scrollY + i;
+    const prefix = globalIndex === state.focusIndex ? indicator : pad;
+
+    const parts: string[] = [];
+
+    if (showCategory && item.category) {
+      const catText = ctx
+        ? ctx.style.styled(ctx.theme.theme.semantic.muted, `[${item.category}]`)
+        : `[${item.category}]`;
+      parts.push(catText);
+    }
+
+    parts.push(item.label);
+
+    if (item.description) {
+      const descText = ctx
+        ? ctx.style.styled(ctx.theme.theme.semantic.muted, item.description)
+        : item.description;
+      parts.push(descText);
+    }
+
+    if (showShortcut && item.shortcut) {
+      const shortcutText = ctx
+        ? ctx.style.styled(ctx.theme.theme.semantic.muted, item.shortcut)
+        : item.shortcut;
+      parts.push(shortcutText);
+    }
+
+    const content = parts.join('  ');
+    const line = `${prefix} ${content}`;
+    lines.push(clipToWidth(line, width));
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for command palette navigation.
+ *
+ * ```ts
+ * const keys = commandPaletteKeyMap({
+ *   focusNext: { type: 'cp-next' },
+ *   focusPrev: { type: 'cp-prev' },
+ *   pageDown: { type: 'cp-page-down' },
+ *   pageUp: { type: 'cp-page-up' },
+ *   select: { type: 'cp-select' },
+ *   close: { type: 'cp-close' },
+ * });
+ * ```
+ */
+export function commandPaletteKeyMap<Msg>(actions: {
+  focusNext: Msg;
+  focusPrev: Msg;
+  pageDown: Msg;
+  pageUp: Msg;
+  select: Msg;
+  close: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Navigation', (g) => g
+      .bind('j', 'Next item', actions.focusNext)
+      .bind('down', 'Next item', actions.focusNext)
+      .bind('k', 'Previous item', actions.focusPrev)
+      .bind('up', 'Previous item', actions.focusPrev)
+      .bind('d', 'Page down', actions.pageDown)
+      .bind('pagedown', 'Page down', actions.pageDown)
+      .bind('u', 'Page up', actions.pageUp)
+      .bind('pageup', 'Page up', actions.pageUp),
+    )
+    .bind('enter', 'Select', actions.select)
+    .bind('escape', 'Close', actions.close);
+}

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -182,7 +182,7 @@ export function commandPalette(
   lines.push(clipToWidth(queryLine, width));
 
   if (state.filteredItems.length === 0) {
-    lines.push('  No matches');
+    lines.push(clipToWidth('  No matches', width));
     return lines.join('\n');
   }
 
@@ -236,6 +236,12 @@ export function commandPalette(
 
 /**
  * Create a preconfigured KeyMap for command palette navigation.
+ *
+ * Bindings: Ctrl+N/Down (next), Ctrl+P/Up (prev), Ctrl+D/PageDown (page down),
+ * Ctrl+U/PageUp (page up), Enter (select), Escape (close).
+ *
+ * Ctrl+D and Ctrl+U follow vim half-page scroll conventions. In raw-mode TUIs
+ * these do not conflict with shell behavior (EOF / line-clear).
  *
  * ```ts
  * const keys = commandPaletteKeyMap({

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -86,6 +86,7 @@ function matchesQuery(item: CommandPaletteItem, query: string): boolean {
   if (item.description?.toLowerCase().includes(q)) return true;
   if (item.category?.toLowerCase().includes(q)) return true;
   if (item.id.toLowerCase().includes(q)) return true;
+  if (item.shortcut?.toLowerCase().includes(q)) return true;
   return false;
 }
 
@@ -257,13 +258,13 @@ export function commandPaletteKeyMap<Msg>(actions: {
 }): KeyMap<Msg> {
   return createKeyMap<Msg>()
     .group('Navigation', (g) => g
-      .bind('j', 'Next item', actions.focusNext)
+      .bind('ctrl+n', 'Next item', actions.focusNext)
       .bind('down', 'Next item', actions.focusNext)
-      .bind('k', 'Previous item', actions.focusPrev)
+      .bind('ctrl+p', 'Previous item', actions.focusPrev)
       .bind('up', 'Previous item', actions.focusPrev)
-      .bind('d', 'Page down', actions.pageDown)
+      .bind('ctrl+d', 'Page down', actions.pageDown)
       .bind('pagedown', 'Page down', actions.pageDown)
-      .bind('u', 'Page up', actions.pageUp)
+      .bind('ctrl+u', 'Page up', actions.pageUp)
       .bind('pageup', 'Page up', actions.pageUp),
     )
     .bind('enter', 'Select', actions.select)

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -174,10 +174,13 @@ export {
   type ToastOptions,
   type DrawerAnchor,
   type DrawerOptions,
+  type TooltipDirection,
+  type TooltipOptions,
   composite,
   modal,
   toast,
   drawer,
+  tooltip,
 } from './overlay.js';
 
 // Interactive accordion

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -237,3 +237,19 @@ export {
   fpBack,
   filePickerKeyMap,
 } from './file-picker.js';
+
+// Command palette
+export {
+  type CommandPaletteItem,
+  type CommandPaletteState,
+  type CommandPaletteOptions,
+  createCommandPaletteState,
+  cpFilter,
+  cpFocusNext,
+  cpFocusPrev,
+  cpPageDown,
+  cpPageUp,
+  cpSelectedItem,
+  commandPalette,
+  commandPaletteKeyMap,
+} from './command-palette.js';

--- a/packages/bijou-tui/src/overlay.test.ts
+++ b/packages/bijou-tui/src/overlay.test.ts
@@ -544,6 +544,16 @@ describe('tooltip', () => {
     expect(t.col).toBeGreaterThanOrEqual(0);
   });
 
+  it('clips content to screen width', () => {
+    const longContent = 'A'.repeat(100);
+    const t = tooltip({ content: longContent, row: 10, col: 0, screenWidth: 20, screenHeight: 24 });
+    const lines = t.content.split('\n');
+    for (const line of lines) {
+      // Each line should not exceed screenWidth
+      expect(visibleLength(stripAnsi(line))).toBeLessThanOrEqual(20);
+    }
+  });
+
   it('composites with background', () => {
     const bg = Array.from({ length: 24 }, () => '.'.repeat(80)).join('\n');
     const t = tooltip({ ...base, row: 12, col: 40, direction: 'bottom' });

--- a/packages/bijou-tui/src/overlay.test.ts
+++ b/packages/bijou-tui/src/overlay.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createTestContext } from '@flyingrobots/bijou/adapters/test';
-import { composite, modal, toast, drawer } from './overlay.js';
+import { composite, modal, toast, drawer, tooltip } from './overlay.js';
 import type { Overlay } from './overlay.js';
 import { visibleLength, stripAnsi } from './viewport.js';
 
@@ -442,5 +442,99 @@ describe('drawer', () => {
     expect(lines4).toHaveLength(3);
     // Top border: ┌  ┐ (2 spaces for padding)
     expect(visibleLength(stripAnsi(lines4[0]!))).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tooltip()
+// ---------------------------------------------------------------------------
+
+describe('tooltip', () => {
+  const base = { content: 'hint', screenWidth: 80, screenHeight: 24 };
+
+  it('top direction positions above target', () => {
+    const t = tooltip({ ...base, row: 10, col: 40, direction: 'top' });
+    const boxH = t.content.split('\n').length;
+    expect(t.row).toBe(10 - boxH);
+  });
+
+  it('bottom direction positions below target', () => {
+    const t = tooltip({ ...base, row: 10, col: 40, direction: 'bottom' });
+    expect(t.row).toBe(11);
+  });
+
+  it('left direction positions to the left of target', () => {
+    const t = tooltip({ ...base, row: 10, col: 40, direction: 'left' });
+    const boxW = visibleLength(t.content.split('\n')[0]!);
+    expect(t.col).toBe(40 - boxW);
+  });
+
+  it('right direction positions to the right of target', () => {
+    const t = tooltip({ ...base, row: 10, col: 40, direction: 'right' });
+    expect(t.col).toBe(41);
+  });
+
+  it('default direction is top', () => {
+    const t = tooltip({ ...base, row: 10, col: 40 });
+    const boxH = t.content.split('\n').length;
+    expect(t.row).toBe(10 - boxH);
+  });
+
+  it('clamps to top edge', () => {
+    const t = tooltip({ ...base, row: 0, col: 40, direction: 'top' });
+    expect(t.row).toBe(0);
+  });
+
+  it('clamps to left edge', () => {
+    const t = tooltip({ ...base, row: 10, col: 0, direction: 'left' });
+    expect(t.col).toBe(0);
+  });
+
+  it('clamps to bottom edge', () => {
+    const t = tooltip({ ...base, row: 23, col: 40, direction: 'bottom' });
+    const boxH = t.content.split('\n').length;
+    expect(t.row).toBeLessThanOrEqual(24 - boxH);
+  });
+
+  it('clamps to right edge', () => {
+    const t = tooltip({ ...base, row: 10, col: 79, direction: 'right' });
+    const boxW = visibleLength(t.content.split('\n')[0]!);
+    expect(t.col).toBeLessThanOrEqual(80 - boxW);
+  });
+
+  it('renders bordered box', () => {
+    const t = tooltip({ ...base, row: 10, col: 40 });
+    const lines = t.content.split('\n');
+    expect(stripAnsi(lines[0]!)).toContain('\u250c');
+    expect(stripAnsi(lines[lines.length - 1]!)).toContain('\u2514');
+    expect(stripAnsi(t.content)).toContain('hint');
+  });
+
+  it('works without ctx', () => {
+    const t = tooltip({ ...base, row: 10, col: 40 });
+    expect(t.content).toContain('\u2502');
+    expect(stripAnsi(t.content)).toContain('hint');
+  });
+
+  it('works with ctx (themed)', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const t = tooltip({
+      ...base,
+      row: 10,
+      col: 40,
+      borderToken: ctx.theme.theme.border.primary,
+      ctx,
+    });
+    expect(stripAnsi(t.content)).toContain('hint');
+    expect(stripAnsi(t.content)).toContain('\u250c');
+  });
+
+  it('composites with background', () => {
+    const bg = Array.from({ length: 24 }, () => '.'.repeat(80)).join('\n');
+    const t = tooltip({ ...base, row: 12, col: 40, direction: 'bottom' });
+    const result = composite(bg, [t]);
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(24);
+    expect(stripAnsi(lines[t.row]!)).toContain('\u250c');
   });
 });

--- a/packages/bijou-tui/src/overlay.test.ts
+++ b/packages/bijou-tui/src/overlay.test.ts
@@ -529,6 +529,21 @@ describe('tooltip', () => {
     expect(stripAnsi(t.content)).toContain('\u250c');
   });
 
+  it('handles multi-line content', () => {
+    const t = tooltip({ ...base, content: 'line1\nline2', row: 10, col: 40 });
+    const lines = t.content.split('\n');
+    // Box wraps 2 content lines: top border + line1 + line2 + bottom border = 4
+    expect(lines).toHaveLength(4);
+    expect(stripAnsi(t.content)).toContain('line1');
+    expect(stripAnsi(t.content)).toContain('line2');
+  });
+
+  it('clamps oversized tooltip to tiny screen', () => {
+    const t = tooltip({ content: 'wide content here', row: 0, col: 0, screenWidth: 5, screenHeight: 3, direction: 'bottom' });
+    expect(t.row).toBeGreaterThanOrEqual(0);
+    expect(t.col).toBeGreaterThanOrEqual(0);
+  });
+
   it('composites with background', () => {
     const bg = Array.from({ length: 24 }, () => '.'.repeat(80)).join('\n');
     const t = tooltip({ ...base, row: 12, col: 40, direction: 'bottom' });

--- a/packages/bijou-tui/src/overlay.ts
+++ b/packages/bijou-tui/src/overlay.ts
@@ -365,13 +365,14 @@ export function tooltip(options: TooltipOptions): Overlay {
     direction = 'top',
     screenWidth,
     screenHeight,
+    borderToken,
     ctx,
   } = options;
 
   const contentLines = content.split('\n');
 
-  const borderColor = ctx && options.borderToken
-    ? (s: string) => ctx.style.styled(options.borderToken!, s)
+  const borderColor = ctx && borderToken
+    ? (s: string) => ctx.style.styled(borderToken, s)
     : (s: string) => s;
 
   const boxStr = renderBox(contentLines, borderColor);

--- a/packages/bijou-tui/src/overlay.ts
+++ b/packages/bijou-tui/src/overlay.ts
@@ -369,7 +369,8 @@ export function tooltip(options: TooltipOptions): Overlay {
     ctx,
   } = options;
 
-  const contentLines = content.split('\n');
+  const maxContentWidth = Math.max(0, screenWidth - 4);
+  const contentLines = content.split('\n').map((l) => clipToWidth(l, maxContentWidth));
 
   const borderColor = ctx && borderToken
     ? (s: string) => ctx.style.styled(borderToken, s)

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/src/core/components/dag-source.ts
+++ b/packages/bijou/src/core/components/dag-source.ts
@@ -34,6 +34,12 @@ export interface DagSource {
 
   /** Optional per-node color/style token. */
   token?(id: string): TokenValue | undefined;
+
+  /** Optional per-node label text color. */
+  labelToken?(id: string): TokenValue | undefined;
+
+  /** Optional per-node badge text color. */
+  badgeToken?(id: string): TokenValue | undefined;
 }
 
 /**
@@ -108,6 +114,8 @@ export function arraySource(nodes: DagNode[]): SlicedDagSource {
     parents: (id) => [...(parentMap.get(id) ?? [])],
     badge: (id) => map.get(id)?.badge,
     token: (id) => map.get(id)?.token,
+    labelToken: (id) => map.get(id)?.labelToken,
+    badgeToken: (id) => map.get(id)?.badgeToken,
     ghost: (id) => map.get(id)?._ghost ?? false,
     ghostLabel: (id) => map.get(id)?._ghostLabel,
   };
@@ -130,6 +138,10 @@ export function materialize(source: SlicedDagSource): DagNode[] {
     if (badge !== undefined) node.badge = badge;
     const token = source.token?.(id);
     if (token !== undefined) node.token = token;
+    const labelToken = source.labelToken?.(id);
+    if (labelToken !== undefined) node.labelToken = labelToken;
+    const badgeToken = source.badgeToken?.(id);
+    if (badgeToken !== undefined) node.badgeToken = badgeToken;
     if (source.ghost(id)) {
       node._ghost = true;
       node._ghostLabel = source.ghostLabel(id);
@@ -301,6 +313,10 @@ export function sliceSource(
     badge: (id) => ghostNodes.has(id) ? undefined : source.badge?.(id),
 
     token: (id) => ghostNodes.has(id) ? undefined : source.token?.(id),
+
+    labelToken: (id) => ghostNodes.has(id) ? undefined : source.labelToken?.(id),
+
+    badgeToken: (id) => ghostNodes.has(id) ? undefined : source.badgeToken?.(id),
 
     ghost: (id) => ghostNodes.has(id) || (inheritGhost !== null && inheritGhost.ghost(id)),
 

--- a/packages/bijou/src/core/components/dag.test.ts
+++ b/packages/bijou/src/core/components/dag.test.ts
@@ -93,6 +93,29 @@ describe('dag', () => {
     });
   });
 
+  describe('non-BMP characters (emoji)', () => {
+    it('renders emoji label without charTypes/chars length mismatch', () => {
+      const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+      const nodes: DagNode[] = [
+        { id: 'a', label: '🚀 Deploy', edges: ['b'] },
+        { id: 'b', label: 'Done' },
+      ];
+      const result = dag(nodes, { ctx });
+      expect(result).toContain('🚀 Deploy');
+      expect(result).toContain('Done');
+    });
+
+    it('renders emoji badge without charTypes/chars length mismatch', () => {
+      const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+      const nodes: DagNode[] = [
+        { id: 'a', label: 'Build', badge: '✅' },
+      ];
+      const result = dag(nodes, { ctx });
+      expect(result).toContain('Build');
+      expect(result).toContain('✅');
+    });
+  });
+
   // ── Mode Tests ──────────────────────────────────────────────────
 
   describe('pipe mode', () => {

--- a/packages/bijou/src/core/components/dag.test.ts
+++ b/packages/bijou/src/core/components/dag.test.ts
@@ -961,3 +961,140 @@ describe('DagSource adapter', () => {
     });
   });
 });
+
+// ── labelToken / badgeToken Tests ──────────────────────────────────
+
+describe('DagNode labelToken / badgeToken', () => {
+  it('labelToken renders node without error', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'Alpha', labelToken: { hex: '#00ff00' } },
+    ];
+    const result = dag(nodes, { ctx });
+    expect(result).toContain('Alpha');
+    expect(result).toContain('╭');
+  });
+
+  it('badgeToken colors badge differently from border', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'Build', badge: 'DONE', badgeToken: { hex: '#ff0000' } },
+    ];
+    const result = dag(nodes, { ctx });
+    expect(result).toContain('Build');
+    expect(result).toContain('DONE');
+  });
+
+  it('both labelToken and badgeToken together', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+    const nodes: DagNode[] = [
+      {
+        id: 'a',
+        label: 'Deploy',
+        badge: 'WIP',
+        labelToken: { hex: '#00ff00' },
+        badgeToken: { hex: '#ff0000' },
+      },
+    ];
+    const result = dag(nodes, { ctx });
+    expect(result).toContain('Deploy');
+    expect(result).toContain('WIP');
+  });
+
+  it('falls back to node token when labelToken/badgeToken omitted', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+    const withTokens: DagNode[] = [
+      {
+        id: 'a',
+        label: 'Deploy',
+        badge: 'OK',
+        token: { hex: '#0000ff' },
+        // no labelToken/badgeToken
+      },
+    ];
+    const withoutTokens: DagNode[] = [
+      {
+        id: 'a',
+        label: 'Deploy',
+        badge: 'OK',
+        token: { hex: '#0000ff' },
+      },
+    ];
+    // Both should render identically since neither has labelToken/badgeToken
+    const result1 = dag(withTokens, { ctx });
+    const result2 = dag(withoutTokens, { ctx });
+    expect(result1).toBe(result2);
+  });
+
+  it('works with selectedId — selectedToken takes precedence for border', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+    const nodes: DagNode[] = [
+      {
+        id: 'a',
+        label: 'Selected',
+        labelToken: { hex: '#00ff00' },
+        badgeToken: { hex: '#ff0000' },
+        badge: 'TAG',
+      },
+    ];
+    // Should not crash and should render
+    const result = dag(nodes, { selectedId: 'a', ctx });
+    expect(result).toContain('Selected');
+    expect(result).toContain('TAG');
+  });
+
+  it('works through arraySource', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'], labelToken: { hex: '#00ff00' } },
+      { id: 'b', label: 'B', badgeToken: { hex: '#ff0000' }, badge: 'X' },
+    ];
+    const src = arraySource(nodes);
+    expect(src.labelToken!('a')).toEqual({ hex: '#00ff00' });
+    expect(src.badgeToken!('b')).toEqual({ hex: '#ff0000' });
+    expect(src.labelToken!('b')).toBeUndefined();
+    expect(src.badgeToken!('a')).toBeUndefined();
+    // Should render without error
+    const result = dag(src, { ctx });
+    expect(result).toContain('A');
+    expect(result).toContain('B');
+  });
+
+  it('works through dagSlice', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
+    const nodes: DagNode[] = [
+      { id: 'a', label: 'A', edges: ['b'], labelToken: { hex: '#00ff00' } },
+      { id: 'b', label: 'B', edges: ['c'], badgeToken: { hex: '#ff0000' }, badge: 'X' },
+      { id: 'c', label: 'C' },
+    ];
+    const src = arraySource(nodes);
+    const sliced = dagSlice(src, 'b', { direction: 'both', depth: 1 });
+    // labelToken should be preserved for 'a'
+    expect(sliced.labelToken!('a')).toEqual({ hex: '#00ff00' });
+    // badgeToken should be preserved for 'b'
+    expect(sliced.badgeToken!('b')).toEqual({ hex: '#ff0000' });
+    // Should render without error
+    const result = dag(sliced, { ctx });
+    expect(result).toContain('A');
+    expect(result).toContain('B');
+  });
+
+  it('pipe mode ignores tokens (no ANSI output)', () => {
+    const ctx = createTestContext({ mode: 'pipe' });
+    const nodes: DagNode[] = [
+      {
+        id: 'a',
+        label: 'Build',
+        badge: 'OK',
+        labelToken: { hex: '#00ff00' },
+        badgeToken: { hex: '#ff0000' },
+        edges: ['b'],
+      },
+      { id: 'b', label: 'Test' },
+    ];
+    const result = dag(nodes, { ctx });
+    // Pipe mode uses plain text adjacency list — no ANSI
+    expect(result).not.toContain('\x1b[');
+    expect(result).toContain('Build (OK) -> Test');
+  });
+});

--- a/packages/bijou/src/core/components/dag.test.ts
+++ b/packages/bijou/src/core/components/dag.test.ts
@@ -1003,27 +1003,23 @@ describe('DagNode labelToken / badgeToken', () => {
 
   it('falls back to node token when labelToken/badgeToken omitted', () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120 } });
-    const withTokens: DagNode[] = [
+    const nodes: DagNode[] = [
       {
         id: 'a',
         label: 'Deploy',
         badge: 'OK',
         token: { hex: '#0000ff' },
-        // no labelToken/badgeToken
+        // no labelToken/badgeToken — should use token for all chars
       },
     ];
-    const withoutTokens: DagNode[] = [
-      {
-        id: 'a',
-        label: 'Deploy',
-        badge: 'OK',
-        token: { hex: '#0000ff' },
-      },
-    ];
-    // Both should render identically since neither has labelToken/badgeToken
-    const result1 = dag(withTokens, { ctx });
-    const result2 = dag(withoutTokens, { ctx });
-    expect(result1).toBe(result2);
+    const src = arraySource(nodes);
+    // arraySource should return undefined for missing token overrides
+    expect(src.labelToken!('a')).toBeUndefined();
+    expect(src.badgeToken!('a')).toBeUndefined();
+    // Should still render without error using the base token
+    const result = dag(nodes, { ctx });
+    expect(result).toContain('Deploy');
+    expect(result).toContain('OK');
   });
 
   it('works with selectedId — selectedToken takes precedence for border', () => {

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -12,6 +12,8 @@ export interface DagNode {
   edges?: string[];
   badge?: string;
   token?: TokenValue;
+  labelToken?: TokenValue;
+  badgeToken?: TokenValue;
   /** @internal Used by dagSlice to mark ghost boundary nodes */
   _ghost?: boolean;
   _ghostLabel?: string;
@@ -281,12 +283,19 @@ function markEdge(
 
 // ── Node Box Rendering ─────────────────────────────────────────────
 
+type CharType = 'border' | 'label' | 'badge' | 'pad';
+
+interface NodeBoxResult {
+  lines: string[];
+  charTypes: CharType[][];
+}
+
 function renderNodeBox(
   label: string,
   badgeText: string | undefined,
   width: number,
   ghost: boolean,
-): string[] {
+): NodeBoxResult {
   const h = ghost ? '\u254c' : '\u2500';
   const v = ghost ? '\u254e' : '\u2502';
 
@@ -294,21 +303,43 @@ function renderNodeBox(
   const contentW = innerW - 2;
 
   let content: string;
+  let midTypes: CharType[];
   if (badgeText) {
     const maxLabelW = contentW - visibleLength(badgeText) - 1;
     const tLabel = truncateLabel(label, maxLabelW);
     const gap = Math.max(1, contentW - visibleLength(tLabel) - visibleLength(badgeText));
     content = tLabel + ' '.repeat(gap) + badgeText;
+
+    // Build char-type map for mid line: border + pad + label + gap + badge + pad + border
+    midTypes = ['border']; // v
+    midTypes.push('pad');  // space
+    for (let i = 0; i < visibleLength(tLabel); i++) midTypes.push('label');
+    for (let i = 0; i < gap; i++) midTypes.push('pad');
+    for (let i = 0; i < visibleLength(badgeText); i++) midTypes.push('badge');
   } else {
     content = truncateLabel(label, contentW);
+
+    // Build char-type map for mid line: border + pad + label + pad + border
+    midTypes = ['border']; // v
+    midTypes.push('pad');  // space
+    for (let i = 0; i < visibleLength(content); i++) midTypes.push('label');
   }
 
   const padRight = Math.max(0, contentW - visibleLength(content));
+  for (let i = 0; i < padRight; i++) midTypes.push('pad');
+  midTypes.push('pad');    // trailing space
+  midTypes.push('border'); // v
+
   const top = '\u256d' + h.repeat(innerW) + '\u256e';
   const mid = v + ' ' + content + ' '.repeat(padRight) + ' ' + v;
   const bot = '\u2570' + h.repeat(innerW) + '\u256f';
 
-  return [top, mid, bot];
+  const borderLine: CharType[] = Array.from({ length: width }, () => 'border');
+
+  return {
+    lines: [top, mid, bot],
+    charTypes: [borderLine, midTypes, borderLine],
+  };
 }
 
 // ── Interactive Renderer ───────────────────────────────────────────
@@ -467,7 +498,7 @@ function renderInteractiveLayout(
 
     positions.set(n.id, { row: startRow, col: startCol, width: nodeWidth, height: 3 });
 
-    const boxLines = renderNodeBox(n.label, n.badge, nodeWidth, n._ghost === true);
+    const box = renderNodeBox(n.label, n.badge, nodeWidth, n._ghost === true);
 
     let nToken: TokenValue;
     if (options.selectedId === n.id) {
@@ -480,16 +511,24 @@ function renderInteractiveLayout(
       nToken = options.nodeToken ?? ctx.theme.theme.border.primary;
     }
 
-    for (let lineIdx = 0; lineIdx < boxLines.length; lineIdx++) {
+    for (let lineIdx = 0; lineIdx < box.lines.length; lineIdx++) {
       const row = startRow + lineIdx;
       if (row >= gridRows) continue;
-      const line = boxLines[lineIdx]!;
+      const line = box.lines[lineIdx]!;
+      const types = box.charTypes[lineIdx]!;
       const chars = [...line];
       for (let ci = 0; ci < chars.length; ci++) {
         const gc = startCol + ci;
         if (gc < gridCols) {
           charGrid[row]![gc] = chars[ci]!;
-          tokenGrid[row]![gc] = nToken;
+          const charType = types[ci];
+          if (charType === 'label' && n.labelToken) {
+            tokenGrid[row]![gc] = n.labelToken;
+          } else if (charType === 'badge' && n.badgeToken) {
+            tokenGrid[row]![gc] = n.badgeToken;
+          } else {
+            tokenGrid[row]![gc] = nToken;
+          }
         }
       }
     }

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -311,18 +311,21 @@ function renderNodeBox(
     content = tLabel + ' '.repeat(gap) + badgeText;
 
     // Build char-type map for mid line: border + pad + label + gap + badge + pad + border
+    // Use [...str].length (code points) instead of visibleLength (.length / UTF-16 code units)
+    // so that non-BMP characters (emoji) align with the [...line] iteration in the renderer.
     midTypes = ['border']; // v
     midTypes.push('pad');  // space
-    for (let i = 0; i < visibleLength(tLabel); i++) midTypes.push('label');
+    for (let i = 0; i < [...tLabel].length; i++) midTypes.push('label');
     for (let i = 0; i < gap; i++) midTypes.push('pad');
-    for (let i = 0; i < visibleLength(badgeText); i++) midTypes.push('badge');
+    for (let i = 0; i < [...badgeText].length; i++) midTypes.push('badge');
   } else {
     content = truncateLabel(label, contentW);
 
     // Build char-type map for mid line: border + pad + label + pad + border
+    // Use [...str].length (code points) — see comment above.
     midTypes = ['border']; // v
     midTypes.push('pad');  // space
-    for (let i = 0; i < visibleLength(content); i++) midTypes.push('label');
+    for (let i = 0; i < [...content].length; i++) midTypes.push('label');
   }
 
   const padRight = Math.max(0, contentW - visibleLength(content));

--- a/packages/bijou/src/core/theme/color.test.ts
+++ b/packages/bijou/src/core/theme/color.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hexToRgb,
+  rgbToHex,
+  lighten,
+  darken,
+  mix,
+  complementary,
+  saturate,
+  desaturate,
+} from './color.js';
+import type { TokenValue } from './tokens.js';
+
+// ── hexToRgb ───────────────────────────────────────────────────────
+
+describe('hexToRgb', () => {
+  it('parses 6-digit hex with #', () => {
+    expect(hexToRgb('#ff0000')).toEqual([255, 0, 0]);
+  });
+
+  it('parses 6-digit hex without #', () => {
+    expect(hexToRgb('00ff00')).toEqual([0, 255, 0]);
+  });
+
+  it('parses 3-digit shorthand with #', () => {
+    expect(hexToRgb('#f00')).toEqual([255, 0, 0]);
+  });
+
+  it('parses 3-digit shorthand without #', () => {
+    expect(hexToRgb('0f0')).toEqual([0, 255, 0]);
+  });
+});
+
+// ── rgbToHex ───────────────────────────────────────────────────────
+
+describe('rgbToHex', () => {
+  it('converts RGB to hex string', () => {
+    expect(rgbToHex([255, 0, 0])).toBe('#ff0000');
+  });
+
+  it('round-trips with hexToRgb', () => {
+    expect(rgbToHex(hexToRgb('#abcdef'))).toBe('#abcdef');
+  });
+
+  it('clamps out-of-range values', () => {
+    expect(rgbToHex([300, -10, 128])).toBe('#ff0080');
+  });
+});
+
+// ── lighten ────────────────────────────────────────────────────────
+
+describe('lighten', () => {
+  const red: TokenValue = { hex: '#ff0000' };
+
+  it('amount 0 returns unchanged color', () => {
+    expect(lighten(red, 0).hex).toBe('#ff0000');
+  });
+
+  it('amount 1 returns white', () => {
+    expect(lighten(red, 1).hex).toBe('#ffffff');
+  });
+
+  it('amount 0.5 returns midpoint toward white', () => {
+    const result = lighten(red, 0.5);
+    expect(hexToRgb(result.hex)).toEqual([255, 128, 128]);
+  });
+
+  it('preserves modifiers', () => {
+    const bold: TokenValue = { hex: '#ff0000', modifiers: ['bold'] };
+    const result = lighten(bold, 0.5);
+    expect(result.modifiers).toEqual(['bold']);
+  });
+
+  it('does not mutate input modifiers array', () => {
+    const mods: ('bold' | 'dim')[] = ['bold'];
+    const token: TokenValue = { hex: '#ff0000', modifiers: mods };
+    const result = lighten(token, 0.5);
+    expect(result.modifiers).not.toBe(mods);
+  });
+});
+
+// ── darken ─────────────────────────────────────────────────────────
+
+describe('darken', () => {
+  const red: TokenValue = { hex: '#ff0000' };
+
+  it('amount 0 returns unchanged color', () => {
+    expect(darken(red, 0).hex).toBe('#ff0000');
+  });
+
+  it('amount 1 returns black', () => {
+    expect(darken(red, 1).hex).toBe('#000000');
+  });
+
+  it('clamps amount above 1', () => {
+    expect(darken(red, 2).hex).toBe('#000000');
+  });
+
+  it('clamps amount below 0', () => {
+    expect(darken(red, -1).hex).toBe('#ff0000');
+  });
+});
+
+// ── mix ────────────────────────────────────────────────────────────
+
+describe('mix', () => {
+  const red: TokenValue = { hex: '#ff0000' };
+  const blue: TokenValue = { hex: '#0000ff' };
+
+  it('ratio 0 returns first color', () => {
+    expect(mix(red, blue, 0).hex).toBe('#ff0000');
+  });
+
+  it('ratio 1 returns second color', () => {
+    expect(mix(red, blue, 1).hex).toBe('#0000ff');
+  });
+
+  it('default ratio 0.5 mixes evenly', () => {
+    const result = mix(red, blue);
+    expect(hexToRgb(result.hex)).toEqual([128, 0, 128]);
+  });
+
+  it('preserves modifiers from first argument', () => {
+    const boldRed: TokenValue = { hex: '#ff0000', modifiers: ['bold'] };
+    const result = mix(boldRed, blue);
+    expect(result.modifiers).toEqual(['bold']);
+  });
+});
+
+// ── complementary ──────────────────────────────────────────────────
+
+describe('complementary', () => {
+  it('red → cyan', () => {
+    const red: TokenValue = { hex: '#ff0000' };
+    const result = complementary(red);
+    const [r, g, b] = hexToRgb(result.hex);
+    expect(r).toBe(0);
+    expect(g).toBe(255);
+    expect(b).toBe(255);
+  });
+
+  it('preserves modifiers', () => {
+    const dimRed: TokenValue = { hex: '#ff0000', modifiers: ['dim'] };
+    const result = complementary(dimRed);
+    expect(result.modifiers).toEqual(['dim']);
+  });
+
+  it('gray stays gray (achromatic)', () => {
+    const gray: TokenValue = { hex: '#808080' };
+    const result = complementary(gray);
+    // Gray has no saturation, so complementary should return the same gray
+    const [r, g, b] = hexToRgb(result.hex);
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+  });
+});
+
+// ── saturate ───────────────────────────────────────────────────────
+
+describe('saturate', () => {
+  it('amount 0 returns unchanged', () => {
+    const muted: TokenValue = { hex: '#996666' };
+    expect(saturate(muted, 0).hex).toBe('#996666');
+  });
+
+  it('amount 1 fully saturates', () => {
+    const muted: TokenValue = { hex: '#996666' };
+    const result = saturate(muted, 1);
+    const [r, g, b] = hexToRgb(result.hex);
+    // Should be more saturated — distance from gray increases
+    const maxChannel = Math.max(r, g, b);
+    const minChannel = Math.min(r, g, b);
+    expect(maxChannel - minChannel).toBeGreaterThan(0x99 - 0x66);
+  });
+});
+
+// ── desaturate ─────────────────────────────────────────────────────
+
+describe('desaturate', () => {
+  it('amount 0 returns unchanged', () => {
+    const red: TokenValue = { hex: '#ff0000' };
+    expect(desaturate(red, 0).hex).toBe('#ff0000');
+  });
+
+  it('amount 1 fully desaturates to gray', () => {
+    const red: TokenValue = { hex: '#ff0000' };
+    const result = desaturate(red, 1);
+    const [r, g, b] = hexToRgb(result.hex);
+    // Fully desaturated: all channels should be equal
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+  });
+
+  it('preserves modifiers', () => {
+    const bold: TokenValue = { hex: '#ff0000', modifiers: ['bold', 'dim'] };
+    const result = desaturate(bold, 0.5);
+    expect(result.modifiers).toEqual(['bold', 'dim']);
+  });
+});

--- a/packages/bijou/src/core/theme/color.test.ts
+++ b/packages/bijou/src/core/theme/color.test.ts
@@ -44,6 +44,11 @@ describe('hexToRgb', () => {
   it('throws on 4-digit hex', () => {
     expect(() => hexToRgb('#abcd')).toThrow('Invalid hex color');
   });
+
+  it('throws on non-hex characters', () => {
+    expect(() => hexToRgb('xyz')).toThrow('Invalid hex color');
+    expect(() => hexToRgb('#gggggg')).toThrow('Invalid hex color');
+  });
 });
 
 // ── rgbToHex ───────────────────────────────────────────────────────

--- a/packages/bijou/src/core/theme/color.test.ts
+++ b/packages/bijou/src/core/theme/color.test.ts
@@ -29,6 +29,21 @@ describe('hexToRgb', () => {
   it('parses 3-digit shorthand without #', () => {
     expect(hexToRgb('0f0')).toEqual([0, 255, 0]);
   });
+  it('throws on invalid length (too short)', () => {
+    expect(() => hexToRgb('#ab')).toThrow('Invalid hex color');
+  });
+
+  it('throws on invalid length (too long)', () => {
+    expect(() => hexToRgb('#1234567')).toThrow('Invalid hex color');
+  });
+
+  it('throws on empty string', () => {
+    expect(() => hexToRgb('')).toThrow('Invalid hex color');
+  });
+
+  it('throws on 4-digit hex', () => {
+    expect(() => hexToRgb('#abcd')).toThrow('Invalid hex color');
+  });
 });
 
 // ── rgbToHex ───────────────────────────────────────────────────────

--- a/packages/bijou/src/core/theme/color.ts
+++ b/packages/bijou/src/core/theme/color.ts
@@ -16,6 +16,9 @@ export function hexToRgb(hex: string): RGB {
   if (h.length === 3) {
     h = h[0]! + h[0]! + h[1]! + h[1]! + h[2]! + h[2]!;
   }
+  if (h.length !== 6) {
+    throw new Error(`Invalid hex color: "${hex}"`);
+  }
   const n = parseInt(h, 16);
   return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
 }

--- a/packages/bijou/src/core/theme/color.ts
+++ b/packages/bijou/src/core/theme/color.ts
@@ -16,7 +16,7 @@ export function hexToRgb(hex: string): RGB {
   if (h.length === 3) {
     h = h[0]! + h[0]! + h[1]! + h[1]! + h[2]! + h[2]!;
   }
-  if (h.length !== 6) {
+  if (h.length !== 6 || !/^[0-9a-f]{6}$/i.test(h)) {
     throw new Error(`Invalid hex color: "${hex}"`);
   }
   const n = parseInt(h, 16);

--- a/packages/bijou/src/core/theme/color.ts
+++ b/packages/bijou/src/core/theme/color.ts
@@ -1,0 +1,157 @@
+/**
+ * Color manipulation utilities for theme tokens.
+ *
+ * Provides conversion between hex and RGB, plus manipulation functions
+ * (lighten, darken, mix, complementary, saturate, desaturate) that
+ * preserve token modifiers.
+ */
+
+import type { RGB, TokenValue } from './tokens.js';
+
+// ── Conversion ─────────────────────────────────────────────────────
+
+/** Parse a hex color string to an RGB tuple. Supports `#RGB` and `#RRGGBB` (with or without `#`). */
+export function hexToRgb(hex: string): RGB {
+  let h = hex.startsWith('#') ? hex.slice(1) : hex;
+  if (h.length === 3) {
+    h = h[0]! + h[0]! + h[1]! + h[1]! + h[2]! + h[2]!;
+  }
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+/** Convert an RGB tuple to a `#rrggbb` hex string. */
+export function rgbToHex(rgb: RGB): string {
+  const r = Math.max(0, Math.min(255, Math.round(rgb[0])));
+  const g = Math.max(0, Math.min(255, Math.round(rgb[1])));
+  const b = Math.max(0, Math.min(255, Math.round(rgb[2])));
+  return '#' + ((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1);
+}
+
+// ── Internal HSL helpers ───────────────────────────────────────────
+
+function rgbToHsl(rgb: RGB): [number, number, number] {
+  const r = rgb[0] / 255;
+  const g = rgb[1] / 255;
+  const b = rgb[2] / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return [0, 0, l];
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+  let h: number;
+  if (max === r) {
+    h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  } else if (max === g) {
+    h = ((b - r) / d + 2) / 6;
+  } else {
+    h = ((r - g) / d + 4) / 6;
+  }
+
+  return [h, s, l];
+}
+
+function hue2rgb(p: number, q: number, t: number): number {
+  let tt = t;
+  if (tt < 0) tt += 1;
+  if (tt > 1) tt -= 1;
+  if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+  if (tt < 1 / 2) return q;
+  if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+  return p;
+}
+
+function hslToRgb(h: number, s: number, l: number): RGB {
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return [v, v, v];
+  }
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  return [
+    Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
+    Math.round(hue2rgb(p, q, h) * 255),
+    Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
+  ];
+}
+
+// ── Token helpers ──────────────────────────────────────────────────
+
+function clampAmount(amount: number): number {
+  return Math.max(0, Math.min(1, amount));
+}
+
+function withHex(token: TokenValue, hex: string): TokenValue {
+  return token.modifiers
+    ? { hex, modifiers: [...token.modifiers] }
+    : { hex };
+}
+
+// ── Manipulation ───────────────────────────────────────────────────
+
+/** Blend a token's color toward white by `amount` (0 = unchanged, 1 = white). */
+export function lighten(token: TokenValue, amount: number): TokenValue {
+  const t = clampAmount(amount);
+  const [r, g, b] = hexToRgb(token.hex);
+  return withHex(token, rgbToHex([
+    r + (255 - r) * t,
+    g + (255 - g) * t,
+    b + (255 - b) * t,
+  ]));
+}
+
+/** Blend a token's color toward black by `amount` (0 = unchanged, 1 = black). */
+export function darken(token: TokenValue, amount: number): TokenValue {
+  const t = clampAmount(amount);
+  const [r, g, b] = hexToRgb(token.hex);
+  return withHex(token, rgbToHex([
+    r * (1 - t),
+    g * (1 - t),
+    b * (1 - t),
+  ]));
+}
+
+/** Blend two token colors by `ratio` (0 = first, 1 = second, default 0.5). Preserves modifiers from the first token. */
+export function mix(a: TokenValue, b: TokenValue, ratio = 0.5): TokenValue {
+  const t = clampAmount(ratio);
+  const [ar, ag, ab] = hexToRgb(a.hex);
+  const [br, bg, bb] = hexToRgb(b.hex);
+  return withHex(a, rgbToHex([
+    ar + (br - ar) * t,
+    ag + (bg - ag) * t,
+    ab + (bb - ab) * t,
+  ]));
+}
+
+/** Rotate hue by 180° to produce the complementary color. */
+export function complementary(token: TokenValue): TokenValue {
+  const rgb = hexToRgb(token.hex);
+  const [h, s, l] = rgbToHsl(rgb);
+  const newH = (h + 0.5) % 1;
+  return withHex(token, rgbToHex(hslToRgb(newH, s, l)));
+}
+
+/** Increase saturation by `amount` (0 = unchanged, 1 = full saturation). */
+export function saturate(token: TokenValue, amount: number): TokenValue {
+  const t = clampAmount(amount);
+  const rgb = hexToRgb(token.hex);
+  const [h, s, l] = rgbToHsl(rgb);
+  const newS = Math.min(1, s + (1 - s) * t);
+  return withHex(token, rgbToHex(hslToRgb(h, newS, l)));
+}
+
+/** Decrease saturation by `amount` (0 = unchanged, 1 = fully desaturated). */
+export function desaturate(token: TokenValue, amount: number): TokenValue {
+  const t = clampAmount(amount);
+  const rgb = hexToRgb(token.hex);
+  const [h, s, l] = rgbToHsl(rgb);
+  const newS = s * (1 - t);
+  return withHex(token, rgbToHex(hslToRgb(h, newS, l)));
+}

--- a/packages/bijou/src/core/theme/index.ts
+++ b/packages/bijou/src/core/theme/index.ts
@@ -41,3 +41,15 @@ export type { GradientTextOptions } from './gradient.js';
 // DTCG interop
 export { fromDTCG, toDTCG } from './dtcg.js';
 export type { DTCGDocument, DTCGToken, DTCGGroup } from './dtcg.js';
+
+// Color manipulation
+export {
+  hexToRgb,
+  rgbToHex,
+  lighten,
+  darken,
+  mix,
+  complementary,
+  saturate,
+  desaturate,
+} from './color.js';

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -61,6 +61,15 @@ export {
   type DTCGDocument,
   type DTCGToken,
   type DTCGGroup,
+  // Color manipulation
+  hexToRgb,
+  rgbToHex,
+  lighten,
+  darken,
+  mix,
+  complementary,
+  saturate,
+  desaturate,
 } from './core/theme/index.js';
 
 // Detection


### PR DESCRIPTION
## Summary

- **`commandPalette()`** — filterable action list with case-insensitive search on label/description/category/id/shortcut, viewport scrolling, and keyboard navigation (Ctrl+N/P/D/U + arrows)
- **`tooltip()`** — positioned overlay with top/bottom/left/right direction and screen-edge clamping
- **Color manipulation** — `hexToRgb()`, `rgbToHex()`, `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` on theme tokens
- **`DagNode` token expansion** — `labelToken` and `badgeToken` for granular per-node text styling

## Test plan

- [x] `npm run build` — clean
- [x] `vitest run` — 1,195 passed, 5 skipped
- [x] Two rounds of self-code-review completed (all findings resolved)
- [ ] CodeRabbit review
- [ ] CI green