### PR TITLE
feat: v0.10.0 — canvas shader, box width, mouse input

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🐛 Fixes
 
+- **`canvas()` surrogate corruption** — replace `ch[0]!` with code-point-aware `[...ch][0]` to correctly extract non-BMP characters (emoji) from shader output
+- **Canvas example unsafe cast** — remove `(msg as Msg)` cast; TypeScript narrows through `'type' in msg` already
+- **`parseMouse()` duplicated ternary** — extract `buttonFromBits()` helper to DRY the button-to-name mapping
 - **`clipToWidth()` / `sliceAnsi()` O(n²) perf** — rewrite to pre-segment stripped text once via `segmentGraphemes()`, then walk original string with a grapheme pointer; removes per-character `str.slice(i)` + re-segment pattern
 - **`clipToWidth()` unconditional reset** — only append `\x1b[0m` when the clipped string actually contains ANSI style sequences
 - **`viewport.ts` duplicate segmenter** — remove `getSegmenter()` singleton; import `segmentGraphemes` from `@flyingrobots/bijou` core
@@ -23,7 +26,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 📝 Documentation
 
 - Add `queueMicrotask` limitation JSDoc to `runScript()` in driver.ts
+- Add missing `CHARS` definition to canvas README snippet
+- Add `canvas` and `mouse` rows to examples README
+- Add `static` mode comment to `canvas()`
 - Fix ROADMAP version label (`v0.8.0` → `v0.9.0`)
+- Fix CHANGELOG test file count (`4 new + 5 expanded` → `2 new + 4 expanded`)
 - Fix CHANGELOG test file count (`8 new + 6 expanded` → `6 new + 7 expanded`)
 - Merge duplicate README documentation bullets in CHANGELOG
 - Fix CHANGELOG example count (`6 new examples` → `5 new examples`)
@@ -53,7 +60,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧪 Tests
 
-- 51 new tests across 4 new + 5 expanded test files (1403 total)
+- 51 new tests across 2 new + 4 expanded test files (1403 total)
 
 ### 📝 Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,34 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - Fix progress-download README unused `vstack` import
 - Remove `(pre-release)` from xyph-title.md
 
+## [0.10.0] — 2026-02-28
+
+### 🚀 Features
+
+#### Core (`@flyingrobots/bijou`)
+
+- **`clipToWidth()`** — grapheme-aware text clipping promoted from bijou-tui to bijou core. O(n) algorithm preserving ANSI escapes, won't split multi-codepoint grapheme clusters (emoji, CJK, ZWJ sequences). Appends reset only when ANSI present
+- **`box()` width override** — optional `width` on `BoxOptions` locks outer box width (including borders). Content lines are clipped via `clipToWidth()` or right-padded to fill. Padding is clamped when it exceeds available interior space. Pipe/accessible modes ignore width
+- **`box()` grapheme-aware width measurement** — replaced naive `stripAnsi().length` with `graphemeWidth()` for correct CJK/emoji box sizing (pre-existing bug fix)
+
+#### TUI (`@flyingrobots/bijou-tui`)
+
+- **`canvas()` shader primitive** — `(cols, rows, shader, options?) → string` character-grid renderer for procedural backgrounds. Shader receives `(x, y, cols, rows, time)` per cell. Returns empty string in pipe/accessible mode. Composes with `composite()` for layered rendering
+- **Mouse input (opt-in)** — SGR mouse protocol support via `RunOptions.mouse?: boolean` (default false). New types: `MouseMsg`, `MouseButton`, `MouseAction`. `parseMouse()` parses SGR sequences (`\x1b[<button;col;rowM/m`). `isMouseMsg()` type guard. EventBus `connectIO()` accepts `{ mouse: true }` option. Runtime sends enable/disable escape sequences on startup/cleanup
+- **`App.update()` signature widened** — now receives `KeyMsg | ResizeMsg | MouseMsg | M` (was `KeyMsg | ResizeMsg | M`). Since `MouseMsg` is never emitted when `mouse: false`, existing apps are unaffected at runtime
+
+### 🔧 Refactors
+
+- **`viewport.ts` `clipToWidth()`** — re-exports from `@flyingrobots/bijou` core instead of maintaining a local copy. Public API unchanged for backward compatibility
+
+### 🧪 Tests
+
+- 51 new tests across 4 new + 5 expanded test files (1403 total)
+
+### 📝 Documentation
+
+- **2 new examples** — `canvas` (animated plasma shader), `mouse` (mouse event inspector)
+
 ## [0.9.0] — 2026-02-28
 
 ### 🚀 Features
@@ -395,7 +423,8 @@ First public release.
 - **Screen control** — `enterScreen()`, `exitScreen()`, `clearAndHome()`, `renderFrame()`
 - **Layout helpers** — `vstack()`, `hstack()`
 
-[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/flyingrobots/bijou/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/flyingrobots/bijou/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/flyingrobots/bijou/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/flyingrobots/bijou/compare/v0.6.0...v0.7.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`canvas()` surrogate corruption** — replace `ch[0]!` with code-point-aware `[...ch][0]` to correctly extract non-BMP characters (emoji) from shader output
 - **Canvas example unsafe cast** — remove `(msg as Msg)` cast; TypeScript narrows through `'type' in msg` already
 - **`parseMouse()` duplicated ternary** — extract `buttonFromBits()` helper to DRY the button-to-name mapping
+- **`parseMouse()` zero coordinate guard** — reject malformed SGR sequences with col/row of 0 (protocol-invalid) instead of producing -1 positions
 - **`clipToWidth()` / `sliceAnsi()` O(n²) perf** — rewrite to pre-segment stripped text once via `segmentGraphemes()`, then walk original string with a grapheme pointer; removes per-character `str.slice(i)` + re-segment pattern
 - **`clipToWidth()` unconditional reset** — only append `\x1b[0m` when the clipped string actually contains ANSI style sequences
 - **`viewport.ts` duplicate segmenter** — remove `getSegmenter()` singleton; import `segmentGraphemes` from `@flyingrobots/bijou` core
@@ -26,6 +27,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 📝 Documentation
 
 - Add `queueMicrotask` limitation JSDoc to `runScript()` in driver.ts
+- Mark canvas README snippet as excerpt
 - Add missing `CHARS` definition to canvas README snippet
 - Add `canvas` and `mouse` rows to examples README
 - Add `static` mode comment to `canvas()`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Tests ARE the Spec.** Every feature is defined by its tests. If it's not tested, it's not guaranteed. Acceptance criteria are written as test descriptions first, implementation second.
 
-Current: **v0.9.0** — Grapheme clusters, markdown, color downsampling, AuditStylePort, type guards
+Current: **v0.10.0** — Canvas shader, box width override, mouse input, clipToWidth in core
 
 ---
 
@@ -343,7 +343,7 @@ Growing toward a full terminal component library:
 | **Navigation** | ~~`tabs()`~~, ~~`breadcrumb()`~~, ~~`paginator()`~~, ~~`stepper()`~~, ~~`commandPalette()`~~ ✅ |
 | **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~, ~~`createPanelGroup()`~~, ~~`navigableTable()`~~, ~~`browsableList()`~~, ~~`filePicker()`~~ ✅ |
 | **Overlay** | ~~`composite()`~~, ~~`modal()`~~, ~~`toast()`~~, ~~`drawer()`~~ ✅ |
-| **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~ ✅, mouse events (`IOPort.onMouse()`) |
+| **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~, ~~`parseMouse()`~~ ✅ |
 | **App** | ~~`statusBar()`~~, ~~`tooltip()`~~ ✅, `splitPane()` |
 
 Each new component should follow this template before implementation:
@@ -409,7 +409,7 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 
 | Feature | Package | Notes |
 |---------|---------|-------|
-| **Mouse input** | bijou + bijou-node + bijou-tui | `IOPort.onMouse()` with SGR mouse parsing, `MouseMsg` in TEA runtime. Breaking change (new port method). |
+| ~~**Mouse input**~~ | bijou-tui | ✅ v0.10.0 — Opt-in SGR mouse protocol via `RunOptions.mouse`. `MouseMsg`, `parseMouse()`, `isMouseMsg()`. No port change needed — reuses `rawInput()`. |
 | ~~**`DagNode` token expansion**~~ | bijou | ✅ v0.8.0 — `labelToken` and `badgeToken` on `DagNode` for granular per-node styling beyond border color. |
 | ~~**`place()`**~~ | bijou-tui | ✅ v0.7.0 — 2D text placement with horizontal + vertical alignment. |
 | ~~**`drawer()`**~~ | bijou-tui | ✅ v0.7.0 — Slide-in side panel built on `composite()`. Left/right anchored, configurable width. |
@@ -421,8 +421,8 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | ~~**Color manipulation**~~ | bijou | ✅ v0.8.0 — `lighten()`, `darken()`, `mix()`, `complementary()`, `saturate()`, `desaturate()` on theme tokens. |
 | ~~**`markdown()`**~~ | bijou | ✅ v0.9.0 — Terminal markdown renderer with headings, inline formatting, lists, code blocks, blockquotes, links, and mode degradation. |
 | ~~**`log()`**~~ | bijou | ✅ v0.7.0 — Leveled styled log output (debug/info/warn/error/fatal). |
-| **`canvas()` shader primitive** | bijou-tui | `(cols, rows, shader, time?) → string` character-grid renderer for procedural backgrounds (rain, plasma, spiral, starfield). Composes with `composite()` for layered rendering. |
-| **`box()` width override** | bijou | Optional `width` on `BoxOptions` to lock outer width for visual stability across state changes. Content right-padded or clipped via `clipToWidth()`. |
+| ~~**`canvas()` shader primitive**~~ | bijou-tui | ✅ v0.10.0 — `(cols, rows, shader, options?) → string` character-grid renderer. Shader per cell, pipe/accessible → empty. |
+| ~~**`box()` width override**~~ | bijou | ✅ v0.10.0 — Optional `width` on `BoxOptions` locks outer width. Content clipped via `clipToWidth()` or right-padded. |
 
 ### P2.5 — Code quality & DX
 
@@ -463,4 +463,4 @@ Once published:
 | Phase 1h (confirm/input overlays) | `composite()`, `modal()` | ✅ Ready |
 | Phase 2 (review actions, detail panel) | `selectedId`, ANSI utils | ✅ Ready |
 | Phase 3 (full DAG interactivity) | `scrollX`, `dagLayout()`, `createPanelGroup()` | ✅ Ready |
-| Title screen (animated splash) | `canvas()`, `box({ width })`, `composite()` | ⏳ Pending `canvas()` + `box()` width |
+| Title screen (animated splash) | `canvas()`, `box({ width })`, `composite()` | ✅ Ready |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-> 59 examples · Run any: `npx tsx examples/<name>/main.ts`
+> 61 examples · Run any: `npx tsx examples/<name>/main.ts`
 > Record all GIFs: `../scripts/record-gifs.sh`
 
 ## Static Components
@@ -75,4 +75,6 @@
 | [`drawer`](./drawer/) | `drawer()`, `composite()` | Togglable slide-in side panel overlay |
 | [`command-palette`](./command-palette/) | `commandPalette()`, `commandPaletteKeyMap()` | Filterable action list with live search |
 | [`tooltip`](./tooltip/) | `tooltip()`, `composite()` | Positioned overlay with directional placement |
+| [`canvas`](./canvas/) | `canvas()`, `ShaderFn` | Animated plasma shader effect |
+| [`mouse`](./mouse/) | `parseMouse()`, `MouseMsg` | Mouse event inspector |
 | [`splash`](./splash/) | `splash` | Animated splash screen |

--- a/examples/canvas/README.md
+++ b/examples/canvas/README.md
@@ -1,0 +1,26 @@
+# canvas
+
+Animated plasma effect using the `canvas()` shader primitive.
+
+## Run
+
+```sh
+npx tsx examples/canvas/main.ts
+```
+
+## Source
+
+```ts
+const shader: ShaderFn = (x, y, cols, rows, time) => {
+  const cx = cols / 2;
+  const cy = rows / 2;
+  const dx = x - cx;
+  const dy = (y - cy) * 2;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  const wave = Math.sin(dist * 0.5 - time * 3) * 0.5 + 0.5;
+  const idx = Math.floor(wave * (CHARS.length - 1));
+  return CHARS[idx]!;
+};
+
+const art = canvas(60, 20, shader, { time });
+```

--- a/examples/canvas/README.md
+++ b/examples/canvas/README.md
@@ -8,7 +8,7 @@ Animated plasma effect using the `canvas()` shader primitive.
 npx tsx examples/canvas/main.ts
 ```
 
-## Source
+## Source (excerpt)
 
 ```ts
 const CHARS = ' .:-=+*#%@';

--- a/examples/canvas/README.md
+++ b/examples/canvas/README.md
@@ -11,6 +11,8 @@ npx tsx examples/canvas/main.ts
 ## Source
 
 ```ts
+const CHARS = ' .:-=+*#%@';
+
 const shader: ShaderFn = (x, y, cols, rows, time) => {
   const cx = cols / 2;
   const cy = rows / 2;

--- a/examples/canvas/main.ts
+++ b/examples/canvas/main.ts
@@ -1,0 +1,52 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { run, quit, tick, isKeyMsg, canvas, type App, type ShaderFn } from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+
+interface Model {
+  time: number;
+  cols: number;
+  rows: number;
+}
+
+type Msg = { type: 'tick' } | { type: 'quit' };
+
+const CHARS = ' .:-=+*#%@';
+
+const shader: ShaderFn = (x, y, cols, rows, time) => {
+  const cx = cols / 2;
+  const cy = rows / 2;
+  const dx = x - cx;
+  const dy = (y - cy) * 2; // aspect ratio correction
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  const wave = Math.sin(dist * 0.5 - time * 3) * 0.5 + 0.5;
+  const idx = Math.floor(wave * (CHARS.length - 1));
+  return CHARS[idx]!;
+};
+
+const app: App<Model, Msg> = {
+  init: () => [
+    { time: 0, cols: 60, rows: 20 },
+    [tick(16)],
+  ],
+
+  update: (msg, model) => {
+    if (isKeyMsg(msg)) {
+      if ((msg.ctrl && msg.key === 'c') || msg.key === 'q') {
+        return [model, [quit()]];
+      }
+      return [model, []];
+    }
+    if ('type' in msg && (msg as Msg).type === 'tick') {
+      return [{ ...model, time: model.time + 0.016 }, [tick(16)]];
+    }
+    return [model, []];
+  },
+
+  view: (model) => {
+    const art = canvas(model.cols, model.rows, shader, { time: model.time });
+    return `\n  Plasma Shader  (q to quit)\n\n${art}\n`;
+  },
+};
+
+run(app);

--- a/examples/canvas/main.ts
+++ b/examples/canvas/main.ts
@@ -37,7 +37,7 @@ const app: App<Model, Msg> = {
       }
       return [model, []];
     }
-    if ('type' in msg && (msg as Msg).type === 'tick') {
+    if ('type' in msg && msg.type === 'tick') {
       return [{ ...model, time: model.time + 0.016 }, [tick(16)]];
     }
     return [model, []];

--- a/examples/mouse/README.md
+++ b/examples/mouse/README.md
@@ -1,0 +1,23 @@
+# mouse
+
+Mouse event inspector showing clicks, releases, scrolls, and drags with modifier keys.
+
+## Run
+
+```sh
+npx tsx examples/mouse/main.ts
+```
+
+## Source
+
+```ts
+run(app, { mouse: true });
+
+// In update:
+if (isMouseMsg(msg)) {
+  // msg.button: 'left' | 'middle' | 'right' | 'none'
+  // msg.action: 'press' | 'release' | 'move' | 'scroll-up' | 'scroll-down'
+  // msg.col, msg.row: 0-based terminal coordinates
+  // msg.ctrl, msg.alt, msg.shift: modifier keys
+}
+```

--- a/examples/mouse/main.ts
+++ b/examples/mouse/main.ts
@@ -1,0 +1,70 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { box, badge, kbd } from '@flyingrobots/bijou';
+import {
+  run, quit, isKeyMsg, isMouseMsg,
+  type App, type MouseMsg,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+
+interface Model {
+  events: MouseMsg[];
+  lastClick: { col: number; row: number } | null;
+}
+
+type Msg = { type: 'quit' };
+
+const MAX_EVENTS = 10;
+
+const app: App<Model, Msg> = {
+  init: () => [{ events: [], lastClick: null }, []],
+
+  update: (msg, model) => {
+    if (isKeyMsg(msg)) {
+      if ((msg.ctrl && msg.key === 'c') || msg.key === 'q') {
+        return [model, [quit()]];
+      }
+      return [model, []];
+    }
+    if (isMouseMsg(msg)) {
+      const events = [...model.events, msg].slice(-MAX_EVENTS);
+      const lastClick = msg.action === 'press' ? { col: msg.col, row: msg.row } : model.lastClick;
+      return [{ events, lastClick }, []];
+    }
+    return [model, []];
+  },
+
+  view: (model) => {
+    const lines: string[] = [
+      '',
+      '  Mouse Event Inspector',
+      '',
+    ];
+
+    if (model.events.length === 0) {
+      lines.push('  Click or scroll anywhere...');
+    } else {
+      for (const e of model.events) {
+        const mods: string[] = [];
+        if (e.ctrl) mods.push(badge('CTRL', { variant: 'warning' }));
+        if (e.alt) mods.push(badge('ALT', { variant: 'info' }));
+        if (e.shift) mods.push(badge('SHIFT', { variant: 'accent' }));
+        const modStr = mods.length > 0 ? mods.join(' ') + ' ' : '';
+        lines.push(`  ${modStr}${e.action} ${e.button} (${e.col}, ${e.row})`);
+      }
+    }
+
+    if (model.lastClick) {
+      lines.push('');
+      lines.push(box(`Last click: (${model.lastClick.col}, ${model.lastClick.row})`));
+    }
+
+    lines.push('');
+    lines.push(`  ${kbd('q')} to quit`);
+    lines.push('');
+
+    return lines.join('\n');
+  },
+};
+
+run(app, { mouse: true });

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -27,7 +27,7 @@
     "chalk": "^5.6.2"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.9.0"
+    "@flyingrobots/bijou": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "0.9.0"
+    "@flyingrobots/bijou": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/src/canvas.test.ts
+++ b/packages/bijou-tui/src/canvas.test.ts
@@ -32,6 +32,12 @@ describe('canvas()', () => {
     expect(result).toBe('AAA');
   });
 
+  it('handles non-BMP emoji shader output without surrogate corruption', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = canvas(3, 1, () => '🔥', { ctx });
+    expect(result).toBe('🔥🔥🔥');
+  });
+
   it('substitutes space for empty return', () => {
     const ctx = createTestContext({ mode: 'interactive' });
     const result = canvas(3, 1, () => '', { ctx });

--- a/packages/bijou-tui/src/canvas.test.ts
+++ b/packages/bijou-tui/src/canvas.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { canvas, type ShaderFn } from './canvas.js';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+
+describe('canvas()', () => {
+  it('calls shader(x, y, cols, rows, time) for every cell', () => {
+    const calls: [number, number, number, number, number][] = [];
+    const shader: ShaderFn = (x, y, cols, rows, time) => {
+      calls.push([x, y, cols, rows, time]);
+      return '.';
+    };
+    const ctx = createTestContext({ mode: 'interactive' });
+    canvas(3, 2, shader, { time: 42, ctx });
+    expect(calls).toHaveLength(6); // 3×2
+    expect(calls[0]).toEqual([0, 0, 3, 2, 42]);
+    expect(calls[5]).toEqual([2, 1, 3, 2, 42]);
+  });
+
+  it('produces exactly rows lines, each cols chars wide', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = canvas(5, 3, () => 'X', { ctx });
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect(line).toHaveLength(5);
+    }
+  });
+
+  it('truncates multi-char return to first character', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = canvas(3, 1, () => 'ABC', { ctx });
+    expect(result).toBe('AAA');
+  });
+
+  it('substitutes space for empty return', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = canvas(3, 1, () => '', { ctx });
+    expect(result).toBe('   ');
+  });
+
+  it('time defaults to 0', () => {
+    let capturedTime = -1;
+    const ctx = createTestContext({ mode: 'interactive' });
+    canvas(1, 1, (_x, _y, _c, _r, time) => {
+      capturedTime = time;
+      return '.';
+    }, { ctx });
+    expect(capturedTime).toBe(0);
+  });
+
+  it('cols=0 returns empty string', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    expect(canvas(0, 5, () => 'X', { ctx })).toBe('');
+  });
+
+  it('rows=0 returns empty string', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    expect(canvas(5, 0, () => 'X', { ctx })).toBe('');
+  });
+
+  describe('pipe mode', () => {
+    it('returns empty string', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      expect(canvas(10, 5, () => 'X', { ctx })).toBe('');
+    });
+  });
+
+  describe('accessible mode', () => {
+    it('returns empty string', () => {
+      const ctx = createTestContext({ mode: 'accessible' });
+      expect(canvas(10, 5, () => 'X', { ctx })).toBe('');
+    });
+  });
+});

--- a/packages/bijou-tui/src/canvas.ts
+++ b/packages/bijou-tui/src/canvas.ts
@@ -1,0 +1,68 @@
+/**
+ * Shader-based canvas primitive for procedural character art.
+ *
+ * Calls a user-provided shader function for every cell in a grid,
+ * producing a string of exactly `rows` lines, each `cols` characters wide.
+ */
+
+import type { BijouContext } from '@flyingrobots/bijou';
+import { getDefaultContext } from '@flyingrobots/bijou';
+
+/**
+ * Shader function called once per cell.
+ *
+ * @param x    Column index (0-based).
+ * @param y    Row index (0-based).
+ * @param cols Total number of columns.
+ * @param rows Total number of rows.
+ * @param time Animation time value.
+ * @returns    A single character (or string — only the first char is used).
+ */
+export type ShaderFn = (
+  x: number,
+  y: number,
+  cols: number,
+  rows: number,
+  time: number,
+) => string;
+
+export interface CanvasOptions {
+  /** Animation time value passed to the shader. Default: 0. */
+  time?: number;
+  /** Bijou context for mode detection. */
+  ctx?: BijouContext;
+}
+
+/**
+ * Render a character grid by calling `shader(x, y, cols, rows, time)` for
+ * every cell. Returns a string of exactly `rows` lines, each `cols` chars wide.
+ *
+ * In pipe or accessible mode, returns empty string (no visual noise).
+ * Returns empty string when cols or rows are ≤ 0.
+ */
+export function canvas(
+  cols: number,
+  rows: number,
+  shader: ShaderFn,
+  options?: CanvasOptions,
+): string {
+  if (cols <= 0 || rows <= 0) return '';
+
+  const ctx = options?.ctx ?? getDefaultContext();
+  if (ctx.mode === 'pipe' || ctx.mode === 'accessible') return '';
+
+  const time = options?.time ?? 0;
+  const lines: string[] = [];
+
+  for (let y = 0; y < rows; y++) {
+    let line = '';
+    for (let x = 0; x < cols; x++) {
+      const ch = shader(x, y, cols, rows, time);
+      // Take first character, or space if empty
+      line += ch.length > 0 ? ch[0]! : ' ';
+    }
+    lines.push(line);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/bijou-tui/src/canvas.ts
+++ b/packages/bijou-tui/src/canvas.ts
@@ -5,8 +5,7 @@
  * producing a string of exactly `rows` lines, each `cols` characters wide.
  */
 
-import type { BijouContext } from '@flyingrobots/bijou';
-import { getDefaultContext } from '@flyingrobots/bijou';
+import { getDefaultContext, type BijouContext } from '@flyingrobots/bijou';
 
 /**
  * Shader function called once per cell.
@@ -50,6 +49,7 @@ export function canvas(
 
   const ctx = options?.ctx ?? getDefaultContext();
   if (ctx.mode === 'pipe' || ctx.mode === 'accessible') return '';
+  // static mode renders normally (same as box/table)
 
   const time = options?.time ?? 0;
   const lines: string[] = [];
@@ -58,8 +58,8 @@ export function canvas(
     let line = '';
     for (let x = 0; x < cols; x++) {
       const ch = shader(x, y, cols, rows, time);
-      // Take first character, or space if empty
-      line += ch.length > 0 ? ch[0]! : ' ';
+      // Take first code point, or space if empty
+      line += ch.length > 0 ? ([...ch][0] ?? ' ') : ' ';
     }
     lines.push(line);
   }

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -1,9 +1,9 @@
 // Types
-export type { App, Cmd, KeyMsg, ResizeMsg, QuitSignal, RunOptions } from './types.js';
-export { QUIT, isKeyMsg, isResizeMsg } from './types.js';
+export type { App, Cmd, KeyMsg, ResizeMsg, MouseMsg, MouseButton, MouseAction, QuitSignal, RunOptions } from './types.js';
+export { QUIT, isKeyMsg, isResizeMsg, isMouseMsg } from './types.js';
 
 // Key parsing
-export { parseKey } from './keys.js';
+export { parseKey, parseMouse } from './keys.js';
 
 // Screen control
 export {
@@ -248,6 +248,13 @@ export {
   type RunScriptResult,
   runScript,
 } from './driver.js';
+
+// Canvas — shader-based character grid
+export {
+  type ShaderFn,
+  type CanvasOptions,
+  canvas,
+} from './canvas.js';
 
 // Command palette
 export {

--- a/packages/bijou-tui/src/keys.test.ts
+++ b/packages/bijou-tui/src/keys.test.ts
@@ -193,4 +193,10 @@ describe('parseMouse', () => {
     expect(msg!.col).toBe(0);
     expect(msg!.row).toBe(0);
   });
+
+  it('rejects malformed zero coordinates', () => {
+    expect(parseMouse('\x1b[<0;0;1M')).toBeNull();
+    expect(parseMouse('\x1b[<0;1;0M')).toBeNull();
+    expect(parseMouse('\x1b[<0;0;0M')).toBeNull();
+  });
 });

--- a/packages/bijou-tui/src/keys.test.ts
+++ b/packages/bijou-tui/src/keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseKey } from './keys.js';
+import { parseKey, parseMouse } from './keys.js';
 
 describe('parseKey', () => {
   describe('arrow keys', () => {
@@ -96,5 +96,101 @@ describe('parseKey', () => {
     it('returns unknown for multi-byte characters', () => {
       expect(parseKey('\xc3\xa9')).toEqual({ type: 'key', key: 'unknown', ctrl: false, alt: false, shift: false });
     });
+  });
+});
+
+describe('parseMouse', () => {
+  it('parses SGR left press', () => {
+    const msg = parseMouse('\x1b[<0;10;20M');
+    expect(msg).toEqual({
+      type: 'mouse', button: 'left', action: 'press',
+      col: 9, row: 19, shift: false, alt: false, ctrl: false,
+    });
+  });
+
+  it('parses SGR middle press', () => {
+    const msg = parseMouse('\x1b[<1;5;5M');
+    expect(msg).toEqual({
+      type: 'mouse', button: 'middle', action: 'press',
+      col: 4, row: 4, shift: false, alt: false, ctrl: false,
+    });
+  });
+
+  it('parses SGR right press', () => {
+    const msg = parseMouse('\x1b[<2;1;1M');
+    expect(msg).toEqual({
+      type: 'mouse', button: 'right', action: 'press',
+      col: 0, row: 0, shift: false, alt: false, ctrl: false,
+    });
+  });
+
+  it('parses release (m suffix)', () => {
+    const msg = parseMouse('\x1b[<0;10;20m');
+    expect(msg).toEqual({
+      type: 'mouse', button: 'left', action: 'release',
+      col: 9, row: 19, shift: false, alt: false, ctrl: false,
+    });
+  });
+
+  it('parses scroll up', () => {
+    const msg = parseMouse('\x1b[<64;10;20M');
+    expect(msg).toEqual({
+      type: 'mouse', button: 'none', action: 'scroll-up',
+      col: 9, row: 19, shift: false, alt: false, ctrl: false,
+    });
+  });
+
+  it('parses scroll down', () => {
+    const msg = parseMouse('\x1b[<65;10;20M');
+    expect(msg).toEqual({
+      type: 'mouse', button: 'none', action: 'scroll-down',
+      col: 9, row: 19, shift: false, alt: false, ctrl: false,
+    });
+  });
+
+  it('extracts shift modifier', () => {
+    // 0 + 4 (shift) = 4
+    const msg = parseMouse('\x1b[<4;1;1M');
+    expect(msg!.shift).toBe(true);
+    expect(msg!.alt).toBe(false);
+    expect(msg!.ctrl).toBe(false);
+  });
+
+  it('extracts alt modifier', () => {
+    // 0 + 8 (alt) = 8
+    const msg = parseMouse('\x1b[<8;1;1M');
+    expect(msg!.alt).toBe(true);
+    expect(msg!.shift).toBe(false);
+    expect(msg!.ctrl).toBe(false);
+  });
+
+  it('extracts ctrl modifier', () => {
+    // 0 + 16 (ctrl) = 16
+    const msg = parseMouse('\x1b[<16;1;1M');
+    expect(msg!.ctrl).toBe(true);
+    expect(msg!.shift).toBe(false);
+    expect(msg!.alt).toBe(false);
+  });
+
+  it('parses drag (motion) events', () => {
+    // 32 (motion) + 0 (left) = 32
+    const msg = parseMouse('\x1b[<32;10;20M');
+    expect(msg).toEqual({
+      type: 'mouse', button: 'left', action: 'move',
+      col: 9, row: 19, shift: false, alt: false, ctrl: false,
+    });
+  });
+
+  it('returns null for non-mouse sequences', () => {
+    expect(parseMouse('\x1b[A')).toBeNull();
+    expect(parseMouse('hello')).toBeNull();
+    expect(parseMouse('')).toBeNull();
+  });
+
+  it('coords are 0-based', () => {
+    // SGR reports 1-based coords
+    const msg = parseMouse('\x1b[<0;1;1M');
+    expect(msg!.col).toBe(0);
+    expect(msg!.row).toBe(0);
   });
 });

--- a/packages/bijou-tui/src/keys.ts
+++ b/packages/bijou-tui/src/keys.ts
@@ -70,8 +70,11 @@ export function parseMouse(raw: string): MouseMsg | null {
   if (!match) return null;
 
   const buttonByte = parseInt(match[1]!, 10);
-  const col = parseInt(match[2]!, 10) - 1; // 1-based → 0-based
-  const row = parseInt(match[3]!, 10) - 1;
+  const rawCol = parseInt(match[2]!, 10);
+  const rawRow = parseInt(match[3]!, 10);
+  if (rawCol < 1 || rawRow < 1) return null;
+  const col = rawCol - 1; // 1-based → 0-based
+  const row = rawRow - 1;
   const suffix = match[4]!;
 
   const shift = (buttonByte & 4) !== 0;

--- a/packages/bijou-tui/src/keys.ts
+++ b/packages/bijou-tui/src/keys.ts
@@ -81,6 +81,8 @@ export function parseMouse(raw: string): MouseMsg | null {
   const isScroll = (buttonByte & 64) !== 0;
 
   const lowBits = buttonByte & 3;
+  const buttonFromBits = (bits: number): MouseButton =>
+    bits === 0 ? 'left' : bits === 1 ? 'middle' : bits === 2 ? 'right' : 'none';
 
   let button: MouseButton;
   let action: MouseAction;
@@ -89,10 +91,10 @@ export function parseMouse(raw: string): MouseMsg | null {
     button = 'none';
     action = lowBits === 0 ? 'scroll-up' : 'scroll-down';
   } else if (isMotion) {
-    button = lowBits === 0 ? 'left' : lowBits === 1 ? 'middle' : lowBits === 2 ? 'right' : 'none';
+    button = buttonFromBits(lowBits);
     action = 'move';
   } else {
-    button = lowBits === 0 ? 'left' : lowBits === 1 ? 'middle' : lowBits === 2 ? 'right' : 'none';
+    button = buttonFromBits(lowBits);
     action = suffix === 'M' ? 'press' : 'release';
   }
 

--- a/packages/bijou-tui/src/types.test.ts
+++ b/packages/bijou-tui/src/types.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { isKeyMsg, isResizeMsg } from './types.js';
-import type { KeyMsg, ResizeMsg } from './types.js';
+import { isKeyMsg, isResizeMsg, isMouseMsg } from './types.js';
+import type { KeyMsg, ResizeMsg, MouseMsg } from './types.js';
 
 describe('isKeyMsg', () => {
   it('returns true for valid KeyMsg', () => {
@@ -68,5 +68,45 @@ describe('isResizeMsg', () => {
 
   it('returns false for empty object', () => {
     expect(isResizeMsg({})).toBe(false);
+  });
+});
+
+describe('isMouseMsg', () => {
+  it('returns true for valid MouseMsg', () => {
+    const msg: MouseMsg = {
+      type: 'mouse', button: 'left', action: 'press',
+      col: 10, row: 20, shift: false, alt: false, ctrl: false,
+    };
+    expect(isMouseMsg(msg)).toBe(true);
+  });
+
+  it('returns false for KeyMsg', () => {
+    const msg: KeyMsg = { type: 'key', key: 'a', ctrl: false, alt: false, shift: false };
+    expect(isMouseMsg(msg)).toBe(false);
+  });
+
+  it('returns false for ResizeMsg', () => {
+    const msg: ResizeMsg = { type: 'resize', columns: 80, rows: 24 };
+    expect(isMouseMsg(msg)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isMouseMsg(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isMouseMsg(undefined)).toBe(false);
+  });
+
+  it('returns false for string', () => {
+    expect(isMouseMsg('mouse')).toBe(false);
+  });
+
+  it('returns false for object with wrong type', () => {
+    expect(isMouseMsg({ type: 'key' })).toBe(false);
+  });
+
+  it('returns false for empty object', () => {
+    expect(isMouseMsg({})).toBe(false);
   });
 });

--- a/packages/bijou-tui/src/types.ts
+++ b/packages/bijou-tui/src/types.ts
@@ -16,6 +16,22 @@ export interface ResizeMsg {
   readonly rows: number;
 }
 
+// --- Mouse messages ---
+
+export type MouseButton = 'left' | 'middle' | 'right' | 'none';
+export type MouseAction = 'press' | 'release' | 'move' | 'scroll-up' | 'scroll-down';
+
+export interface MouseMsg {
+  readonly type: 'mouse';
+  readonly button: MouseButton;
+  readonly action: MouseAction;
+  readonly col: number;   // 0-based
+  readonly row: number;   // 0-based
+  readonly shift: boolean;
+  readonly alt: boolean;
+  readonly ctrl: boolean;
+}
+
 // --- Type guards ---
 
 /** Narrow an unknown message to KeyMsg. */
@@ -26,6 +42,11 @@ export function isKeyMsg(msg: unknown): msg is KeyMsg {
 /** Narrow an unknown message to ResizeMsg. */
 export function isResizeMsg(msg: unknown): msg is ResizeMsg {
   return typeof msg === 'object' && msg !== null && 'type' in msg && (msg as ResizeMsg).type === 'resize';
+}
+
+/** Narrow an unknown message to MouseMsg. */
+export function isMouseMsg(msg: unknown): msg is MouseMsg {
+  return typeof msg === 'object' && msg !== null && 'type' in msg && (msg as MouseMsg).type === 'mouse';
 }
 
 // --- Commands ---
@@ -43,7 +64,7 @@ export type Cmd<M> = (emit: (msg: M) => void) => Promise<M | QuitSignal | void>;
 
 export interface App<Model, M = never> {
   init(): [Model, Cmd<M>[]];
-  update(msg: KeyMsg | ResizeMsg | M, model: Model): [Model, Cmd<M>[]];
+  update(msg: KeyMsg | ResizeMsg | MouseMsg | M, model: Model): [Model, Cmd<M>[]];
   view(model: Model): string;
 }
 
@@ -52,5 +73,7 @@ export interface App<Model, M = never> {
 export interface RunOptions {
   altScreen?: boolean;
   hideCursor?: boolean;
+  /** Enable mouse input (SGR mode). Default: false. */
+  mouse?: boolean;
   ctx?: BijouContext;
 }

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/src/core/components/box.test.ts
+++ b/packages/bijou/src/core/components/box.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { box, headerBox } from './box.js';
 import { createTestContext } from '../../adapters/test/index.js';
+import { graphemeWidth } from '../text/grapheme.js';
 
 describe('box', () => {
   it('renders box in interactive mode', () => {
@@ -42,5 +43,84 @@ describe('headerBox', () => {
   it('renders label only when no detail', () => {
     const ctx = createTestContext({ mode: 'pipe' });
     expect(headerBox('Title', { ctx })).toBe('Title');
+  });
+});
+
+describe('box() with width override', () => {
+  it('outer width matches specified width exactly', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = box('Hi', { width: 20, ctx });
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(graphemeWidth(line)).toBe(20);
+    }
+  });
+
+  it('short content lines right-padded to fill interior', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = box('Hi', { width: 20, ctx });
+    const lines = result.split('\n');
+    // Content line (middle) should be padded to width 20
+    expect(graphemeWidth(lines[1]!)).toBe(20);
+  });
+
+  it('long content lines clipped to interior width', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = box('This is a very long line of text', { width: 12, ctx });
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(graphemeWidth(line)).toBe(12);
+    }
+  });
+
+  it('padding subtracted from width for interior', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    // width=10, padding left=2, right=2 → inner=8, content=4
+    const result = box('ABCDEFGH', { width: 10, padding: { left: 2, right: 2 }, ctx });
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(graphemeWidth(line)).toBe(10);
+    }
+    // Content should be clipped to 4 chars
+    expect(lines[1]).toContain('ABCD');
+    expect(lines[1]).not.toContain('ABCDE');
+  });
+
+  it('width < minimum (border + padding) results in zero-width interior', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    // width=2 → inner=0, content=0
+    const result = box('Hello', { width: 2, ctx });
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(graphemeWidth(line)).toBe(2);
+    }
+  });
+
+  it('visibleLength of every output line equals specified width', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = box('Line 1\nLonger Line 2\nL3', { width: 30, ctx });
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(graphemeWidth(line)).toBe(30);
+    }
+  });
+
+  it('pipe mode ignores width', () => {
+    const ctx = createTestContext({ mode: 'pipe' });
+    expect(box('Hello', { width: 20, ctx })).toBe('Hello');
+  });
+
+  it('accessible mode ignores width', () => {
+    const ctx = createTestContext({ mode: 'accessible' });
+    expect(box('Hello', { width: 20, ctx })).toBe('Hello');
+  });
+
+  it('headerBox() with width passes through to box', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const result = headerBox('Title', { width: 30, detail: 'info', ctx });
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(graphemeWidth(line)).toBe(30);
+    }
   });
 });

--- a/packages/bijou/src/core/text/clip.test.ts
+++ b/packages/bijou/src/core/text/clip.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { clipToWidth } from './clip.js';
+
+describe('clipToWidth()', () => {
+  it('clips string to exact visible width', () => {
+    expect(clipToWidth('Hello World', 5)).toBe('Hello');
+  });
+
+  it('returns original when it fits', () => {
+    expect(clipToWidth('Hi', 10)).toBe('Hi');
+  });
+
+  it('returns empty for maxWidth=0', () => {
+    expect(clipToWidth('Hello', 0)).toBe('');
+  });
+
+  it('preserves ANSI escapes in clipped output', () => {
+    const styled = '\x1b[31mHello World\x1b[0m';
+    const result = clipToWidth(styled, 5);
+    expect(result).toBe('\x1b[31mHello\x1b[0m');
+  });
+
+  it('appends reset only when ANSI present', () => {
+    // No ANSI — no reset appended
+    const plain = clipToWidth('Hello World', 5);
+    expect(plain).toBe('Hello');
+    expect(plain).not.toContain('\x1b[0m');
+
+    // With ANSI — reset appended when clipped
+    const styled = clipToWidth('\x1b[31mHello World\x1b[0m', 5);
+    expect(styled).toContain('\x1b[0m');
+  });
+
+  it('does not split multi-codepoint emoji', () => {
+    // Family emoji (ZWJ sequence) is width 2
+    const family = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}';
+    // Width 2 — should fit in maxWidth=2 but not maxWidth=1
+    expect(clipToWidth(family, 2)).toBe(family);
+    expect(clipToWidth(family, 1)).toBe('');
+  });
+
+  it('correctly measures CJK as width 2', () => {
+    // Three CJK chars = width 6
+    const cjk = '\u4F60\u597D\u4E16'; // 你好世
+    expect(clipToWidth(cjk, 4)).toBe('\u4F60\u597D'); // 你好 (width 4)
+    expect(clipToWidth(cjk, 5)).toBe('\u4F60\u597D'); // Can't fit 世 (would be 6)
+    expect(clipToWidth(cjk, 6)).toBe(cjk);
+  });
+
+  it('handles empty string', () => {
+    expect(clipToWidth('', 10)).toBe('');
+  });
+
+  it('handles string with only ANSI escapes', () => {
+    expect(clipToWidth('\x1b[31m\x1b[0m', 10)).toBe('\x1b[31m\x1b[0m');
+  });
+});

--- a/packages/bijou/src/core/text/clip.ts
+++ b/packages/bijou/src/core/text/clip.ts
@@ -1,0 +1,75 @@
+/**
+ * Grapheme-aware text clipping for terminal display.
+ *
+ * Clips a string to a maximum visible width, preserving ANSI escapes.
+ * Won't split multi-codepoint grapheme clusters (emoji, CJK, ZWJ sequences).
+ */
+
+import { segmentGraphemes, graphemeClusterWidth } from './grapheme.js';
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Clip a string to a maximum visible width, preserving ANSI escapes.
+ * Grapheme-cluster aware: won't split multi-codepoint sequences.
+ * Appends a reset sequence if the string was clipped mid-style.
+ *
+ * O(n): pre-segments stripped text once, then walks the original string
+ * with a grapheme pointer instead of re-segmenting per character.
+ */
+export function clipToWidth(str: string, maxWidth: number): string {
+  if (maxWidth <= 0) return '';
+
+  const stripped = str.replace(ANSI_RE, '');
+  const graphemes = segmentGraphemes(stripped);
+
+  let result = '';
+  let visible = 0;
+  let inEscape = false;
+  let escBuf = '';
+  let hasStyle = false;
+  let gi = 0;
+  let i = 0;
+
+  while (i < str.length) {
+    const ch = str[i]!;
+
+    if (ch === '\x1b') {
+      inEscape = true;
+      escBuf = ch;
+      i++;
+      continue;
+    }
+
+    if (inEscape) {
+      escBuf += ch;
+      if (ch === 'm') {
+        inEscape = false;
+        result += escBuf;
+        escBuf = '';
+        hasStyle = true;
+      }
+      i++;
+      continue;
+    }
+
+    // Visible character — consume next pre-segmented grapheme
+    if (gi >= graphemes.length) break;
+
+    const grapheme = graphemes[gi]!;
+    const gWidth = graphemeClusterWidth(grapheme);
+
+    if (visible + gWidth > maxWidth) {
+      if (hasStyle) result += '\x1b[0m';
+      break;
+    }
+
+    result += grapheme;
+    visible += gWidth;
+    gi++;
+    i += grapheme.length;
+  }
+
+  return result;
+}

--- a/packages/bijou/src/core/text/index.ts
+++ b/packages/bijou/src/core/text/index.ts
@@ -4,3 +4,5 @@ export {
   graphemeClusterWidth,
   graphemeWidth,
 } from './grapheme.js';
+
+export { clipToWidth } from './clip.js';

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -84,6 +84,7 @@ export {
   segmentGraphemes,
   graphemeClusterWidth,
   graphemeWidth,
+  clipToWidth,
 } from './core/text/index.js';
 
 // Detection


### PR DESCRIPTION
## Summary

- **`clipToWidth()` in bijou core** — O(n) grapheme-aware text clipping promoted from bijou-tui; viewport re-exports for backward compat
- **`canvas()` shader primitive** — `canvas(cols, rows, shader, {time})` per-cell character grid renderer; empty in pipe/accessible mode
- **`box()` width override** — `BoxOptions.width` locks outer width with content clipping/padding; fixes pre-existing `visibleLength` bug (`.length` → `graphemeWidth()`)
- **Mouse input (opt-in)** — `RunOptions.mouse: true` enables SGR protocol; `MouseMsg` type, `parseMouse()`, `isMouseMsg()` guard; `App.update()` widened but existing apps unaffected

## Test plan

- [x] `npm run build` — clean compile across all 3 packages
- [x] `npm test` — 1403 tests passing (51 new), all 83 test files green
- [x] Viewport still passes all 37 existing tests after `clipToWidth` re-export
- [x] Box width tests verify `graphemeWidth()` of every output line matches specified width
- [x] `parseMouse('\x1b[<0;10;20M')` returns correct `MouseMsg` with 0-based coords
- [ ] Run canvas example: `npx tsx examples/canvas/main.ts`
- [ ] Run mouse example: `npx tsx examples/mouse/main.ts`