### PR TITLE
feat: v0.9.0 quality & DX improvements

### DIFF
--- a/demo-tui.ts
+++ b/demo-tui.ts
@@ -44,6 +44,8 @@ import {
   scrollBy,
   createKeyMap,
   createInputStack,
+  isKeyMsg,
+  isResizeMsg,
   type App,
   type Cmd,
   type KeyMsg,
@@ -223,7 +225,7 @@ const app: App<Model, Msg | ResizeMsg> = {
 
   update: (msg, model) => {
     // Resize
-    if ('type' in msg && msg.type === 'resize') {
+    if (isResizeMsg(msg)) {
       return [{ ...model, cols: msg.columns, rows: msg.rows }, []];
     }
 
@@ -281,8 +283,8 @@ const app: App<Model, Msg | ResizeMsg> = {
 
     // Input Dispatch
     let action: Msg | undefined;
-    if ('type' in msg && msg.type === 'key') {
-      action = inputStack.dispatch(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      action = inputStack.dispatch(msg);
     } else {
       action = msg as Msg;
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`markdown()` wordWrap grapheme width** — use `graphemeWidth()` instead of `.length` for correct CJK/emoji word wrapping
 - **`markdown()` inline parse order** — code spans (`` ` ``) now parsed before bold/italic to prevent `*` inside backticks being treated as emphasis
 - **`markdown()` bold regex** — changed from `[^*]+` to `.+?` to allow `*` inside bold spans (e.g. `**a*b**`)
+- **`runScript()` init command settling** — add microtask yield after init commands and before dispose so async init commands settle before step processing begins
+- **`runScript()` init-command test** — strengthen assertion to verify model mutation, not just frame count
 
 ### 📝 Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,25 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### 🐛 Fixes
+
+- **`markdown()` word wrap** — wrap plain text before applying inline styles to prevent ANSI escape bytes from causing premature line breaks
+- **`sliceAnsi()` double reset** — prevent emitting `\x1b[0m` twice when loop breaks at the endCol boundary
+- **`chalkStyle()` global mutation** — scope chalk level override to a per-call instance instead of mutating the global chalk, fixing test order-dependence
+- **Hangul syllable range** — correct `isWideChar()` upper bound from `0xD7FF` to `0xD7A3`, excluding narrow Jamo Extended-B characters
+- **`wasStyled()` equality** — use structural comparison (hex + modifiers) instead of reference equality on `TokenValue` objects
+
+### 🔧 Refactors
+
+- **`viewport.ts` grapheme dedup** — remove duplicated `_graphemeClusterWidth()` and `_isWide()`, delegate to `@flyingrobots/bijou` core exports; add lazy singleton `Intl.Segmenter`
+
+### 📝 Documentation
+
+- Fix 4 example READMEs (help, navigable-table, print-key, stopwatch) to use `isKeyMsg()` guard instead of `as KeyMsg` casts
+- Fix CHANGELOG missing blank line before `## [0.8.0]`
+- Fix ROADMAP `StyleAuditPort` → `AuditStylePort`
+- Add bare-escape limitation comments to select, filter, multiselect, textarea
+
 ## [0.9.0] — 2026-02-28
 
 ### 🚀 Features
@@ -47,6 +66,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 📝 Documentation
 
 - Updated 23 example README code snippets to use type guards
+
 ## [0.8.0] — 2026-02-28
 
 ### 🚀 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,27 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### 🐛 Fixes
+
+- **`clipToWidth()` / `sliceAnsi()` O(n²) perf** — rewrite to pre-segment stripped text once via `segmentGraphemes()`, then walk original string with a grapheme pointer; removes per-character `str.slice(i)` + re-segment pattern
+- **`clipToWidth()` unconditional reset** — only append `\x1b[0m` when the clipped string actually contains ANSI style sequences
+- **`viewport.ts` duplicate segmenter** — remove `getSegmenter()` singleton; import `segmentGraphemes` from `@flyingrobots/bijou` core
+- **`markdown()` blockquote greedy continuation** — blockquote parser no longer swallows non-`>` continuation lines into the quote block
+- **`markdown()` wordWrap grapheme width** — use `graphemeWidth()` instead of `.length` for correct CJK/emoji word wrapping
+- **`markdown()` inline parse order** — code spans (`` ` ``) now parsed before bold/italic to prevent `*` inside backticks being treated as emphasis
+- **`markdown()` bold regex** — changed from `[^*]+` to `.+?` to allow `*` inside bold spans (e.g. `**a*b**`)
+
+### 📝 Documentation
+
+- Add `queueMicrotask` limitation JSDoc to `runScript()` in driver.ts
+- Fix ROADMAP version label (`v0.8.0` → `v0.9.0`)
+- Fix CHANGELOG test file count (`8 new + 6 expanded` → `6 new + 7 expanded`)
+- Merge duplicate README documentation bullets in CHANGELOG
+- Fix CHANGELOG example count (`6 new examples` → `5 new examples`)
+- Fix CHANGELOG v0.6.0 section heading (`Bug Fixes` → `Fixes`)
+- Fix progress-download README unused `vstack` import
+- Remove `(pre-release)` from xyph-title.md
+
 ## [0.9.0] — 2026-02-28
 
 ### 🚀 Features
@@ -54,12 +75,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧪 Tests
 
-- 143 new tests across 8 new + 6 expanded test files (1352 total)
+- 143 new tests across 6 new + 7 expanded test files (1352 total)
 
 ### 📝 Documentation
 
-- Updated 23 example README code snippets to use type guards
-- Fix 4 example READMEs (help, navigable-table, print-key, stopwatch) to use `isKeyMsg()` guard instead of `as KeyMsg` casts
+- Updated 23 example README code snippets to use type guards (including help, navigable-table, print-key, stopwatch `isKeyMsg()` guard fixes)
 - Fix CHANGELOG missing blank line before `## [0.8.0]`
 - Fix ROADMAP `StyleAuditPort` → `AuditStylePort`
 - Add bare-escape limitation comments to select, filter, multiselect, textarea
@@ -117,7 +137,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 📝 Documentation
 
-- **6 new examples** — `enumerated-list`, `hyperlink`, `log`, `status-bar`, `drawer`
+- **5 new examples** — `enumerated-list`, `hyperlink`, `log`, `status-bar`, `drawer`
 
 ## [0.6.0] — 2026-02-27
 
@@ -142,7 +162,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`fpEnter()` / `fpBack()`** — directory traversal (enter child / go to parent)
 - **`filePickerKeyMap()`** — preconfigured vim-style keybindings (j/k, arrows, enter, backspace)
 
-### 🐛 Bug Fixes
+### 🐛 Fixes
 
 #### Node adapter (`@flyingrobots/bijou-node`)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`markdown()` inline parse order** — code spans (`` ` ``) now parsed before bold/italic to prevent `*` inside backticks being treated as emphasis
 - **`markdown()` bold regex** — changed from `[^*]+` to `.+?` to allow `*` inside bold spans (e.g. `**a*b**`)
 - **`runScript()` init command settling** — add microtask yield after init commands and before dispose so async init commands settle before step processing begins
+- **`runScript()` exception safety** — wrap lifecycle in `try/finally` so `bus.dispose()` runs even if app throws
+- **`runScript()` unsafe cast** — remove `as KeyMsg | M` cast; `BusMsg<M>` already matches `app.update` signature
 - **`runScript()` init-command test** — strengthen assertion to verify model mutation, not just frame count
 
 ### 📝 Documentation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,10 +6,47 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-02-28
+
+### 🚀 Features
+
+#### Core (`@flyingrobots/bijou`)
+
+- **Grapheme cluster support** — `segmentGraphemes()`, `graphemeWidth()`, `isWideChar()` utilities using `Intl.Segmenter` for correct Unicode text measurement. East Asian Wide characters (CJK = 2 columns), emoji (flags, ZWJ families, skin tones = 2 columns), and combining marks handled correctly
+- **`markdown()`** — terminal markdown renderer supporting headings, bold, italic, code spans, bullet/numbered lists, fenced code blocks, blockquotes, horizontal rules, and links. Two-pass parser with mode degradation (interactive → styled, pipe → plain, accessible → labeled)
+- **Color downsampling** — `rgbToAnsi256()`, `nearestAnsi256()`, `rgbToAnsi16()`, `ansi256ToAnsi16()` pure conversion functions for terminals with limited color support. `ColorLevel` type for color capability detection
+- **`AuditStylePort`** — `auditStyle()` test adapter that records all `styled()`/`rgb()`/`hex()`/`bold()` calls for post-hoc assertion. `wasStyled(token, substring)` convenience method. Returns text unchanged for compatibility with existing string assertions
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`isKeyMsg()` / `isResizeMsg()` type guards** — replace unsafe `as KeyMsg` casts with proper runtime type narrowing
+- **`runScript()`** — scripted CLI/stdin driver for automated testing and demos. Feeds key sequences into a TEA app and captures all rendered frames. Supports delays, `onFrame` callbacks, and returns final model + frame history
+
+#### Node adapter (`@flyingrobots/bijou-node`)
+
+- **`chalkStyle()` level override** — accepts optional `level?: 0|1|2|3` for explicit color level control in tests
+
+### 🐛 Fixes
+
+- **`visibleLength()`** — now grapheme-cluster aware in both `dag.ts` and `viewport.ts`; correctly measures CJK, emoji, and combining marks
+- **`clipToWidth()`** — grapheme-cluster aware clipping; won't split multi-codepoint sequences
+- **`sliceAnsi()`** — grapheme-cluster aware column slicing
+- **`truncateLabel()`** — truncates by grapheme clusters, not UTF-16 code units
+- **`renderNodeBox()` char iteration** — uses grapheme segmenter instead of `[...line]` code-point spread
+- **`flex.ts` duplicate `clipToWidth()`** — removed duplicate; imports from `viewport.ts`
+- **`select()` / `multiselect()` / `textarea()` / `filter()`** — Escape key now cancels (in addition to Ctrl+C)
+
 ### 🔧 Refactors
 
-- Replace `as KeyMsg` / `as ResizeMsg` type casts with `isKeyMsg()` / `isResizeMsg()` type guards across all 24 example `main.ts` files, `demo-tui.ts`, and `eventbus.test.ts`
+- Replace `as KeyMsg` / `as ResizeMsg` type casts with `isKeyMsg()` / `isResizeMsg()` type guards across all 23 example `main.ts` files, `demo-tui.ts`, `runtime.ts`, and `eventbus.test.ts`
 
+### 🧪 Tests
+
+- 141 new tests across 8 new + 6 expanded test files (1350 total)
+
+### 📝 Documentation
+
+- Updated 23 example README code snippets to use type guards
 ## [0.8.0] — 2026-02-28
 
 ### 🚀 Features
@@ -316,7 +353,8 @@ First public release.
 - **Screen control** — `enterScreen()`, `exitScreen()`, `clearAndHome()`, `renderFrame()`
 - **Layout helpers** — `vstack()`, `hstack()`
 
-[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/flyingrobots/bijou/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/flyingrobots/bijou/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/flyingrobots/bijou/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/flyingrobots/bijou/compare/v0.5.1...v0.6.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### 🔧 Refactors
+
+- Replace `as KeyMsg` / `as ResizeMsg` type casts with `isKeyMsg()` / `isResizeMsg()` type guards across all 24 example `main.ts` files, `demo-tui.ts`, and `eventbus.test.ts`
+
 ## [0.8.0] — 2026-02-28
 
 ### 🚀 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,25 +6,6 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
-### 🐛 Fixes
-
-- **`markdown()` word wrap** — wrap plain text before applying inline styles to prevent ANSI escape bytes from causing premature line breaks
-- **`sliceAnsi()` double reset** — prevent emitting `\x1b[0m` twice when loop breaks at the endCol boundary
-- **`chalkStyle()` global mutation** — scope chalk level override to a per-call instance instead of mutating the global chalk, fixing test order-dependence
-- **Hangul syllable range** — correct `isWideChar()` upper bound from `0xD7FF` to `0xD7A3`, excluding narrow Jamo Extended-B characters
-- **`wasStyled()` equality** — use structural comparison (hex + modifiers) instead of reference equality on `TokenValue` objects
-
-### 🔧 Refactors
-
-- **`viewport.ts` grapheme dedup** — remove duplicated `_graphemeClusterWidth()` and `_isWide()`, delegate to `@flyingrobots/bijou` core exports; add lazy singleton `Intl.Segmenter`
-
-### 📝 Documentation
-
-- Fix 4 example READMEs (help, navigable-table, print-key, stopwatch) to use `isKeyMsg()` guard instead of `as KeyMsg` casts
-- Fix CHANGELOG missing blank line before `## [0.8.0]`
-- Fix ROADMAP `StyleAuditPort` → `AuditStylePort`
-- Add bare-escape limitation comments to select, filter, multiselect, textarea
-
 ## [0.9.0] — 2026-02-28
 
 ### 🚀 Features
@@ -54,10 +35,16 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`renderNodeBox()` char iteration** — uses grapheme segmenter instead of `[...line]` code-point spread
 - **`flex.ts` duplicate `clipToWidth()`** — removed duplicate; imports from `viewport.ts`
 - **`select()` / `multiselect()` / `textarea()` / `filter()`** — Escape key now cancels (in addition to Ctrl+C)
+- **`markdown()` word wrap** — wrap plain text before applying inline styles to prevent ANSI escape bytes from causing premature line breaks
+- **`sliceAnsi()` double reset** — prevent emitting `\x1b[0m` twice when loop breaks at the endCol boundary
+- **`chalkStyle()` global mutation** — scope chalk level override to a per-call instance instead of mutating the global chalk, fixing test order-dependence
+- **Hangul syllable range** — correct `isWideChar()` upper bound from `0xD7FF` to `0xD7A3`, excluding narrow Jamo Extended-B characters
+- **`wasStyled()` equality** — use structural comparison (hex + modifiers) instead of reference equality on `TokenValue` objects
 
 ### 🔧 Refactors
 
 - Replace `as KeyMsg` / `as ResizeMsg` type casts with `isKeyMsg()` / `isResizeMsg()` type guards across all 23 example `main.ts` files, `demo-tui.ts`, `runtime.ts`, and `eventbus.test.ts`
+- **`viewport.ts` grapheme dedup** — remove duplicated `_graphemeClusterWidth()` and `_isWide()`, delegate to `@flyingrobots/bijou` core exports; add lazy singleton `Intl.Segmenter`
 
 ### 🧪 Tests
 
@@ -66,6 +53,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 📝 Documentation
 
 - Updated 23 example README code snippets to use type guards
+- Fix 4 example READMEs (help, navigable-table, print-key, stopwatch) to use `isKeyMsg()` guard instead of `as KeyMsg` casts
+- Fix CHANGELOG missing blank line before `## [0.8.0]`
+- Fix ROADMAP `StyleAuditPort` → `AuditStylePort`
+- Add bare-escape limitation comments to select, filter, multiselect, textarea
 
 ## [0.8.0] — 2026-02-28
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,7 +44,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`ansi256ToAnsi16()` negative input** — clamp input to 0–255 range
 - **`markdown()` blockquote regex** — handle indented blockquotes (leading whitespace before `>`)
 - **`auditStyle()` mutable reference** — `get calls()` now returns a defensive copy
-- **progress-download example** — add missing `{ type: 'quit' }` handler for auto-exit
+- **progress-download example** — add missing `{ type: 'quit' }` handler for auto-exit; remove unused `vstack` import
 - **help example** — clamp `selected` index to >= 0 when deleting last item
 
 ### 🔧 Refactors
@@ -63,6 +63,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - Fix CHANGELOG missing blank line before `## [0.8.0]`
 - Fix ROADMAP `StyleAuditPort` → `AuditStylePort`
 - Add bare-escape limitation comments to select, filter, multiselect, textarea
+- Add `canvas()` shader primitive and `box()` width override to ROADMAP backlog (from XYPH title screen request)
 
 ## [0.8.0] — 2026-02-28
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`chalkStyle()` global mutation** — scope chalk level override to a per-call instance instead of mutating the global chalk, fixing test order-dependence
 - **Hangul syllable range** — correct `isWideChar()` upper bound from `0xD7FF` to `0xD7A3`, excluding narrow Jamo Extended-B characters
 - **`wasStyled()` equality** — use structural comparison (hex + modifiers) instead of reference equality on `TokenValue` objects
+- **`chalkStyle()` noColor leaking ANSI** — `styled()` and `bold()` now short-circuit when `noColor` is true, preventing modifier ANSI codes from leaking
+- **`ansi256ToAnsi16()` negative input** — clamp input to 0–255 range
+- **`markdown()` blockquote regex** — handle indented blockquotes (leading whitespace before `>`)
+- **`auditStyle()` mutable reference** — `get calls()` now returns a defensive copy
+- **progress-download example** — add missing `{ type: 'quit' }` handler for auto-exit
+- **help example** — clamp `selected` index to >= 0 when deleting last item
 
 ### 🔧 Refactors
 
@@ -48,7 +54,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧪 Tests
 
-- 141 new tests across 8 new + 6 expanded test files (1350 total)
+- 143 new tests across 8 new + 6 expanded test files (1352 total)
 
 ### 📝 Documentation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -413,22 +413,22 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | ~~**`DagNode` token expansion**~~ | bijou | ✅ v0.8.0 — `labelToken` and `badgeToken` on `DagNode` for granular per-node styling beyond border color. |
 | ~~**`place()`**~~ | bijou-tui | ✅ v0.7.0 — 2D text placement with horizontal + vertical alignment. |
 | ~~**`drawer()`**~~ | bijou-tui | ✅ v0.7.0 — Slide-in side panel built on `composite()`. Left/right anchored, configurable width. |
-| **CLI/stdin component driver** | bijou-tui | Drive component state via CLI flags or streaming stdin commands. Enables scripted demos, testing, and external control. |
+| ~~**CLI/stdin component driver**~~ | bijou-tui | ✅ v0.9.0 — `runScript()` feeds key sequences into TEA apps and captures frames. |
 | ~~**`enumeratedList()`**~~ | bijou | ✅ v0.7.0 — Ordered/unordered lists with bullet styles (arabic, alpha, roman, bullet, dash, none). |
 | ~~**Terminal hyperlinks**~~ | bijou | ✅ v0.7.0 — Clickable OSC 8 links with graceful fallback. |
 | **Adaptive colors** | bijou | Runtime light/dark background detection, auto color switching. |
-| **Color downsampling** | bijou | Truecolor → ANSI256 → ANSI graceful fallback chain. |
+| ~~**Color downsampling**~~ | bijou | ✅ v0.9.0 — `rgbToAnsi256()`, `rgbToAnsi16()`, `nearestAnsi256()`, `ansi256ToAnsi16()` pure conversion functions. |
 | ~~**Color manipulation**~~ | bijou | ✅ v0.8.0 — `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` on theme tokens. |
-| **`markdown()`** | bijou | Render markdown with syntax highlighting. |
+| ~~**`markdown()`**~~ | bijou | ✅ v0.9.0 — Terminal markdown renderer with headings, inline formatting, lists, code blocks, blockquotes, links, and mode degradation. |
 | ~~**`log()`**~~ | bijou | ✅ v0.7.0 — Leveled styled log output (debug/info/warn/error/fatal). |
 
 ### P2.5 — Code quality & DX
 
 | Feature | Package | Notes |
 |---------|---------|-------|
-| **Eliminate `as KeyMsg` casts in examples** | examples | All 20+ examples use `'type' in msg && msg.type === 'key'` with an unsafe `as KeyMsg` cast. Refactor Msg unions to include `KeyMsg` for proper type narrowing. |
-| **`StyleAuditPort` test adapter** | bijou | Current `plainStyle()` is a no-op — can't verify token application in tests. Add an adapter that records styled calls for assertion. |
-| **Grapheme cluster support** | bijou-tui | `[...str]` splits by code points, not grapheme clusters. Multi-codepoint emoji (flags, skin tones) misalign charType mapping in dag renderer and width calculations in viewport/layout. Consider `Intl.Segmenter`. |
+| ~~**Eliminate `as KeyMsg` casts in examples**~~ | examples | ✅ v0.9.0 — Replaced with `isKeyMsg()` / `isResizeMsg()` type guards across all examples, runtime, and tests. |
+| ~~**`StyleAuditPort` test adapter**~~ | bijou | ✅ v0.9.0 — `auditStyle()` records styled calls for assertion with `wasStyled()` convenience method. |
+| ~~**Grapheme cluster support**~~ | bijou + bijou-tui | ✅ v0.9.0 — `segmentGraphemes()`, `graphemeWidth()`, `isWideChar()` using `Intl.Segmenter`. Fixed `visibleLength()`, `clipToWidth()`, `sliceAnsi()`, `truncateLabel()`, and `renderNodeBox()`. |
 
 ### P3 — Nice to have
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Tests ARE the Spec.** Every feature is defined by its tests. If it's not tested, it's not guaranteed. Acceptance criteria are written as test descriptions first, implementation second.
 
-Current: **v0.8.0** — Command palette, tooltip, color utils, DAG token expansion
+Current: **v0.9.0** — Grapheme clusters, markdown, color downsampling, AuditStylePort, type guards
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -427,7 +427,7 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | Feature | Package | Notes |
 |---------|---------|-------|
 | ~~**Eliminate `as KeyMsg` casts in examples**~~ | examples | ✅ v0.9.0 — Replaced with `isKeyMsg()` / `isResizeMsg()` type guards across all examples, runtime, and tests. |
-| ~~**`StyleAuditPort` test adapter**~~ | bijou | ✅ v0.9.0 — `auditStyle()` records styled calls for assertion with `wasStyled()` convenience method. |
+| ~~**`AuditStylePort` test adapter**~~ | bijou | ✅ v0.9.0 — `auditStyle()` records styled calls for assertion with `wasStyled()` convenience method. |
 | ~~**Grapheme cluster support**~~ | bijou + bijou-tui | ✅ v0.9.0 — `segmentGraphemes()`, `graphemeWidth()`, `isWideChar()` using `Intl.Segmenter`. Fixed `visibleLength()`, `clipToWidth()`, `sliceAnsi()`, `truncateLabel()`, and `renderNodeBox()`. |
 
 ### P3 — Nice to have

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -421,6 +421,8 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | ~~**Color manipulation**~~ | bijou | ✅ v0.8.0 — `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` on theme tokens. |
 | ~~**`markdown()`**~~ | bijou | ✅ v0.9.0 — Terminal markdown renderer with headings, inline formatting, lists, code blocks, blockquotes, links, and mode degradation. |
 | ~~**`log()`**~~ | bijou | ✅ v0.7.0 — Leveled styled log output (debug/info/warn/error/fatal). |
+| **`canvas()` shader primitive** | bijou-tui | `(cols, rows, shader, time?) → string` character-grid renderer for procedural backgrounds (rain, plasma, spiral, starfield). Composes with `composite()` for layered rendering. |
+| **`box()` width override** | bijou | Optional `width` on `BoxOptions` to lock outer width for visual stability across state changes. Content right-padded or clipped via `clipToWidth()`. |
 
 ### P2.5 — Code quality & DX
 
@@ -461,3 +463,4 @@ Once published:
 | Phase 1h (confirm/input overlays) | `composite()`, `modal()` | ✅ Ready |
 | Phase 2 (review actions, detail panel) | `selectedId`, ANSI utils | ✅ Ready |
 | Phase 3 (full DAG interactivity) | `scrollX`, `dagLayout()`, `createPanelGroup()` | ✅ Ready |
+| Title screen (animated splash) | `canvas()`, `box({ width })`, `composite()` | ⏳ Pending `canvas()` + `box()` width |

--- a/docs/requests/xyph-title.md
+++ b/docs/requests/xyph-title.md
@@ -1,0 +1,214 @@
+# Feature Request: Canvas Primitive & Box Width Override
+
+**From:** XYPH TUI title screen
+**Date:** 2026-02-28
+**bijou version:** v0.9.0 (pre-release)
+
+---
+
+## Context
+
+XYPH's landing screen renders an animated ASCII spiral shader as a
+full-screen background, with the logo and status text inside a solid
+bordered box composited on top. With v0.9.0, `composite()` + `box()`
+eliminate most of the hand-rolled compositing code, but two gaps remain.
+
+### What v0.9.0 already solves
+
+| Problem | v0.9.0 solution |
+|---------|-----------------|
+| Row-by-row compositing loop | `composite(bg, [overlay], { dim })` |
+| Manual box-drawing characters | `box(content, { borderToken, padding })` |
+| Tracking visual widths alongside styled text | `visibleLength()` |
+| ANSI-safe background slicing | `sliceAnsi()` via `spliceLine()` internals |
+| Centering math | `modal()` pattern (or trivial manual calc) |
+
+---
+
+## Request 1: `canvas()` — Character-grid shader primitive
+
+### Problem
+
+The spiral background is a `(x, y, time) -> character` function evaluated
+over a `cols x rows` grid. The tight loop is pure boilerplate:
+
+```typescript
+const lines: string[] = [];
+for (let y = 0; y < rows; y++) {
+  let line = '';
+  for (let x = 0; x < cols; x++) {
+    line += shaderFn(x, y, cols, rows, time);
+  }
+  lines.push(line);
+}
+return lines.join('\n');
+```
+
+Every app that wants a procedural background (rain, static, plasma, matrix,
+starfield) re-implements this loop. The pattern is general enough to live
+in bijou.
+
+### Proposed API
+
+```typescript
+// bijou-tui or bijou core
+
+type ShaderFn = (
+  x: number,
+  y: number,
+  cols: number,
+  rows: number,
+  time: number,
+) => string; // single character
+
+function canvas(
+  cols: number,
+  rows: number,
+  shader: ShaderFn,
+  time?: number,
+): string;
+```
+
+**Returns:** A single string of `rows` newline-separated lines, each
+`cols` characters wide.
+
+**Behavior:**
+- Calls `shader(x, y, cols, rows, time ?? 0)` for every cell
+- If the shader returns more than one character, take only the first
+- If it returns an empty string, substitute a space
+- `time` defaults to `0` for static patterns
+
+### Why bijou, not app code
+
+1. **Reusable** — any TUI splash screen, screensaver, or background effect
+   benefits from the same loop.
+2. **Optimizable** — bijou could later add row-level string building
+   optimizations, canvas caching, or dirty-rect diffing without changing
+   the shader contract.
+3. **Composable** — `canvas()` output feeds directly into `composite()`
+   as a background string. The two together form a complete layered
+   rendering pipeline.
+
+### Acceptance criteria
+
+```
+canvas()
+  ✓ calls shader(x, y, cols, rows, time) for every cell in order
+  ✓ produces exactly `rows` lines separated by newlines
+  ✓ each line is exactly `cols` characters wide
+  ✓ truncates multi-char shader return to first character
+  ✓ substitutes space for empty shader return
+  ✓ time defaults to 0 when omitted
+  ✓ works with cols=0 or rows=0 (returns empty string)
+  pipe mode
+    ✓ returns empty string (no visual output in pipes)
+```
+
+---
+
+## Request 2: `box()` width override
+
+### Problem
+
+`modal()` accepts an optional `width` to force a fixed box size, but
+`box()` doesn't. On the XYPH title screen, the box content changes between
+states:
+
+| State | Content inside box |
+|-------|--------------------|
+| Loading | Logo + copyright (2 lines below logo) |
+| Error | Logo + copyright + error + "press any key" |
+| Ready | Logo + copyright + stats + "press any key" |
+
+The widest content line (the logo) is the same across all states, so the
+box width doesn't jump. But the box *height* changes — it's taller in the
+ready state than the loading state. If the widest line ever differed between
+states (e.g., a long error message), the box would visually jump widths
+between frames.
+
+A `width` option on `box()` would let consumers lock the box to a fixed
+size for visual stability.
+
+### Proposed API
+
+```typescript
+export interface BoxOptions {
+  borderToken?: TokenValue;
+  padding?: { top?: number; bottom?: number; left?: number; right?: number };
+  width?: number;  // <-- new: total outer width (border + padding + content)
+  ctx?: BijouContext;
+}
+```
+
+**Behavior:**
+- When `width` is set, the box outer width is fixed to that value
+- Content lines shorter than the interior are right-padded with spaces
+- Content lines longer than the interior are clipped via `clipToWidth()`
+- When `width` is not set, behavior is unchanged (auto-size to content)
+
+### Acceptance criteria
+
+```
+box() with width override
+  ✓ outer width matches specified width exactly
+  ✓ short content lines are right-padded to fill interior
+  ✓ long content lines are clipped to interior width
+  ✓ padding is subtracted from width to compute interior
+  ✓ width < minimum (border + padding) produces zero-width interior
+  ✓ visibleLength of every output line equals specified width
+```
+
+---
+
+## Non-request: Transparent compositing
+
+Initially considered requesting a `transparent` option for `composite()`
+where space characters in the overlay would reveal the background. After
+review, `composite()`'s current opaque behavior is correct for the box
+use case — the solid interior is the whole point. Transparent compositing
+is a different primitive (sprite rendering) and would complicate the
+common case. Noting it here as a future thought, not a request.
+
+---
+
+## Usage sketch (v0.9.0 + these two features)
+
+```typescript
+import { box } from '@flyingrobots/bijou';
+import { composite, canvas } from '@flyingrobots/bijou-tui';
+import { spiralShader } from './shaders/spiral.js';
+
+export function landingView(model: DashboardModel): string {
+  // 1. Render full-screen spiral background
+  const bg = canvas(model.cols, model.rows, spiralShader, Date.now());
+  const styledBg = styled(muted, bg);
+
+  // 2. Build foreground content
+  const content = [gradientLogo, '', copyright, '', statusText]
+    .filter(Boolean).join('\n');
+
+  // 3. Wrap in a fixed-width box
+  const panel = box(content, {
+    borderToken: border,
+    padding: { top: 1, bottom: 1, left: 3, right: 3 },
+    width: logoWidth + 8, // lock to logo width + padding + border
+  });
+
+  // 4. Center and composite
+  const panelLines = panel.split('\n');
+  const row = Math.floor((model.rows - panelLines.length) / 2);
+  const col = Math.floor((model.cols - visibleLength(panelLines[0])) / 2);
+
+  let result = composite(styledBg, [{ content: panel, row, col }], { dim: true });
+
+  // 5. Progress bar at bottom
+  if (model.loading) {
+    const bar = progressBar(model.loadingProgress, { width: model.cols });
+    result = composite(result, [{ content: bar, row: model.rows - 1, col: 0 }]);
+  }
+
+  return result;
+}
+```
+
+~25 lines vs. the current ~130 lines of manual compositing.

--- a/docs/requests/xyph-title.md
+++ b/docs/requests/xyph-title.md
@@ -2,7 +2,7 @@
 
 **From:** XYPH TUI title screen
 **Date:** 2026-02-28
-**bijou version:** v0.9.0 (pre-release)
+**bijou version:** v0.9.0
 
 ---
 

--- a/examples/browsable-list/main.ts
+++ b/examples/browsable-list/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   createBrowsableListState, browsableList,
   listFocusNext, listFocusPrev, listPageDown, listPageUp,
   browsableListKeyMap, helpShort, vstack,
@@ -50,8 +50,8 @@ const app: App<Model, Msg> = {
   init: () => [{ list: createBrowsableListState({ items, height: 8 }) }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -16,7 +16,7 @@ npx tsx examples/chat/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { badge, separator, kbd } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, viewport, createScrollState, scrollBy, scrollToBottom, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -63,27 +63,25 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ ...model, cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.ctrl && k.key === 'c') return [model, [quit()]];
-      if (k.key === 'q' && model.input === '') return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.ctrl && msg.key === 'c') return [model, [quit()]];
+      if (msg.key === 'q' && model.input === '') return [model, [quit()]];
 
-      if (k.key === 'enter' && model.input.trim()) {
+      if (msg.key === 'enter' && model.input.trim()) {
         const newMsg: Message = { sender: 'you', text: model.input.trim(), variant: 'primary' };
         return [{ ...model, messages: [...model.messages, newMsg], input: '' }, []];
       }
 
-      if (k.key === 'backspace') {
+      if (msg.key === 'backspace') {
         return [{ ...model, input: model.input.slice(0, -1) }, []];
       }
 
       // Printable character
-      if (k.key.length === 1 && !k.ctrl && !k.alt) {
-        return [{ ...model, input: model.input + k.key }, []];
+      if (msg.key.length === 1 && !msg.ctrl && !msg.alt) {
+        return [{ ...model, input: model.input + msg.key }, []];
       }
     }
     return [model, []];

--- a/examples/chat/main.ts
+++ b/examples/chat/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { badge, separator, kbd } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, viewport, createScrollState, scrollBy, scrollToBottom, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -48,27 +48,25 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ ...model, cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.ctrl && k.key === 'c') return [model, [quit()]];
-      if (k.key === 'q' && model.input === '') return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.ctrl && msg.key === 'c') return [model, [quit()]];
+      if (msg.key === 'q' && model.input === '') return [model, [quit()]];
 
-      if (k.key === 'enter' && model.input.trim()) {
+      if (msg.key === 'enter' && model.input.trim()) {
         const newMsg: Message = { sender: 'you', text: model.input.trim(), variant: 'primary' };
         return [{ ...model, messages: [...model.messages, newMsg], input: '' }, []];
       }
 
-      if (k.key === 'backspace') {
+      if (msg.key === 'backspace') {
         return [{ ...model, input: model.input.slice(0, -1) }, []];
       }
 
       // Printable character
-      if (k.key.length === 1 && !k.ctrl && !k.alt) {
-        return [{ ...model, input: model.input + k.key }, []];
+      if (msg.key.length === 1 && !msg.ctrl && !msg.alt) {
+        return [{ ...model, input: model.input + msg.key }, []];
       }
     }
     return [model, []];

--- a/examples/composable/README.md
+++ b/examples/composable/README.md
@@ -19,7 +19,7 @@ import {
   tabs, table, tree, progressBar, timeline,
 } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -106,18 +106,16 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ ...model, cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
-      if (k.key === 'left' || k.key === 'h') {
+      if (msg.key === 'left' || msg.key === 'h') {
         return [{ ...model, activeTab: Math.max(0, model.activeTab - 1) }, []];
       }
-      if (k.key === 'right' || k.key === 'l') {
+      if (msg.key === 'right' || msg.key === 'l') {
         return [{ ...model, activeTab: Math.min(TAB_ITEMS.length - 1, model.activeTab + 1) }, []];
       }
     }

--- a/examples/composable/main.ts
+++ b/examples/composable/main.ts
@@ -4,7 +4,7 @@ import {
   tabs, table, tree, progressBar, timeline,
 } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -91,18 +91,16 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ ...model, cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
-      if (k.key === 'left' || k.key === 'h') {
+      if (msg.key === 'left' || msg.key === 'h') {
         return [{ ...model, activeTab: Math.max(0, model.activeTab - 1) }, []];
       }
-      if (k.key === 'right' || k.key === 'l') {
+      if (msg.key === 'right' || msg.key === 'l') {
         return [{ ...model, activeTab: Math.min(TAB_ITEMS.length - 1, model.activeTab + 1) }, []];
       }
     }

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -15,7 +15,7 @@ npx tsx examples/counter/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd } from '@flyingrobots/bijou';
-import { run, quit, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -29,12 +29,11 @@ const app: App<Model, Msg> = {
   init: () => [{ count: 0 }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'k' || key === '+' || key === 'up') return [{ count: model.count + 1 }, []];
-      if (key === 'j' || key === '-' || key === 'down') return [{ count: model.count - 1 }, []];
-      if (key === 'q') return [model, [quit()]];
-      if ((msg as KeyMsg).ctrl && key === 'c') return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'k' || msg.key === '+' || msg.key === 'up') return [{ count: model.count + 1 }, []];
+      if (msg.key === 'j' || msg.key === '-' || msg.key === 'down') return [{ count: model.count - 1 }, []];
+      if (msg.key === 'q') return [model, [quit()]];
+      if (msg.ctrl && msg.key === 'c') return [model, [quit()]];
     }
     return [model, []];
   },

--- a/examples/counter/main.ts
+++ b/examples/counter/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd } from '@flyingrobots/bijou';
-import { run, quit, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -14,12 +14,11 @@ const app: App<Model, Msg> = {
   init: () => [{ count: 0 }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'k' || key === '+' || key === 'up') return [{ count: model.count + 1 }, []];
-      if (key === 'j' || key === '-' || key === 'down') return [{ count: model.count - 1 }, []];
-      if (key === 'q') return [model, [quit()]];
-      if ((msg as KeyMsg).ctrl && key === 'c') return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'k' || msg.key === '+' || msg.key === 'up') return [{ count: model.count + 1 }, []];
+      if (msg.key === 'j' || msg.key === '-' || msg.key === 'down') return [{ count: model.count - 1 }, []];
+      if (msg.key === 'q') return [model, [quit()]];
+      if (msg.ctrl && msg.key === 'c') return [model, [quit()]];
     }
     return [model, []];
   },

--- a/examples/file-picker/README.md
+++ b/examples/file-picker/README.md
@@ -16,7 +16,7 @@ npx tsx examples/file-picker/main.ts
 import { initDefaultContext, nodeIO } from '@flyingrobots/bijou-node';
 import { separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   createFilePickerState, filePicker,
   fpFocusNext, fpFocusPrev, fpEnter, fpBack,
   filePickerKeyMap, helpShort, vstack,
@@ -53,9 +53,14 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns }, []];
+    }
+
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
+
       switch (action.type) {
         case 'quit': return [model, [quit()]];
         case 'focus-next': return [{ ...model, fp: fpFocusNext(model.fp) }, []];
@@ -68,6 +73,7 @@ const app: App<Model, Msg> = {
         case 'back': return [{ ...model, fp: fpBack(model.fp, io) }, []];
       }
     }
+
     return [model, []];
   },
 

--- a/examples/file-picker/main.ts
+++ b/examples/file-picker/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext, nodeIO } from '@flyingrobots/bijou-node';
 import { separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   createFilePickerState, filePicker,
   fpFocusNext, fpFocusPrev, fpEnter, fpBack,
   filePickerKeyMap, helpShort, vstack,
@@ -38,13 +38,12 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as { columns: number };
-      return [{ ...model, cols: r.columns }, []];
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns }, []];
     }
 
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/flex-layout/README.md
+++ b/examples/flex-layout/README.md
@@ -16,7 +16,7 @@ npx tsx examples/flex-layout/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, badge, separator, kbd, tree } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -43,13 +43,11 @@ const app: App<Model, Msg> = {
   init: () => [{ cols: process.stdout.columns ?? 80, rows: process.stdout.rows ?? 24 }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
     return [model, []];
   },

--- a/examples/flex-layout/main.ts
+++ b/examples/flex-layout/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, badge, separator, kbd, tree } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -28,13 +28,11 @@ const app: App<Model, Msg> = {
   init: () => [{ cols: process.stdout.columns ?? 80, rows: process.stdout.rows ?? 24 }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
     return [model, []];
   },

--- a/examples/fullscreen/README.md
+++ b/examples/fullscreen/README.md
@@ -15,7 +15,7 @@ npx tsx examples/fullscreen/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd } from '@flyingrobots/bijou';
-import { run, quit, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, isKeyMsg, isResizeMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -30,12 +30,11 @@ const app: App<Model, Msg> = {
   init: () => [{ cols: process.stdout.columns ?? 80, rows: process.stdout.rows ?? 24 }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
+    if (isResizeMsg(msg)) {
       return [{ cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'q' || key === 'enter' || ((msg as KeyMsg).ctrl && key === 'c')) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || msg.key === 'enter' || (msg.ctrl && msg.key === 'c')) {
         return [model, [quit()]];
       }
     }

--- a/examples/fullscreen/main.ts
+++ b/examples/fullscreen/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd } from '@flyingrobots/bijou';
-import { run, quit, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, isKeyMsg, isResizeMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -15,12 +15,11 @@ const app: App<Model, Msg> = {
   init: () => [{ cols: process.stdout.columns ?? 80, rows: process.stdout.rows ?? 24 }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
+    if (isResizeMsg(msg)) {
       return [{ cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'q' || key === 'enter' || ((msg as KeyMsg).ctrl && key === 'c')) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || msg.key === 'enter' || (msg.ctrl && msg.key === 'c')) {
         return [model, [quit()]];
       }
     }

--- a/examples/help/README.md
+++ b/examples/help/README.md
@@ -75,7 +75,7 @@ const app: App<Model, Msg> = {
         case 'delete': {
           if (model.items.length === 0) return [model, []];
           const items = model.items.filter((_, i) => i !== model.selected);
-          const selected = Math.min(model.selected, items.length - 1);
+          const selected = Math.max(0, Math.min(model.selected, items.length - 1));
           return [{ ...model, items, selected }, []];
         }
       }

--- a/examples/help/README.md
+++ b/examples/help/README.md
@@ -16,7 +16,7 @@ npx tsx examples/help/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   createKeyMap, helpView, helpShort, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -63,8 +63,8 @@ const app: App<Model, Msg> = {
   init: () => [{ showHelp: false, selected: 0, items: [...ITEMS] }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/help/main.ts
+++ b/examples/help/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   createKeyMap, helpView, helpShort, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -48,8 +48,8 @@ const app: App<Model, Msg> = {
   init: () => [{ showHelp: false, selected: 0, items: [...ITEMS] }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/help/main.ts
+++ b/examples/help/main.ts
@@ -60,7 +60,7 @@ const app: App<Model, Msg> = {
         case 'delete': {
           if (model.items.length === 0) return [model, []];
           const items = model.items.filter((_, i) => i !== model.selected);
-          const selected = Math.min(model.selected, items.length - 1);
+          const selected = Math.max(0, Math.min(model.selected, items.length - 1));
           return [{ ...model, items, selected }, []];
         }
       }

--- a/examples/interactive-accordion/README.md
+++ b/examples/interactive-accordion/README.md
@@ -14,22 +14,51 @@ npx tsx examples/interactive-accordion/main.ts
 
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { kbd, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   createAccordionState, interactiveAccordion,
-  focusNext, focusPrev, toggleFocused,
+  focusNext, focusPrev, toggleFocused, expandAll, collapseAll,
   accordionKeyMap, helpShort, vstack,
 } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
 const SECTIONS = [
-  { title: 'Section A', content: 'Content for A', expanded: true },
-  { title: 'Section B', content: 'Content for B', expanded: false },
-  { title: 'Section C', content: 'Content for C', expanded: false },
+  {
+    title: 'What is bijou?',
+    content: 'A physics-powered TUI engine for TypeScript.\nZero dependencies. Hexagonal architecture.',
+    expanded: true,
+  },
+  {
+    title: 'Components',
+    content: 'box, table, tree, accordion, tabs, badge, alert,\nseparator, skeleton, kbd, breadcrumb, stepper,\ntimeline, paginator, progress, spinner, dag.',
+    expanded: false,
+  },
+  {
+    title: 'TUI Runtime',
+    content: 'TEA architecture (Model → Update → View).\nSpring animations, flexbox layout, viewport,\nkeybindings, input stack, event bus.',
+    expanded: false,
+  },
+  {
+    title: 'Theme Engine',
+    content: 'DTCG interop with built-in presets:\ncyan-magenta, nord, catppuccin.\nCustom themes via BIJOU_THEME env var.',
+    expanded: false,
+  },
+  {
+    title: 'Getting Started',
+    content: 'npm install @flyingrobots/bijou @flyingrobots/bijou-node\nimport { initDefaultContext } from "@flyingrobots/bijou-node";\ninitDefaultContext();',
+    expanded: false,
+  },
 ];
 
-type Msg = { type: 'next' } | { type: 'prev' } | { type: 'toggle' } | { type: 'quit' };
+type Msg =
+  | { type: 'next' }
+  | { type: 'prev' }
+  | { type: 'toggle' }
+  | { type: 'expand-all' }
+  | { type: 'collapse-all' }
+  | { type: 'quit' };
 
 const keys = accordionKeyMap<Msg>({
   focusNext: { type: 'next' },
@@ -38,28 +67,42 @@ const keys = accordionKeyMap<Msg>({
   quit: { type: 'quit' },
 });
 
-interface Model { accordion: ReturnType<typeof createAccordionState> }
+// Add extra bindings for expand/collapse all
+keys
+  .bind('e', 'Expand all', { type: 'expand-all' })
+  .bind('c', 'Collapse all', { type: 'collapse-all' });
+
+interface Model {
+  accordion: ReturnType<typeof createAccordionState>;
+}
 
 const app: App<Model, Msg> = {
   init: () => [{ accordion: createAccordionState(SECTIONS) }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
+
       switch (action.type) {
         case 'quit': return [model, [quit()]];
         case 'next': return [{ accordion: focusNext(model.accordion) }, []];
         case 'prev': return [{ accordion: focusPrev(model.accordion) }, []];
         case 'toggle': return [{ accordion: toggleFocused(model.accordion) }, []];
+        case 'expand-all': return [{ accordion: expandAll(model.accordion) }, []];
+        case 'collapse-all': return [{ accordion: collapseAll(model.accordion) }, []];
       }
     }
+
     return [model, []];
   },
 
-  view: (model) => vstack(
-    '', interactiveAccordion(model.accordion), '', `  ${helpShort(keys)}`, '',
-  ),
+  view: (model) => {
+    const header = separator({ label: 'interactive accordion' });
+    const body = interactiveAccordion(model.accordion);
+    const help = `  ${helpShort(keys)}`;
+    return vstack('', header, '', body, '', help, '');
+  },
 };
 
 run(app);

--- a/examples/interactive-accordion/main.ts
+++ b/examples/interactive-accordion/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { kbd, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   createAccordionState, interactiveAccordion,
   focusNext, focusPrev, toggleFocused, expandAll, collapseAll,
   accordionKeyMap, helpShort, vstack,
@@ -65,8 +65,8 @@ const app: App<Model, Msg> = {
   init: () => [{ accordion: createAccordionState(SECTIONS) }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/modal/README.md
+++ b/examples/modal/README.md
@@ -16,7 +16,7 @@ npx tsx examples/modal/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator, badge } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App, type KeyMsg,
   createKeyMap, createInputStack, helpShort, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -73,8 +73,8 @@ const app: App<Model, Msg> = {
   },
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = stack.dispatch(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = stack.dispatch(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/modal/main.ts
+++ b/examples/modal/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator, badge } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App, type KeyMsg,
   createKeyMap, createInputStack, helpShort, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -58,8 +58,8 @@ const app: App<Model, Msg> = {
   },
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = stack.dispatch(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = stack.dispatch(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/navigable-table/README.md
+++ b/examples/navigable-table/README.md
@@ -16,7 +16,7 @@ npx tsx examples/navigable-table/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   createNavigableTableState, navigableTable,
   navTableFocusNext, navTableFocusPrev,
   navTablePageDown, navTablePageUp,
@@ -72,8 +72,8 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
       switch (action.type) {
         case 'quit':       return [model, [quit()]];

--- a/examples/navigable-table/main.ts
+++ b/examples/navigable-table/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   createNavigableTableState, navigableTable,
   navTableFocusNext, navTableFocusPrev,
   navTablePageDown, navTablePageUp,
@@ -57,8 +57,8 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/package-manager/README.md
+++ b/examples/package-manager/README.md
@@ -15,7 +15,7 @@ npx tsx examples/package-manager/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { spinnerFrame, progressBar, badge, alert, tree, separator } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg, vstack } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App, vstack } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -56,9 +56,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
     if ('type' in msg && msg.type === 'tick') {

--- a/examples/package-manager/main.ts
+++ b/examples/package-manager/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { spinnerFrame, progressBar, badge, alert, tree, separator } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg, vstack } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App, vstack } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -41,9 +41,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
     if ('type' in msg && msg.type === 'tick') {

--- a/examples/pager/README.md
+++ b/examples/pager/README.md
@@ -16,14 +16,19 @@ npx tsx examples/pager/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   createPagerState, pager, pagerScrollBy, pagerPageDown, pagerPageUp,
   pagerScrollToTop, pagerScrollToBottom, pagerKeyMap, helpShort, vstack,
 } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
-const CONTENT = Array.from({ length: 80 }, (_, i) => `  Line ${i + 1}`).join('\n');
+// Generate some content to page through
+const CONTENT = Array.from({ length: 80 }, (_, i) => {
+  if (i === 0) return '  Welcome to the bijou pager!';
+  if (i % 10 === 0) return `  ── Section ${i / 10} ──`;
+  return `  Line ${i}: ${'Lorem ipsum dolor sit amet'.repeat(Math.ceil(Math.random() * 2))}`;
+}).join('\n');
 
 type Msg =
   | { type: 'scroll'; dy: number }
@@ -45,30 +50,52 @@ const keys = pagerKeyMap<Msg>({
 
 interface Model {
   pager: ReturnType<typeof createPagerState>;
+  cols: number;
+  rows: number;
 }
 
 const app: App<Model, Msg> = {
-  init: () => [{
-    pager: createPagerState({ content: CONTENT, width: 80, height: 20 }),
-  }, []],
+  init: () => {
+    const cols = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    return [{
+      pager: createPagerState({ content: CONTENT, width: cols, height: rows - 2 }),
+      cols,
+      rows,
+    }, []];
+  },
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isResizeMsg(msg)) {
+      const p = createPagerState({ content: CONTENT, width: msg.columns, height: msg.rows - 2 });
+      // Preserve scroll position across resize
+      const clampedY = Math.min(model.pager.scroll.y, p.scroll.maxY);
+      return [{ ...model, pager: { ...p, scroll: { ...p.scroll, y: clampedY } }, cols: msg.columns, rows: msg.rows }, []];
+    }
+
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
+
       switch (action.type) {
         case 'quit': return [model, [quit()]];
-        case 'scroll': return [{ pager: pagerScrollBy(model.pager, action.dy) }, []];
-        case 'page-up': return [{ pager: pagerPageUp(model.pager) }, []];
-        case 'page-down': return [{ pager: pagerPageDown(model.pager) }, []];
-        case 'top': return [{ pager: pagerScrollToTop(model.pager) }, []];
-        case 'bottom': return [{ pager: pagerScrollToBottom(model.pager) }, []];
+        case 'scroll': return [{ ...model, pager: pagerScrollBy(model.pager, action.dy) }, []];
+        case 'page-up': return [{ ...model, pager: pagerPageUp(model.pager) }, []];
+        case 'page-down': return [{ ...model, pager: pagerPageDown(model.pager) }, []];
+        case 'top': return [{ ...model, pager: pagerScrollToTop(model.pager) }, []];
+        case 'bottom': return [{ ...model, pager: pagerScrollToBottom(model.pager) }, []];
       }
     }
+
     return [model, []];
   },
 
-  view: (model) => vstack(pager(model.pager), `  ${helpShort(keys)}`),
+  view: (model) => {
+    const header = separator({ label: 'pager', width: model.cols });
+    const body = pager(model.pager);
+    const help = `  ${helpShort(keys)}`;
+    return vstack(header, body, help);
+  },
 };
 
 run(app);

--- a/examples/pager/main.ts
+++ b/examples/pager/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   createPagerState, pager, pagerScrollBy, pagerPageDown, pagerPageUp,
   pagerScrollToTop, pagerScrollToBottom, pagerKeyMap, helpShort, vstack,
 } from '@flyingrobots/bijou-tui';
@@ -51,16 +51,15 @@ const app: App<Model, Msg> = {
   },
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as { columns: number; rows: number };
-      const p = createPagerState({ content: CONTENT, width: r.columns, height: r.rows - 2 });
+    if (isResizeMsg(msg)) {
+      const p = createPagerState({ content: CONTENT, width: msg.columns, height: msg.rows - 2 });
       // Preserve scroll position across resize
       const clampedY = Math.min(model.pager.scroll.y, p.scroll.maxY);
-      return [{ ...model, pager: { ...p, scroll: { ...p.scroll, y: clampedY } }, cols: r.columns, rows: r.rows }, []];
+      return [{ ...model, pager: { ...p, scroll: { ...p.scroll, y: clampedY } }, cols: msg.columns, rows: msg.rows }, []];
     }
 
-    if ('type' in msg && msg.type === 'key') {
-      const action = keys.handle(msg as KeyMsg);
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
       if (!action) return [model, []];
 
       switch (action.type) {

--- a/examples/print-key/README.md
+++ b/examples/print-key/README.md
@@ -15,7 +15,7 @@ npx tsx examples/print-key/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator, badge } from '@flyingrobots/bijou';
-import { run, quit, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -38,11 +38,10 @@ const app: App<Model, Msg> = {
   init: () => [{ history: [] }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.ctrl && k.key === 'c') return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.ctrl && msg.key === 'c') return [model, [quit()]];
 
-      const entry: KeyEntry = { key: k.key, ctrl: k.ctrl, alt: k.alt, shift: k.shift };
+      const entry: KeyEntry = { key: msg.key, ctrl: msg.ctrl, alt: msg.alt, shift: msg.shift };
       const history = [...model.history, entry].slice(-MAX_HISTORY);
       return [{ history }, []];
     }

--- a/examples/print-key/main.ts
+++ b/examples/print-key/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator, badge } from '@flyingrobots/bijou';
-import { run, quit, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -23,11 +23,10 @@ const app: App<Model, Msg> = {
   init: () => [{ history: [] }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.ctrl && k.key === 'c') return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.ctrl && msg.key === 'c') return [model, [quit()]];
 
-      const entry: KeyEntry = { key: k.key, ctrl: k.ctrl, alt: k.alt, shift: k.shift };
+      const entry: KeyEntry = { key: msg.key, ctrl: msg.ctrl, alt: msg.alt, shift: msg.shift };
       const history = [...model.history, entry].slice(-MAX_HISTORY);
       return [{ history }, []];
     }

--- a/examples/progress-animated/README.md
+++ b/examples/progress-animated/README.md
@@ -15,7 +15,7 @@ npx tsx examples/progress-animated/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { progressBar, badge } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -33,9 +33,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'q' || ((msg as KeyMsg).ctrl && key === 'c')) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) {
         return [model, [quit()]];
       }
     }

--- a/examples/progress-animated/main.ts
+++ b/examples/progress-animated/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { progressBar, badge } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -18,9 +18,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'q' || ((msg as KeyMsg).ctrl && key === 'c')) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) {
         return [model, [quit()]];
       }
     }

--- a/examples/progress-download/README.md
+++ b/examples/progress-download/README.md
@@ -15,7 +15,7 @@ npx tsx examples/progress-download/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { progressBar, badge, separator, spinnerFrame } from '@flyingrobots/bijou';
-import { run, quit, tick, isKeyMsg, type App, vstack } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 

--- a/examples/progress-download/README.md
+++ b/examples/progress-download/README.md
@@ -55,6 +55,10 @@ const app: App<Model, Msg> = {
       if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
+    if ('type' in msg && msg.type === 'quit') {
+      return [model, [quit()]];
+    }
+
     if ('type' in msg && msg.type === 'tick') {
       const downloads = model.downloads.map(d => {
         if (d.done) return d;

--- a/examples/progress-download/README.md
+++ b/examples/progress-download/README.md
@@ -15,7 +15,7 @@ npx tsx examples/progress-download/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { progressBar, badge, separator, spinnerFrame } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg, vstack } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App, vstack } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -51,9 +51,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
     if ('type' in msg && msg.type === 'tick') {

--- a/examples/progress-download/main.ts
+++ b/examples/progress-download/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { progressBar, badge, separator, spinnerFrame } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg, vstack } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App, vstack } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -36,9 +36,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
     if ('type' in msg && msg.type === 'tick') {

--- a/examples/progress-download/main.ts
+++ b/examples/progress-download/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { progressBar, badge, separator, spinnerFrame } from '@flyingrobots/bijou';
-import { run, quit, tick, isKeyMsg, type App, vstack } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 

--- a/examples/progress-download/main.ts
+++ b/examples/progress-download/main.ts
@@ -40,6 +40,10 @@ const app: App<Model, Msg> = {
       if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
+    if ('type' in msg && msg.type === 'quit') {
+      return [model, [quit()]];
+    }
+
     if ('type' in msg && msg.type === 'tick') {
       const downloads = model.downloads.map(d => {
         if (d.done) return d;

--- a/examples/spinner/README.md
+++ b/examples/spinner/README.md
@@ -15,7 +15,7 @@ npx tsx examples/spinner/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { spinnerFrame, badge } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -36,9 +36,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'q' || ((msg as KeyMsg).ctrl && key === 'c')) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) {
         return [model, [quit()]];
       }
     }

--- a/examples/spinner/main.ts
+++ b/examples/spinner/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { spinnerFrame, badge } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -21,9 +21,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const key = (msg as KeyMsg).key;
-      if (key === 'q' || ((msg as KeyMsg).ctrl && key === 'c')) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) {
         return [model, [quit()]];
       }
     }

--- a/examples/splash/README.md
+++ b/examples/splash/README.md
@@ -16,7 +16,7 @@ npx tsx examples/splash/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { gradientText, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, tick, type App, type KeyMsg,
+  run, quit, tick, isKeyMsg, type App,
   animate, sequence, EASINGS,
 } from '@flyingrobots/bijou-tui';
 
@@ -67,9 +67,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c') || model.showPrompt) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c') || model.showPrompt) {
         return [model, [quit()]];
       }
     }

--- a/examples/splash/main.ts
+++ b/examples/splash/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { gradientText, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, tick, type App, type KeyMsg,
+  run, quit, tick, isKeyMsg, type App,
   animate, sequence, EASINGS,
 } from '@flyingrobots/bijou-tui';
 
@@ -52,9 +52,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c') || model.showPrompt) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c') || model.showPrompt) {
         return [model, [quit()]];
       }
     }

--- a/examples/split-editors/README.md
+++ b/examples/split-editors/README.md
@@ -16,7 +16,7 @@ npx tsx examples/split-editors/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator, badge } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, viewport, createScrollState, scrollBy, pageDown, pageUp, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -125,25 +125,23 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ ...model, cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
-      if (k.key === 'tab') {
+      if (msg.key === 'tab') {
         return [{ ...model, focusLeft: !model.focusLeft }, []];
       }
 
       const scrollKey = model.focusLeft ? 'leftScroll' : 'rightScroll';
       let scroll = model[scrollKey];
 
-      if (k.key === 'j' || k.key === 'down') scroll = scrollBy(scroll, 1);
-      else if (k.key === 'k' || k.key === 'up') scroll = scrollBy(scroll, -1);
-      else if (k.key === 'd') scroll = pageDown(scroll);
-      else if (k.key === 'u') scroll = pageUp(scroll);
+      if (msg.key === 'j' || msg.key === 'down') scroll = scrollBy(scroll, 1);
+      else if (msg.key === 'k' || msg.key === 'up') scroll = scrollBy(scroll, -1);
+      else if (msg.key === 'd') scroll = pageDown(scroll);
+      else if (msg.key === 'u') scroll = pageUp(scroll);
 
       return [{ ...model, [scrollKey]: scroll }, []];
     }

--- a/examples/split-editors/main.ts
+++ b/examples/split-editors/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator, badge } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg, type ResizeMsg,
+  run, quit, isKeyMsg, isResizeMsg, type App,
   flex, viewport, createScrollState, scrollBy, pageDown, pageUp, vstack,
 } from '@flyingrobots/bijou-tui';
 
@@ -110,25 +110,23 @@ const app: App<Model, Msg> = {
   }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'resize') {
-      const r = msg as ResizeMsg;
-      return [{ ...model, cols: r.columns, rows: r.rows }, []];
+    if (isResizeMsg(msg)) {
+      return [{ ...model, cols: msg.columns, rows: msg.rows }, []];
     }
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
-      if (k.key === 'tab') {
+      if (msg.key === 'tab') {
         return [{ ...model, focusLeft: !model.focusLeft }, []];
       }
 
       const scrollKey = model.focusLeft ? 'leftScroll' : 'rightScroll';
       let scroll = model[scrollKey];
 
-      if (k.key === 'j' || k.key === 'down') scroll = scrollBy(scroll, 1);
-      else if (k.key === 'k' || k.key === 'up') scroll = scrollBy(scroll, -1);
-      else if (k.key === 'd') scroll = pageDown(scroll);
-      else if (k.key === 'u') scroll = pageUp(scroll);
+      if (msg.key === 'j' || msg.key === 'down') scroll = scrollBy(scroll, 1);
+      else if (msg.key === 'k' || msg.key === 'up') scroll = scrollBy(scroll, -1);
+      else if (msg.key === 'd') scroll = pageDown(scroll);
+      else if (msg.key === 'u') scroll = pageUp(scroll);
 
       return [{ ...model, [scrollKey]: scroll }, []];
     }

--- a/examples/spring/README.md
+++ b/examples/spring/README.md
@@ -16,7 +16,7 @@ npx tsx examples/spring/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { badge, kbd } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   animate, vstack, SPRING_PRESETS,
 } from '@flyingrobots/bijou-tui';
 
@@ -57,10 +57,9 @@ const app: App<Model, Msg> = {
   },
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
-      if (k.key === 'space' && !model.running) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
+      if (msg.key === 'space' && !model.running) {
         // Toggle direction
         const current = model.positions[PRESETS[0]] ?? 0;
         const target = current > WIDTH / 2 ? 0 : WIDTH;

--- a/examples/spring/main.ts
+++ b/examples/spring/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { badge, kbd } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   animate, vstack, SPRING_PRESETS,
 } from '@flyingrobots/bijou-tui';
 
@@ -42,10 +42,9 @@ const app: App<Model, Msg> = {
   },
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
-      if (k.key === 'space' && !model.running) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
+      if (msg.key === 'space' && !model.running) {
         // Toggle direction
         const current = model.positions[PRESETS[0]] ?? 0;
         const target = current > WIDTH / 2 ? 0 : WIDTH;

--- a/examples/stopwatch/README.md
+++ b/examples/stopwatch/README.md
@@ -15,7 +15,7 @@ npx tsx examples/stopwatch/main.ts
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -40,11 +40,10 @@ const app: App<Model, Msg> = {
   init: () => [{ elapsed: 0, running: false, laps: [] }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
-      if (k.key === 'space') {
+      if (msg.key === 'space') {
         // Toggle start/stop
         if (model.running) {
           return [{ ...model, running: false }, []];
@@ -53,11 +52,11 @@ const app: App<Model, Msg> = {
         }
       }
 
-      if (k.key === 'l' && model.running) {
+      if (msg.key === 'l' && model.running) {
         return [{ ...model, laps: [...model.laps, model.elapsed] }, []];
       }
 
-      if (k.key === 'r' && !model.running) {
+      if (msg.key === 'r' && !model.running) {
         return [{ elapsed: 0, running: false, laps: [] }, []];
       }
     }

--- a/examples/stopwatch/main.ts
+++ b/examples/stopwatch/main.ts
@@ -1,6 +1,6 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd, separator } from '@flyingrobots/bijou';
-import { run, quit, tick, type App, type KeyMsg } from '@flyingrobots/bijou-tui';
+import { run, quit, tick, isKeyMsg, type App } from '@flyingrobots/bijou-tui';
 
 initDefaultContext();
 
@@ -25,11 +25,10 @@ const app: App<Model, Msg> = {
   init: () => [{ elapsed: 0, running: false, laps: [] }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
-      if (k.key === 'space') {
+      if (msg.key === 'space') {
         // Toggle start/stop
         if (model.running) {
           return [{ ...model, running: false }, []];
@@ -38,11 +37,11 @@ const app: App<Model, Msg> = {
         }
       }
 
-      if (k.key === 'l' && model.running) {
+      if (msg.key === 'l' && model.running) {
         return [{ ...model, laps: [...model.laps, model.elapsed] }, []];
       }
 
-      if (k.key === 'r' && !model.running) {
+      if (msg.key === 'r' && !model.running) {
         return [{ elapsed: 0, running: false, laps: [] }, []];
       }
     }

--- a/examples/timeline-anim/README.md
+++ b/examples/timeline-anim/README.md
@@ -16,7 +16,7 @@ npx tsx examples/timeline-anim/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, badge, progressBar, gradientText } from '@flyingrobots/bijou';
 import {
-  run, quit, tick, type App, type KeyMsg,
+  run, quit, tick, isKeyMsg, type App,
   animate, sequence, vstack, EASINGS,
 } from '@flyingrobots/bijou-tui';
 
@@ -78,9 +78,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
     switch (msg.type) {

--- a/examples/timeline-anim/main.ts
+++ b/examples/timeline-anim/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, badge, progressBar, gradientText } from '@flyingrobots/bijou';
 import {
-  run, quit, tick, type App, type KeyMsg,
+  run, quit, tick, isKeyMsg, type App,
   animate, sequence, vstack, EASINGS,
 } from '@flyingrobots/bijou-tui';
 
@@ -63,9 +63,8 @@ const app: App<Model, Msg> = {
   ],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
     }
 
     switch (msg.type) {

--- a/examples/viewport/README.md
+++ b/examples/viewport/README.md
@@ -16,7 +16,7 @@ npx tsx examples/viewport/main.ts
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { kbd, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   viewport, createScrollState, scrollBy, pageDown, pageUp,
   scrollToTop, scrollToBottom, vstack,
 } from '@flyingrobots/bijou-tui';
@@ -79,17 +79,16 @@ const app: App<Model, Msg> = {
   init: () => [{ scroll: createScrollState(CONTENT, VIEWPORT_HEIGHT) }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
       let scroll = model.scroll;
-      if (k.key === 'j' || k.key === 'down') scroll = scrollBy(scroll, 1);
-      else if (k.key === 'k' || k.key === 'up') scroll = scrollBy(scroll, -1);
-      else if (k.key === 'pagedown' || k.key === 'd') scroll = pageDown(scroll);
-      else if (k.key === 'pageup' || k.key === 'u') scroll = pageUp(scroll);
-      else if (k.key === 'g') scroll = scrollToTop(scroll);
-      else if (k.key === 'G' || (k.shift && k.key === 'g')) scroll = scrollToBottom(scroll);
+      if (msg.key === 'j' || msg.key === 'down') scroll = scrollBy(scroll, 1);
+      else if (msg.key === 'k' || msg.key === 'up') scroll = scrollBy(scroll, -1);
+      else if (msg.key === 'pagedown' || msg.key === 'd') scroll = pageDown(scroll);
+      else if (msg.key === 'pageup' || msg.key === 'u') scroll = pageUp(scroll);
+      else if (msg.key === 'g') scroll = scrollToTop(scroll);
+      else if (msg.key === 'G' || (msg.shift && msg.key === 'g')) scroll = scrollToBottom(scroll);
 
       return [{ scroll }, []];
     }

--- a/examples/viewport/main.ts
+++ b/examples/viewport/main.ts
@@ -1,7 +1,7 @@
 import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { kbd, separator } from '@flyingrobots/bijou';
 import {
-  run, quit, type App, type KeyMsg,
+  run, quit, isKeyMsg, type App,
   viewport, createScrollState, scrollBy, pageDown, pageUp,
   scrollToTop, scrollToBottom, vstack,
 } from '@flyingrobots/bijou-tui';
@@ -64,17 +64,16 @@ const app: App<Model, Msg> = {
   init: () => [{ scroll: createScrollState(CONTENT, VIEWPORT_HEIGHT) }, []],
 
   update: (msg, model) => {
-    if ('type' in msg && msg.type === 'key') {
-      const k = msg as KeyMsg;
-      if (k.key === 'q' || (k.ctrl && k.key === 'c')) return [model, [quit()]];
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.ctrl && msg.key === 'c')) return [model, [quit()]];
 
       let scroll = model.scroll;
-      if (k.key === 'j' || k.key === 'down') scroll = scrollBy(scroll, 1);
-      else if (k.key === 'k' || k.key === 'up') scroll = scrollBy(scroll, -1);
-      else if (k.key === 'pagedown' || k.key === 'd') scroll = pageDown(scroll);
-      else if (k.key === 'pageup' || k.key === 'u') scroll = pageUp(scroll);
-      else if (k.key === 'g') scroll = scrollToTop(scroll);
-      else if (k.key === 'G' || (k.shift && k.key === 'g')) scroll = scrollToBottom(scroll);
+      if (msg.key === 'j' || msg.key === 'down') scroll = scrollBy(scroll, 1);
+      else if (msg.key === 'k' || msg.key === 'up') scroll = scrollBy(scroll, -1);
+      else if (msg.key === 'pagedown' || msg.key === 'd') scroll = pageDown(scroll);
+      else if (msg.key === 'pageup' || msg.key === 'u') scroll = pageUp(scroll);
+      else if (msg.key === 'g') scroll = scrollToTop(scroll);
+      else if (msg.key === 'G' || (msg.shift && msg.key === 'g')) scroll = scrollToBottom(scroll);
 
       return [{ scroll }, []];
     }

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -27,7 +27,7 @@
     "chalk": "^5.6.2"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.8.0"
+    "@flyingrobots/bijou": "0.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-node/src/index.ts
+++ b/packages/bijou-node/src/index.ts
@@ -6,7 +6,7 @@ import { chalkStyle } from './style.js';
 
 export { nodeRuntime } from './runtime.js';
 export { nodeIO } from './io.js';
-export { chalkStyle } from './style.js';
+export { chalkStyle, type ChalkStyleOptions } from './style.js';
 
 export function createNodeContext(): BijouContext {
   const runtime = nodeRuntime();

--- a/packages/bijou-node/src/style.ts
+++ b/packages/bijou-node/src/style.ts
@@ -1,4 +1,4 @@
-import chalk, { type ChalkInstance } from 'chalk';
+import chalk, { Chalk, type ChalkInstance } from 'chalk';
 import type { StylePort, TokenValue } from '@flyingrobots/bijou';
 
 export interface ChalkStyleOptions {
@@ -12,9 +12,9 @@ export function chalkStyle(options?: ChalkStyleOptions): StylePort;
 export function chalkStyle(arg?: boolean | ChalkStyleOptions): StylePort {
   const opts = typeof arg === 'boolean' ? { noColor: arg } : (arg ?? {});
   const isNoColor = opts.noColor ?? false;
-  if (opts.level !== undefined) {
-    chalk.level = opts.level;
-  }
+  const instance: ChalkInstance = opts.level !== undefined
+    ? new Chalk({ level: opts.level })
+    : chalk;
 
   function applyModifiers(c: ChalkInstance, modifiers?: TokenValue['modifiers']): ChalkInstance {
     if (modifiers === undefined) return c;
@@ -36,22 +36,22 @@ export function chalkStyle(arg?: boolean | ChalkStyleOptions): StylePort {
 
   return {
     styled(token: TokenValue, text: string): string {
-      const base: ChalkInstance = isNoColor ? chalk : chalk.hex(token.hex);
+      const base: ChalkInstance = isNoColor ? instance : instance.hex(token.hex);
       return applyModifiers(base, token.modifiers)(text);
     },
 
     rgb(r: number, g: number, b: number, text: string): string {
       if (isNoColor) return text;
-      return chalk.rgb(r, g, b)(text);
+      return instance.rgb(r, g, b)(text);
     },
 
     hex(color: string, text: string): string {
       if (isNoColor) return text;
-      return chalk.hex(color)(text);
+      return instance.hex(color)(text);
     },
 
     bold(text: string): string {
-      return chalk.bold(text);
+      return instance.bold(text);
     },
   };
 }

--- a/packages/bijou-node/src/style.ts
+++ b/packages/bijou-node/src/style.ts
@@ -36,7 +36,8 @@ export function chalkStyle(arg?: boolean | ChalkStyleOptions): StylePort {
 
   return {
     styled(token: TokenValue, text: string): string {
-      const base: ChalkInstance = isNoColor ? instance : instance.hex(token.hex);
+      if (isNoColor) return text;
+      const base: ChalkInstance = instance.hex(token.hex);
       return applyModifiers(base, token.modifiers)(text);
     },
 
@@ -51,6 +52,7 @@ export function chalkStyle(arg?: boolean | ChalkStyleOptions): StylePort {
     },
 
     bold(text: string): string {
+      if (isNoColor) return text;
       return instance.bold(text);
     },
   };

--- a/packages/bijou-node/src/style.ts
+++ b/packages/bijou-node/src/style.ts
@@ -1,8 +1,20 @@
 import chalk, { type ChalkInstance } from 'chalk';
 import type { StylePort, TokenValue } from '@flyingrobots/bijou';
 
-export function chalkStyle(noColor?: boolean): StylePort {
-  const isNoColor = noColor ?? false;
+export interface ChalkStyleOptions {
+  noColor?: boolean;
+  /** Explicit chalk color level override: 0=none, 1=ansi16, 2=ansi256, 3=truecolor */
+  level?: 0 | 1 | 2 | 3;
+}
+
+export function chalkStyle(noColor?: boolean): StylePort;
+export function chalkStyle(options?: ChalkStyleOptions): StylePort;
+export function chalkStyle(arg?: boolean | ChalkStyleOptions): StylePort {
+  const opts = typeof arg === 'boolean' ? { noColor: arg } : (arg ?? {});
+  const isNoColor = opts.noColor ?? false;
+  if (opts.level !== undefined) {
+    chalk.level = opts.level;
+  }
 
   function applyModifiers(c: ChalkInstance, modifiers?: TokenValue['modifiers']): ChalkInstance {
     if (modifiers === undefined) return c;

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.8.0"
+    "@flyingrobots/bijou": "0.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/src/driver.test.ts
+++ b/packages/bijou-tui/src/driver.test.ts
@@ -107,8 +107,9 @@ describe('runScript', () => {
     };
 
     const result = await runScript(app, []);
-    // Should have processed the init command
-    expect(result.frames.length).toBeGreaterThanOrEqual(1);
+    // Init command should have settled and updated the model
+    expect(result.model.loaded).toBe(true);
+    expect(result.model.data).toBe('hello');
   });
 
   it('handles empty steps array', async () => {

--- a/packages/bijou-tui/src/driver.test.ts
+++ b/packages/bijou-tui/src/driver.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { runScript } from './driver.js';
+import type { App, Cmd, KeyMsg } from './types.js';
+import { quit } from './commands.js';
+import { isKeyMsg } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Test app: counter that increments on 'up', decrements on 'down', quits on 'q'
+// ---------------------------------------------------------------------------
+
+interface CounterModel {
+  count: number;
+}
+
+const counterApp: App<CounterModel> = {
+  init() {
+    return [{ count: 0 }, []];
+  },
+  update(msg, model) {
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'up') return [{ count: model.count + 1 }, []];
+      if (msg.key === 'down') return [{ count: model.count - 1 }, []];
+      if (msg.key === 'q') return [model, [quit()]];
+    }
+    return [model, []];
+  },
+  view(model) {
+    return `Count: ${model.count}`;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runScript', () => {
+  it('captures initial frame', async () => {
+    const result = await runScript(counterApp, []);
+    expect(result.frames).toHaveLength(1);
+    expect(result.frames[0]).toBe('Count: 0');
+    expect(result.model.count).toBe(0);
+  });
+
+  it('processes key steps and captures frames', async () => {
+    const result = await runScript(counterApp, [
+      { key: '\x1b[A' }, // up
+      { key: '\x1b[A' }, // up
+      { key: '\x1b[B' }, // down
+    ]);
+    // Initial frame + 3 update frames
+    expect(result.frames).toHaveLength(4);
+    expect(result.model.count).toBe(1);
+    expect(result.frames[1]).toBe('Count: 1');
+    expect(result.frames[2]).toBe('Count: 2');
+    expect(result.frames[3]).toBe('Count: 1');
+  });
+
+  it('stops on quit signal', async () => {
+    const result = await runScript(counterApp, [
+      { key: '\x1b[A' }, // up
+      { key: 'q' },      // quit
+      { key: '\x1b[A' }, // should not be processed
+    ]);
+    expect(result.model.count).toBe(1);
+  });
+
+  it('calls onFrame callback', async () => {
+    const captured: Array<{ frame: string; index: number }> = [];
+    await runScript(counterApp, [{ key: '\x1b[A' }], {
+      onFrame(frame, index) {
+        captured.push({ frame, index });
+      },
+    });
+    expect(captured).toHaveLength(2); // initial + 1 update
+    expect(captured[0]!.index).toBe(0);
+    expect(captured[1]!.index).toBe(1);
+  });
+
+  it('supports delays between steps', async () => {
+    const start = Date.now();
+    const result = await runScript(counterApp, [
+      { key: '\x1b[A', delay: 50 },
+      { key: '\x1b[A', delay: 50 },
+    ]);
+    expect(result.elapsed).toBeGreaterThanOrEqual(80); // some margin
+    expect(result.model.count).toBe(2);
+  });
+
+  it('works with app that has init commands', async () => {
+    type Msg = { type: 'loaded'; data: string };
+    interface Model { data: string; loaded: boolean }
+
+    const app: App<Model, Msg> = {
+      init(): [Model, Cmd<Msg>[]] {
+        const cmd: Cmd<Msg> = async () => ({ type: 'loaded' as const, data: 'hello' });
+        return [{ data: '', loaded: false }, [cmd]];
+      },
+      update(msg, model) {
+        if ('data' in msg && (msg as Msg).type === 'loaded') {
+          return [{ data: (msg as Msg).data, loaded: true }, []];
+        }
+        return [model, []];
+      },
+      view(model) {
+        return model.loaded ? `Data: ${model.data}` : 'Loading...';
+      },
+    };
+
+    const result = await runScript(app, []);
+    // Should have processed the init command
+    expect(result.frames.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('handles empty steps array', async () => {
+    const result = await runScript(counterApp, []);
+    expect(result.frames).toHaveLength(1);
+    expect(result.model.count).toBe(0);
+    expect(result.elapsed).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/bijou-tui/src/driver.ts
+++ b/packages/bijou-tui/src/driver.ts
@@ -59,6 +59,12 @@ export interface RunScriptResult<Model> {
  * The app quits when:
  * - A command returns QUIT
  * - All script steps are exhausted (auto-quits)
+ *
+ * **Limitation:** Between steps the driver yields via `queueMicrotask`,
+ * which only settles microtask-based async (e.g. `Promise.resolve()`).
+ * Commands that use `setTimeout`, real I/O, or other macrotask-based async
+ * may not have completed before the next key is dispatched. Use `delay`
+ * on subsequent steps to allow time for macrotask-based commands.
  */
 export async function runScript<Model, M>(
   app: App<Model, M>,

--- a/packages/bijou-tui/src/driver.ts
+++ b/packages/bijou-tui/src/driver.ts
@@ -16,8 +16,7 @@
  * ```
  */
 
-import type { App, Cmd, KeyMsg, RunOptions } from './types.js';
-import { QUIT } from './types.js';
+import type { App, KeyMsg, RunOptions } from './types.js';
 import { createEventBus } from './eventbus.js';
 import { parseKey } from './keys.js';
 

--- a/packages/bijou-tui/src/driver.ts
+++ b/packages/bijou-tui/src/driver.ts
@@ -107,6 +107,9 @@ export async function runScript<Model, M>(
     bus.runCmd(cmd);
   }
 
+  // Yield so microtask-based init commands can settle
+  await new Promise<void>((r) => queueMicrotask(r));
+
   // Feed script steps
   for (const step of steps) {
     if (!running) break;
@@ -123,6 +126,9 @@ export async function runScript<Model, M>(
     // Yield to allow async commands to settle
     await new Promise<void>((r) => queueMicrotask(r));
   }
+
+  // Final yield so any trailing commands can settle
+  await new Promise<void>((r) => queueMicrotask(r));
 
   bus.dispose();
 

--- a/packages/bijou-tui/src/driver.ts
+++ b/packages/bijou-tui/src/driver.ts
@@ -1,0 +1,129 @@
+/**
+ * Scripted driver for TEA applications.
+ *
+ * Feeds a sequence of key events into an app and captures all rendered
+ * frames. Useful for automated demos, integration tests, and CI.
+ *
+ * ```ts
+ * const result = await runScript(counterApp, [
+ *   { key: 'up' },
+ *   { key: 'up' },
+ *   { key: 'down' },
+ *   { key: 'q' },
+ * ]);
+ * console.log(result.model);   // final model state
+ * console.log(result.frames);  // all rendered frames
+ * ```
+ */
+
+import type { App, Cmd, KeyMsg, RunOptions } from './types.js';
+import { QUIT } from './types.js';
+import { createEventBus } from './eventbus.js';
+import { parseKey } from './keys.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ScriptStep {
+  /** Key to send (raw terminal key string, e.g., 'a', '\x1b[A', '\x03'). */
+  key: string;
+  /** Milliseconds to wait before sending this key. Default: 0. */
+  delay?: number;
+}
+
+export interface RunScriptOptions extends RunOptions {
+  /** Capture each rendered frame. */
+  onFrame?: (frame: string, index: number) => void;
+}
+
+export interface RunScriptResult<Model> {
+  /** Final model state after all steps. */
+  model: Model;
+  /** All rendered frames in order. */
+  frames: string[];
+  /** Total elapsed time in milliseconds. */
+  elapsed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a TEA app with a scripted key sequence.
+ *
+ * Internally creates an EventBus and feeds parsed keys from the script.
+ * Captures all frames rendered via `view()`. Returns the final model
+ * and all frames for assertion or GIF generation.
+ *
+ * The app quits when:
+ * - A command returns QUIT
+ * - All script steps are exhausted (auto-quits)
+ */
+export async function runScript<Model, M>(
+  app: App<Model, M>,
+  steps: ScriptStep[],
+  options?: RunScriptOptions,
+): Promise<RunScriptResult<Model>> {
+  const start = Date.now();
+  const frames: string[] = [];
+  const bus = createEventBus<M>();
+
+  const [initModel, initCmds] = app.init();
+  let model = initModel;
+  let running = true;
+
+  function shutdown(): void {
+    running = false;
+  }
+
+  bus.onQuit(shutdown);
+
+  bus.on((msg) => {
+    if (!running) return;
+    const [newModel, cmds] = app.update(msg as KeyMsg | M, model);
+    model = newModel;
+    const frame = app.view(model);
+    frames.push(frame);
+    options?.onFrame?.(frame, frames.length - 1);
+    for (const cmd of cmds) {
+      bus.runCmd(cmd);
+    }
+  });
+
+  // Capture initial frame
+  const initFrame = app.view(model);
+  frames.push(initFrame);
+  options?.onFrame?.(initFrame, 0);
+
+  // Run init commands
+  for (const cmd of initCmds) {
+    bus.runCmd(cmd);
+  }
+
+  // Feed script steps
+  for (const step of steps) {
+    if (!running) break;
+
+    if (step.delay && step.delay > 0) {
+      await new Promise<void>((r) => setTimeout(r, step.delay));
+    }
+
+    if (!running) break;
+
+    const keyMsg = parseKey(step.key);
+    bus.emit(keyMsg);
+
+    // Yield to allow async commands to settle
+    await new Promise<void>((r) => queueMicrotask(r));
+  }
+
+  bus.dispose();
+
+  return {
+    model,
+    frames,
+    elapsed: Date.now() - start,
+  };
+}

--- a/packages/bijou-tui/src/eventbus.test.ts
+++ b/packages/bijou-tui/src/eventbus.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createEventBus, type BusMsg } from './eventbus.js';
-import type { KeyMsg, ResizeMsg, Cmd } from './types.js';
-import { QUIT } from './types.js';
+import type { Cmd } from './types.js';
+import { QUIT, isKeyMsg, isResizeMsg } from './types.js';
 import type { IOPort, RawInputHandle } from '@flyingrobots/bijou';
 
 // ---------------------------------------------------------------------------
@@ -113,8 +113,10 @@ describe('connectIO keyboard', () => {
     simulateKey('a');
 
     expect(received).toHaveLength(1);
-    expect((received[0] as KeyMsg).type).toBe('key');
-    expect((received[0] as KeyMsg).key).toBe('a');
+    expect(isKeyMsg(received[0])).toBe(true);
+    if (isKeyMsg(received[0])) {
+      expect(received[0].key).toBe('a');
+    }
   });
 
   it('filters unknown key sequences', () => {
@@ -160,10 +162,11 @@ describe('connectIO resize', () => {
     simulateResize(120, 40);
 
     expect(received).toHaveLength(1);
-    const msg = received[0] as ResizeMsg;
-    expect(msg.type).toBe('resize');
-    expect(msg.columns).toBe(120);
-    expect(msg.rows).toBe(40);
+    expect(isResizeMsg(received[0])).toBe(true);
+    if (isResizeMsg(received[0])) {
+      expect(received[0].columns).toBe(120);
+      expect(received[0].rows).toBe(40);
+    }
   });
 });
 

--- a/packages/bijou-tui/src/flex.ts
+++ b/packages/bijou-tui/src/flex.ts
@@ -46,14 +46,14 @@ export interface FlexChild {
   readonly align?: 'start' | 'center' | 'end';
 }
 
+import { visibleLength, clipToWidth } from './viewport.js';
+
 // ---------------------------------------------------------------------------
 // ANSI helpers
 // ---------------------------------------------------------------------------
 
-const ANSI_RE = /\x1b\[[0-9;]*m/g;
-
 function visualWidth(s: string): number {
-  return s.replace(ANSI_RE, '').length;
+  return visibleLength(s);
 }
 
 // ---------------------------------------------------------------------------
@@ -187,38 +187,6 @@ function fitWidth(content: string, width: number, align: 'start' | 'center' | 'e
       }
     }
   });
-}
-
-function clipToWidth(str: string, maxWidth: number): string {
-  let visible = 0;
-  let result = '';
-  let inEscape = false;
-
-  for (let i = 0; i < str.length; i++) {
-    const ch = str[i]!;
-
-    if (ch === '\x1b') {
-      inEscape = true;
-      result += ch;
-      continue;
-    }
-
-    if (inEscape) {
-      result += ch;
-      if (ch === 'm') inEscape = false;
-      continue;
-    }
-
-    if (visible >= maxWidth) {
-      result += '\x1b[0m';
-      break;
-    }
-
-    result += ch;
-    visible++;
-  }
-
-  return result;
 }
 
 /**

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -1,6 +1,6 @@
 // Types
 export type { App, Cmd, KeyMsg, ResizeMsg, QuitSignal, RunOptions } from './types.js';
-export { QUIT } from './types.js';
+export { QUIT, isKeyMsg, isResizeMsg } from './types.js';
 
 // Key parsing
 export { parseKey } from './keys.js';

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -241,6 +241,14 @@ export {
   filePickerKeyMap,
 } from './file-picker.js';
 
+// Scripted driver
+export {
+  type ScriptStep,
+  type RunScriptOptions,
+  type RunScriptResult,
+  runScript,
+} from './driver.js';
+
 // Command palette
 export {
   type CommandPaletteItem,

--- a/packages/bijou-tui/src/runtime.ts
+++ b/packages/bijou-tui/src/runtime.ts
@@ -1,5 +1,6 @@
 import { getDefaultContext } from '@flyingrobots/bijou';
-import type { App, Cmd, KeyMsg, ResizeMsg, RunOptions } from './types.js';
+import type { App, Cmd, RunOptions } from './types.js';
+import { isKeyMsg } from './types.js';
 import { enterScreen, exitScreen, renderFrame } from './screen.js';
 import { createEventBus } from './eventbus.js';
 
@@ -79,8 +80,7 @@ export async function run<Model, M>(
     if (!running) return;
 
     // Double Ctrl+C force-quit
-    const keyMsg = msg as KeyMsg;
-    if (keyMsg.type === 'key' && keyMsg.key === 'c' && keyMsg.ctrl) {
+    if (isKeyMsg(msg) && msg.key === 'c' && msg.ctrl) {
       const now = Date.now();
       if (now - lastCtrlC < 1000) {
         shutdown();
@@ -89,7 +89,7 @@ export async function run<Model, M>(
       lastCtrlC = now;
     }
 
-    const [newModel, cmds] = app.update(msg as KeyMsg | ResizeMsg | M, model);
+    const [newModel, cmds] = app.update(msg, model);
     model = newModel;
     render();
     executeCommands(cmds);

--- a/packages/bijou-tui/src/types.test.ts
+++ b/packages/bijou-tui/src/types.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { isKeyMsg, isResizeMsg } from './types.js';
+import type { KeyMsg, ResizeMsg } from './types.js';
+
+describe('isKeyMsg', () => {
+  it('returns true for valid KeyMsg', () => {
+    const msg: KeyMsg = { type: 'key', key: 'a', ctrl: false, alt: false, shift: false };
+    expect(isKeyMsg(msg)).toBe(true);
+  });
+
+  it('returns true for Ctrl+C KeyMsg', () => {
+    const msg: KeyMsg = { type: 'key', key: 'c', ctrl: true, alt: false, shift: false };
+    expect(isKeyMsg(msg)).toBe(true);
+  });
+
+  it('returns false for ResizeMsg', () => {
+    const msg: ResizeMsg = { type: 'resize', columns: 80, rows: 24 };
+    expect(isKeyMsg(msg)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isKeyMsg(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isKeyMsg(undefined)).toBe(false);
+  });
+
+  it('returns false for string', () => {
+    expect(isKeyMsg('key')).toBe(false);
+  });
+
+  it('returns false for object without type', () => {
+    expect(isKeyMsg({ key: 'a' })).toBe(false);
+  });
+
+  it('returns false for object with wrong type', () => {
+    expect(isKeyMsg({ type: 'custom', key: 'a' })).toBe(false);
+  });
+});
+
+describe('isResizeMsg', () => {
+  it('returns true for valid ResizeMsg', () => {
+    const msg: ResizeMsg = { type: 'resize', columns: 120, rows: 40 };
+    expect(isResizeMsg(msg)).toBe(true);
+  });
+
+  it('returns false for KeyMsg', () => {
+    const msg: KeyMsg = { type: 'key', key: 'q', ctrl: false, alt: false, shift: false };
+    expect(isResizeMsg(msg)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isResizeMsg(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isResizeMsg(undefined)).toBe(false);
+  });
+
+  it('returns false for object with wrong type', () => {
+    expect(isResizeMsg({ type: 'key' })).toBe(false);
+  });
+});

--- a/packages/bijou-tui/src/types.test.ts
+++ b/packages/bijou-tui/src/types.test.ts
@@ -61,4 +61,12 @@ describe('isResizeMsg', () => {
   it('returns false for object with wrong type', () => {
     expect(isResizeMsg({ type: 'key' })).toBe(false);
   });
+
+  it('returns false for a plain string', () => {
+    expect(isResizeMsg('some string')).toBe(false);
+  });
+
+  it('returns false for empty object', () => {
+    expect(isResizeMsg({})).toBe(false);
+  });
 });

--- a/packages/bijou-tui/src/types.ts
+++ b/packages/bijou-tui/src/types.ts
@@ -16,6 +16,18 @@ export interface ResizeMsg {
   readonly rows: number;
 }
 
+// --- Type guards ---
+
+/** Narrow an unknown message to KeyMsg. */
+export function isKeyMsg(msg: unknown): msg is KeyMsg {
+  return typeof msg === 'object' && msg !== null && 'type' in msg && (msg as KeyMsg).type === 'key';
+}
+
+/** Narrow an unknown message to ResizeMsg. */
+export function isResizeMsg(msg: unknown): msg is ResizeMsg {
+  return typeof msg === 'object' && msg !== null && 'type' in msg && (msg as ResizeMsg).type === 'resize';
+}
+
 // --- Commands ---
 
 export const QUIT: unique symbol = Symbol('QUIT');

--- a/packages/bijou-tui/src/viewport.ts
+++ b/packages/bijou-tui/src/viewport.ts
@@ -183,6 +183,7 @@ export function sliceAnsi(str: string, startCol: number, endCol: number): string
   let result = '';
   let collecting = false;
   let hasStyle = false;
+  let didBreakAtEnd = false;
 
   const seg = new Intl.Segmenter('en', { granularity: 'grapheme' });
 
@@ -223,6 +224,7 @@ export function sliceAnsi(str: string, startCol: number, endCol: number): string
 
     if (visible >= endCol) {
       if (hasStyle) result += '\x1b[0m';
+      didBreakAtEnd = true;
       break;
     }
 
@@ -239,7 +241,7 @@ export function sliceAnsi(str: string, startCol: number, endCol: number): string
     i += grapheme.length;
   }
 
-  if (collecting && hasStyle) result += '\x1b[0m';
+  if (collecting && hasStyle && !didBreakAtEnd) result += '\x1b[0m';
 
   return result;
 }

--- a/packages/bijou-tui/src/viewport.ts
+++ b/packages/bijou-tui/src/viewport.ts
@@ -94,7 +94,7 @@ function _isWide(cp: number): boolean {
   if (cp >= 0x3000 && cp <= 0x33FF) return true;
   if (cp >= 0x3400 && cp <= 0x4DBF) return true;
   if (cp >= 0x4E00 && cp <= 0x9FFF) return true;
-  if (cp >= 0xAC00 && cp <= 0xD7FF) return true;
+  if (cp >= 0xAC00 && cp <= 0xD7A3) return true;
   if (cp >= 0xF900 && cp <= 0xFAFF) return true;
   if (cp >= 0xFE30 && cp <= 0xFE4F) return true;
   if (cp >= 0x20000 && cp <= 0x3FFFF) return true;

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/src/adapters/test/audit-style.test.ts
+++ b/packages/bijou/src/adapters/test/audit-style.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { auditStyle } from './audit-style.js';
+import type { TokenValue } from '../../core/theme/tokens.js';
+import { createTestContext } from './index.js';
+
+const token: TokenValue = { hex: '#ff0000' };
+const token2: TokenValue = { hex: '#00ff00', modifiers: ['bold'] };
+
+describe('auditStyle', () => {
+  it('records styled() calls', () => {
+    const style = auditStyle();
+    style.styled(token, 'hello');
+    expect(style.calls).toHaveLength(1);
+    expect(style.calls[0]).toEqual({ method: 'styled', text: 'hello', token });
+  });
+
+  it('records rgb() calls', () => {
+    const style = auditStyle();
+    style.rgb(255, 0, 0, 'red text');
+    expect(style.calls).toHaveLength(1);
+    expect(style.calls[0]).toEqual({ method: 'rgb', text: 'red text', color: [255, 0, 0] });
+  });
+
+  it('records hex() calls', () => {
+    const style = auditStyle();
+    style.hex('#ff0000', 'hex text');
+    expect(style.calls).toHaveLength(1);
+    expect(style.calls[0]).toEqual({ method: 'hex', text: 'hex text', color: '#ff0000' });
+  });
+
+  it('records bold() calls', () => {
+    const style = auditStyle();
+    style.bold('strong');
+    expect(style.calls).toHaveLength(1);
+    expect(style.calls[0]).toEqual({ method: 'bold', text: 'strong' });
+  });
+
+  it('returns text unchanged', () => {
+    const style = auditStyle();
+    expect(style.styled(token, 'hello')).toBe('hello');
+    expect(style.rgb(255, 0, 0, 'red')).toBe('red');
+    expect(style.hex('#ff0000', 'hex')).toBe('hex');
+    expect(style.bold('bold')).toBe('bold');
+  });
+
+  it('records multiple calls in order', () => {
+    const style = auditStyle();
+    style.styled(token, 'first');
+    style.bold('second');
+    style.styled(token2, 'third');
+    expect(style.calls).toHaveLength(3);
+    expect(style.calls[0]!.text).toBe('first');
+    expect(style.calls[1]!.text).toBe('second');
+    expect(style.calls[2]!.text).toBe('third');
+  });
+
+  it('wasStyled() finds matching calls', () => {
+    const style = auditStyle();
+    style.styled(token, 'hello world');
+    style.styled(token2, 'goodbye');
+    expect(style.wasStyled(token, 'hello')).toBe(true);
+    expect(style.wasStyled(token, 'world')).toBe(true);
+    expect(style.wasStyled(token, 'hello world')).toBe(true);
+  });
+
+  it('wasStyled() returns false for non-matching token', () => {
+    const style = auditStyle();
+    style.styled(token, 'hello');
+    expect(style.wasStyled(token2, 'hello')).toBe(false);
+  });
+
+  it('wasStyled() returns false for non-matching substring', () => {
+    const style = auditStyle();
+    style.styled(token, 'hello');
+    expect(style.wasStyled(token, 'xyz')).toBe(false);
+  });
+
+  it('wasStyled() ignores non-styled calls', () => {
+    const style = auditStyle();
+    style.bold('hello');
+    style.hex('#ff0000', 'hello');
+    expect(style.wasStyled(token, 'hello')).toBe(false);
+  });
+
+  it('reset() clears all recorded calls', () => {
+    const style = auditStyle();
+    style.styled(token, 'hello');
+    style.bold('world');
+    expect(style.calls).toHaveLength(2);
+    style.reset();
+    expect(style.calls).toHaveLength(0);
+  });
+
+  it('interops with createTestContext', () => {
+    const style = auditStyle();
+    const ctx = createTestContext();
+    // Replace the style in the context
+    const testCtx = { ...ctx, style };
+    testCtx.style.styled(token, 'test');
+    expect(style.calls).toHaveLength(1);
+    expect(style.wasStyled(token, 'test')).toBe(true);
+  });
+});

--- a/packages/bijou/src/adapters/test/audit-style.ts
+++ b/packages/bijou/src/adapters/test/audit-style.ts
@@ -1,6 +1,5 @@
 import type { StylePort } from '../../ports/style.js';
-import type { TokenValue } from '../../core/theme/tokens.js';
-import type { RGB } from '../../core/theme/tokens.js';
+import type { TokenValue, RGB } from '../../core/theme/tokens.js';
 
 export interface StyledCall {
   method: 'styled' | 'rgb' | 'hex' | 'bold';
@@ -30,7 +29,7 @@ export function auditStyle(): AuditStylePort {
 
   return {
     get calls(): readonly StyledCall[] {
-      return _calls;
+      return _calls.slice();
     },
 
     styled(token: TokenValue, text: string): string {

--- a/packages/bijou/src/adapters/test/audit-style.ts
+++ b/packages/bijou/src/adapters/test/audit-style.ts
@@ -1,0 +1,66 @@
+import type { StylePort } from '../../ports/style.js';
+import type { TokenValue } from '../../core/theme/tokens.js';
+import type { RGB } from '../../core/theme/tokens.js';
+
+export interface StyledCall {
+  method: 'styled' | 'rgb' | 'hex' | 'bold';
+  text: string;
+  token?: TokenValue;
+  color?: string | RGB;
+}
+
+export interface AuditStylePort extends StylePort {
+  /** All recorded style calls in order. */
+  readonly calls: readonly StyledCall[];
+  /** Was the given token applied to text containing substring? */
+  wasStyled(token: TokenValue, substring: string): boolean;
+  /** Reset recorded calls. */
+  reset(): void;
+}
+
+/**
+ * Create a StylePort that records all styling calls for test assertions.
+ *
+ * Returns text unchanged (like `plainStyle`) so existing string assertions
+ * still work. Records every call for post-hoc assertion via `calls` array
+ * and `wasStyled()` convenience method.
+ */
+export function auditStyle(): AuditStylePort {
+  const _calls: StyledCall[] = [];
+
+  return {
+    get calls(): readonly StyledCall[] {
+      return _calls;
+    },
+
+    styled(token: TokenValue, text: string): string {
+      _calls.push({ method: 'styled', text, token });
+      return text;
+    },
+
+    rgb(r: number, g: number, b: number, text: string): string {
+      _calls.push({ method: 'rgb', text, color: [r, g, b] });
+      return text;
+    },
+
+    hex(color: string, text: string): string {
+      _calls.push({ method: 'hex', text, color });
+      return text;
+    },
+
+    bold(text: string): string {
+      _calls.push({ method: 'bold', text });
+      return text;
+    },
+
+    wasStyled(token: TokenValue, substring: string): boolean {
+      return _calls.some(
+        (c) => c.method === 'styled' && c.token === token && c.text.includes(substring),
+      );
+    },
+
+    reset(): void {
+      _calls.length = 0;
+    },
+  };
+}

--- a/packages/bijou/src/adapters/test/audit-style.ts
+++ b/packages/bijou/src/adapters/test/audit-style.ts
@@ -55,7 +55,11 @@ export function auditStyle(): AuditStylePort {
 
     wasStyled(token: TokenValue, substring: string): boolean {
       return _calls.some(
-        (c) => c.method === 'styled' && c.token === token && c.text.includes(substring),
+        (c) =>
+          c.method === 'styled'
+          && c.token?.hex === token.hex
+          && JSON.stringify(c.token?.modifiers ?? []) === JSON.stringify(token.modifiers ?? [])
+          && c.text.includes(substring),
       );
     },
 

--- a/packages/bijou/src/adapters/test/audit-style.ts
+++ b/packages/bijou/src/adapters/test/audit-style.ts
@@ -58,7 +58,7 @@ export function auditStyle(): AuditStylePort {
         (c) =>
           c.method === 'styled'
           && c.token?.hex === token.hex
-          && JSON.stringify(c.token?.modifiers ?? []) === JSON.stringify(token.modifiers ?? [])
+          && JSON.stringify([...(c.token?.modifiers ?? [])].sort()) === JSON.stringify([...(token.modifiers ?? [])].sort())
           && c.text.includes(substring),
       );
     },

--- a/packages/bijou/src/adapters/test/index.ts
+++ b/packages/bijou/src/adapters/test/index.ts
@@ -10,6 +10,7 @@ import type { Theme } from '../../core/theme/tokens.js';
 export { mockRuntime, type MockRuntimeOptions } from './runtime.js';
 export { mockIO, type MockIOOptions, type MockIO } from './io.js';
 export { plainStyle } from './style.js';
+export { auditStyle, type StyledCall, type AuditStylePort } from './audit-style.js';
 
 export interface TestContextOptions {
   runtime?: MockRuntimeOptions;

--- a/packages/bijou/src/core/components/index.ts
+++ b/packages/bijou/src/core/components/index.ts
@@ -66,3 +66,6 @@ export type { HyperlinkOptions } from './hyperlink.js';
 
 export { log } from './log.js';
 export type { LogLevel, LogOptions } from './log.js';
+
+export { markdown } from './markdown.js';
+export type { MarkdownOptions } from './markdown.js';

--- a/packages/bijou/src/core/components/markdown.test.ts
+++ b/packages/bijou/src/core/components/markdown.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { markdown } from './markdown.js';
+import { createTestContext } from '../../adapters/test/index.js';
+
+function ctx(mode: 'interactive' | 'pipe' | 'accessible' = 'interactive', width = 80) {
+  return createTestContext({ mode, runtime: { columns: width } });
+}
+
+describe('markdown()', () => {
+  describe('headings', () => {
+    it('renders h1 in interactive mode', () => {
+      const result = markdown('# Hello World', { ctx: ctx() });
+      expect(result).toContain('Hello World');
+    });
+
+    it('renders h2 in interactive mode', () => {
+      const result = markdown('## Section', { ctx: ctx() });
+      expect(result).toContain('Section');
+    });
+
+    it('renders heading in pipe mode with # prefix', () => {
+      const result = markdown('# Title', { ctx: ctx('pipe') });
+      expect(result).toContain('# Title');
+    });
+
+    it('renders heading in accessible mode with label', () => {
+      const result = markdown('# Title', { ctx: ctx('accessible') });
+      expect(result).toContain('Heading level 1: Title');
+    });
+
+    it('renders h3 in accessible mode', () => {
+      const result = markdown('### Sub-section', { ctx: ctx('accessible') });
+      expect(result).toContain('Heading level 3: Sub-section');
+    });
+  });
+
+  describe('bold and italic', () => {
+    it('renders bold text', () => {
+      const result = markdown('This is **bold** text.', { ctx: ctx() });
+      expect(result).toContain('bold');
+    });
+
+    it('renders italic text', () => {
+      const result = markdown('This is *italic* text.', { ctx: ctx() });
+      expect(result).toContain('italic');
+    });
+
+    it('strips bold markers in pipe mode', () => {
+      const result = markdown('**bold** text', { ctx: ctx('pipe') });
+      expect(result).toBe('bold text');
+      expect(result).not.toContain('**');
+    });
+
+    it('strips italic markers in pipe mode', () => {
+      const result = markdown('*italic* text', { ctx: ctx('pipe') });
+      expect(result).toBe('italic text');
+    });
+  });
+
+  describe('code spans', () => {
+    it('renders inline code', () => {
+      const result = markdown('Use `npm install` to install.', { ctx: ctx() });
+      expect(result).toContain('npm install');
+    });
+
+    it('strips backticks in pipe mode', () => {
+      const result = markdown('Run `cmd`', { ctx: ctx('pipe') });
+      expect(result).toBe('Run cmd');
+    });
+  });
+
+  describe('bullet lists', () => {
+    it('renders bullet list with unicode bullets', () => {
+      const result = markdown('- Item 1\n- Item 2\n- Item 3', { ctx: ctx() });
+      expect(result).toContain('\u2022 Item 1');
+      expect(result).toContain('\u2022 Item 2');
+      expect(result).toContain('\u2022 Item 3');
+    });
+
+    it('renders bullet list in pipe mode with dashes', () => {
+      const result = markdown('- First\n- Second', { ctx: ctx('pipe') });
+      expect(result).toContain('- First');
+      expect(result).toContain('- Second');
+    });
+
+    it('renders asterisk bullets same as dashes', () => {
+      const result = markdown('* Alpha\n* Beta', { ctx: ctx() });
+      expect(result).toContain('\u2022 Alpha');
+      expect(result).toContain('\u2022 Beta');
+    });
+  });
+
+  describe('numbered lists', () => {
+    it('renders numbered list', () => {
+      const result = markdown('1. First\n2. Second\n3. Third', { ctx: ctx() });
+      expect(result).toContain('1. First');
+      expect(result).toContain('2. Second');
+      expect(result).toContain('3. Third');
+    });
+
+    it('renders in pipe mode', () => {
+      const result = markdown('1. A\n2. B', { ctx: ctx('pipe') });
+      expect(result).toContain('1. A');
+      expect(result).toContain('2. B');
+    });
+  });
+
+  describe('code blocks', () => {
+    it('renders code block content', () => {
+      const source = '```js\nconsole.log("hi");\n```';
+      const result = markdown(source, { ctx: ctx() });
+      expect(result).toContain('console.log("hi");');
+    });
+
+    it('preserves code block in pipe mode', () => {
+      const source = '```\ncode\n```';
+      const result = markdown(source, { ctx: ctx('pipe') });
+      expect(result).toContain('```');
+      expect(result).toContain('code');
+    });
+
+    it('handles empty code block', () => {
+      const source = '```\n```';
+      const result = markdown(source, { ctx: ctx() });
+      // Should not crash
+      expect(typeof result).toBe('string');
+    });
+  });
+
+  describe('horizontal rules', () => {
+    it('renders hr with dashes', () => {
+      const result = markdown('---', { ctx: ctx() });
+      // Should contain separator content (uses unicode box-drawing)
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('renders hr with asterisks', () => {
+      const result = markdown('***', { ctx: ctx() });
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('renders hr in pipe mode', () => {
+      const result = markdown('---', { ctx: ctx('pipe') });
+      expect(result).toContain('---');
+    });
+  });
+
+  describe('links', () => {
+    it('renders link in interactive mode as hyperlink', () => {
+      const result = markdown('[Click](https://example.com)', { ctx: ctx() });
+      expect(result).toContain('Click');
+    });
+
+    it('renders link in pipe mode as text (url)', () => {
+      const result = markdown('[Click](https://example.com)', { ctx: ctx('pipe') });
+      expect(result).toContain('Click');
+      expect(result).toContain('https://example.com');
+    });
+
+    it('renders link in accessible mode with Link: prefix', () => {
+      const result = markdown('[Docs](https://docs.com)', { ctx: ctx('accessible') });
+      expect(result).toContain('Link: Docs (https://docs.com)');
+    });
+  });
+
+  describe('blockquotes', () => {
+    it('renders blockquote with pipe character', () => {
+      const result = markdown('> This is a quote', { ctx: ctx() });
+      expect(result).toContain('This is a quote');
+    });
+
+    it('renders blockquote in pipe mode with > prefix', () => {
+      const result = markdown('> Quote text', { ctx: ctx('pipe') });
+      expect(result).toContain('> Quote text');
+    });
+
+    it('renders multi-line blockquote', () => {
+      const result = markdown('> Line 1\n> Line 2', { ctx: ctx('pipe') });
+      expect(result).toContain('> Line 1');
+      expect(result).toContain('> Line 2');
+    });
+  });
+
+  describe('width wrapping', () => {
+    it('wraps long paragraphs to specified width', () => {
+      const longText = 'word '.repeat(20).trim();
+      const result = markdown(longText, { ctx: ctx('pipe'), width: 30 });
+      const lines = result.split('\n');
+      for (const line of lines) {
+        expect(line.length).toBeLessThanOrEqual(30);
+      }
+    });
+
+    it('uses ctx.runtime.columns as default width', () => {
+      const c = ctx('pipe', 40);
+      const longText = 'word '.repeat(20).trim();
+      const result = markdown(longText, { ctx: c });
+      const lines = result.split('\n');
+      for (const line of lines) {
+        expect(line.length).toBeLessThanOrEqual(40);
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for empty input', () => {
+      expect(markdown('', { ctx: ctx() })).toBe('');
+    });
+
+    it('returns empty string for whitespace-only input', () => {
+      expect(markdown('   \n  \n  ', { ctx: ctx() })).toBe('');
+    });
+
+    it('handles mixed content', () => {
+      const source = [
+        '# Title',
+        '',
+        'A **bold** paragraph with `code`.',
+        '',
+        '- Item 1',
+        '- Item 2',
+        '',
+        '---',
+        '',
+        '> A quote',
+      ].join('\n');
+      const result = markdown(source, { ctx: ctx('pipe') });
+      expect(result).toContain('# Title');
+      expect(result).toContain('bold');
+      expect(result).toContain('code');
+      expect(result).toContain('- Item 1');
+      expect(result).toContain('---');
+      expect(result).toContain('> A quote');
+    });
+
+    it('handles nested inline formatting', () => {
+      const result = markdown('This has **bold and `code`** inside.', { ctx: ctx('pipe') });
+      expect(result).toContain('bold and code');
+    });
+  });
+});

--- a/packages/bijou/src/core/components/markdown.ts
+++ b/packages/bijou/src/core/components/markdown.ts
@@ -1,0 +1,382 @@
+/**
+ * Terminal markdown renderer.
+ *
+ * Two-pass: block-level parse (line-by-line), then inline parse within each block.
+ * Reuses existing components: `separator()` for HRs, `hyperlink()` for links.
+ *
+ * Supported syntax: headings (# through ####), bold, italic, code spans,
+ * bullet lists, numbered lists, code blocks, horizontal rules, links,
+ * blockquotes.
+ */
+
+import type { BijouContext } from '../../ports/context.js';
+import { getDefaultContext } from '../../context.js';
+import { separator } from './separator.js';
+import { hyperlink } from './hyperlink.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MarkdownOptions {
+  /** Wrap width. Defaults to `ctx.runtime.columns`. */
+  width?: number;
+  ctx?: BijouContext;
+}
+
+type BlockType =
+  | { type: 'heading'; level: number; text: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'bullet-list'; items: string[] }
+  | { type: 'numbered-list'; items: string[] }
+  | { type: 'code-block'; lang: string; lines: string[] }
+  | { type: 'blockquote'; lines: string[] }
+  | { type: 'hr' }
+  | { type: 'blank' };
+
+// ---------------------------------------------------------------------------
+// Block-level parser
+// ---------------------------------------------------------------------------
+
+function parseBlocks(source: string): BlockType[] {
+  const lines = source.split('\n');
+  const blocks: BlockType[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+
+    // Blank line
+    if (line.trim() === '') {
+      blocks.push({ type: 'blank' });
+      i++;
+      continue;
+    }
+
+    // Code block (fenced)
+    if (line.trimStart().startsWith('```')) {
+      const lang = line.trimStart().slice(3).trim();
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i]!.trimStart().startsWith('```')) {
+        codeLines.push(lines[i]!);
+        i++;
+      }
+      if (i < lines.length) i++; // skip closing ```
+      blocks.push({ type: 'code-block', lang, lines: codeLines });
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line.trim())) {
+      blocks.push({ type: 'hr' });
+      i++;
+      continue;
+    }
+
+    // Heading
+    const headingMatch = line.match(/^(#{1,4})\s+(.+)$/);
+    if (headingMatch) {
+      blocks.push({ type: 'heading', level: headingMatch[1]!.length, text: headingMatch[2]! });
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (line.trimStart().startsWith('>')) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && (lines[i]!.trimStart().startsWith('>') || (lines[i]!.trim() !== '' && quoteLines.length > 0))) {
+        const ql = lines[i]!;
+        quoteLines.push(ql.replace(/^>\s?/, ''));
+        i++;
+        if (i < lines.length && lines[i]!.trim() === '') break;
+      }
+      blocks.push({ type: 'blockquote', lines: quoteLines });
+      continue;
+    }
+
+    // Bullet list
+    if (/^\s*[-*]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*[-*]\s+/.test(lines[i]!)) {
+        items.push(lines[i]!.replace(/^\s*[-*]\s+/, ''));
+        i++;
+      }
+      blocks.push({ type: 'bullet-list', items });
+      continue;
+    }
+
+    // Numbered list
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i]!)) {
+        items.push(lines[i]!.replace(/^\s*\d+\.\s+/, ''));
+        i++;
+      }
+      blocks.push({ type: 'numbered-list', items });
+      continue;
+    }
+
+    // Paragraph: collect consecutive non-special lines
+    let text = line;
+    i++;
+    while (i < lines.length && lines[i]!.trim() !== '' && !isBlockStart(lines[i]!)) {
+      text += ' ' + lines[i]!;
+      i++;
+    }
+    blocks.push({ type: 'paragraph', text });
+  }
+
+  return blocks;
+}
+
+function isBlockStart(line: string): boolean {
+  if (line.trimStart().startsWith('```')) return true;
+  if (/^(#{1,4})\s+/.test(line)) return true;
+  if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line.trim())) return true;
+  if (line.trimStart().startsWith('>')) return true;
+  if (/^\s*[-*]\s+/.test(line)) return true;
+  if (/^\s*\d+\.\s+/.test(line)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Inline parser
+// ---------------------------------------------------------------------------
+
+function parseInline(text: string, ctx: BijouContext, mode: string): string {
+  if (mode === 'accessible') return parseInlineAccessible(text, ctx);
+  if (mode === 'pipe') return parseInlinePlain(text);
+  return parseInlineStyled(text, ctx);
+}
+
+function parseInlineStyled(text: string, ctx: BijouContext): string {
+  let result = text;
+
+  // Links: [text](url)
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, linkText: string, url: string) => {
+    return hyperlink(linkText, url, { ctx });
+  });
+
+  // Bold: **text**
+  result = result.replace(/\*\*([^*]+)\*\*/g, (_m, bold: string) => {
+    return ctx.style.bold(bold);
+  });
+
+  // Italic: *text* (but not inside **)
+  result = result.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, (_m, italic: string) => {
+    return ctx.style.styled(ctx.theme.theme.semantic.muted, italic);
+  });
+
+  // Code spans: `text`
+  result = result.replace(/`([^`]+)`/g, (_m, code: string) => {
+    return ctx.style.styled(ctx.theme.theme.semantic.warning, code);
+  });
+
+  return result;
+}
+
+function parseInlinePlain(text: string): string {
+  let result = text;
+
+  // Links: [text](url) → text (url)
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 ($2)');
+
+  // Bold: **text** → text
+  result = result.replace(/\*\*([^*]+)\*\*/g, '$1');
+
+  // Italic: *text* → text
+  result = result.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '$1');
+
+  // Code: `text` → text
+  result = result.replace(/`([^`]+)`/g, '$1');
+
+  return result;
+}
+
+function parseInlineAccessible(text: string, _ctx: BijouContext): string {
+  let result = text;
+
+  // Links: [text](url) → Link: text (url)
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, 'Link: $1 ($2)');
+
+  // Bold: **text** → text
+  result = result.replace(/\*\*([^*]+)\*\*/g, '$1');
+
+  // Italic: *text* → text
+  result = result.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '$1');
+
+  // Code: `text` → text
+  result = result.replace(/`([^`]+)`/g, '$1');
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Word wrapping
+// ---------------------------------------------------------------------------
+
+function wordWrap(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const words = text.split(' ');
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current += ' ' + word;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current.length > 0) lines.push(current);
+  return lines.length > 0 ? lines : [''];
+}
+
+// ---------------------------------------------------------------------------
+// Block renderer
+// ---------------------------------------------------------------------------
+
+function renderBlocks(
+  blocks: BlockType[],
+  ctx: BijouContext,
+  width: number,
+): string {
+  const mode = ctx.mode;
+  const lines: string[] = [];
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'blank':
+        lines.push('');
+        break;
+
+      case 'heading': {
+        const text = parseInline(block.text, ctx, mode);
+        if (mode === 'accessible') {
+          lines.push(`Heading level ${block.level}: ${text}`);
+        } else if (mode === 'pipe') {
+          lines.push('#'.repeat(block.level) + ' ' + text);
+        } else {
+          // Interactive: bold, h1 uses primary color
+          const styled = ctx.style.bold(text);
+          if (block.level === 1) {
+            lines.push(ctx.style.styled(ctx.theme.theme.border.primary, styled));
+          } else {
+            lines.push(styled);
+          }
+        }
+        lines.push('');
+        break;
+      }
+
+      case 'paragraph': {
+        const inlined = parseInline(block.text, ctx, mode);
+        const wrapped = wordWrap(inlined, width);
+        lines.push(...wrapped);
+        lines.push('');
+        break;
+      }
+
+      case 'bullet-list': {
+        for (const item of block.items) {
+          const inlined = parseInline(item, ctx, mode);
+          const bullet = mode === 'pipe' ? '- ' : '  \u2022 ';
+          const indentWidth = width - bullet.length;
+          const wrapped = wordWrap(inlined, indentWidth > 0 ? indentWidth : width);
+          lines.push(bullet + wrapped[0]!);
+          for (let i = 1; i < wrapped.length; i++) {
+            lines.push(' '.repeat(bullet.length) + wrapped[i]!);
+          }
+        }
+        lines.push('');
+        break;
+      }
+
+      case 'numbered-list': {
+        for (let n = 0; n < block.items.length; n++) {
+          const inlined = parseInline(block.items[n]!, ctx, mode);
+          const prefix = mode === 'pipe' ? `${n + 1}. ` : `  ${n + 1}. `;
+          const indentWidth = width - prefix.length;
+          const wrapped = wordWrap(inlined, indentWidth > 0 ? indentWidth : width);
+          lines.push(prefix + wrapped[0]!);
+          for (let i = 1; i < wrapped.length; i++) {
+            lines.push(' '.repeat(prefix.length) + wrapped[i]!);
+          }
+        }
+        lines.push('');
+        break;
+      }
+
+      case 'code-block': {
+        if (mode === 'pipe' || mode === 'accessible') {
+          lines.push('```' + block.lang);
+          lines.push(...block.lines);
+          lines.push('```');
+        } else {
+          // Interactive: dim styling
+          for (const codeLine of block.lines) {
+            lines.push(ctx.style.styled(ctx.theme.theme.semantic.muted, '  ' + codeLine));
+          }
+        }
+        lines.push('');
+        break;
+      }
+
+      case 'blockquote': {
+        for (const ql of block.lines) {
+          const inlined = parseInline(ql, ctx, mode);
+          if (mode === 'pipe' || mode === 'accessible') {
+            lines.push('> ' + inlined);
+          } else {
+            const prefix = ctx.style.styled(ctx.theme.theme.border.muted, '\u2502 ');
+            lines.push(prefix + ctx.style.styled(ctx.theme.theme.semantic.muted, inlined));
+          }
+        }
+        lines.push('');
+        break;
+      }
+
+      case 'hr': {
+        lines.push(separator({ width, ctx }));
+        lines.push('');
+        break;
+      }
+    }
+  }
+
+  // Trim trailing blank lines
+  while (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a markdown string for terminal display.
+ *
+ * Supports headings, bold, italic, code spans, bullet/numbered lists,
+ * code blocks, horizontal rules, links, and blockquotes.
+ *
+ * Mode degradation:
+ * - `interactive`: full styled output with colors and Unicode
+ * - `pipe`: plain text with minimal formatting
+ * - `accessible`: structured text with explicit labels
+ */
+export function markdown(source: string, options?: MarkdownOptions): string {
+  const ctx = options?.ctx ?? getDefaultContext();
+  const width = options?.width ?? ctx.runtime.columns;
+
+  if (source.trim() === '') return '';
+
+  const blocks = parseBlocks(source);
+  return renderBlocks(blocks, ctx, width);
+}

--- a/packages/bijou/src/core/components/markdown.ts
+++ b/packages/bijou/src/core/components/markdown.ts
@@ -274,22 +274,20 @@ function renderBlocks(
       }
 
       case 'paragraph': {
-        const inlined = parseInline(block.text, ctx, mode);
-        const wrapped = wordWrap(inlined, width);
-        lines.push(...wrapped);
+        const wrapped = wordWrap(block.text, width);
+        lines.push(...wrapped.map(line => parseInline(line, ctx, mode)));
         lines.push('');
         break;
       }
 
       case 'bullet-list': {
         for (const item of block.items) {
-          const inlined = parseInline(item, ctx, mode);
           const bullet = mode === 'pipe' ? '- ' : '  \u2022 ';
           const indentWidth = width - bullet.length;
-          const wrapped = wordWrap(inlined, indentWidth > 0 ? indentWidth : width);
-          lines.push(bullet + wrapped[0]!);
+          const wrapped = wordWrap(item, indentWidth > 0 ? indentWidth : width);
+          lines.push(bullet + parseInline(wrapped[0]!, ctx, mode));
           for (let i = 1; i < wrapped.length; i++) {
-            lines.push(' '.repeat(bullet.length) + wrapped[i]!);
+            lines.push(' '.repeat(bullet.length) + parseInline(wrapped[i]!, ctx, mode));
           }
         }
         lines.push('');
@@ -298,13 +296,12 @@ function renderBlocks(
 
       case 'numbered-list': {
         for (let n = 0; n < block.items.length; n++) {
-          const inlined = parseInline(block.items[n]!, ctx, mode);
           const prefix = mode === 'pipe' ? `${n + 1}. ` : `  ${n + 1}. `;
           const indentWidth = width - prefix.length;
-          const wrapped = wordWrap(inlined, indentWidth > 0 ? indentWidth : width);
-          lines.push(prefix + wrapped[0]!);
+          const wrapped = wordWrap(block.items[n]!, indentWidth > 0 ? indentWidth : width);
+          lines.push(prefix + parseInline(wrapped[0]!, ctx, mode));
           for (let i = 1; i < wrapped.length; i++) {
-            lines.push(' '.repeat(prefix.length) + wrapped[i]!);
+            lines.push(' '.repeat(prefix.length) + parseInline(wrapped[i]!, ctx, mode));
           }
         }
         lines.push('');

--- a/packages/bijou/src/core/components/markdown.ts
+++ b/packages/bijou/src/core/components/markdown.ts
@@ -87,7 +87,7 @@ function parseBlocks(source: string): BlockType[] {
       const quoteLines: string[] = [];
       while (i < lines.length && (lines[i]!.trimStart().startsWith('>') || (lines[i]!.trim() !== '' && quoteLines.length > 0))) {
         const ql = lines[i]!;
-        quoteLines.push(ql.replace(/^>\s?/, ''));
+        quoteLines.push(ql.replace(/^\s*>\s?/, ''));
         i++;
         if (i < lines.length && lines[i]!.trim() === '') break;
       }

--- a/packages/bijou/src/core/forms/confirm.test.ts
+++ b/packages/bijou/src/core/forms/confirm.test.ts
@@ -118,6 +118,14 @@ describe('confirm()', () => {
     expect(ctx.io.written.length).toBeGreaterThan(0);
   });
 
+  describe('Ctrl+C / cancellation', () => {
+    it('rejected question() (Ctrl+C) propagates without crashing', async () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      ctx.io.question = () => Promise.reject(new Error('readline was closed'));
+      await expect(confirm({ title: 'Continue?', ctx })).rejects.toThrow('readline was closed');
+    });
+  });
+
   describe('empty answer in interactive mode', () => {
     it('empty answer in interactive mode returns default (true)', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { answers: [''] } });

--- a/packages/bijou/src/core/forms/filter.ts
+++ b/packages/bijou/src/core/forms/filter.ts
@@ -170,6 +170,9 @@ async function interactiveFilter<T>(options: FilterOptions<T>, ctx: BijouContext
 
       if (key === '\x03' || key === '\x1b') {
         // Ctrl+C or Escape — cancel
+        // Note: bare \x1b may false-trigger on slow connections where escape
+        // sequences arrive as separate bytes. Timer-based disambiguation is a
+        // separate future improvement.
         handle.dispose();
         cleanup();
         resolve(options.defaultValue ?? options.options[0]!.value);

--- a/packages/bijou/src/core/forms/filter.ts
+++ b/packages/bijou/src/core/forms/filter.ts
@@ -168,8 +168,8 @@ async function interactiveFilter<T>(options: FilterOptions<T>, ctx: BijouContext
         return;
       }
 
-      if (key === '\x03') {
-        // Ctrl+C — cancel
+      if (key === '\x03' || key === '\x1b') {
+        // Ctrl+C or Escape — cancel
         handle.dispose();
         cleanup();
         resolve(options.defaultValue ?? options.options[0]!.value);

--- a/packages/bijou/src/core/forms/input.test.ts
+++ b/packages/bijou/src/core/forms/input.test.ts
@@ -111,6 +111,13 @@ describe('input()', () => {
       const result = await input({ title: 'Name', defaultValue: 'fallback', ctx });
       expect(result).toBe('fallback');
     });
+
+    it('rejected question() (Ctrl+C) propagates without crashing', async () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      // Override question to reject (simulates readline close via Ctrl+C)
+      ctx.io.question = () => Promise.reject(new Error('readline was closed'));
+      await expect(input({ title: 'Name', ctx })).rejects.toThrow('readline was closed');
+    });
   });
 
   describe('edge cases', () => {

--- a/packages/bijou/src/core/forms/multiselect.test.ts
+++ b/packages/bijou/src/core/forms/multiselect.test.ts
@@ -92,6 +92,12 @@ describe('multiselect()', () => {
       expect(result).toEqual([]);
     });
 
+    it('Escape returns empty array', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b'] } });
+      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      expect(result).toEqual([]);
+    });
+
     it('toggle on and off deselects item', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: [' ', ' ', '\r'] } });
       const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });

--- a/packages/bijou/src/core/forms/multiselect.ts
+++ b/packages/bijou/src/core/forms/multiselect.ts
@@ -112,7 +112,7 @@ async function interactiveMultiselect<T>(options: MultiselectOptions<T>, ctx: Bi
       } else if (key === '\r' || key === '\n') {
         handle.dispose(); cleanup();
         resolve([...selected].sort().map((i) => options.options[i]!.value));
-      } else if (key === '\x03') {
+      } else if (key === '\x03' || key === '\x1b') {
         handle.dispose(); cleanup(); resolve([]);
       }
     });

--- a/packages/bijou/src/core/forms/multiselect.ts
+++ b/packages/bijou/src/core/forms/multiselect.ts
@@ -113,6 +113,9 @@ async function interactiveMultiselect<T>(options: MultiselectOptions<T>, ctx: Bi
         handle.dispose(); cleanup();
         resolve([...selected].sort().map((i) => options.options[i]!.value));
       } else if (key === '\x03' || key === '\x1b') {
+        // Note: bare \x1b may false-trigger on slow connections where escape
+        // sequences arrive as separate bytes. Timer-based disambiguation is a
+        // separate future improvement.
         handle.dispose(); cleanup(); resolve([]);
       }
     });

--- a/packages/bijou/src/core/forms/select.test.ts
+++ b/packages/bijou/src/core/forms/select.test.ts
@@ -109,6 +109,18 @@ describe('select()', () => {
       const result = await select({ title: 'Color', options: OPTIONS, ctx });
       expect(result).toBe('red');
     });
+
+    it('Escape returns default/first value', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b'] } });
+      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      expect(result).toBe('red');
+    });
+
+    it('Escape returns defaultValue when set', async () => {
+      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b'] } });
+      const result = await select({ title: 'Color', options: OPTIONS, defaultValue: 'blue', ctx });
+      expect(result).toBe('blue');
+    });
   });
 
   it('accepts ctx parameter', async () => {

--- a/packages/bijou/src/core/forms/select.ts
+++ b/packages/bijou/src/core/forms/select.ts
@@ -103,7 +103,7 @@ async function interactiveSelect<T>(options: SelectOptions<T>, ctx: BijouContext
         clearRender(); render();
       } else if (key === '\r' || key === '\n') {
         handle.dispose(); cleanup(); resolve(options.options[cursor]!.value);
-      } else if (key === '\x03') {
+      } else if (key === '\x03' || key === '\x1b') {
         handle.dispose(); cleanup(); resolve(options.defaultValue ?? options.options[0]!.value);
       }
     });

--- a/packages/bijou/src/core/forms/select.ts
+++ b/packages/bijou/src/core/forms/select.ts
@@ -104,6 +104,9 @@ async function interactiveSelect<T>(options: SelectOptions<T>, ctx: BijouContext
       } else if (key === '\r' || key === '\n') {
         handle.dispose(); cleanup(); resolve(options.options[cursor]!.value);
       } else if (key === '\x03' || key === '\x1b') {
+        // Note: bare \x1b may false-trigger on slow connections where escape
+        // sequences arrive as separate bytes. Timer-based disambiguation is a
+        // separate future improvement.
         handle.dispose(); cleanup(); resolve(options.defaultValue ?? options.options[0]!.value);
       }
     });

--- a/packages/bijou/src/core/forms/textarea.ts
+++ b/packages/bijou/src/core/forms/textarea.ts
@@ -157,6 +157,9 @@ async function interactiveTextarea(options: TextareaOptions, ctx: BijouContext):
 
       if (key === '\x03' || key === '\x1b') {
         // Ctrl+C or Escape — cancel
+        // Note: bare \x1b may false-trigger on slow connections where escape
+        // sequences arrive as separate bytes. Timer-based disambiguation is a
+        // separate future improvement.
         handle.dispose();
         cleanup(false);
         resolve(options.defaultValue ?? '');

--- a/packages/bijou/src/core/forms/textarea.ts
+++ b/packages/bijou/src/core/forms/textarea.ts
@@ -155,8 +155,8 @@ async function interactiveTextarea(options: TextareaOptions, ctx: BijouContext):
         return;
       }
 
-      if (key === '\x03') {
-        // Ctrl+C — cancel
+      if (key === '\x03' || key === '\x1b') {
+        // Ctrl+C or Escape — cancel
         handle.dispose();
         cleanup(false);
         resolve(options.defaultValue ?? '');

--- a/packages/bijou/src/core/text/grapheme.test.ts
+++ b/packages/bijou/src/core/text/grapheme.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isWideChar,
+  segmentGraphemes,
+  graphemeClusterWidth,
+  graphemeWidth,
+} from './grapheme.js';
+
+describe('isWideChar', () => {
+  it('returns false for ASCII', () => {
+    expect(isWideChar(0x41)).toBe(false); // 'A'
+    expect(isWideChar(0x7A)).toBe(false); // 'z'
+    expect(isWideChar(0x20)).toBe(false); // space
+  });
+
+  it('returns true for CJK Unified Ideographs', () => {
+    expect(isWideChar(0x4E00)).toBe(true);  // '一'
+    expect(isWideChar(0x6F22)).toBe(true);  // '漢'
+    expect(isWideChar(0x9FFF)).toBe(true);  // end of block
+  });
+
+  it('returns true for Fullwidth Forms', () => {
+    expect(isWideChar(0xFF01)).toBe(true);  // '！'
+    expect(isWideChar(0xFF21)).toBe(true);  // 'Ａ'
+  });
+
+  it('returns true for Hangul', () => {
+    expect(isWideChar(0xAC00)).toBe(true);  // '가'
+    expect(isWideChar(0xD7A3)).toBe(true);  // last Hangul syllable
+  });
+
+  it('returns true for common emoji ranges', () => {
+    expect(isWideChar(0x1F600)).toBe(true);  // 😀
+    expect(isWideChar(0x1F4A9)).toBe(true);  // 💩
+    expect(isWideChar(0x1F680)).toBe(true);  // 🚀
+  });
+
+  it('returns true for regional indicators', () => {
+    expect(isWideChar(0x1F1FA)).toBe(true);  // regional indicator U
+    expect(isWideChar(0x1F1F8)).toBe(true);  // regional indicator S
+  });
+
+  it('returns false for combining marks', () => {
+    expect(isWideChar(0x0301)).toBe(false);  // combining acute accent
+    expect(isWideChar(0x0308)).toBe(false);  // combining diaeresis
+  });
+
+  it('returns false for Latin Extended', () => {
+    expect(isWideChar(0x00E9)).toBe(false);  // é
+    expect(isWideChar(0x00FC)).toBe(false);  // ü
+  });
+});
+
+describe('segmentGraphemes', () => {
+  it('segments ASCII text', () => {
+    expect(segmentGraphemes('abc')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('segments empty string', () => {
+    expect(segmentGraphemes('')).toEqual([]);
+  });
+
+  it('treats flag emoji as single grapheme', () => {
+    const segments = segmentGraphemes('🇺🇸');
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toBe('🇺🇸');
+  });
+
+  it('treats ZWJ family as single grapheme', () => {
+    const family = '👨‍👩‍👧‍👦';
+    const segments = segmentGraphemes(family);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toBe(family);
+  });
+
+  it('treats skin tone emoji as single grapheme', () => {
+    const wave = '👋🏿';
+    const segments = segmentGraphemes(wave);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toBe(wave);
+  });
+
+  it('treats combining marks as single grapheme', () => {
+    // e + combining acute accent = é
+    const composed = 'e\u0301';
+    const segments = segmentGraphemes(composed);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toBe(composed);
+  });
+
+  it('segments CJK characters individually', () => {
+    expect(segmentGraphemes('漢字')).toEqual(['漢', '字']);
+  });
+
+  it('segments mixed ASCII and emoji', () => {
+    const segments = segmentGraphemes('hi👋🏿!');
+    expect(segments).toEqual(['h', 'i', '👋🏿', '!']);
+  });
+});
+
+describe('graphemeClusterWidth', () => {
+  it('returns 1 for ASCII characters', () => {
+    expect(graphemeClusterWidth('a')).toBe(1);
+    expect(graphemeClusterWidth(' ')).toBe(1);
+    expect(graphemeClusterWidth('Z')).toBe(1);
+  });
+
+  it('returns 2 for CJK characters', () => {
+    expect(graphemeClusterWidth('漢')).toBe(2);
+    expect(graphemeClusterWidth('字')).toBe(2);
+  });
+
+  it('returns 2 for emoji', () => {
+    expect(graphemeClusterWidth('😀')).toBe(2);
+    expect(graphemeClusterWidth('🚀')).toBe(2);
+  });
+
+  it('returns 2 for flag emoji', () => {
+    expect(graphemeClusterWidth('🇺🇸')).toBe(2);
+  });
+
+  it('returns 2 for ZWJ family', () => {
+    expect(graphemeClusterWidth('👨‍👩‍👧‍👦')).toBe(2);
+  });
+
+  it('returns 2 for skin tone emoji', () => {
+    expect(graphemeClusterWidth('👋🏿')).toBe(2);
+  });
+
+  it('returns 1 for combining mark sequences', () => {
+    expect(graphemeClusterWidth('e\u0301')).toBe(1);
+  });
+
+  it('returns 2 for fullwidth forms', () => {
+    expect(graphemeClusterWidth('Ａ')).toBe(2);
+  });
+});
+
+describe('graphemeWidth', () => {
+  it('returns 0 for empty string', () => {
+    expect(graphemeWidth('')).toBe(0);
+  });
+
+  it('counts ASCII characters as 1 each', () => {
+    expect(graphemeWidth('hello')).toBe(5);
+    expect(graphemeWidth('abc 123')).toBe(7);
+  });
+
+  it('counts CJK characters as 2 each', () => {
+    expect(graphemeWidth('漢字')).toBe(4);
+  });
+
+  it('counts mixed ASCII and CJK', () => {
+    expect(graphemeWidth('hi漢字!')).toBe(7); // 2 + 4 + 1
+  });
+
+  it('counts flag emoji as 2 columns', () => {
+    expect(graphemeWidth('🇺🇸')).toBe(2);
+  });
+
+  it('counts ZWJ family as 2 columns', () => {
+    expect(graphemeWidth('👨‍👩‍👧‍👦')).toBe(2);
+  });
+
+  it('counts skin tone emoji as 2 columns', () => {
+    expect(graphemeWidth('👋🏿')).toBe(2);
+  });
+
+  it('counts combining mark character as 1 column', () => {
+    expect(graphemeWidth('e\u0301')).toBe(1);  // é
+  });
+
+  it('strips ANSI escapes before measuring', () => {
+    expect(graphemeWidth('\x1b[31mhello\x1b[0m')).toBe(5);
+    expect(graphemeWidth('\x1b[1;32m漢字\x1b[0m')).toBe(4);
+  });
+
+  it('returns 0 for ANSI-only strings', () => {
+    expect(graphemeWidth('\x1b[31m\x1b[0m')).toBe(0);
+  });
+
+  it('handles multiple emoji in sequence', () => {
+    expect(graphemeWidth('🚀🎉💯')).toBe(6); // 3 emoji × 2 columns
+  });
+
+  it('handles mixed content', () => {
+    // "Hello 漢字 🇺🇸!" = 5 + 1 + 4 + 1 + 2 + 1 = 14
+    expect(graphemeWidth('Hello 漢字 🇺🇸!')).toBe(14);
+  });
+});

--- a/packages/bijou/src/core/text/grapheme.ts
+++ b/packages/bijou/src/core/text/grapheme.ts
@@ -35,8 +35,7 @@ function segmenter(): Intl.Segmenter {
  * - CJK Symbols and Punctuation (U+3000–U+303F)
  * - Enclosed CJK Letters (U+3200–U+33FF)
  * - CJK Compatibility (U+FE30–U+FE4F)
- * - Hangul Syllables (U+AC00–U+D7AF)
- * - Hangul Jamo Extended-B (U+D7B0–U+D7FF)
+ * - Hangul Syllables (U+AC00–U+D7A3)
  * - Emoji (most U+1F000+)
  */
 export function isWideChar(cp: number): boolean {
@@ -56,8 +55,8 @@ export function isWideChar(cp: number): boolean {
   // CJK Unified Ideographs
   if (cp >= 0x4E00 && cp <= 0x9FFF) return true;
 
-  // Hangul Syllables
-  if (cp >= 0xAC00 && cp <= 0xD7FF) return true;
+  // Hangul Syllables (U+AC00–U+D7A3; excludes Jamo Extended-B which are narrow)
+  if (cp >= 0xAC00 && cp <= 0xD7A3) return true;
 
   // CJK Compatibility Ideographs
   if (cp >= 0xF900 && cp <= 0xFAFF) return true;

--- a/packages/bijou/src/core/text/grapheme.ts
+++ b/packages/bijou/src/core/text/grapheme.ts
@@ -1,0 +1,162 @@
+/**
+ * Grapheme cluster utilities for correct Unicode text measurement.
+ *
+ * Uses `Intl.Segmenter` for proper grapheme cluster iteration and a compact
+ * lookup for East Asian Wide / emoji display widths.
+ */
+
+// ---------------------------------------------------------------------------
+// Segmenter (lazy singleton)
+// ---------------------------------------------------------------------------
+
+let _segmenter: Intl.Segmenter | undefined;
+
+function segmenter(): Intl.Segmenter {
+  if (!_segmenter) {
+    _segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
+  }
+  return _segmenter;
+}
+
+// ---------------------------------------------------------------------------
+// Wide character detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the given code point occupies 2 terminal columns.
+ *
+ * Covers:
+ * - CJK Unified Ideographs (U+4E00–U+9FFF)
+ * - CJK Extension A (U+3400–U+4DBF)
+ * - CJK Extension B–I (U+20000–U+3FFFF)
+ * - CJK Compatibility Ideographs (U+F900–U+FAFF)
+ * - Fullwidth Forms (U+FF01–U+FF60, U+FFE0–U+FFE6)
+ * - CJK Radicals / Kangxi (U+2E80–U+2FDF)
+ * - CJK Symbols and Punctuation (U+3000–U+303F)
+ * - Enclosed CJK Letters (U+3200–U+33FF)
+ * - CJK Compatibility (U+FE30–U+FE4F)
+ * - Hangul Syllables (U+AC00–U+D7AF)
+ * - Hangul Jamo Extended-B (U+D7B0–U+D7FF)
+ * - Emoji (most U+1F000+)
+ */
+export function isWideChar(cp: number): boolean {
+  // Fullwidth Forms
+  if (cp >= 0xFF01 && cp <= 0xFF60) return true;
+  if (cp >= 0xFFE0 && cp <= 0xFFE6) return true;
+
+  // CJK Radicals, Kangxi Radicals
+  if (cp >= 0x2E80 && cp <= 0x2FDF) return true;
+
+  // CJK Symbols and Punctuation, Hiragana, Katakana
+  if (cp >= 0x3000 && cp <= 0x33FF) return true;
+
+  // CJK Extension A
+  if (cp >= 0x3400 && cp <= 0x4DBF) return true;
+
+  // CJK Unified Ideographs
+  if (cp >= 0x4E00 && cp <= 0x9FFF) return true;
+
+  // Hangul Syllables
+  if (cp >= 0xAC00 && cp <= 0xD7FF) return true;
+
+  // CJK Compatibility Ideographs
+  if (cp >= 0xF900 && cp <= 0xFAFF) return true;
+
+  // CJK Compatibility Forms
+  if (cp >= 0xFE30 && cp <= 0xFE4F) return true;
+
+  // CJK Extension B–I and beyond
+  if (cp >= 0x20000 && cp <= 0x3FFFF) return true;
+
+  // Emoji blocks (most render as 2 columns)
+  // Miscellaneous Symbols and Pictographs
+  if (cp >= 0x1F300 && cp <= 0x1F9FF) return true;
+  // Supplemental Symbols and Pictographs
+  if (cp >= 0x1FA00 && cp <= 0x1FA6F) return true;
+  // Symbols and Pictographs Extended-A
+  if (cp >= 0x1FA70 && cp <= 0x1FAFF) return true;
+  // Emoticons
+  if (cp >= 0x1F600 && cp <= 0x1F64F) return true;
+  // Transport and Map Symbols
+  if (cp >= 0x1F680 && cp <= 0x1F6FF) return true;
+  // Dingbats (common emoji like ✂️ ✈️)
+  if (cp >= 0x2702 && cp <= 0x27B0) return true;
+  // Regional indicators (flags)
+  if (cp >= 0x1F1E0 && cp <= 0x1F1FF) return true;
+  // Playing Cards, Mahjong Tiles
+  if (cp >= 0x1F000 && cp <= 0x1F02F) return true;
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Grapheme segmentation
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a string into an array of grapheme clusters.
+ *
+ * Each element is a single user-perceived character (handles combining
+ * marks, ZWJ sequences, flag pairs, skin tones, etc.).
+ */
+export function segmentGraphemes(str: string): string[] {
+  const segments = segmenter().segment(str);
+  const result: string[] = [];
+  for (const { segment } of segments) {
+    result.push(segment);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Display width
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the terminal display width of a single grapheme cluster.
+ *
+ * The width is determined by the widest code point in the cluster:
+ * - East Asian Wide / Fullwidth characters → 2
+ * - Emoji (U+1F300+) → 2
+ * - Everything else (ASCII, Latin, combining marks, etc.) → 1
+ *
+ * Zero-width characters (combining marks, ZWJ, variation selectors)
+ * don't add width on their own — they're part of the cluster.
+ */
+export function graphemeClusterWidth(grapheme: string): number {
+  let maxWidth = 1;
+  for (const ch of grapheme) {
+    const cp = ch.codePointAt(0)!;
+    // Skip zero-width joiners and variation selectors
+    if (cp === 0x200D || (cp >= 0xFE00 && cp <= 0xFE0F) || (cp >= 0xE0100 && cp <= 0xE01EF)) {
+      continue;
+    }
+    if (isWideChar(cp)) {
+      maxWidth = 2;
+      break;  // Can't be wider than 2
+    }
+  }
+  return maxWidth;
+}
+
+/**
+ * Compute the terminal display width of a string.
+ *
+ * Strips ANSI escape sequences, segments into grapheme clusters,
+ * and sums display widths. Correctly handles:
+ * - Multi-codepoint emoji (flags, ZWJ families, skin tones)
+ * - East Asian Wide characters (CJK, fullwidth forms)
+ * - Combining marks (accented characters)
+ * - ANSI escape sequences (ignored)
+ */
+export function graphemeWidth(str: string): number {
+  // Strip ANSI escapes first
+  const clean = str.replace(/\x1b\[[0-9;]*m/g, '');
+  if (clean.length === 0) return 0;
+
+  let width = 0;
+  for (const { segment } of segmenter().segment(clean)) {
+    width += graphemeClusterWidth(segment);
+  }
+  return width;
+}

--- a/packages/bijou/src/core/text/index.ts
+++ b/packages/bijou/src/core/text/index.ts
@@ -1,0 +1,6 @@
+export {
+  isWideChar,
+  segmentGraphemes,
+  graphemeClusterWidth,
+  graphemeWidth,
+} from './grapheme.js';

--- a/packages/bijou/src/core/theme/downsample.test.ts
+++ b/packages/bijou/src/core/theme/downsample.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rgbToAnsi256,
+  nearestAnsi256,
+  rgbToAnsi16,
+  ansi256ToAnsi16,
+} from './downsample.js';
+
+describe('rgbToAnsi256', () => {
+  it('maps pure black', () => {
+    expect(rgbToAnsi256(0, 0, 0)).toBe(16);
+  });
+
+  it('maps pure white', () => {
+    expect(rgbToAnsi256(255, 255, 255)).toBe(231);
+  });
+
+  it('maps pure red to cube index', () => {
+    expect(rgbToAnsi256(255, 0, 0)).toBe(196); // 16 + 36*5 + 6*0 + 0
+  });
+
+  it('maps pure green to cube index', () => {
+    expect(rgbToAnsi256(0, 255, 0)).toBe(46); // 16 + 36*0 + 6*5 + 0
+  });
+
+  it('maps pure blue to cube index', () => {
+    expect(rgbToAnsi256(0, 0, 255)).toBe(21); // 16 + 36*0 + 6*0 + 5
+  });
+
+  it('maps mid-gray to grayscale ramp', () => {
+    const idx = rgbToAnsi256(128, 128, 128);
+    expect(idx).toBeGreaterThanOrEqual(232);
+    expect(idx).toBeLessThanOrEqual(255);
+  });
+
+  it('maps near-black gray to grayscale', () => {
+    const idx = rgbToAnsi256(10, 10, 10);
+    expect(idx).toBeGreaterThanOrEqual(232);
+  });
+
+  it('maps near-white gray to grayscale', () => {
+    const idx = rgbToAnsi256(250, 250, 250);
+    expect(idx).toBe(231); // close to white
+  });
+});
+
+describe('nearestAnsi256', () => {
+  it('returns same as rgbToAnsi256 for pure colors', () => {
+    expect(nearestAnsi256(255, 0, 0)).toBe(196);
+    expect(nearestAnsi256(0, 255, 0)).toBe(46);
+    expect(nearestAnsi256(0, 0, 255)).toBe(21);
+  });
+
+  it('maps pure grayscale to grayscale ramp', () => {
+    const idx = nearestAnsi256(100, 100, 100);
+    expect(idx).toBeGreaterThanOrEqual(232);
+    expect(idx).toBeLessThanOrEqual(255);
+  });
+
+  it('returns valid index range (16-255)', () => {
+    for (let r = 0; r <= 255; r += 85) {
+      for (let g = 0; g <= 255; g += 85) {
+        for (let b = 0; b <= 255; b += 85) {
+          const idx = nearestAnsi256(r, g, b);
+          expect(idx).toBeGreaterThanOrEqual(16);
+          expect(idx).toBeLessThanOrEqual(255);
+        }
+      }
+    }
+  });
+});
+
+describe('rgbToAnsi16', () => {
+  it('maps black to 0', () => {
+    expect(rgbToAnsi16(0, 0, 0)).toBe(0);
+  });
+
+  it('maps white to 15', () => {
+    expect(rgbToAnsi16(255, 255, 255)).toBe(15);
+  });
+
+  it('maps bright red to 9', () => {
+    expect(rgbToAnsi16(255, 0, 0)).toBe(9);
+  });
+
+  it('maps bright green to 10', () => {
+    expect(rgbToAnsi16(0, 255, 0)).toBe(10);
+  });
+
+  it('maps bright blue to 12', () => {
+    expect(rgbToAnsi16(0, 0, 255)).toBe(12);
+  });
+
+  it('maps bright yellow to 11', () => {
+    expect(rgbToAnsi16(255, 255, 0)).toBe(11);
+  });
+
+  it('maps bright cyan to 14', () => {
+    expect(rgbToAnsi16(0, 255, 255)).toBe(14);
+  });
+
+  it('maps bright magenta to 13', () => {
+    expect(rgbToAnsi16(255, 0, 255)).toBe(13);
+  });
+
+  it('maps dark red to 1', () => {
+    expect(rgbToAnsi16(128, 0, 0)).toBe(1);
+  });
+
+  it('maps dark green to 2', () => {
+    expect(rgbToAnsi16(0, 128, 0)).toBe(2);
+  });
+
+  it('maps light gray to 7', () => {
+    expect(rgbToAnsi16(192, 192, 192)).toBe(7);
+  });
+
+  it('maps dark gray to 8', () => {
+    expect(rgbToAnsi16(128, 128, 128)).toBe(8);
+  });
+
+  it('returns valid range (0-15)', () => {
+    for (let r = 0; r <= 255; r += 51) {
+      for (let g = 0; g <= 255; g += 51) {
+        for (let b = 0; b <= 255; b += 51) {
+          const idx = rgbToAnsi16(r, g, b);
+          expect(idx).toBeGreaterThanOrEqual(0);
+          expect(idx).toBeLessThanOrEqual(15);
+        }
+      }
+    }
+  });
+});
+
+describe('ansi256ToAnsi16', () => {
+  it('passes through standard colors (0-15)', () => {
+    for (let i = 0; i < 16; i++) {
+      expect(ansi256ToAnsi16(i)).toBe(i);
+    }
+  });
+
+  it('maps cube red (196) to bright red (9)', () => {
+    expect(ansi256ToAnsi16(196)).toBe(9);
+  });
+
+  it('maps cube green (46) to bright green (10)', () => {
+    expect(ansi256ToAnsi16(46)).toBe(10);
+  });
+
+  it('maps cube blue (21) to bright blue (12)', () => {
+    expect(ansi256ToAnsi16(21)).toBe(12);
+  });
+
+  it('maps grayscale entries to closest ANSI 16', () => {
+    // Very dark gray (232) should map to black (0)
+    expect(ansi256ToAnsi16(232)).toBe(0);
+    // Very light gray (255) should map to white (15)
+    expect(ansi256ToAnsi16(255)).toBe(15);
+  });
+
+  it('returns valid range (0-15)', () => {
+    for (let i = 16; i <= 255; i++) {
+      const idx = ansi256ToAnsi16(i);
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThanOrEqual(15);
+    }
+  });
+});

--- a/packages/bijou/src/core/theme/downsample.ts
+++ b/packages/bijou/src/core/theme/downsample.ts
@@ -149,9 +149,10 @@ export function rgbToAnsi16(r: number, g: number, b: number): number {
  * Convert an ANSI 256 color index to the nearest ANSI 16 color index.
  */
 export function ansi256ToAnsi16(code: number): number {
+  const clamped = Math.max(0, Math.min(255, Math.round(code)));
   // Standard colors pass through
-  if (code < 16) return code;
+  if (clamped < 16) return clamped;
 
-  const [r, g, b] = ansi256ToRgb(code);
+  const [r, g, b] = ansi256ToRgb(clamped);
   return rgbToAnsi16(r, g, b);
 }

--- a/packages/bijou/src/core/theme/downsample.ts
+++ b/packages/bijou/src/core/theme/downsample.ts
@@ -1,0 +1,157 @@
+/**
+ * Color downsampling utilities for terminals with limited color support.
+ *
+ * Provides pure conversion functions for mapping RGB colors to lower
+ * color levels (ANSI 256, ANSI 16) without external dependencies.
+ */
+
+export type ColorLevel = 'none' | 'ansi16' | 'ansi256' | 'truecolor';
+
+// ---------------------------------------------------------------------------
+// RGB → ANSI 256
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an RGB color to the nearest ANSI 256 color index (16–255).
+ *
+ * The ANSI 256 palette has:
+ * - Indices 0–15: standard + bright colors (not targeted here)
+ * - Indices 16–231: 6×6×6 color cube
+ * - Indices 232–255: grayscale ramp (24 shades)
+ */
+export function rgbToAnsi256(r: number, g: number, b: number): number {
+  // Check if it's close to grayscale first
+  if (r === g && g === b) {
+    if (r < 8) return 16;         // black end of cube
+    if (r > 248) return 231;      // white end of cube
+    return Math.round((r - 8) / 247 * 24) + 232;
+  }
+
+  // Map to 6×6×6 color cube (indices 16–231)
+  const ri = Math.round(r / 255 * 5);
+  const gi = Math.round(g / 255 * 5);
+  const bi = Math.round(b / 255 * 5);
+  return 16 + (36 * ri) + (6 * gi) + bi;
+}
+
+/**
+ * Find the nearest ANSI 256 color using Euclidean distance in RGB space.
+ *
+ * Considers both the 6×6×6 cube and the grayscale ramp, returning
+ * whichever is closest to the input color.
+ */
+export function nearestAnsi256(r: number, g: number, b: number): number {
+  const cubeIdx = rgbToAnsi256(r, g, b);
+
+  // Also check the grayscale ramp for a closer match
+  let grayIdx = cubeIdx;
+  if (r !== g || g !== b) {
+    const gray = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
+    if (gray < 8) {
+      grayIdx = 16;
+    } else if (gray > 248) {
+      grayIdx = 231;
+    } else {
+      grayIdx = Math.round((gray - 8) / 247 * 24) + 232;
+    }
+  }
+
+  if (cubeIdx === grayIdx) return cubeIdx;
+
+  // Compare distances
+  const cubeRgb = ansi256ToRgb(cubeIdx);
+  const grayRgb = ansi256ToRgb(grayIdx);
+
+  const cubeDist = colorDistance(r, g, b, cubeRgb[0], cubeRgb[1], cubeRgb[2]);
+  const grayDist = colorDistance(r, g, b, grayRgb[0], grayRgb[1], grayRgb[2]);
+
+  return grayDist < cubeDist ? grayIdx : cubeIdx;
+}
+
+/** Convert an ANSI 256 index (16–255) back to approximate RGB. */
+function ansi256ToRgb(idx: number): [number, number, number] {
+  if (idx >= 232) {
+    const gray = (idx - 232) * 10 + 8;
+    return [gray, gray, gray];
+  }
+  const value = idx - 16;
+  const ri = Math.floor(value / 36);
+  const gi = Math.floor((value % 36) / 6);
+  const bi = value % 6;
+  return [
+    ri > 0 ? ri * 40 + 55 : 0,
+    gi > 0 ? gi * 40 + 55 : 0,
+    bi > 0 ? bi * 40 + 55 : 0,
+  ];
+}
+
+function colorDistance(
+  r1: number, g1: number, b1: number,
+  r2: number, g2: number, b2: number,
+): number {
+  return (r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2;
+}
+
+// ---------------------------------------------------------------------------
+// RGB → ANSI 16
+// ---------------------------------------------------------------------------
+
+/**
+ * The 16 standard ANSI colors in RGB, indexed 0–15.
+ * 0–7: standard, 8–15: bright variants.
+ */
+const ANSI16_PALETTE: readonly [number, number, number][] = [
+  [0, 0, 0],       // 0: black
+  [128, 0, 0],     // 1: red
+  [0, 128, 0],     // 2: green
+  [128, 128, 0],   // 3: yellow
+  [0, 0, 128],     // 4: blue
+  [128, 0, 128],   // 5: magenta
+  [0, 128, 128],   // 6: cyan
+  [192, 192, 192], // 7: white (light gray)
+  [128, 128, 128], // 8: bright black (dark gray)
+  [255, 0, 0],     // 9: bright red
+  [0, 255, 0],     // 10: bright green
+  [255, 255, 0],   // 11: bright yellow
+  [0, 0, 255],     // 12: bright blue
+  [255, 0, 255],   // 13: bright magenta
+  [0, 255, 255],   // 14: bright cyan
+  [255, 255, 255], // 15: bright white
+];
+
+/**
+ * Map an RGB color to the nearest ANSI 16 color index (0–15).
+ *
+ * Uses Euclidean distance in RGB space to find the closest match
+ * among the 16 standard terminal colors.
+ */
+export function rgbToAnsi16(r: number, g: number, b: number): number {
+  let bestIdx = 0;
+  let bestDist = Infinity;
+
+  for (let i = 0; i < ANSI16_PALETTE.length; i++) {
+    const [pr, pg, pb] = ANSI16_PALETTE[i]!;
+    const dist = colorDistance(r, g, b, pr, pg, pb);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIdx = i;
+    }
+  }
+
+  return bestIdx;
+}
+
+// ---------------------------------------------------------------------------
+// ANSI 256 → ANSI 16
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an ANSI 256 color index to the nearest ANSI 16 color index.
+ */
+export function ansi256ToAnsi16(code: number): number {
+  // Standard colors pass through
+  if (code < 16) return code;
+
+  const [r, g, b] = ansi256ToRgb(code);
+  return rgbToAnsi16(r, g, b);
+}

--- a/packages/bijou/src/core/theme/index.ts
+++ b/packages/bijou/src/core/theme/index.ts
@@ -42,6 +42,15 @@ export type { GradientTextOptions } from './gradient.js';
 export { fromDTCG, toDTCG } from './dtcg.js';
 export type { DTCGDocument, DTCGToken, DTCGGroup } from './dtcg.js';
 
+// Color downsampling
+export {
+  rgbToAnsi256,
+  nearestAnsi256,
+  rgbToAnsi16,
+  ansi256ToAnsi16,
+  type ColorLevel,
+} from './downsample.js';
+
 // Color manipulation
 export {
   hexToRgb,

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -72,6 +72,14 @@ export {
   desaturate,
 } from './core/theme/index.js';
 
+// Text / grapheme utilities
+export {
+  isWideChar,
+  segmentGraphemes,
+  graphemeClusterWidth,
+  graphemeWidth,
+} from './core/text/index.js';
+
 // Detection
 export { detectOutputMode, type OutputMode } from './core/detect/index.js';
 

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -61,6 +61,12 @@ export {
   type DTCGDocument,
   type DTCGToken,
   type DTCGGroup,
+  // Color downsampling
+  rgbToAnsi256,
+  nearestAnsi256,
+  rgbToAnsi16,
+  ansi256ToAnsi16,
+  type ColorLevel,
   // Color manipulation
   hexToRgb,
   rgbToHex,

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -169,6 +169,8 @@ export {
   log,
   type LogLevel,
   type LogOptions,
+  markdown,
+  type MarkdownOptions,
 } from './core/components/index.js';
 
 // Forms


### PR DESCRIPTION
## Summary

- **Grapheme cluster support** — `segmentGraphemes()`, `graphemeWidth()`, `isWideChar()` using `Intl.Segmenter` for correct Unicode text measurement across CJK, emoji, and combining marks
- **`markdown()`** — terminal markdown renderer with headings, inline formatting, lists, code blocks, blockquotes, links, and mode degradation
- **Color downsampling** — `rgbToAnsi256()`, `rgbToAnsi16()`, `nearestAnsi256()`, `ansi256ToAnsi16()` pure conversion functions for limited terminals
- **`AuditStylePort`** — `auditStyle()` test adapter recording all style calls for post-hoc assertion
- **`isKeyMsg()` / `isResizeMsg()` type guards** — replace unsafe `as KeyMsg` casts across all 23 examples, runtime, and tests
- **`runScript()`** — scripted CLI/stdin driver for automated testing and demos
- **`chalkStyle()` level override** — scoped chalk instance instead of global mutation
- **Bug fixes** — `sliceAnsi()` double reset, Hangul range, `wasStyled()` equality, markdown word wrap with ANSI, Escape key cancellation in forms
- **Refactors** — deduplicate grapheme utils from viewport into bijou core with lazy singleton `Intl.Segmenter`
- **141 new tests** (1350 total), all passing

## Test plan

- [x] `vitest run` — 1350 tests pass (81 files, 5 skipped)
- [x] `tsc --noEmit` — clean across all 3 packages (bijou, bijou-node, bijou-tui)
- [x] Self code review — 0 critical/high, 1 medium + 1 low resolved in final commit