### PR TITLE
feat(bijou-tui): add focusArea and dagPane building blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Bijou is a growing ecosystem. Transparency is our baseline—here is the current
 | `filePicker` | ✅ Stable | Directory browser with IOPort integration and extension filtering. |
 | `commandPalette` | ✅ Stable | Filterable action list with search and keyboard navigation. |
 | `tooltip` | ✅ Stable | Positioned overlay with directional placement and screen clamping. |
+| `focusArea` | ✅ Stable | Scrollable pane with colored focus gutter and horizontal overflow. |
+| `dagPane` | ✅ Stable | Interactive DAG viewer with arrow-key navigation and auto-highlight path. |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,6 +128,8 @@ interface BijouContext {
 | **Keybinding manager** | `createKeyMap()` — declarative binding, modifier combos, named groups, enable/disable |
 | **Help generator** | `helpView()`, `helpShort()`, `helpFor()` — auto-generated from bindings |
 | **Input stack** | `createInputStack()` — layered dispatch with opaque/passthrough modes |
+| **Focus area** | `focusArea()` — scrollable pane with colored focus gutter and horizontal overflow |
+| **DAG pane** | `dagPane()` — interactive DAG viewer with spatial arrow-key navigation and auto-highlight |
 | **Layout** | `vstack()`, `hstack()` |
 
 ## Data Flow

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,12 +21,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 - **`DagPaneRenderOptions`** — replace empty interface with type alias
 - **Merge duplicate imports** — consolidate split `import type` lines in `focus-area.ts` and `dag-pane.ts`
-- **Remove dead code** — remove unused `toggle-focus` Msg variant and unreachable `case 'quit'` from focus-area example
+- **Remove dead code** — remove unused `toggle-focus` Msg variant and unreachable `case 'quit'` switch arm from focus-area example
 
 ### 📝 Documentation
 
 - **GUIDE.md** — add missing `focusAreaSetContent` to Focus Area import example
 - **2 new examples** — `focus-area` (scrollable pane with focus gutter), `dag-pane` (interactive DAG viewer with node navigation)
+- **EXAMPLES.md** — add 18 missing example entries (dag-stats, enumerated-list, hyperlink, log, textarea, filter, wizard, pager, navigable-table, browsable-list, file-picker, interactive-accordion, status-bar, drawer, command-palette, tooltip, canvas, mouse) and update totals to 54/63
 
 ## [1.0.0] — 2026-03-03
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`dagPane` redundant adjacency** — `updateSelection()` no longer rebuilds the adjacency map when all callers already have one; adjacency is now passed through as a parameter
 - **`dagPane` unsafe cast** — replace `source as DagNode[]` with `isSlicedDagSource()` type guard in `renderLayout()`
 - **`dagPaneSelectNode` unknown ID** — preserves existing selection when the requested node ID is not in the layout (previously cleared to `undefined`)
+- **`dagPaneKeyMap` confirm binding** — fix `'return'` → `'enter'` key descriptor; `parseKey()` emits `'enter'` for Enter keypresses, so the confirm binding was unreachable
+- **`createDagPaneState` invalid `selectedId`** — validate that `selectedId` exists in the source graph; fall back to no selection if the ID is unknown, preventing a stuck invalid selection state
+- **`createFocusAreaState` dimension clamping** — clamp `width` and `height` to a minimum of 1, preventing invalid viewport state on zero or negative dimensions
+- **`focusArea` scrollbar-aware horizontal bounds** — account for the scrollbar column when computing horizontal scroll `maxX`, preventing the rightmost column of content from being hidden behind the scrollbar
+- **`focusArea` render-time scrollX clamping** — clamp `scrollX` against render-time content width to prevent one-column overscroll when pipe/accessible mode removes the gutter
 
 ### ♻️ Refactors
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 📝 Documentation
 
 - **GUIDE.md** — add missing `focusAreaSetContent` to Focus Area import example
+- **2 new examples** — `focus-area` (scrollable pane with focus gutter), `dag-pane` (interactive DAG viewer with node navigation)
 
 ## [1.0.0] — 2026-03-03
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **`focusArea()`** (bijou-tui) — new scrollable pane building block with a colored left gutter bar indicating focus state. Wraps `viewport()` with gutter chrome, horizontal overflow support (`overflowX: 'scroll' | 'hidden'`), and a convenience keymap. Degrades gracefully: pipe/accessible modes omit the gutter; static mode renders it unstyled.
+- **`dagPane()`** (bijou-tui) — new interactive DAG viewer building block. Wraps `dagLayout()` in a `focusArea()` with arrow-key node navigation (parent/child/sibling via spatial proximity), auto-highlight-path from root to selected node, and auto-scroll-to-selection. Includes full keymap with vim scroll bindings and arrow-key selection.
+
 ## [1.0.0] — 2026-03-03
 
 ### 💥 BREAKING CHANGES

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,22 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **`focusArea()`** (bijou-tui) — new scrollable pane building block with a colored left gutter bar indicating focus state. Wraps `viewport()` with gutter chrome, horizontal overflow support (`overflowX: 'scroll' | 'hidden'`), and a convenience keymap. Degrades gracefully: pipe/accessible modes omit the gutter; static mode renders it unstyled.
 - **`dagPane()`** (bijou-tui) — new interactive DAG viewer building block. Wraps `dagLayout()` in a `focusArea()` with arrow-key node navigation (parent/child/sibling via spatial proximity), auto-highlight-path from root to selected node, and auto-scroll-to-selection. Includes full keymap with vim scroll bindings and arrow-key selection.
 
+### 🐛 Fixed
+
+- **`dagPane` redundant adjacency** — `updateSelection()` no longer rebuilds the adjacency map when all callers already have one; adjacency is now passed through as a parameter
+- **`dagPane` unsafe cast** — replace `source as DagNode[]` with `isSlicedDagSource()` type guard in `renderLayout()`
+- **`dagPaneSelectNode` unknown ID** — preserves existing selection when the requested node ID is not in the layout (previously cleared to `undefined`)
+
+### ♻️ Refactors
+
+- **`DagPaneRenderOptions`** — replace empty interface with type alias
+- **Merge duplicate imports** — consolidate split `import type` lines in `focus-area.ts` and `dag-pane.ts`
+- **Remove dead code** — remove unused `toggle-focus` Msg variant and unreachable `case 'quit'` from focus-area example
+
+### 📝 Documentation
+
+- **GUIDE.md** — add missing `focusAreaSetContent` to Focus Area import example
+
 ## [1.0.0] — 2026-03-03
 
 ### 💥 BREAKING CHANGES

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -119,6 +119,30 @@ Render output and exit. GIFs are short recordings of the final output.
 **Demo:** Start with a large DAG (12+ nodes), then render 3 fragments: ancestors of a leaf node, descendants of the root, and a 2-hop neighborhood around a middle node. Show ghost nodes with dashed borders at slice boundaries.
 **GIF:** Single frame showing full DAG then the 3 fragments. ~3s.
 
+### [x] `dag-stats`
+
+**Component:** `dagStats()` + `dag()` + `table()`
+**Demo:** Render a project planning DAG (8 nodes with status badges), then display graph statistics (nodes, edges, depth, width, roots, leaves) in a table. Show a summary box with key metrics.
+**GIF:** Single frame showing the DAG, stats table, and summary box. ~2s.
+
+### [ ] `enumerated-list`
+
+**Component:** `enumeratedList()`
+**Demo:** Render ordered and unordered lists in 5 bullet styles: numeric (default), alpha, roman, bullet, and dash. Each list has 3-4 items showing the style variation.
+**GIF:** Single frame showing all 5 list styles stacked vertically. ~2s.
+
+### [ ] `hyperlink`
+
+**Component:** `hyperlink()`
+**Demo:** Render 3 hyperlinks demonstrating OSC 8 terminal links: a standard link with display text, a link with URL fallback mode, and a link with text-only fallback. Shows clickable terminal links where supported.
+**GIF:** Single frame showing all 3 hyperlink variants. ~2s.
+
+### [ ] `log`
+
+**Component:** `log()`
+**Demo:** Render leveled log output at all 5 levels (debug, info, warn, error, fatal) with colored prefixes. Show a second group with timestamps enabled and a third with prefix disabled.
+**GIF:** Single frame showing all log levels and variants. ~2s.
+
 ### [x] `pipe`
 
 **Component:** `detectOutputMode()`, all components
@@ -166,6 +190,24 @@ Prompt the user, collect input, display result. GIFs show the interaction.
 **Component:** `group()`
 **Demo:** Multi-field form: project name (input), framework (select), features (multiselect), deploy now? (confirm). Show the final collected result object.
 **GIF:** Fill out each field in sequence, show final JSON result. ~12s.
+
+### [x] `textarea`
+
+**Component:** `textarea()`
+**Demo:** Multi-line text input for writing a commit message. Shows line numbers, placeholder text, and cursor navigation. On submit, displays the result in a header box. Cancel shows a cancellation message.
+**GIF:** Type a multi-line message → navigate with arrow keys → submit → see result. ~8s.
+
+### [x] `filter`
+
+**Component:** `filter()`
+**Demo:** Fuzzy-filter select from a list of 8 programming languages with keyword metadata. Type to narrow results in real-time, arrow keys to navigate filtered matches, Enter to select. Shows the chosen language as a badge.
+**GIF:** Type "fun" → see Elixir/Haskell/OCaml → select one → see badge result. ~6s.
+
+### [x] `wizard`
+
+**Component:** `wizard()`
+**Demo:** Multi-step deployment wizard with conditional skip logic: choose a target (cloud/self-hosted/local), then conditionally prompt for cloud provider or server hostname based on the selection, then confirm monitoring. Shows the summary in a box.
+**GIF:** Select "cloud" → enter provider → skip hostname → confirm monitoring → see summary. ~10s.
 
 ---
 
@@ -263,6 +305,36 @@ Full-screen interactive apps using the TEA runtime. GIFs show live interaction.
 **Demo:** Two side-by-side panes (50/50 flex). Each is a scrollable viewport. Tab to switch focus (highlighted border on active pane). Each pane scrolls independently.
 **GIF:** Scroll left pane → Tab → scroll right pane → Tab → scroll left again. ~8s.
 
+### [x] `pager`
+
+**Component:** `pager()`, `pagerKeyMap()`
+**Demo:** Scrollable text viewer displaying 80 lines of content with section headers. Vim-style navigation (j/k to scroll, d/u for half-page, g/G for top/bottom) with a status line. Handles terminal resize.
+**GIF:** Scroll down with j → page down → jump to bottom → scroll back up. ~8s.
+
+### [x] `navigable-table`
+
+**Component:** `navigableTable()`, `navTableKeyMap()`
+**Demo:** Keyboard-navigable data table showing 12 open-source projects with name, language, stars, and license columns. Arrow keys move the focused row, page up/down for fast scrolling, with a scrollable viewport.
+**GIF:** Navigate rows with j/k → page down → page up → quit. ~8s.
+
+### [x] `browsable-list`
+
+**Component:** `browsableList()`, `browsableListKeyMap()`
+**Demo:** Navigable list of 12 bijou components, each with a label and description. Arrow keys move focus, page up/down for fast scrolling through a viewport. Enter selects the focused item.
+**GIF:** Browse items with j/k → page down → select an item → quit. ~8s.
+
+### [x] `file-picker`
+
+**Component:** `filePicker()`, `filePickerKeyMap()`
+**Demo:** Directory browser starting at the current working directory. Shows files and directories with icons. Arrow keys navigate, Enter opens directories or selects files, Backspace goes up a level. Handles terminal resize.
+**GIF:** Navigate files → enter a directory → go back → select a file → quit. ~8s.
+
+### [x] `interactive-accordion`
+
+**Component:** `interactiveAccordion()`, `accordionKeyMap()`
+**Demo:** Keyboard-navigable accordion with 5 sections about bijou (what it is, components, runtime, themes, getting started). Arrow keys move focus between sections, Enter/Space toggles expand/collapse, `e`/`c` to expand/collapse all.
+**GIF:** Navigate sections → expand → collapse → expand all → collapse all → quit. ~8s.
+
 ### [x] `composable`
 
 **Component:** Multiple components together
@@ -274,6 +346,42 @@ Full-screen interactive apps using the TEA runtime. GIFs show live interaction.
 **Component:** Real-world showcase
 **Demo:** Simulate `npm install`. Show a spinner with "Resolving dependencies...", then switch to a multi-progress view as packages "download", then a tree view of what was installed, then a success alert with stats. Fully automated (no user input).
 **GIF:** Watch the full install simulation play out. ~10s.
+
+### [ ] `status-bar`
+
+**Component:** `statusBar()`
+**Demo:** Render 3 status bar variants: a code-editor bar with filename, language, and cursor position; a minimal bar with mode and line count using a fill character; and a recording bar with emoji icons. All with configurable width.
+**GIF:** Single frame showing all 3 status bar variants stacked. ~2s.
+
+### [ ] `drawer`
+
+**Component:** `drawer()`, `composite()`
+**Demo:** Full-screen app with a togglable side panel. Press `d` to slide in a drawer overlay showing a details panel (name, version, status). The background dims when the drawer is open. Press `d` again to close.
+**GIF:** Show main screen → press d → drawer opens → press d → drawer closes. ~6s.
+
+### [ ] `command-palette`
+
+**Component:** `commandPalette()`, `commandPaletteKeyMap()`
+**Demo:** Filterable action list showing 12 bijou components organized by category (Display, Feedback, Forms, Layout, Navigation). Type to filter in real-time, arrow keys to navigate, Enter to select. Shows keyboard shortcuts where available.
+**GIF:** Type "tab" → see filtered results → select one → quit. ~6s.
+
+### [ ] `tooltip`
+
+**Component:** `tooltip()`, `composite()`
+**Demo:** Positioned overlay demo with a movable target marker. Arrow keys reposition the target, `d` cycles through 4 tooltip directions (top, bottom, left, right). The tooltip shows its current direction and coordinates.
+**GIF:** Move target → cycle directions → see tooltip reposition. ~6s.
+
+### [ ] `canvas`
+
+**Component:** `canvas()`, `ShaderFn`
+**Demo:** Animated plasma shader effect rendered as ASCII art. A radial wave pattern emanates from the center of the screen using a 10-character density ramp. Runs at 60fps with smooth time-based animation. Press `q` to quit.
+**GIF:** Watch the plasma animation pulse for a few seconds → quit. ~5s.
+
+### [ ] `mouse`
+
+**Component:** `parseMouse()`, `MouseMsg`
+**Demo:** Mouse event inspector that logs click, scroll, and drag events with modifier badges (CTRL, ALT, SHIFT). Shows the last 10 events in a scrolling log with button type, action, and coordinates. Displays the last click position in a box.
+**GIF:** Click around → scroll → see event log populate → quit. ~6s.
 
 ### [x] `splash`
 
@@ -299,12 +407,12 @@ Full-screen interactive apps using the TEA runtime. GIFs show live interaction.
 
 | Category | Count |
 |---|---|
-| Static components | 20/20 |
-| Interactive forms | 5/5 |
-| TUI apps | 20/20 |
-| **Total** | **45/45** |
+| Static components | 24/24 |
+| Interactive forms | 8/8 |
+| TUI apps | 22/31 |
+| **Total** | **54/63** |
 
-> All examples complete.
+> 54 of 63 examples have GIFs recorded. Remaining 9 need demo tapes.
 
 ---
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -281,6 +281,18 @@ Full-screen interactive apps using the TEA runtime. GIFs show live interaction.
 **Demo:** Animated splash screen: logo springs in from above, tagline fades in with a tween, gradient sweeps across, then a "Press any key" prompt pulses. Press a key to exit.
 **GIF:** Watch the splash animate in, press a key. ~6s.
 
+### [x] `focus-area`
+
+**Component:** `focusArea()`, `focusAreaScrollBy()`, `focusAreaKeyMap()`
+**Demo:** Scrollable text pane with a colored left gutter bar. Vim-style scroll (j/k/d/u/g/G) plus horizontal scroll (h/l). Press Tab to toggle focus state (accent vs muted gutter).
+**GIF:** Scroll through content → toggle focus → scroll horizontally → quit. ~8s.
+
+### [x] `dag-pane`
+
+**Component:** `dagPane()`, `dagPaneSelectChild()`, `dagPaneKeyMap()`
+**Demo:** Interactive DAG viewer showing a project dependency graph. Arrow keys navigate nodes spatially, auto-highlighting the path from root to selected node. Vim keys scroll the viewport.
+**GIF:** Arrow down through nodes → left/right between siblings → scroll → quit. ~10s.
+
 ---
 
 ## Totals
@@ -289,8 +301,8 @@ Full-screen interactive apps using the TEA runtime. GIFs show live interaction.
 |---|---|
 | Static components | 20/20 |
 | Interactive forms | 5/5 |
-| TUI apps | 18/18 |
-| **Total** | **43/43** |
+| TUI apps | 20/20 |
+| **Total** | **45/45** |
 
 > All examples complete.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,13 +2,15 @@
 
 > **Tests ARE the Spec.** Every feature is defined by its tests. If it's not tested, it's not guaranteed. Acceptance criteria are written as test descriptions first, implementation second.
 
-Current: **v1.0.0** — Architecture audit remediation
+Current: **v1.0.0** — Architecture audit + app shell
 
 ---
 
-## v1.0.0 — Architecture audit remediation
+## v1.0.0 — Architecture audit + app shell
 
-Findings from a full-codebase audit of SOLID, DRY, and test quality. No hexagonal architecture violations were found — the port system is clean. These items address structural debt discovered in component internals and test patterns.
+Phases 1–7: Findings from a full-codebase audit of SOLID, DRY, and test quality. No hexagonal architecture violations were found — the port system is clean. These items address structural debt discovered in component internals and test patterns.
+
+Phases 8–9: App shell primitives — the layout and framing components needed to build full-screen multi-pane TUI applications without boilerplate.
 
 ### Phase 1: Port interface cleanup (ISP)
 
@@ -92,6 +94,29 @@ Findings from a full-codebase audit of SOLID, DRY, and test quality. No hexagona
 |------|---------|-------|
 | **Add theme query helpers** | bijou | `ctx.semantic(key)`, `ctx.border(key)` convenience accessors that encapsulate the path traversal. |
 | **Migrate components** | bijou | Replace `ctx.theme.theme.semantic.*` with `ctx.semantic()` calls across all components. |
+
+### Phase 8: App shell primitives
+
+**Problem:** Building a multi-pane TUI app requires manually composing `flex()`, `focusArea()`, `createPanelGroup()`, `InputStack`, keymaps, and resize handling. Every non-trivial app re-implements the same shell: tabbed pages, help overlay, scroll, gutters, fullscreen layout. We need higher-level primitives so this is a one-liner.
+
+**DX research needed first:** What are the right abstractions? How do grids, splits, and focus areas compose? Study real apps (lazygit, k9s, btop) and existing TUI frameworks (Charm bubbletea layouts, Ratatui) to identify the minimal primitive set.
+
+| Task | Package | Notes |
+|------|---------|-------|
+| **DX deep dive: app layout patterns** | research | Study real-world TUI layouts. Identify the 3–5 layout patterns that cover 90% of apps. Document findings and propose API surface. |
+| **`splitPane()`** | bijou-tui | Resizable split view (horizontal/vertical) with draggable divider, min/max constraints, and focus delegation. Each pane is a render function `(w, h) => string`. |
+| **`grid()` layout primitive** | bijou-tui | CSS Grid-inspired layout: named areas, row/column track sizing (fixed, fractional, auto), gap. Each cell receives allocated `(w, h)`. Composes with `focusArea()` for per-cell scroll. |
+| **Scrollable `select()` / `filter()`** | bijou | Add `maxVisible` + scroll offset to `select()`. Fix `filter()` scroll (currently a static slice from index 0, not a real scrolling viewport). Shared `adjustScroll()` logic from `browsable-list`. |
+
+### Phase 9: `appFrame()` — TEA app shell
+
+**Problem:** Every TUI app beyond "hello world" re-implements tabbed pages, help overlay, scroll management, gutter chrome, and fullscreen layout. `appFrame()` eliminates this boilerplate.
+
+| Task | Package | Notes |
+|------|---------|-------|
+| **`appFrame()` higher-order app** | bijou-tui | `createFramedApp({ pages, globalKeys })` → `App<FrameModel, FrameMsg>`. Each page declares view + keymap + help. Frame owns tab switching, `?` help toggle, scroll, gutter/chrome. |
+| **Per-page scroll isolation** | bijou-tui | Each page/pane has independent scroll state preserved across tab switches. Focus determines which pane receives scroll input. |
+| **Multi-pane page support** | bijou-tui | Pages can declare `splitPane()` or `grid()` layouts. Frame delegates focus and input routing per pane via `InputStack`. |
 
 ---
 
@@ -396,11 +421,9 @@ round-trip
 
 ## Future features
 
-### `appFrame` — TEA app shell (bijou-tui)
+### ~~`appFrame` — TEA app shell (bijou-tui)~~ → Scheduled as Phase 9
 
-Higher-order TEA app that eliminates the boilerplate every TUI app re-implements: tabbed pages, help overlay, scroll, gutters, fullscreen layout.
-
-**Lives in:** `@flyingrobots/bijou-tui` (owns state, not a pure view)
+See Phase 9 above. Original design notes preserved here for reference:
 
 **Core idea:**
 - `createFramedApp({ pages, globalKeys })` → `App<FrameModel, FrameMsg>`
@@ -431,7 +454,7 @@ Growing toward a full terminal component library:
 | **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~, ~~`createPanelGroup()`~~, ~~`navigableTable()`~~, ~~`browsableList()`~~, ~~`filePicker()`~~, ~~`focusArea()`~~, ~~`dagPane()`~~ ✅ |
 | **Overlay** | ~~`composite()`~~, ~~`modal()`~~, ~~`toast()`~~, ~~`drawer()`~~ ✅ |
 | **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~, ~~`parseMouse()`~~ ✅ |
-| **App** | ~~`statusBar()`~~, ~~`tooltip()`~~ ✅, `splitPane()` |
+| **App** | ~~`statusBar()`~~, ~~`tooltip()`~~ ✅, `splitPane()`, `grid()`, `appFrame()` |
 
 Each new component should follow this template before implementation:
 1. Write user story and requirements
@@ -532,7 +555,6 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | **Dynamic forms** | bijou | Fields that change based on previous input values. |
 | **Custom fill chars** | bijou | Custom characters for padding/margin areas. |
 | **Note field** | bijou | Display-only text within a form flow. |
-| **Scrollable select** | bijou | Fixed-height select with overflow scrolling. |
 | **Parse F-keys** | bijou-tui | Recognize F1–F12 escape sequences in `parseKey()` and surface as `KeyMsg`. |
 | **CodeRabbit review exclusions** | repo config | Add `CLAUDE.md`, `TASKS.md`, `docs/ROADMAP.md` to `.coderabbit.yaml` path filters to reduce false positives on project instructions and planning artifacts. |
 | **`detectColorScheme` env accessor** | bijou | Refactor inline `runtime ? runtime.env(key) : process.env[key]` to use shared `env()` closure, matching `detectOutputMode` pattern in the same file (`core/detect/tty.ts`). |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -428,7 +428,7 @@ Growing toward a full terminal component library:
 | **Data** | ~~`accordion()`~~, ~~`tree()`~~, ~~`timeline()`~~, ~~`dag()`~~, ~~`dagSlice()`~~, ~~`dagLayout()`~~, ~~`dagStats()`~~ ✅ |
 | **Forms** | ~~`input()`~~, ~~`select()`~~, ~~`multiselect()`~~, ~~`confirm()`~~, ~~`group()`~~, ~~`textarea()`~~, ~~`filter()`~~, ~~`wizard()`~~ ✅ |
 | **Navigation** | ~~`tabs()`~~, ~~`breadcrumb()`~~, ~~`paginator()`~~, ~~`stepper()`~~, ~~`commandPalette()`~~ ✅ |
-| **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~, ~~`createPanelGroup()`~~, ~~`navigableTable()`~~, ~~`browsableList()`~~, ~~`filePicker()`~~ ✅ |
+| **TUI Building Blocks** | ~~`viewport()`~~, ~~`pager()`~~, ~~`interactiveAccordion()`~~, ~~`createPanelGroup()`~~, ~~`navigableTable()`~~, ~~`browsableList()`~~, ~~`filePicker()`~~, ~~`focusArea()`~~, ~~`dagPane()`~~ ✅ |
 | **Overlay** | ~~`composite()`~~, ~~`modal()`~~, ~~`toast()`~~, ~~`drawer()`~~ ✅ |
 | **Input** | ~~`parseKey()`~~, ~~`createKeyMap()`~~, ~~`createInputStack()`~~, ~~`parseMouse()`~~ ✅ |
 | **App** | ~~`statusBar()`~~, ~~`tooltip()`~~ ✅, `splitPane()` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-> 61 examples · Run any: `npx tsx examples/<name>/main.ts`
+> 63 examples · Run any: `npx tsx examples/<name>/main.ts`
 > Record all GIFs: `../scripts/record-gifs.sh`
 
 ## Static Components
@@ -77,4 +77,6 @@
 | [`tooltip`](./tooltip/) | `tooltip()`, `composite()` | Positioned overlay with directional placement |
 | [`canvas`](./canvas/) | `canvas()`, `ShaderFn` | Animated plasma shader effect |
 | [`mouse`](./mouse/) | `parseMouse()`, `MouseMsg` | Mouse event inspector |
+| [`focus-area`](./focus-area/) | `focusArea()`, `focusAreaKeyMap()` | Scrollable pane with colored focus gutter |
+| [`dag-pane`](./dag-pane/) | `dagPane()`, `dagPaneKeyMap()` | Interactive DAG viewer with node navigation |
 | [`splash`](./splash/) | `splash` | Animated splash screen |

--- a/examples/dag-pane/README.md
+++ b/examples/dag-pane/README.md
@@ -87,8 +87,8 @@ const app: App<Model, Msg> = {
     return [{
       pane: createDagPaneState({
         source: nodes,
-        width: cols,
-        height: rows - 3,
+        width: Math.max(1, cols),
+        height: Math.max(1, rows - 3),
         ctx,
       }),
       cols,
@@ -102,8 +102,8 @@ const app: App<Model, Msg> = {
         ...model,
         pane: createDagPaneState({
           source: nodes,
-          width: msg.columns,
-          height: msg.rows - 3,
+          width: Math.max(1, msg.columns),
+          height: Math.max(1, msg.rows - 3),
           selectedId: model.pane.selectedId,
           ctx,
         }),

--- a/examples/dag-pane/README.md
+++ b/examples/dag-pane/README.md
@@ -1,0 +1,151 @@
+# `dagPane()`
+
+Interactive DAG viewer with arrow-key node navigation and auto-highlight
+
+![demo](demo.gif)
+
+## Run
+
+```sh
+npx tsx examples/dag-pane/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext, getDefaultContext } from '@flyingrobots/bijou-node';
+import { separator } from '@flyingrobots/bijou';
+import type { DagNode } from '@flyingrobots/bijou';
+import {
+  run, quit, isKeyMsg, isResizeMsg, type App,
+  createDagPaneState, dagPane,
+  dagPaneSelectChild, dagPaneSelectParent,
+  dagPaneSelectLeft, dagPaneSelectRight,
+  dagPaneScrollBy, dagPaneScrollByX,
+  dagPaneScrollToTop, dagPaneScrollToBottom,
+  dagPanePageDown, dagPanePageUp,
+  dagPaneKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+const ctx = getDefaultContext();
+
+// Sample project dependency graph
+const nodes: DagNode[] = [
+  { id: 'core', label: 'Core Library', edges: ['api', 'cli', 'web'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'api', label: 'REST API', edges: ['auth', 'db'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'cli', label: 'CLI Tool', edges: ['auth'], badge: 'WIP', token: { hex: '#f9e2af' } },
+  { id: 'web', label: 'Web Frontend', edges: ['auth', 'ui'], badge: 'WIP', token: { hex: '#f9e2af' } },
+  { id: 'auth', label: 'Auth Module', edges: ['deploy'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'db', label: 'Database Layer', edges: ['deploy'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'ui', label: 'UI Components', edges: ['deploy'], badge: '3d', token: { hex: '#89b4fa' } },
+  { id: 'deploy', label: 'Deploy Pipeline', badge: 'BLOCKED', token: { hex: '#f38ba8' } },
+];
+
+type Msg =
+  | { type: 'select-parent' }
+  | { type: 'select-child' }
+  | { type: 'select-left' }
+  | { type: 'select-right' }
+  | { type: 'scroll'; dy: number }
+  | { type: 'scroll-left' }
+  | { type: 'scroll-right' }
+  | { type: 'page-up' }
+  | { type: 'page-down' }
+  | { type: 'top' }
+  | { type: 'bottom' }
+  | { type: 'confirm' }
+  | { type: 'quit' };
+
+const keys = dagPaneKeyMap<Msg>({
+  selectParent: { type: 'select-parent' },
+  selectChild: { type: 'select-child' },
+  selectLeft: { type: 'select-left' },
+  selectRight: { type: 'select-right' },
+  scrollUp: { type: 'scroll', dy: -1 },
+  scrollDown: { type: 'scroll', dy: 1 },
+  scrollLeft: { type: 'scroll-left' },
+  scrollRight: { type: 'scroll-right' },
+  pageUp: { type: 'page-up' },
+  pageDown: { type: 'page-down' },
+  top: { type: 'top' },
+  bottom: { type: 'bottom' },
+  confirm: { type: 'confirm' },
+  quit: { type: 'quit' },
+});
+
+interface Model {
+  pane: ReturnType<typeof createDagPaneState>;
+  cols: number;
+  rows: number;
+}
+
+const app: App<Model, Msg> = {
+  init: () => {
+    const cols = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    return [{
+      pane: createDagPaneState({
+        source: nodes,
+        width: cols,
+        height: rows - 3,
+        ctx,
+      }),
+      cols,
+      rows,
+    }, []];
+  },
+
+  update: (msg, model) => {
+    if (isResizeMsg(msg)) {
+      return [{
+        ...model,
+        pane: createDagPaneState({
+          source: nodes,
+          width: msg.columns,
+          height: msg.rows - 3,
+          selectedId: model.pane.selectedId,
+          ctx,
+        }),
+        cols: msg.columns,
+        rows: msg.rows,
+      }, []];
+    }
+
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
+      if (!action) return [model, []];
+
+      switch (action.type) {
+        case 'quit': return [model, [quit()]];
+        case 'confirm': return [model, [quit()]];
+        case 'select-parent': return [{ ...model, pane: dagPaneSelectParent(model.pane, ctx) }, []];
+        case 'select-child': return [{ ...model, pane: dagPaneSelectChild(model.pane, ctx) }, []];
+        case 'select-left': return [{ ...model, pane: dagPaneSelectLeft(model.pane, ctx) }, []];
+        case 'select-right': return [{ ...model, pane: dagPaneSelectRight(model.pane, ctx) }, []];
+        case 'scroll': return [{ ...model, pane: dagPaneScrollBy(model.pane, action.dy) }, []];
+        case 'scroll-left': return [{ ...model, pane: dagPaneScrollByX(model.pane, -3) }, []];
+        case 'scroll-right': return [{ ...model, pane: dagPaneScrollByX(model.pane, 3) }, []];
+        case 'page-up': return [{ ...model, pane: dagPanePageUp(model.pane) }, []];
+        case 'page-down': return [{ ...model, pane: dagPanePageDown(model.pane) }, []];
+        case 'top': return [{ ...model, pane: dagPaneScrollToTop(model.pane) }, []];
+        case 'bottom': return [{ ...model, pane: dagPaneScrollToBottom(model.pane) }, []];
+      }
+    }
+
+    return [model, []];
+  },
+
+  view: (model) => {
+    const selected = model.pane.selectedId ?? 'none';
+    const header = separator({ label: `dag pane — selected: ${selected}`, width: model.cols, ctx });
+    const body = dagPane(model.pane, { focused: true, ctx });
+    const help = `  ${helpShort(keys)}`;
+    return vstack(header, body, help);
+  },
+};
+
+run(app);
+```
+
+[← Examples](../README.md)

--- a/examples/dag-pane/main.ts
+++ b/examples/dag-pane/main.ts
@@ -1,0 +1,133 @@
+import { initDefaultContext, getDefaultContext } from '@flyingrobots/bijou-node';
+import { separator } from '@flyingrobots/bijou';
+import type { DagNode } from '@flyingrobots/bijou';
+import {
+  run, quit, isKeyMsg, isResizeMsg, type App,
+  createDagPaneState, dagPane,
+  dagPaneSelectChild, dagPaneSelectParent,
+  dagPaneSelectLeft, dagPaneSelectRight,
+  dagPaneScrollBy, dagPaneScrollByX,
+  dagPaneScrollToTop, dagPaneScrollToBottom,
+  dagPanePageDown, dagPanePageUp,
+  dagPaneKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+const ctx = getDefaultContext();
+
+// Sample project dependency graph
+const nodes: DagNode[] = [
+  { id: 'core', label: 'Core Library', edges: ['api', 'cli', 'web'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'api', label: 'REST API', edges: ['auth', 'db'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'cli', label: 'CLI Tool', edges: ['auth'], badge: 'WIP', token: { hex: '#f9e2af' } },
+  { id: 'web', label: 'Web Frontend', edges: ['auth', 'ui'], badge: 'WIP', token: { hex: '#f9e2af' } },
+  { id: 'auth', label: 'Auth Module', edges: ['deploy'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'db', label: 'Database Layer', edges: ['deploy'], badge: 'DONE', token: { hex: '#a6e3a1' } },
+  { id: 'ui', label: 'UI Components', edges: ['deploy'], badge: '3d', token: { hex: '#89b4fa' } },
+  { id: 'deploy', label: 'Deploy Pipeline', badge: 'BLOCKED', token: { hex: '#f38ba8' } },
+];
+
+type Msg =
+  | { type: 'select-parent' }
+  | { type: 'select-child' }
+  | { type: 'select-left' }
+  | { type: 'select-right' }
+  | { type: 'scroll'; dy: number }
+  | { type: 'scroll-left' }
+  | { type: 'scroll-right' }
+  | { type: 'page-up' }
+  | { type: 'page-down' }
+  | { type: 'top' }
+  | { type: 'bottom' }
+  | { type: 'confirm' }
+  | { type: 'quit' };
+
+const keys = dagPaneKeyMap<Msg>({
+  selectParent: { type: 'select-parent' },
+  selectChild: { type: 'select-child' },
+  selectLeft: { type: 'select-left' },
+  selectRight: { type: 'select-right' },
+  scrollUp: { type: 'scroll', dy: -1 },
+  scrollDown: { type: 'scroll', dy: 1 },
+  scrollLeft: { type: 'scroll-left' },
+  scrollRight: { type: 'scroll-right' },
+  pageUp: { type: 'page-up' },
+  pageDown: { type: 'page-down' },
+  top: { type: 'top' },
+  bottom: { type: 'bottom' },
+  confirm: { type: 'confirm' },
+  quit: { type: 'quit' },
+});
+
+interface Model {
+  pane: ReturnType<typeof createDagPaneState>;
+  cols: number;
+  rows: number;
+}
+
+const app: App<Model, Msg> = {
+  init: () => {
+    const cols = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    return [{
+      pane: createDagPaneState({
+        source: nodes,
+        width: cols,
+        height: rows - 3,
+        ctx,
+      }),
+      cols,
+      rows,
+    }, []];
+  },
+
+  update: (msg, model) => {
+    if (isResizeMsg(msg)) {
+      return [{
+        ...model,
+        pane: createDagPaneState({
+          source: nodes,
+          width: msg.columns,
+          height: msg.rows - 3,
+          selectedId: model.pane.selectedId,
+          ctx,
+        }),
+        cols: msg.columns,
+        rows: msg.rows,
+      }, []];
+    }
+
+    if (isKeyMsg(msg)) {
+      const action = keys.handle(msg);
+      if (!action) return [model, []];
+
+      switch (action.type) {
+        case 'quit': return [model, [quit()]];
+        case 'confirm': return [model, [quit()]];
+        case 'select-parent': return [{ ...model, pane: dagPaneSelectParent(model.pane, ctx) }, []];
+        case 'select-child': return [{ ...model, pane: dagPaneSelectChild(model.pane, ctx) }, []];
+        case 'select-left': return [{ ...model, pane: dagPaneSelectLeft(model.pane, ctx) }, []];
+        case 'select-right': return [{ ...model, pane: dagPaneSelectRight(model.pane, ctx) }, []];
+        case 'scroll': return [{ ...model, pane: dagPaneScrollBy(model.pane, action.dy) }, []];
+        case 'scroll-left': return [{ ...model, pane: dagPaneScrollByX(model.pane, -3) }, []];
+        case 'scroll-right': return [{ ...model, pane: dagPaneScrollByX(model.pane, 3) }, []];
+        case 'page-up': return [{ ...model, pane: dagPanePageUp(model.pane) }, []];
+        case 'page-down': return [{ ...model, pane: dagPanePageDown(model.pane) }, []];
+        case 'top': return [{ ...model, pane: dagPaneScrollToTop(model.pane) }, []];
+        case 'bottom': return [{ ...model, pane: dagPaneScrollToBottom(model.pane) }, []];
+      }
+    }
+
+    return [model, []];
+  },
+
+  view: (model) => {
+    const selected = model.pane.selectedId ?? 'none';
+    const header = separator({ label: `dag pane — selected: ${selected}`, width: model.cols, ctx });
+    const body = dagPane(model.pane, { focused: true, ctx });
+    const help = `  ${helpShort(keys)}`;
+    return vstack(header, body, help);
+  },
+};
+
+run(app);

--- a/examples/dag-pane/main.ts
+++ b/examples/dag-pane/main.ts
@@ -72,8 +72,8 @@ const app: App<Model, Msg> = {
     return [{
       pane: createDagPaneState({
         source: nodes,
-        width: cols,
-        height: rows - 3,
+        width: Math.max(1, cols),
+        height: Math.max(1, rows - 3),
         ctx,
       }),
       cols,
@@ -87,8 +87,8 @@ const app: App<Model, Msg> = {
         ...model,
         pane: createDagPaneState({
           source: nodes,
-          width: msg.columns,
-          height: msg.rows - 3,
+          width: Math.max(1, msg.columns),
+          height: Math.max(1, msg.rows - 3),
           selectedId: model.pane.selectedId,
           ctx,
         }),

--- a/examples/focus-area/README.md
+++ b/examples/focus-area/README.md
@@ -1,0 +1,130 @@
+# `focusArea()`
+
+Scrollable pane with colored focus gutter and horizontal overflow
+
+![demo](demo.gif)
+
+## Run
+
+```sh
+npx tsx examples/focus-area/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext, getDefaultContext } from '@flyingrobots/bijou-node';
+import { separator } from '@flyingrobots/bijou';
+import {
+  run, quit, isKeyMsg, isResizeMsg, type App,
+  createFocusAreaState, focusArea,
+  focusAreaScrollBy, focusAreaPageDown, focusAreaPageUp,
+  focusAreaScrollToTop, focusAreaScrollToBottom,
+  focusAreaScrollByX,
+  focusAreaKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+const ctx = getDefaultContext();
+
+// Generate some content to scroll through
+const CONTENT = Array.from({ length: 60 }, (_, i) => {
+  if (i === 0) return 'Welcome to the focus area demo!';
+  if (i % 10 === 0) return `── Section ${i / 10} ${'─'.repeat(60)}`;
+  return `Line ${String(i).padStart(2, ' ')}: ${('Lorem ipsum dolor sit amet, consectetur adipiscing elit. ').repeat(Math.ceil(Math.random() * 2))}`;
+}).join('\n');
+
+type Msg =
+  | { type: 'scroll'; dy: number }
+  | { type: 'scroll-left' }
+  | { type: 'scroll-right' }
+  | { type: 'page-up' }
+  | { type: 'page-down' }
+  | { type: 'top' }
+  | { type: 'bottom' }
+  | { type: 'quit' };
+
+const keys = focusAreaKeyMap<Msg>({
+  scrollUp: { type: 'scroll', dy: -1 },
+  scrollDown: { type: 'scroll', dy: 1 },
+  pageUp: { type: 'page-up' },
+  pageDown: { type: 'page-down' },
+  top: { type: 'top' },
+  bottom: { type: 'bottom' },
+  scrollLeft: { type: 'scroll-left' },
+  scrollRight: { type: 'scroll-right' },
+});
+
+interface Model {
+  fa: ReturnType<typeof createFocusAreaState>;
+  focused: boolean;
+  cols: number;
+  rows: number;
+}
+
+const app: App<Model, Msg> = {
+  init: () => {
+    const cols = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    return [{
+      fa: createFocusAreaState({
+        content: CONTENT,
+        width: cols,
+        height: rows - 3,
+        overflowX: 'scroll',
+      }),
+      focused: true,
+      cols,
+      rows,
+    }, []];
+  },
+
+  update: (msg, model) => {
+    if (isResizeMsg(msg)) {
+      return [{
+        ...model,
+        fa: createFocusAreaState({
+          content: CONTENT,
+          width: msg.columns,
+          height: msg.rows - 3,
+          overflowX: 'scroll',
+        }),
+        cols: msg.columns,
+        rows: msg.rows,
+      }, []];
+    }
+
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.key === 'c' && msg.ctrl)) return [model, [quit()]];
+      if (msg.key === 'tab') return [{ ...model, focused: !model.focused }, []];
+
+      const action = keys.handle(msg);
+      if (!action) return [model, []];
+
+      switch (action.type) {
+        case 'scroll': return [{ ...model, fa: focusAreaScrollBy(model.fa, action.dy) }, []];
+        case 'page-up': return [{ ...model, fa: focusAreaPageUp(model.fa) }, []];
+        case 'page-down': return [{ ...model, fa: focusAreaPageDown(model.fa) }, []];
+        case 'top': return [{ ...model, fa: focusAreaScrollToTop(model.fa) }, []];
+        case 'bottom': return [{ ...model, fa: focusAreaScrollToBottom(model.fa) }, []];
+        case 'scroll-left': return [{ ...model, fa: focusAreaScrollByX(model.fa, -3) }, []];
+        case 'scroll-right': return [{ ...model, fa: focusAreaScrollByX(model.fa, 3) }, []];
+      }
+    }
+
+    return [model, []];
+  },
+
+  view: (model) => {
+    const header = separator({ label: 'focus area', width: model.cols, ctx });
+    const focusLabel = model.focused ? 'focused' : 'unfocused';
+    const body = focusArea(model.fa, { focused: model.focused, ctx });
+    const help = `  ${helpShort(keys)}  Tab: toggle focus (${focusLabel})  q: quit`;
+    return vstack(header, body, help);
+  },
+};
+
+run(app);
+```
+
+[← Examples](../README.md)

--- a/examples/focus-area/README.md
+++ b/examples/focus-area/README.md
@@ -69,8 +69,8 @@ const app: App<Model, Msg> = {
     return [{
       fa: createFocusAreaState({
         content: CONTENT,
-        width: cols,
-        height: rows - 3,
+        width: Math.max(1, cols),
+        height: Math.max(1, rows - 3),
         overflowX: 'scroll',
       }),
       focused: true,
@@ -85,8 +85,8 @@ const app: App<Model, Msg> = {
         ...model,
         fa: createFocusAreaState({
           content: CONTENT,
-          width: msg.columns,
-          height: msg.rows - 3,
+          width: Math.max(1, msg.columns),
+          height: Math.max(1, msg.rows - 3),
           overflowX: 'scroll',
         }),
         cols: msg.columns,

--- a/examples/focus-area/main.ts
+++ b/examples/focus-area/main.ts
@@ -1,0 +1,114 @@
+import { initDefaultContext, getDefaultContext } from '@flyingrobots/bijou-node';
+import { separator } from '@flyingrobots/bijou';
+import {
+  run, quit, isKeyMsg, isResizeMsg, type App,
+  createFocusAreaState, focusArea,
+  focusAreaScrollBy, focusAreaPageDown, focusAreaPageUp,
+  focusAreaScrollToTop, focusAreaScrollToBottom,
+  focusAreaScrollByX,
+  focusAreaKeyMap, helpShort, vstack,
+} from '@flyingrobots/bijou-tui';
+
+initDefaultContext();
+const ctx = getDefaultContext();
+
+// Generate some content to scroll through
+const CONTENT = Array.from({ length: 60 }, (_, i) => {
+  if (i === 0) return 'Welcome to the focus area demo!';
+  if (i % 10 === 0) return `── Section ${i / 10} ${'─'.repeat(60)}`;
+  return `Line ${String(i).padStart(2, ' ')}: ${('Lorem ipsum dolor sit amet, consectetur adipiscing elit. ').repeat(Math.ceil(Math.random() * 2))}`;
+}).join('\n');
+
+type Msg =
+  | { type: 'scroll'; dy: number }
+  | { type: 'scroll-left' }
+  | { type: 'scroll-right' }
+  | { type: 'page-up' }
+  | { type: 'page-down' }
+  | { type: 'top' }
+  | { type: 'bottom' }
+  | { type: 'toggle-focus' }
+  | { type: 'quit' };
+
+const keys = focusAreaKeyMap<Msg>({
+  scrollUp: { type: 'scroll', dy: -1 },
+  scrollDown: { type: 'scroll', dy: 1 },
+  pageUp: { type: 'page-up' },
+  pageDown: { type: 'page-down' },
+  top: { type: 'top' },
+  bottom: { type: 'bottom' },
+  scrollLeft: { type: 'scroll-left' },
+  scrollRight: { type: 'scroll-right' },
+});
+
+interface Model {
+  fa: ReturnType<typeof createFocusAreaState>;
+  focused: boolean;
+  cols: number;
+  rows: number;
+}
+
+const app: App<Model, Msg> = {
+  init: () => {
+    const cols = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    return [{
+      fa: createFocusAreaState({
+        content: CONTENT,
+        width: cols,
+        height: rows - 3,
+        overflowX: 'scroll',
+      }),
+      focused: true,
+      cols,
+      rows,
+    }, []];
+  },
+
+  update: (msg, model) => {
+    if (isResizeMsg(msg)) {
+      return [{
+        ...model,
+        fa: createFocusAreaState({
+          content: CONTENT,
+          width: msg.columns,
+          height: msg.rows - 3,
+          overflowX: 'scroll',
+        }),
+        cols: msg.columns,
+        rows: msg.rows,
+      }, []];
+    }
+
+    if (isKeyMsg(msg)) {
+      if (msg.key === 'q' || (msg.key === 'c' && msg.ctrl)) return [model, [quit()]];
+      if (msg.key === 'tab') return [{ ...model, focused: !model.focused }, []];
+
+      const action = keys.handle(msg);
+      if (!action) return [model, []];
+
+      switch (action.type) {
+        case 'quit': return [model, [quit()]];
+        case 'scroll': return [{ ...model, fa: focusAreaScrollBy(model.fa, action.dy) }, []];
+        case 'page-up': return [{ ...model, fa: focusAreaPageUp(model.fa) }, []];
+        case 'page-down': return [{ ...model, fa: focusAreaPageDown(model.fa) }, []];
+        case 'top': return [{ ...model, fa: focusAreaScrollToTop(model.fa) }, []];
+        case 'bottom': return [{ ...model, fa: focusAreaScrollToBottom(model.fa) }, []];
+        case 'scroll-left': return [{ ...model, fa: focusAreaScrollByX(model.fa, -3) }, []];
+        case 'scroll-right': return [{ ...model, fa: focusAreaScrollByX(model.fa, 3) }, []];
+      }
+    }
+
+    return [model, []];
+  },
+
+  view: (model) => {
+    const header = separator({ label: 'focus area', width: model.cols, ctx });
+    const focusLabel = model.focused ? 'focused' : 'unfocused';
+    const body = focusArea(model.fa, { focused: model.focused, ctx });
+    const help = `  ${helpShort(keys)}  Tab: toggle focus (${focusLabel})  q: quit`;
+    return vstack(header, body, help);
+  },
+};
+
+run(app);

--- a/examples/focus-area/main.ts
+++ b/examples/focus-area/main.ts
@@ -27,7 +27,6 @@ type Msg =
   | { type: 'page-down' }
   | { type: 'top' }
   | { type: 'bottom' }
-  | { type: 'toggle-focus' }
   | { type: 'quit' };
 
 const keys = focusAreaKeyMap<Msg>({
@@ -88,7 +87,6 @@ const app: App<Model, Msg> = {
       if (!action) return [model, []];
 
       switch (action.type) {
-        case 'quit': return [model, [quit()]];
         case 'scroll': return [{ ...model, fa: focusAreaScrollBy(model.fa, action.dy) }, []];
         case 'page-up': return [{ ...model, fa: focusAreaPageUp(model.fa) }, []];
         case 'page-down': return [{ ...model, fa: focusAreaPageDown(model.fa) }, []];

--- a/examples/focus-area/main.ts
+++ b/examples/focus-area/main.ts
@@ -54,8 +54,8 @@ const app: App<Model, Msg> = {
     return [{
       fa: createFocusAreaState({
         content: CONTENT,
-        width: cols,
-        height: rows - 3,
+        width: Math.max(1, cols),
+        height: Math.max(1, rows - 3),
         overflowX: 'scroll',
       }),
       focused: true,
@@ -70,8 +70,8 @@ const app: App<Model, Msg> = {
         ...model,
         fa: createFocusAreaState({
           content: CONTENT,
-          width: msg.columns,
-          height: msg.rows - 3,
+          width: Math.max(1, msg.columns),
+          height: Math.max(1, msg.rows - 3),
           overflowX: 'scroll',
         }),
         cols: msg.columns,

--- a/packages/bijou-tui/ARCHITECTURE.md
+++ b/packages/bijou-tui/ARCHITECTURE.md
@@ -77,6 +77,8 @@ src/
 ├── help.ts          # helpView, helpShort, helpFor — auto-generated help
 ├── inputstack.ts    # InputStack — layered input dispatch
 ├── overlay.ts       # composite(), modal(), toast() — overlay compositing
+├── focus-area.ts    # focusArea() — scrollable pane with colored gutter
+├── dag-pane.ts      # dagPane() — interactive DAG viewer with node navigation
 └── index.ts         # Public API barrel
 ```
 
@@ -240,6 +242,67 @@ Builds a bordered box with optional title (bold), body, and hint (muted) section
 Builds a bordered single-line box with a variant icon (`✔` success, `✘` error, `ℹ` info), then computes position from anchor corner (`top-right`, `bottom-right`, `bottom-left`, `top-left`) and margin. Returns an `Overlay` object.
 
 **Key design decision:** No dependency on `box()` from bijou core. The `box()` component degrades in pipe/accessible modes (returns raw content, no borders), but overlays are inherently interactive-mode constructs that always need borders. Border rendering uses the same unicode box-drawing characters directly.
+
+## Focus Area (`focus-area.ts`)
+
+A scrollable pane building block that wraps `viewport()` and prepends a styled gutter character (`▎` U+258E) indicating focus state.
+
+### Composition
+
+```
+focusArea(state, options)
+    │
+    ├── resolveGutter(focused, ctx)  →  styled '▎' character
+    │     └── ctx.style.styled(token, '▎')
+    │
+    └── viewport({ width: state.width - 1, ... })
+          └── standard viewport rendering with scrollbar
+```
+
+### Width Accounting
+
+- Gutter consumes 1 column (always present in interactive/static modes)
+- Viewport gets `width - 1` columns
+- Viewport internally handles scrollbar (another 1 column when `showScrollbar=true`)
+- Pipe/accessible modes: no gutter, full width to content
+
+### Horizontal Overflow
+
+`overflowX: 'scroll'` enables horizontal scrolling — `createScrollState()` receives a `viewportWidth` to compute `maxX`. When `'hidden'`, horizontal scroll functions are no-ops.
+
+## DAG Pane (`dag-pane.ts`)
+
+Interactive DAG viewer composing `dagLayout()` from bijou core with `focusArea()` for viewport management.
+
+### Composition
+
+```
+dagPane(state, options)
+    │
+    └── focusArea(state.focusArea, options)
+          └── viewport with gutter
+
+createDagPaneState / updateSelection
+    │
+    ├── buildAdjacency(source)         →  parent/child maps
+    ├── computeHighlightPath(id, adj)  →  BFS root→selected path
+    ├── renderLayout(source, id, path) →  dagLayout() with highlight/selected
+    ├── focusAreaSetContent(fa, output) →  update viewport content
+    └── scrollToNode(fa, nodePos)      →  ensure selected node visible
+```
+
+### Spatial Navigation
+
+Arrow-key navigation uses `DagNodePosition { row, col, width, height }` from `dagLayout()`:
+
+- **selectChild**: Children from adjacency map → pick by closest column center
+- **selectParent**: Parents from adjacency map → pick by closest column center
+- **selectLeft/Right**: Nodes on same row sorted by column → move to adjacent
+- **No selection**: Auto-select first root node
+
+### Re-rendering on Selection
+
+Each selection change triggers a full `dagLayout()` call because `selectedId` and `highlightPath` affect the rendered output. The layout result replaces the focus area content via `focusAreaSetContent()`.
 
 ## Graceful Degradation
 

--- a/packages/bijou-tui/GUIDE.md
+++ b/packages/bijou-tui/GUIDE.md
@@ -560,6 +560,119 @@ if (model.modal) overlays.push(modal({ ...model.modal, screenWidth, screenHeight
 return composite(background, overlays, { dim: model.modal != null });
 ```
 
+## Focus Area
+
+A scrollable pane with a colored left gutter indicating focus state. Wraps `viewport()` with gutter chrome and horizontal overflow support.
+
+```typescript
+import {
+  createFocusAreaState, focusArea,
+  focusAreaScrollBy, focusAreaPageDown, focusAreaScrollByX,
+  focusAreaKeyMap,
+} from '@flyingrobots/bijou-tui';
+
+// Create state with horizontal scrolling enabled
+const fa = createFocusAreaState({
+  content: longContent,
+  width: 60,
+  height: 20,
+  overflowX: 'scroll', // or 'hidden' (default)
+});
+
+// In TEA view — gutter is accent-colored when focused, muted when not
+focusArea(fa, { focused: true, ctx });
+
+// In TEA update — scroll transformers
+focusAreaScrollBy(fa, 1);      // down one line
+focusAreaPageDown(fa);          // one page
+focusAreaScrollByX(fa, 5);     // scroll right (only when overflowX='scroll')
+
+// Update content while preserving scroll position
+focusAreaSetContent(fa, newContent);
+```
+
+The gutter character (`▎`) degrades gracefully:
+- **Interactive/static mode**: colored or unstyled gutter
+- **Pipe/accessible mode**: no gutter (full width to content)
+
+### Keymap
+
+Arrow keys are intentionally excluded — reserved for content-specific navigation (e.g., DAG node selection). Scroll uses vim keys:
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Scroll down / up |
+| `d` / `u` | Page down / up |
+| `g` / `G` | Top / bottom |
+| `h` / `l` | Scroll left / right |
+
+## DAG Pane
+
+An interactive DAG viewer that wraps `dagLayout()` in a `focusArea()` with arrow-key node navigation, auto-highlight-path, and auto-scroll-to-selection.
+
+```typescript
+import type { DagNode } from '@flyingrobots/bijou';
+import {
+  createDagPaneState, dagPane,
+  dagPaneSelectChild, dagPaneSelectParent,
+  dagPaneSelectLeft, dagPaneSelectRight,
+  dagPaneKeyMap,
+} from '@flyingrobots/bijou-tui';
+
+const nodes: DagNode[] = [
+  { id: 'A', label: 'Root', edges: ['B', 'C'] },
+  { id: 'B', label: 'Left', edges: ['D'] },
+  { id: 'C', label: 'Right', edges: ['D'] },
+  { id: 'D', label: 'Merge' },
+];
+
+// Create state — overflowX defaults to 'scroll' for DAGs
+const pane = createDagPaneState({
+  source: nodes,
+  width: 80,
+  height: 24,
+  ctx,
+});
+
+// In TEA view
+dagPane(pane, { focused: true, ctx });
+
+// In TEA update — arrow keys navigate nodes spatially
+dagPaneSelectChild(pane, ctx);   // down arrow — picks closest child by column
+dagPaneSelectParent(pane, ctx);  // up arrow — picks closest parent by column
+dagPaneSelectLeft(pane, ctx);    // left arrow — sibling in same row
+dagPaneSelectRight(pane, ctx);   // right arrow — sibling in same row
+```
+
+### Navigation Logic
+
+Arrow-key navigation uses the `DagNodePosition` map from `dagLayout()` for spatial selection:
+
+- **Down (child)**: Get children from adjacency map. Pick the child whose column center is closest to the current node's column center.
+- **Up (parent)**: Same logic using the parent adjacency map.
+- **Left/Right (sibling)**: Find all nodes on the same row. Sort by column. Move to the adjacent node. No wrap-around.
+- **No selection + any arrow key**: Auto-select the first root node.
+
+### Auto-Highlight Path
+
+When a node is selected, the pane automatically computes a BFS path from the nearest root to the selected node and passes it as `highlightPath` to `dagLayout()`. This highlights the edges and nodes along the dependency chain.
+
+### Auto-Scroll to Selection
+
+When the selection changes, the viewport automatically scrolls (both vertically and horizontally) to bring the selected node's box into view.
+
+### Keymap
+
+| Key | Action |
+|-----|--------|
+| Arrow keys | Node selection (parent/child/left/right) |
+| `j` / `k` | Scroll down / up |
+| `h` / `l` | Scroll left / right |
+| `d` / `u` | Page down / up |
+| `g` / `G` | Top / bottom |
+| `Enter` | Confirm selection |
+| `q` / `Ctrl+C` | Quit |
+
 ## Pure Functions Everywhere
 
 The spring engine, tween engine, timeline, viewport, scroll state, keybinding matching, and help generation are all pure functions operating on immutable state. This means:

--- a/packages/bijou-tui/GUIDE.md
+++ b/packages/bijou-tui/GUIDE.md
@@ -566,7 +566,7 @@ A scrollable pane with a colored left gutter indicating focus state. Wraps `view
 
 ```typescript
 import {
-  createFocusAreaState, focusArea,
+  createFocusAreaState, focusArea, focusAreaSetContent,
   focusAreaScrollBy, focusAreaPageDown, focusAreaScrollByX,
   focusAreaKeyMap,
 } from '@flyingrobots/bijou-tui';

--- a/packages/bijou-tui/README.md
+++ b/packages/bijou-tui/README.md
@@ -326,6 +326,31 @@ const state = createFilePickerState({ cwd: process.cwd(), io, height: 15 });
 const output = filePicker(state);
 ```
 
+### Focus Area
+
+```typescript
+import {
+  createFocusAreaState, focusArea, focusAreaScrollBy,
+  focusAreaKeyMap,
+} from '@flyingrobots/bijou-tui';
+
+const state = createFocusAreaState({ content, width: 60, height: 20, overflowX: 'scroll' });
+const output = focusArea(state, { focused: true, ctx });
+```
+
+### DAG Pane
+
+```typescript
+import {
+  createDagPaneState, dagPane, dagPaneSelectChild,
+  dagPaneSelectParent, dagPaneKeyMap,
+} from '@flyingrobots/bijou-tui';
+
+const state = createDagPaneState({ source: nodes, width: 80, height: 24, ctx });
+const output = dagPane(state, { focused: true, ctx });
+const next = dagPaneSelectChild(state, ctx); // arrow-key navigation
+```
+
 All building blocks include `*KeyMap()` factories for preconfigured vim-style keybindings.
 
 ## Related Packages

--- a/packages/bijou-tui/src/dag-pane.test.ts
+++ b/packages/bijou-tui/src/dag-pane.test.ts
@@ -349,12 +349,11 @@ describe('auto-scroll to selection', () => {
     const next = dagPaneSelectNode(state, 'C', ctx);
     // The node C is in the last layer, which starts well below row 0
     const nodePos = next.layout.nodes.get('C');
-    if (nodePos) {
-      // Scroll should have adjusted so the node is within the viewport
-      const scrollY = next.focusArea.scroll.y;
-      expect(scrollY).toBeLessThanOrEqual(nodePos.row);
-      expect(scrollY + next.focusArea.height).toBeGreaterThanOrEqual(nodePos.row);
-    }
+    expect(nodePos).toBeDefined();
+    // Scroll should have adjusted so the node is within the viewport
+    const scrollY = next.focusArea.scroll.y;
+    expect(scrollY).toBeLessThanOrEqual(nodePos!.row);
+    expect(scrollY + next.focusArea.height).toBeGreaterThanOrEqual(nodePos!.row);
   });
 });
 
@@ -408,7 +407,7 @@ describe('dagPaneKeyMap', () => {
   });
 
   it('handles enter for confirm', () => {
-    expect(km.handle(keyMsg('return'))).toEqual({ type: 'ok' });
+    expect(km.handle(keyMsg('enter'))).toEqual({ type: 'ok' });
   });
 
   it('handles quit', () => {

--- a/packages/bijou-tui/src/dag-pane.test.ts
+++ b/packages/bijou-tui/src/dag-pane.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import type { DagNode } from '@flyingrobots/bijou';
+import type { KeyMsg } from './types.js';
+import {
+  createDagPaneState,
+  dagPane,
+  dagPaneSelectChild,
+  dagPaneSelectParent,
+  dagPaneSelectLeft,
+  dagPaneSelectRight,
+  dagPaneSelectNode,
+  dagPaneClearSelection,
+  dagPaneScrollBy,
+  dagPaneScrollToTop,
+  dagPaneScrollToBottom,
+  dagPanePageDown,
+  dagPanePageUp,
+  dagPaneScrollByX,
+  dagPaneSetSource,
+  dagPaneKeyMap,
+} from './dag-pane.js';
+
+// ── Test Data ──────────────────────────────────────────────────────
+
+/** Simple linear chain: A → B → C */
+const LINEAR_NODES: DagNode[] = [
+  { id: 'A', label: 'Alpha', edges: ['B'] },
+  { id: 'B', label: 'Beta', edges: ['C'] },
+  { id: 'C', label: 'Gamma' },
+];
+
+/** Diamond graph: A → B, A → C, B → D, C → D */
+const DIAMOND_NODES: DagNode[] = [
+  { id: 'A', label: 'Root', edges: ['B', 'C'] },
+  { id: 'B', label: 'Left', edges: ['D'] },
+  { id: 'C', label: 'Right', edges: ['D'] },
+  { id: 'D', label: 'Merge' },
+];
+
+/** Wide graph with multiple roots and siblings in same layer */
+const WIDE_NODES: DagNode[] = [
+  { id: 'R1', label: 'Root 1', edges: ['C1', 'C2'] },
+  { id: 'R2', label: 'Root 2', edges: ['C3'] },
+  { id: 'C1', label: 'Child 1' },
+  { id: 'C2', label: 'Child 2' },
+  { id: 'C3', label: 'Child 3' },
+];
+
+const ctx = createTestContext();
+
+function keyMsg(key: string, mods?: Partial<KeyMsg>): KeyMsg {
+  return { type: 'key', key, ctrl: false, alt: false, shift: false, ...mods };
+}
+
+// ── createDagPaneState ────────────────────────────────────────────
+
+describe('createDagPaneState', () => {
+  it('creates state with no selection', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    expect(state.selectedId).toBeUndefined();
+    expect(state.highlightPath).toEqual([]);
+  });
+
+  it('caches layout', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    expect(state.layout.output).toBeTruthy();
+    expect(state.layout.nodes.size).toBe(3);
+  });
+
+  it('creates focusArea state', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    expect(state.focusArea.width).toBe(60);
+    expect(state.focusArea.height).toBe(20);
+  });
+
+  it('allows initial selectedId', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'B', ctx });
+    expect(state.selectedId).toBe('B');
+    expect(state.highlightPath.length).toBeGreaterThan(0);
+  });
+
+  it('defaults overflowX to scroll (DAGs are wide)', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    expect(state.focusArea.overflowX).toBe('scroll');
+  });
+
+  it('stores source reference', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    expect(state.source).toBe(LINEAR_NODES);
+  });
+});
+
+// ── Arrow key navigation ──────────────────────────────────────────
+
+describe('dagPaneSelectChild (arrow down)', () => {
+  it('auto-selects first root when nothing is selected', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const next = dagPaneSelectChild(state, ctx);
+    expect(next.selectedId).toBeDefined();
+    // Should select a root node (A in the linear chain)
+    expect(next.selectedId).toBe('A');
+  });
+
+  it('moves to child node', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'A', ctx });
+    const next = dagPaneSelectChild(state, ctx);
+    expect(next.selectedId).toBe('B');
+  });
+
+  it('stays on leaf node (no children)', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'C', ctx });
+    const next = dagPaneSelectChild(state, ctx);
+    expect(next.selectedId).toBe('C');
+  });
+
+  it('updates highlight path', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'A', ctx });
+    const next = dagPaneSelectChild(state, ctx);
+    expect(next.highlightPath).toContain('A');
+    expect(next.highlightPath).toContain('B');
+  });
+});
+
+describe('dagPaneSelectParent (arrow up)', () => {
+  it('auto-selects first root when nothing is selected', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const next = dagPaneSelectParent(state, ctx);
+    expect(next.selectedId).toBe('A');
+  });
+
+  it('moves to parent node', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'B', ctx });
+    const next = dagPaneSelectParent(state, ctx);
+    expect(next.selectedId).toBe('A');
+  });
+
+  it('stays on root node (no parents)', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'A', ctx });
+    const next = dagPaneSelectParent(state, ctx);
+    expect(next.selectedId).toBe('A');
+  });
+});
+
+describe('dagPaneSelectLeft / dagPaneSelectRight (siblings)', () => {
+  it('moves left among siblings in same layer', () => {
+    const state = createDagPaneState({ source: DIAMOND_NODES, width: 80, height: 20, selectedId: 'C', ctx });
+    const next = dagPaneSelectLeft(state, ctx);
+    // B and C are in the same layer — moving left should go to B
+    // (B has smaller col position)
+    expect(next.selectedId).toBe('B');
+  });
+
+  it('moves right among siblings in same layer', () => {
+    const state = createDagPaneState({ source: DIAMOND_NODES, width: 80, height: 20, selectedId: 'B', ctx });
+    const next = dagPaneSelectRight(state, ctx);
+    expect(next.selectedId).toBe('C');
+  });
+
+  it('stays at left edge (no more siblings)', () => {
+    const state = createDagPaneState({ source: DIAMOND_NODES, width: 80, height: 20, selectedId: 'B', ctx });
+    const next = dagPaneSelectLeft(state, ctx);
+    // B is already leftmost in its layer
+    expect(next.selectedId).toBe('B');
+  });
+
+  it('stays at right edge (no more siblings)', () => {
+    const state = createDagPaneState({ source: DIAMOND_NODES, width: 80, height: 20, selectedId: 'C', ctx });
+    const next = dagPaneSelectRight(state, ctx);
+    expect(next.selectedId).toBe('C');
+  });
+
+  it('auto-selects first root when nothing is selected', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const next = dagPaneSelectLeft(state, ctx);
+    expect(next.selectedId).toBe('A');
+  });
+});
+
+// ── Direct selection ──────────────────────────────────────────────
+
+describe('dagPaneSelectNode', () => {
+  it('selects a specific node by ID', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const next = dagPaneSelectNode(state, 'C', ctx);
+    expect(next.selectedId).toBe('C');
+  });
+
+  it('computes highlight path to root', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const next = dagPaneSelectNode(state, 'C', ctx);
+    expect(next.highlightPath).toContain('A');
+    expect(next.highlightPath).toContain('B');
+    expect(next.highlightPath).toContain('C');
+  });
+
+  it('ignores unknown node IDs', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const next = dagPaneSelectNode(state, 'UNKNOWN', ctx);
+    expect(next.selectedId).toBeUndefined();
+  });
+});
+
+describe('dagPaneClearSelection', () => {
+  it('clears the selection', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'B', ctx });
+    const next = dagPaneClearSelection(state, ctx);
+    expect(next.selectedId).toBeUndefined();
+    expect(next.highlightPath).toEqual([]);
+  });
+});
+
+// ── Auto-highlight path ───────────────────────────────────────────
+
+describe('auto-highlight path', () => {
+  it('path includes root to selected node in linear chain', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'C', ctx });
+    expect(state.highlightPath).toEqual(['A', 'B', 'C']);
+  });
+
+  it('path is single node for root selection', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'A', ctx });
+    expect(state.highlightPath).toEqual(['A']);
+  });
+
+  it('path follows one branch in diamond graph', () => {
+    const state = createDagPaneState({ source: DIAMOND_NODES, width: 80, height: 20, selectedId: 'D', ctx });
+    // Should find a path from A through either B or C to D
+    expect(state.highlightPath[0]).toBe('A');
+    expect(state.highlightPath[state.highlightPath.length - 1]).toBe('D');
+    expect(state.highlightPath.length).toBe(3); // A → B|C → D
+  });
+
+  it('empty path when no selection', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    expect(state.highlightPath).toEqual([]);
+  });
+});
+
+// ── Scroll transformers ───────────────────────────────────────────
+
+describe('dagPaneScrollBy', () => {
+  it('scrolls viewport vertically', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 5, ctx });
+    const next = dagPaneScrollBy(state, 2);
+    expect(next.focusArea.scroll.y).toBe(2);
+  });
+});
+
+describe('dagPaneScrollToTop / dagPaneScrollToBottom', () => {
+  it('scrolls to top', () => {
+    let state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 5, ctx });
+    state = dagPaneScrollBy(state, 5);
+    const next = dagPaneScrollToTop(state);
+    expect(next.focusArea.scroll.y).toBe(0);
+  });
+
+  it('scrolls to bottom', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 5, ctx });
+    const next = dagPaneScrollToBottom(state);
+    expect(next.focusArea.scroll.y).toBe(state.focusArea.scroll.maxY);
+  });
+});
+
+describe('dagPanePageDown / dagPanePageUp', () => {
+  it('pages down', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 5, ctx });
+    const next = dagPanePageDown(state);
+    expect(next.focusArea.scroll.y).toBeGreaterThanOrEqual(0);
+  });
+
+  it('pages up', () => {
+    let state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 5, ctx });
+    state = dagPaneScrollBy(state, 10);
+    const next = dagPanePageUp(state);
+    expect(next.focusArea.scroll.y).toBeLessThan(state.focusArea.scroll.y);
+  });
+});
+
+describe('dagPaneScrollByX', () => {
+  it('scrolls horizontally', () => {
+    const state = createDagPaneState({ source: WIDE_NODES, width: 40, height: 20, ctx });
+    const next = dagPaneScrollByX(state, 5);
+    expect(next.focusArea.scroll.x).toBe(5);
+  });
+});
+
+// ── dagPaneSetSource ──────────────────────────────────────────────
+
+describe('dagPaneSetSource', () => {
+  it('updates source and re-renders layout', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const next = dagPaneSetSource(state, DIAMOND_NODES, ctx);
+    expect(next.source).toBe(DIAMOND_NODES);
+    expect(next.layout.nodes.size).toBe(4);
+  });
+
+  it('clears selection', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'B', ctx });
+    const next = dagPaneSetSource(state, DIAMOND_NODES, ctx);
+    expect(next.selectedId).toBeUndefined();
+    expect(next.highlightPath).toEqual([]);
+  });
+});
+
+// ── Render ─────────────────────────────────────────────────────────
+
+describe('dagPane', () => {
+  it('renders a string', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, ctx });
+    const output = dagPane(state, { ctx });
+    expect(typeof output).toBe('string');
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  it('renders exactly height lines', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 10, ctx });
+    const output = dagPane(state, { ctx });
+    expect(output.split('\n')).toHaveLength(10);
+  });
+
+  it('includes gutter in interactive mode', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 10, ctx });
+    const output = dagPane(state, { ctx });
+    expect(output).toContain('▎');
+  });
+
+  it('pipe mode omits gutter', () => {
+    const pipeCtx = createTestContext({ mode: 'pipe' });
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 10, ctx: pipeCtx });
+    const output = dagPane(state, { ctx: pipeCtx });
+    expect(output).not.toContain('▎');
+  });
+});
+
+// ── Auto-scroll to selection ──────────────────────────────────────
+
+describe('auto-scroll to selection', () => {
+  it('scrolls to bring selected node into view', () => {
+    // Use a small viewport height to ensure the last node in a tall graph
+    // is outside the initial viewport
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 5, ctx });
+    const next = dagPaneSelectNode(state, 'C', ctx);
+    // The node C is in the last layer, which starts well below row 0
+    const nodePos = next.layout.nodes.get('C');
+    if (nodePos) {
+      // Scroll should have adjusted so the node is within the viewport
+      const scrollY = next.focusArea.scroll.y;
+      expect(scrollY).toBeLessThanOrEqual(nodePos.row);
+      expect(scrollY + next.focusArea.height).toBeGreaterThanOrEqual(nodePos.row);
+    }
+  });
+});
+
+// ── Keymap ──────────────────────────────────────────────────────────
+
+describe('dagPaneKeyMap', () => {
+  type Msg = { type: string };
+
+  const km = dagPaneKeyMap<Msg>({
+    selectParent: { type: 'parent' },
+    selectChild: { type: 'child' },
+    selectLeft: { type: 'left' },
+    selectRight: { type: 'right' },
+    scrollUp: { type: 'up' },
+    scrollDown: { type: 'down' },
+    scrollLeft: { type: 'sleft' },
+    scrollRight: { type: 'sright' },
+    pageUp: { type: 'pu' },
+    pageDown: { type: 'pd' },
+    top: { type: 'top' },
+    bottom: { type: 'bot' },
+    confirm: { type: 'ok' },
+    quit: { type: 'quit' },
+  });
+
+  it('handles arrow keys for node selection', () => {
+    expect(km.handle(keyMsg('up'))).toEqual({ type: 'parent' });
+    expect(km.handle(keyMsg('down'))).toEqual({ type: 'child' });
+    expect(km.handle(keyMsg('left'))).toEqual({ type: 'left' });
+    expect(km.handle(keyMsg('right'))).toEqual({ type: 'right' });
+  });
+
+  it('handles j/k for scroll', () => {
+    expect(km.handle(keyMsg('j'))).toEqual({ type: 'down' });
+    expect(km.handle(keyMsg('k'))).toEqual({ type: 'up' });
+  });
+
+  it('handles h/l for horizontal scroll', () => {
+    expect(km.handle(keyMsg('h'))).toEqual({ type: 'sleft' });
+    expect(km.handle(keyMsg('l'))).toEqual({ type: 'sright' });
+  });
+
+  it('handles page keys', () => {
+    expect(km.handle(keyMsg('d'))).toEqual({ type: 'pd' });
+    expect(km.handle(keyMsg('u'))).toEqual({ type: 'pu' });
+  });
+
+  it('handles top/bottom', () => {
+    expect(km.handle(keyMsg('g'))).toEqual({ type: 'top' });
+    expect(km.handle(keyMsg('g', { shift: true }))).toEqual({ type: 'bot' });
+  });
+
+  it('handles enter for confirm', () => {
+    expect(km.handle(keyMsg('return'))).toEqual({ type: 'ok' });
+  });
+
+  it('handles quit', () => {
+    expect(km.handle(keyMsg('q'))).toEqual({ type: 'quit' });
+    expect(km.handle(keyMsg('c', { ctrl: true }))).toEqual({ type: 'quit' });
+  });
+
+  it('returns undefined for unbound keys', () => {
+    expect(km.handle(keyMsg('x'))).toBeUndefined();
+  });
+});

--- a/packages/bijou-tui/src/dag-pane.test.ts
+++ b/packages/bijou-tui/src/dag-pane.test.ts
@@ -199,6 +199,12 @@ describe('dagPaneSelectNode', () => {
     const next = dagPaneSelectNode(state, 'UNKNOWN', ctx);
     expect(next.selectedId).toBeUndefined();
   });
+
+  it('preserves existing selection when ID is unknown', () => {
+    const state = createDagPaneState({ source: LINEAR_NODES, width: 60, height: 20, selectedId: 'B', ctx });
+    const next = dagPaneSelectNode(state, 'UNKNOWN', ctx);
+    expect(next.selectedId).toBe('B');
+  });
 });
 
 describe('dagPaneClearSelection', () => {

--- a/packages/bijou-tui/src/dag-pane.ts
+++ b/packages/bijou-tui/src/dag-pane.ts
@@ -21,9 +21,8 @@
  * ```
  */
 
-import type { BijouContext, TokenValue, DagNode, DagNodePosition, DagLayout, DagOptions } from '@flyingrobots/bijou';
+import type { BijouContext, TokenValue, DagNode, DagNodePosition, DagLayout, DagOptions, SlicedDagSource } from '@flyingrobots/bijou';
 import { dagLayout, isSlicedDagSource } from '@flyingrobots/bijou';
-import type { SlicedDagSource } from '@flyingrobots/bijou';
 import {
   type FocusAreaState,
   type FocusAreaRenderOptions,
@@ -98,7 +97,7 @@ export interface DagPaneOptions {
 }
 
 /** Options for rendering the DAG pane view. */
-export interface DagPaneRenderOptions extends FocusAreaRenderOptions {}
+export type DagPaneRenderOptions = FocusAreaRenderOptions;
 
 // ---------------------------------------------------------------------------
 // Internal: Adjacency maps
@@ -318,15 +317,17 @@ function renderLayout(
     highlightPath: highlightPath.length > 0 ? [...highlightPath] : undefined,
     ctx,
   };
-  return dagLayout(source as DagNode[], opts);
+  return isSlicedDagSource(source)
+    ? dagLayout(source, opts)
+    : dagLayout(source, opts);
 }
 
 function updateSelection(
   state: DagPaneState,
   newId: string | undefined,
+  adjacency: Adjacency,
   ctx?: BijouContext,
 ): DagPaneState {
-  const adjacency = buildAdjacency(state.source);
   const highlightPath = computeHighlightPath(newId, adjacency);
   const layout = renderLayout(state.source, newId, highlightPath, state.dagOptions, ctx);
   let fa = focusAreaSetContent(state.focusArea, layout.output);
@@ -416,7 +417,7 @@ export function dagPaneSelectChild(state: DagPaneState, ctx?: BijouContext): Dag
 
   if (!state.selectedId) {
     const firstRoot = adjacency.roots[0];
-    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+    return firstRoot ? updateSelection(state, firstRoot, adjacency, ctx) : state;
   }
 
   const children = adjacency.children.get(state.selectedId) ?? [];
@@ -425,7 +426,7 @@ export function dagPaneSelectChild(state: DagPaneState, ctx?: BijouContext): Dag
   const currentPos = state.layout.nodes.get(state.selectedId);
   const currentCenter = currentPos ? currentPos.col + currentPos.width / 2 : 0;
   const target = closestByCol(children, currentCenter, state.layout.nodes);
-  return target ? updateSelection(state, target, ctx) : state;
+  return target ? updateSelection(state, target, adjacency, ctx) : state;
 }
 
 /**
@@ -441,7 +442,7 @@ export function dagPaneSelectParent(state: DagPaneState, ctx?: BijouContext): Da
 
   if (!state.selectedId) {
     const firstRoot = adjacency.roots[0];
-    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+    return firstRoot ? updateSelection(state, firstRoot, adjacency, ctx) : state;
   }
 
   const parents = adjacency.parents.get(state.selectedId) ?? [];
@@ -450,7 +451,7 @@ export function dagPaneSelectParent(state: DagPaneState, ctx?: BijouContext): Da
   const currentPos = state.layout.nodes.get(state.selectedId);
   const currentCenter = currentPos ? currentPos.col + currentPos.width / 2 : 0;
   const target = closestByCol(parents, currentCenter, state.layout.nodes);
-  return target ? updateSelection(state, target, ctx) : state;
+  return target ? updateSelection(state, target, adjacency, ctx) : state;
 }
 
 /**
@@ -466,7 +467,7 @@ export function dagPaneSelectLeft(state: DagPaneState, ctx?: BijouContext): DagP
 
   if (!state.selectedId) {
     const firstRoot = adjacency.roots[0];
-    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+    return firstRoot ? updateSelection(state, firstRoot, adjacency, ctx) : state;
   }
 
   const currentPos = state.layout.nodes.get(state.selectedId);
@@ -476,7 +477,7 @@ export function dagPaneSelectLeft(state: DagPaneState, ctx?: BijouContext): DagP
   const idx = siblings.indexOf(state.selectedId);
   if (idx <= 0) return state; // already leftmost
 
-  return updateSelection(state, siblings[idx - 1]!, ctx);
+  return updateSelection(state, siblings[idx - 1]!, adjacency, ctx);
 }
 
 /**
@@ -492,7 +493,7 @@ export function dagPaneSelectRight(state: DagPaneState, ctx?: BijouContext): Dag
 
   if (!state.selectedId) {
     const firstRoot = adjacency.roots[0];
-    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+    return firstRoot ? updateSelection(state, firstRoot, adjacency, ctx) : state;
   }
 
   const currentPos = state.layout.nodes.get(state.selectedId);
@@ -502,7 +503,7 @@ export function dagPaneSelectRight(state: DagPaneState, ctx?: BijouContext): Dag
   const idx = siblings.indexOf(state.selectedId);
   if (idx < 0 || idx >= siblings.length - 1) return state; // already rightmost
 
-  return updateSelection(state, siblings[idx + 1]!, ctx);
+  return updateSelection(state, siblings[idx + 1]!, adjacency, ctx);
 }
 
 /**
@@ -518,7 +519,8 @@ export function dagPaneSelectNode(state: DagPaneState, nodeId: string, ctx?: Bij
   if (!state.layout.nodes.has(nodeId)) {
     return state;
   }
-  return updateSelection(state, nodeId, ctx);
+  const adjacency = buildAdjacency(state.source);
+  return updateSelection(state, nodeId, adjacency, ctx);
 }
 
 /**
@@ -529,7 +531,8 @@ export function dagPaneSelectNode(state: DagPaneState, nodeId: string, ctx?: Bij
  * @returns Updated state with no selection.
  */
 export function dagPaneClearSelection(state: DagPaneState, ctx?: BijouContext): DagPaneState {
-  return updateSelection(state, undefined, ctx);
+  const adjacency = buildAdjacency(state.source);
+  return updateSelection(state, undefined, adjacency, ctx);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/bijou-tui/src/dag-pane.ts
+++ b/packages/bijou-tui/src/dag-pane.ts
@@ -1,0 +1,693 @@
+/**
+ * Interactive DAG pane building block.
+ *
+ * Composes `dagLayout()` with `focusArea()` to provide a scrollable,
+ * keyboard-navigable DAG viewer with arrow-key node selection,
+ * auto-scroll-to-selection, and auto-highlight-path.
+ *
+ * Follows the building block pattern: immutable state + pure transformers +
+ * pure render + convenience keymap factory.
+ *
+ * ```ts
+ * // In TEA init:
+ * const pane = createDagPaneState({ source: nodes, width: 80, height: 24, ctx });
+ *
+ * // In TEA view:
+ * const output = dagPane(pane, { focused: true, ctx });
+ *
+ * // In TEA update:
+ * case 'select-child':
+ *   return [{ ...model, pane: dagPaneSelectChild(model.pane, ctx) }, []];
+ * ```
+ */
+
+import type { BijouContext, TokenValue, DagNode, DagNodePosition, DagLayout, DagOptions } from '@flyingrobots/bijou';
+import { dagLayout, isSlicedDagSource } from '@flyingrobots/bijou';
+import type { SlicedDagSource } from '@flyingrobots/bijou';
+import {
+  type FocusAreaState,
+  type FocusAreaRenderOptions,
+  type OverflowX,
+  createFocusAreaState,
+  focusArea,
+  focusAreaScrollBy,
+  focusAreaScrollToTop,
+  focusAreaScrollToBottom,
+  focusAreaPageDown,
+  focusAreaPageUp,
+  focusAreaScrollByX,
+  focusAreaSetContent,
+} from './focus-area.js';
+import { scrollTo, scrollToX } from './viewport.js';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** DAG rendering options forwarded to `dagLayout()`. */
+export interface DagPaneDagOptions {
+  /** Default color/style token for node box borders. */
+  readonly nodeToken?: TokenValue;
+  /** Color/style token for edge lines and arrowheads. */
+  readonly edgeToken?: TokenValue;
+  /** Color/style token for highlighted path nodes/edges. */
+  readonly highlightToken?: TokenValue;
+  /** Color/style token for the selected node box. */
+  readonly selectedToken?: TokenValue;
+  /** Fixed character width per node box. */
+  readonly nodeWidth?: number;
+  /** Maximum total character width. */
+  readonly maxWidth?: number;
+  /** Layout direction. */
+  readonly direction?: 'down' | 'right';
+}
+
+/** Immutable state for the DAG pane widget. */
+export interface DagPaneState {
+  /** Graph data source. */
+  readonly source: DagNode[] | SlicedDagSource;
+  /** Currently selected node ID, or undefined. */
+  readonly selectedId: string | undefined;
+  /** Cached `dagLayout()` result. */
+  readonly layout: DagLayout;
+  /** Ordered path from root to selected node (for highlighting). */
+  readonly highlightPath: readonly string[];
+  /** Underlying focus area (scroll/viewport) state. */
+  readonly focusArea: FocusAreaState;
+  /** DAG rendering options forwarded to `dagLayout()`. */
+  readonly dagOptions: DagPaneDagOptions;
+}
+
+/** Options for creating a new DAG pane state. */
+export interface DagPaneOptions {
+  /** Graph data source (array of nodes or sliced source). */
+  readonly source: DagNode[] | SlicedDagSource;
+  /** Total width in columns (including gutter). */
+  readonly width: number;
+  /** Total height in rows. */
+  readonly height: number;
+  /** Initially selected node ID. */
+  readonly selectedId?: string;
+  /** Horizontal overflow. Default: `'scroll'` (DAGs are wide). */
+  readonly overflowX?: OverflowX;
+  /** DAG rendering options. */
+  readonly dagOptions?: DagPaneDagOptions;
+  /** Bijou context for rendering. */
+  readonly ctx?: BijouContext;
+}
+
+/** Options for rendering the DAG pane view. */
+export interface DagPaneRenderOptions extends FocusAreaRenderOptions {}
+
+// ---------------------------------------------------------------------------
+// Internal: Adjacency maps
+// ---------------------------------------------------------------------------
+
+interface Adjacency {
+  /** Map from node ID to its child IDs. */
+  children: ReadonlyMap<string, readonly string[]>;
+  /** Map from node ID to its parent IDs. */
+  parents: ReadonlyMap<string, readonly string[]>;
+  /** Root nodes (no parents). */
+  roots: readonly string[];
+}
+
+function buildAdjacency(source: DagNode[] | SlicedDagSource): Adjacency {
+  const childMap = new Map<string, string[]>();
+  const parentMap = new Map<string, string[]>();
+
+  if (isSlicedDagSource(source)) {
+    const ids = source.ids();
+    const idSet = new Set(ids);
+    for (const id of ids) {
+      const children = source.children(id).filter((c) => idSet.has(c));
+      childMap.set(id, [...children]);
+      if (!parentMap.has(id)) parentMap.set(id, []);
+      for (const child of children) {
+        let parents = parentMap.get(child);
+        if (!parents) {
+          parents = [];
+          parentMap.set(child, parents);
+        }
+        parents.push(id);
+      }
+    }
+  } else {
+    const idSet = new Set(source.map((n) => n.id));
+    for (const node of source) {
+      const children = (node.edges ?? []).filter((e) => idSet.has(e));
+      childMap.set(node.id, children);
+      if (!parentMap.has(node.id)) parentMap.set(node.id, []);
+      for (const child of children) {
+        let parents = parentMap.get(child);
+        if (!parents) {
+          parents = [];
+          parentMap.set(child, parents);
+        }
+        parents.push(node.id);
+      }
+    }
+  }
+
+  const roots: string[] = [];
+  for (const [id, parents] of parentMap) {
+    if (parents.length === 0) roots.push(id);
+  }
+  // Also add any nodes that are in childMap but not parentMap (shouldn't happen, but safe)
+  for (const id of childMap.keys()) {
+    if (!parentMap.has(id)) roots.push(id);
+  }
+
+  return {
+    children: childMap,
+    parents: parentMap,
+    roots,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Highlight path computation
+// ---------------------------------------------------------------------------
+
+function computeHighlightPath(
+  selectedId: string | undefined,
+  adjacency: Adjacency,
+): readonly string[] {
+  if (!selectedId) return [];
+
+  // BFS upward from selected to find a root, then reverse
+  const visited = new Set<string>();
+  const cameFrom = new Map<string, string>();
+  const queue: string[] = [selectedId];
+  visited.add(selectedId);
+
+  let rootFound: string | undefined;
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const parents = adjacency.parents.get(current) ?? [];
+    if (parents.length === 0) {
+      rootFound = current;
+      break;
+    }
+    for (const parent of parents) {
+      if (!visited.has(parent)) {
+        visited.add(parent);
+        cameFrom.set(parent, current);
+        queue.push(parent);
+      }
+    }
+  }
+
+  if (rootFound === undefined) {
+    // Selected node is itself a root (or disconnected)
+    return [selectedId];
+  }
+
+  // Reconstruct path from root to selected
+  const path: string[] = [];
+  let cursor: string | undefined = rootFound;
+  while (cursor !== undefined) {
+    path.push(cursor);
+    if (cursor === selectedId) break;
+    cursor = cameFrom.get(cursor);
+  }
+
+  // If we couldn't reach selectedId from the root, just return selected
+  if (path[path.length - 1] !== selectedId) {
+    return [selectedId];
+  }
+
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Spatial navigation helpers
+// ---------------------------------------------------------------------------
+
+function closestByCol(
+  candidates: readonly string[],
+  currentCenter: number,
+  positions: ReadonlyMap<string, DagNodePosition>,
+): string | undefined {
+  let best: string | undefined;
+  let bestDist = Infinity;
+  for (const id of candidates) {
+    const pos = positions.get(id);
+    if (!pos) continue;
+    const center = pos.col + pos.width / 2;
+    const dist = Math.abs(center - currentCenter);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = id;
+    }
+  }
+  return best;
+}
+
+function nodesOnSameRow(
+  row: number,
+  positions: ReadonlyMap<string, DagNodePosition>,
+): string[] {
+  const result: string[] = [];
+  for (const [id, pos] of positions) {
+    if (pos.row === row) result.push(id);
+  }
+  return result.sort((a, b) => {
+    const pa = positions.get(a)!;
+    const pb = positions.get(b)!;
+    return pa.col - pb.col;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Auto-scroll to node
+// ---------------------------------------------------------------------------
+
+function scrollToNode(
+  faState: FocusAreaState,
+  nodePos: DagNodePosition,
+): FocusAreaState {
+  let scroll = faState.scroll;
+
+  // Vertical: ensure node box (row .. row+height) is within viewport
+  const nodeTop = nodePos.row;
+  const nodeBottom = nodePos.row + nodePos.height - 1;
+  const viewTop = scroll.y;
+  const viewBottom = scroll.y + faState.height - 1;
+
+  if (nodeTop < viewTop) {
+    scroll = scrollTo(scroll, nodeTop);
+  } else if (nodeBottom > viewBottom) {
+    scroll = scrollTo(scroll, nodeBottom - faState.height + 1);
+  }
+
+  // Horizontal: ensure node box (col .. col+width) is within viewport
+  if (faState.overflowX === 'scroll') {
+    const contentWidth = Math.max(1, faState.width - 1); // minus gutter
+    const nodeLeft = nodePos.col;
+    const nodeRight = nodePos.col + nodePos.width - 1;
+    const viewLeft = scroll.x;
+    const viewRight = scroll.x + contentWidth - 1;
+
+    if (nodeLeft < viewLeft) {
+      scroll = scrollToX(scroll, nodeLeft);
+    } else if (nodeRight > viewRight) {
+      scroll = scrollToX(scroll, nodeRight - contentWidth + 1);
+    }
+  }
+
+  return { ...faState, scroll };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Selection update
+// ---------------------------------------------------------------------------
+
+function renderLayout(
+  source: DagNode[] | SlicedDagSource,
+  selectedId: string | undefined,
+  highlightPath: readonly string[],
+  dagOptions: DagPaneDagOptions,
+  ctx?: BijouContext,
+): DagLayout {
+  const opts: DagOptions = {
+    ...dagOptions,
+    selectedId,
+    highlightPath: highlightPath.length > 0 ? [...highlightPath] : undefined,
+    ctx,
+  };
+  return dagLayout(source as DagNode[], opts);
+}
+
+function updateSelection(
+  state: DagPaneState,
+  newId: string | undefined,
+  ctx?: BijouContext,
+): DagPaneState {
+  const adjacency = buildAdjacency(state.source);
+  const highlightPath = computeHighlightPath(newId, adjacency);
+  const layout = renderLayout(state.source, newId, highlightPath, state.dagOptions, ctx);
+  let fa = focusAreaSetContent(state.focusArea, layout.output);
+
+  // Auto-scroll to selected node
+  if (newId) {
+    const nodePos = layout.nodes.get(newId);
+    if (nodePos) {
+      fa = scrollToNode(fa, nodePos);
+    }
+  }
+
+  return {
+    ...state,
+    selectedId: newId,
+    highlightPath,
+    layout,
+    focusArea: fa,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial DAG pane state for the given source and dimensions.
+ *
+ * @param options - Source, dimensions, and rendering options.
+ * @returns Fresh DAG pane state.
+ */
+export function createDagPaneState(options: DagPaneOptions): DagPaneState {
+  const {
+    source,
+    width,
+    height,
+    selectedId,
+    overflowX = 'scroll',
+    dagOptions = {},
+    ctx,
+  } = options;
+
+  const adjacency = buildAdjacency(source);
+  const highlightPath = computeHighlightPath(selectedId, adjacency);
+  const layout = renderLayout(source, selectedId, highlightPath, dagOptions, ctx);
+
+  const fa = createFocusAreaState({
+    content: layout.output,
+    width,
+    height,
+    overflowX,
+  });
+
+  // Auto-scroll to initial selection
+  let finalFa = fa;
+  if (selectedId) {
+    const nodePos = layout.nodes.get(selectedId);
+    if (nodePos) {
+      finalFa = scrollToNode(fa, nodePos);
+    }
+  }
+
+  return {
+    source,
+    selectedId,
+    layout,
+    highlightPath,
+    focusArea: finalFa,
+    dagOptions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Navigation transformers
+// ---------------------------------------------------------------------------
+
+/**
+ * Select a child node (arrow down).
+ * If nothing is selected, auto-selects the first root node.
+ *
+ * @param state - Current DAG pane state.
+ * @param ctx - Bijou context for re-rendering.
+ * @returns Updated state with new selection.
+ */
+export function dagPaneSelectChild(state: DagPaneState, ctx?: BijouContext): DagPaneState {
+  const adjacency = buildAdjacency(state.source);
+
+  if (!state.selectedId) {
+    const firstRoot = adjacency.roots[0];
+    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+  }
+
+  const children = adjacency.children.get(state.selectedId) ?? [];
+  if (children.length === 0) return state;
+
+  const currentPos = state.layout.nodes.get(state.selectedId);
+  const currentCenter = currentPos ? currentPos.col + currentPos.width / 2 : 0;
+  const target = closestByCol(children, currentCenter, state.layout.nodes);
+  return target ? updateSelection(state, target, ctx) : state;
+}
+
+/**
+ * Select a parent node (arrow up).
+ * If nothing is selected, auto-selects the first root node.
+ *
+ * @param state - Current DAG pane state.
+ * @param ctx - Bijou context for re-rendering.
+ * @returns Updated state with new selection.
+ */
+export function dagPaneSelectParent(state: DagPaneState, ctx?: BijouContext): DagPaneState {
+  const adjacency = buildAdjacency(state.source);
+
+  if (!state.selectedId) {
+    const firstRoot = adjacency.roots[0];
+    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+  }
+
+  const parents = adjacency.parents.get(state.selectedId) ?? [];
+  if (parents.length === 0) return state;
+
+  const currentPos = state.layout.nodes.get(state.selectedId);
+  const currentCenter = currentPos ? currentPos.col + currentPos.width / 2 : 0;
+  const target = closestByCol(parents, currentCenter, state.layout.nodes);
+  return target ? updateSelection(state, target, ctx) : state;
+}
+
+/**
+ * Select the sibling node to the left in the same layer.
+ * If nothing is selected, auto-selects the first root node.
+ *
+ * @param state - Current DAG pane state.
+ * @param ctx - Bijou context for re-rendering.
+ * @returns Updated state with new selection.
+ */
+export function dagPaneSelectLeft(state: DagPaneState, ctx?: BijouContext): DagPaneState {
+  const adjacency = buildAdjacency(state.source);
+
+  if (!state.selectedId) {
+    const firstRoot = adjacency.roots[0];
+    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+  }
+
+  const currentPos = state.layout.nodes.get(state.selectedId);
+  if (!currentPos) return state;
+
+  const siblings = nodesOnSameRow(currentPos.row, state.layout.nodes);
+  const idx = siblings.indexOf(state.selectedId);
+  if (idx <= 0) return state; // already leftmost
+
+  return updateSelection(state, siblings[idx - 1]!, ctx);
+}
+
+/**
+ * Select the sibling node to the right in the same layer.
+ * If nothing is selected, auto-selects the first root node.
+ *
+ * @param state - Current DAG pane state.
+ * @param ctx - Bijou context for re-rendering.
+ * @returns Updated state with new selection.
+ */
+export function dagPaneSelectRight(state: DagPaneState, ctx?: BijouContext): DagPaneState {
+  const adjacency = buildAdjacency(state.source);
+
+  if (!state.selectedId) {
+    const firstRoot = adjacency.roots[0];
+    return firstRoot ? updateSelection(state, firstRoot, ctx) : state;
+  }
+
+  const currentPos = state.layout.nodes.get(state.selectedId);
+  if (!currentPos) return state;
+
+  const siblings = nodesOnSameRow(currentPos.row, state.layout.nodes);
+  const idx = siblings.indexOf(state.selectedId);
+  if (idx < 0 || idx >= siblings.length - 1) return state; // already rightmost
+
+  return updateSelection(state, siblings[idx + 1]!, ctx);
+}
+
+/**
+ * Select a specific node by ID.
+ * If the ID is not found in the layout, returns state unchanged (no selection).
+ *
+ * @param state - Current DAG pane state.
+ * @param nodeId - ID of the node to select.
+ * @param ctx - Bijou context for re-rendering.
+ * @returns Updated state with new selection.
+ */
+export function dagPaneSelectNode(state: DagPaneState, nodeId: string, ctx?: BijouContext): DagPaneState {
+  if (!state.layout.nodes.has(nodeId)) {
+    return state;
+  }
+  return updateSelection(state, nodeId, ctx);
+}
+
+/**
+ * Clear the current selection.
+ *
+ * @param state - Current DAG pane state.
+ * @param ctx - Bijou context for re-rendering.
+ * @returns Updated state with no selection.
+ */
+export function dagPaneClearSelection(state: DagPaneState, ctx?: BijouContext): DagPaneState {
+  return updateSelection(state, undefined, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Scroll transformers
+// ---------------------------------------------------------------------------
+
+/**
+ * Scroll vertically by a relative amount.
+ *
+ * @param state - Current DAG pane state.
+ * @param dy - Relative vertical offset (positive = down).
+ * @returns Updated state.
+ */
+export function dagPaneScrollBy(state: DagPaneState, dy: number): DagPaneState {
+  return { ...state, focusArea: focusAreaScrollBy(state.focusArea, dy) };
+}
+
+/**
+ * Scroll to the top.
+ *
+ * @param state - Current DAG pane state.
+ * @returns Updated state.
+ */
+export function dagPaneScrollToTop(state: DagPaneState): DagPaneState {
+  return { ...state, focusArea: focusAreaScrollToTop(state.focusArea) };
+}
+
+/**
+ * Scroll to the bottom.
+ *
+ * @param state - Current DAG pane state.
+ * @returns Updated state.
+ */
+export function dagPaneScrollToBottom(state: DagPaneState): DagPaneState {
+  return { ...state, focusArea: focusAreaScrollToBottom(state.focusArea) };
+}
+
+/**
+ * Page down.
+ *
+ * @param state - Current DAG pane state.
+ * @returns Updated state.
+ */
+export function dagPanePageDown(state: DagPaneState): DagPaneState {
+  return { ...state, focusArea: focusAreaPageDown(state.focusArea) };
+}
+
+/**
+ * Page up.
+ *
+ * @param state - Current DAG pane state.
+ * @returns Updated state.
+ */
+export function dagPanePageUp(state: DagPaneState): DagPaneState {
+  return { ...state, focusArea: focusAreaPageUp(state.focusArea) };
+}
+
+/**
+ * Scroll horizontally by a relative amount.
+ *
+ * @param state - Current DAG pane state.
+ * @param dx - Relative horizontal offset (positive = right).
+ * @returns Updated state.
+ */
+export function dagPaneScrollByX(state: DagPaneState, dx: number): DagPaneState {
+  return { ...state, focusArea: focusAreaScrollByX(state.focusArea, dx) };
+}
+
+/**
+ * Replace the graph source and re-render. Clears selection.
+ *
+ * @param state - Current DAG pane state.
+ * @param source - New graph data source.
+ * @param ctx - Bijou context for re-rendering.
+ * @returns Updated state with new source and cleared selection.
+ */
+export function dagPaneSetSource(
+  state: DagPaneState,
+  source: DagNode[] | SlicedDagSource,
+  ctx?: BijouContext,
+): DagPaneState {
+  const highlightPath: readonly string[] = [];
+  const layout = renderLayout(source, undefined, highlightPath, state.dagOptions, ctx);
+  const fa = focusAreaSetContent(state.focusArea, layout.output);
+
+  return {
+    ...state,
+    source,
+    selectedId: undefined,
+    highlightPath,
+    layout,
+    focusArea: fa,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the DAG pane — focus area wrapping the DAG layout output.
+ *
+ * @param state - Current DAG pane state.
+ * @param options - Rendering options (focus, tokens, scrollbar, ctx).
+ * @returns Rendered DAG pane string.
+ */
+export function dagPane(state: DagPaneState, options?: DagPaneRenderOptions): string {
+  return focusArea(state.focusArea, options);
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for DAG pane interaction.
+ *
+ * Arrow keys are bound to node selection. Vim keys (j/k/h/l) are bound
+ * to scroll. `Enter` confirms, `q`/`Ctrl+C` quits.
+ *
+ * @template Msg - Application message type dispatched by key bindings.
+ * @param actions - Map of actions to message values.
+ * @returns Preconfigured key map with DAG pane bindings.
+ */
+export function dagPaneKeyMap<Msg>(actions: {
+  selectParent: Msg;
+  selectChild: Msg;
+  selectLeft: Msg;
+  selectRight: Msg;
+  scrollUp: Msg;
+  scrollDown: Msg;
+  scrollLeft: Msg;
+  scrollRight: Msg;
+  pageUp: Msg;
+  pageDown: Msg;
+  top: Msg;
+  bottom: Msg;
+  confirm: Msg;
+  quit: Msg;
+}): KeyMap<Msg> {
+  return createKeyMap<Msg>()
+    .group('Selection', (g) => g
+      .bind('up', 'Select parent', actions.selectParent)
+      .bind('down', 'Select child', actions.selectChild)
+      .bind('left', 'Select left', actions.selectLeft)
+      .bind('right', 'Select right', actions.selectRight),
+    )
+    .group('Scroll', (g) => g
+      .bind('j', 'Down', actions.scrollDown)
+      .bind('k', 'Up', actions.scrollUp)
+      .bind('h', 'Scroll left', actions.scrollLeft)
+      .bind('l', 'Scroll right', actions.scrollRight)
+      .bind('d', 'Page down', actions.pageDown)
+      .bind('u', 'Page up', actions.pageUp)
+      .bind('g', 'Top', actions.top)
+      .bind('shift+g', 'Bottom', actions.bottom),
+    )
+    .bind('return', 'Confirm', actions.confirm)
+    .bind('q', 'Quit', actions.quit)
+    .bind('ctrl+c', 'Quit', actions.quit);
+}

--- a/packages/bijou-tui/src/dag-pane.ts
+++ b/packages/bijou-tui/src/dag-pane.ts
@@ -317,6 +317,8 @@ function renderLayout(
     highlightPath: highlightPath.length > 0 ? [...highlightPath] : undefined,
     ctx,
   };
+  // Type narrowing required — dagLayout has separate overloads for
+  // DagNode[] and SlicedDagSource; a union won't resolve either overload.
   return isSlicedDagSource(source)
     ? dagLayout(source, opts)
     : dagLayout(source, opts);
@@ -371,8 +373,12 @@ export function createDagPaneState(options: DagPaneOptions): DagPaneState {
   } = options;
 
   const adjacency = buildAdjacency(source);
-  const highlightPath = computeHighlightPath(selectedId, adjacency);
-  const layout = renderLayout(source, selectedId, highlightPath, dagOptions, ctx);
+
+  // Validate selectedId — fall back to no selection if not in the source
+  const validatedId = selectedId !== undefined && adjacency.children.has(selectedId) ? selectedId : undefined;
+
+  const highlightPath = computeHighlightPath(validatedId, adjacency);
+  const layout = renderLayout(source, validatedId, highlightPath, dagOptions, ctx);
 
   const fa = createFocusAreaState({
     content: layout.output,
@@ -383,8 +389,8 @@ export function createDagPaneState(options: DagPaneOptions): DagPaneState {
 
   // Auto-scroll to initial selection
   let finalFa = fa;
-  if (selectedId) {
-    const nodePos = layout.nodes.get(selectedId);
+  if (validatedId) {
+    const nodePos = layout.nodes.get(validatedId);
     if (nodePos) {
       finalFa = scrollToNode(fa, nodePos);
     }
@@ -392,7 +398,7 @@ export function createDagPaneState(options: DagPaneOptions): DagPaneState {
 
   return {
     source,
-    selectedId,
+    selectedId: validatedId,
     layout,
     highlightPath,
     focusArea: finalFa,
@@ -690,7 +696,7 @@ export function dagPaneKeyMap<Msg>(actions: {
       .bind('g', 'Top', actions.top)
       .bind('shift+g', 'Bottom', actions.bottom),
     )
-    .bind('return', 'Confirm', actions.confirm)
+    .bind('enter', 'Confirm', actions.confirm)
     .bind('q', 'Quit', actions.quit)
     .bind('ctrl+c', 'Quit', actions.quit);
 }

--- a/packages/bijou-tui/src/focus-area.test.ts
+++ b/packages/bijou-tui/src/focus-area.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import type { KeyMsg } from './types.js';
+import {
+  createFocusAreaState,
+  focusArea,
+  focusAreaScrollBy,
+  focusAreaScrollTo,
+  focusAreaScrollToTop,
+  focusAreaScrollToBottom,
+  focusAreaPageDown,
+  focusAreaPageUp,
+  focusAreaScrollByX,
+  focusAreaScrollToX,
+  focusAreaSetContent,
+  focusAreaKeyMap,
+} from './focus-area.js';
+
+// ── Test Data ──────────────────────────────────────────────────────
+
+const SHORT_CONTENT = 'line 1\nline 2\nline 3';
+const LONG_CONTENT = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n');
+const WIDE_CONTENT = Array.from({ length: 10 }, (_, i) => `${'x'.repeat(80)} row ${i + 1}`).join('\n');
+
+function keyMsg(key: string, mods?: Partial<KeyMsg>): KeyMsg {
+  return { type: 'key', key, ctrl: false, alt: false, shift: false, ...mods };
+}
+
+// ── createFocusAreaState ──────────────────────────────────────────
+
+describe('createFocusAreaState', () => {
+  it('creates state with scroll at 0', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    expect(state.scroll.y).toBe(0);
+    expect(state.scroll.x).toBe(0);
+    expect(state.width).toBe(40);
+    expect(state.height).toBe(10);
+  });
+
+  it('stores content', () => {
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 10 });
+    expect(state.content).toBe(SHORT_CONTENT);
+  });
+
+  it('defaults overflowX to hidden', () => {
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 10 });
+    expect(state.overflowX).toBe('hidden');
+  });
+
+  it('respects overflowX scroll', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10, overflowX: 'scroll' });
+    expect(state.overflowX).toBe('scroll');
+  });
+
+  it('computes maxX when overflowX is scroll', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10, overflowX: 'scroll' });
+    // Gutter takes 1 col, scrollbar takes 1 col → content width = 38
+    // Lines are 80+ chars → maxX > 0
+    expect(state.scroll.maxX).toBeGreaterThan(0);
+  });
+
+  it('maxX is 0 when overflowX is hidden', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10 });
+    expect(state.scroll.maxX).toBe(0);
+  });
+
+  it('handles content shorter than viewport', () => {
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 10 });
+    expect(state.scroll.maxY).toBe(0);
+    expect(state.scroll.totalLines).toBe(3);
+  });
+});
+
+// ── Vertical scroll transformers ──────────────────────────────────
+
+describe('focusAreaScrollBy', () => {
+  it('scrolls down', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollBy(state, 5);
+    expect(next.scroll.y).toBe(5);
+  });
+
+  it('clamps to maxY', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollBy(state, 999);
+    expect(next.scroll.y).toBe(state.scroll.maxY);
+  });
+
+  it('clamps to 0', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollBy(state, -5);
+    expect(next.scroll.y).toBe(0);
+  });
+});
+
+describe('focusAreaScrollTo', () => {
+  it('scrolls to absolute position', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollTo(state, 10);
+    expect(next.scroll.y).toBe(10);
+  });
+
+  it('clamps to valid range', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollTo(state, 999);
+    expect(next.scroll.y).toBe(state.scroll.maxY);
+  });
+});
+
+describe('focusAreaScrollToTop / focusAreaScrollToBottom', () => {
+  it('scrolls to top', () => {
+    const state = focusAreaScrollBy(
+      createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      20,
+    );
+    expect(focusAreaScrollToTop(state).scroll.y).toBe(0);
+  });
+
+  it('scrolls to bottom', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollToBottom(state);
+    expect(next.scroll.y).toBe(state.scroll.maxY);
+  });
+});
+
+describe('focusAreaPageDown / focusAreaPageUp', () => {
+  it('pages down by viewport height', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const next = focusAreaPageDown(state);
+    expect(next.scroll.y).toBe(10); // visibleLines = height = 10
+  });
+
+  it('pages up by viewport height', () => {
+    const state = focusAreaScrollBy(
+      createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      20,
+    );
+    const next = focusAreaPageUp(state);
+    expect(next.scroll.y).toBe(10); // 20 - 10
+  });
+});
+
+// ── Horizontal scroll transformers ────────────────────────────────
+
+describe('focusAreaScrollByX', () => {
+  it('scrolls right when overflowX is scroll', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10, overflowX: 'scroll' });
+    const next = focusAreaScrollByX(state, 5);
+    expect(next.scroll.x).toBe(5);
+  });
+
+  it('is a no-op when overflowX is hidden', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollByX(state, 5);
+    expect(next.scroll.x).toBe(0);
+  });
+
+  it('clamps to maxX', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10, overflowX: 'scroll' });
+    const next = focusAreaScrollByX(state, 9999);
+    expect(next.scroll.x).toBe(state.scroll.maxX);
+  });
+});
+
+describe('focusAreaScrollToX', () => {
+  it('scrolls to absolute X when overflowX is scroll', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10, overflowX: 'scroll' });
+    const next = focusAreaScrollToX(state, 10);
+    expect(next.scroll.x).toBe(10);
+  });
+
+  it('is a no-op when overflowX is hidden', () => {
+    const state = createFocusAreaState({ content: WIDE_CONTENT, width: 40, height: 10 });
+    const next = focusAreaScrollToX(state, 10);
+    expect(next.scroll.x).toBe(0);
+  });
+});
+
+// ── focusAreaSetContent ───────────────────────────────────────────
+
+describe('focusAreaSetContent', () => {
+  it('updates content and preserves scroll', () => {
+    const state = focusAreaScrollBy(
+      createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      5,
+    );
+    const newContent = Array.from({ length: 60 }, (_, i) => `new ${i}`).join('\n');
+    const next = focusAreaSetContent(state, newContent);
+    expect(next.scroll.y).toBe(5);
+    expect(next.scroll.totalLines).toBe(60);
+    expect(next.content).toBe(newContent);
+  });
+
+  it('clamps scroll when new content is shorter', () => {
+    const state = focusAreaScrollBy(
+      createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 }),
+      40,
+    );
+    const next = focusAreaSetContent(state, SHORT_CONTENT);
+    expect(next.scroll.y).toBe(0); // 3 lines < viewport, maxY = 0
+  });
+});
+
+// ── Render ─────────────────────────────────────────────────────────
+
+describe('focusArea', () => {
+  it('renders exactly height lines', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const output = focusArea(state);
+    expect(output.split('\n')).toHaveLength(10);
+  });
+
+  it('prepends gutter character to each line', () => {
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 5 });
+    const output = focusArea(state);
+    const lines = output.split('\n');
+    for (const line of lines) {
+      expect(line).toContain('▎');
+    }
+  });
+
+  it('focused gutter is styled when ctx is provided', () => {
+    const ctx = createTestContext();
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 5 });
+    const focused = focusArea(state, { focused: true, ctx });
+    const unfocused = focusArea(state, { focused: false, ctx });
+    // Both should contain the gutter char (plainStyle won't add ANSI, but
+    // the styled() call was made — we verify the gutter is present)
+    expect(focused).toContain('▎');
+    expect(unfocused).toContain('▎');
+  });
+
+  it('defaults to focused=true', () => {
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 5 });
+    const output = focusArea(state);
+    expect(output).toContain('▎');
+  });
+
+  it('first visible line matches scroll position', () => {
+    const state = focusAreaScrollBy(
+      createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 5 }),
+      3,
+    );
+    const output = focusArea(state);
+    const lines = output.split('\n');
+    expect(lines[0]).toContain('line 4');
+  });
+
+  it('pipe mode renders without gutter', () => {
+    const ctx = createTestContext({ mode: 'pipe' });
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 5 });
+    const output = focusArea(state, { ctx });
+    expect(output).not.toContain('▎');
+  });
+
+  it('accessible mode renders without gutter', () => {
+    const ctx = createTestContext({ mode: 'accessible' });
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 5 });
+    const output = focusArea(state, { ctx });
+    expect(output).not.toContain('▎');
+  });
+
+  it('static mode renders unstyled gutter', () => {
+    const ctx = createTestContext({ mode: 'static' });
+    const state = createFocusAreaState({ content: SHORT_CONTENT, width: 40, height: 5 });
+    const output = focusArea(state, { ctx });
+    expect(output).toContain('▎');
+  });
+
+  it('renders scrollbar when content exceeds height', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const output = focusArea(state, { showScrollbar: true });
+    // Scrollbar uses █ and │ characters
+    expect(output).toMatch(/[█│]/);
+  });
+
+  it('hides scrollbar when showScrollbar is false', () => {
+    const state = createFocusAreaState({ content: LONG_CONTENT, width: 40, height: 10 });
+    const output = focusArea(state, { showScrollbar: false });
+    expect(output).not.toContain('│');
+    expect(output).not.toContain('█');
+  });
+});
+
+// ── Keymap ──────────────────────────────────────────────────────────
+
+describe('focusAreaKeyMap', () => {
+  type Msg = { type: string };
+
+  const km = focusAreaKeyMap<Msg>({
+    scrollUp: { type: 'up' },
+    scrollDown: { type: 'down' },
+    pageUp: { type: 'pu' },
+    pageDown: { type: 'pd' },
+    top: { type: 'top' },
+    bottom: { type: 'bot' },
+    scrollLeft: { type: 'left' },
+    scrollRight: { type: 'right' },
+  });
+
+  it('handles j/k for scroll', () => {
+    expect(km.handle(keyMsg('j'))).toEqual({ type: 'down' });
+    expect(km.handle(keyMsg('k'))).toEqual({ type: 'up' });
+  });
+
+  it('handles page keys', () => {
+    expect(km.handle(keyMsg('d'))).toEqual({ type: 'pd' });
+    expect(km.handle(keyMsg('u'))).toEqual({ type: 'pu' });
+  });
+
+  it('handles top/bottom', () => {
+    expect(km.handle(keyMsg('g'))).toEqual({ type: 'top' });
+    expect(km.handle(keyMsg('g', { shift: true }))).toEqual({ type: 'bot' });
+  });
+
+  it('handles h/l for horizontal scroll', () => {
+    expect(km.handle(keyMsg('h'))).toEqual({ type: 'left' });
+    expect(km.handle(keyMsg('l'))).toEqual({ type: 'right' });
+  });
+
+  it('returns undefined for unbound keys', () => {
+    expect(km.handle(keyMsg('x'))).toBeUndefined();
+  });
+
+  it('does not bind arrow keys (reserved for content navigation)', () => {
+    expect(km.handle(keyMsg('up'))).toBeUndefined();
+    expect(km.handle(keyMsg('down'))).toBeUndefined();
+    expect(km.handle(keyMsg('left'))).toBeUndefined();
+    expect(km.handle(keyMsg('right'))).toBeUndefined();
+  });
+});

--- a/packages/bijou-tui/src/focus-area.ts
+++ b/packages/bijou-tui/src/focus-area.ts
@@ -20,8 +20,7 @@
  * ```
  */
 
-import type { BijouContext } from '@flyingrobots/bijou';
-import type { TokenValue } from '@flyingrobots/bijou';
+import type { BijouContext, TokenValue } from '@flyingrobots/bijou';
 import {
   type ScrollState,
   viewport,

--- a/packages/bijou-tui/src/focus-area.ts
+++ b/packages/bijou-tui/src/focus-area.ts
@@ -105,10 +105,16 @@ const GUTTER_CHAR = '▎';
  * @returns Fresh focus area state with scroll at the top-left.
  */
 export function createFocusAreaState(options: FocusAreaOptions): FocusAreaState {
-  const { content, width, height, overflowX = 'hidden' } = options;
-  // Gutter consumes 1 column
+  const { content, overflowX = 'hidden' } = options;
+  // Clamp dimensions to at least 1
+  const width = Math.max(1, options.width);
+  const height = Math.max(1, options.height);
+  // Gutter consumes 1 column; scrollbar consumes 1 more when visible
   const contentWidth = Math.max(1, width - 1);
-  const viewportWidth = overflowX === 'scroll' ? contentWidth : undefined;
+  const totalLines = content.split('\n').length;
+  const hasScrollbar = totalLines > height;
+  const scrollableWidth = hasScrollbar ? Math.max(1, contentWidth - 1) : contentWidth;
+  const viewportWidth = overflowX === 'scroll' ? scrollableWidth : undefined;
   return {
     content,
     scroll: createScrollState(content, height, viewportWidth),
@@ -219,7 +225,10 @@ export function focusAreaScrollToX(state: FocusAreaState, x: number): FocusAreaS
  */
 export function focusAreaSetContent(state: FocusAreaState, content: string): FocusAreaState {
   const contentWidth = Math.max(1, state.width - 1);
-  const viewportWidth = state.overflowX === 'scroll' ? contentWidth : undefined;
+  const totalLines = content.split('\n').length;
+  const hasScrollbar = totalLines > state.height;
+  const scrollableWidth = hasScrollbar ? Math.max(1, contentWidth - 1) : contentWidth;
+  const viewportWidth = state.overflowX === 'scroll' ? scrollableWidth : undefined;
   const newScroll = createScrollState(content, state.height, viewportWidth);
   const clampedY = Math.min(state.scroll.y, newScroll.maxY);
   const clampedX = Math.min(state.scroll.x, newScroll.maxX);
@@ -257,12 +266,20 @@ export function focusArea(state: FocusAreaState, options?: FocusAreaRenderOption
   const hasGutter = mode !== 'pipe' && mode !== 'accessible';
   const contentWidth = hasGutter ? Math.max(1, state.width - 1) : state.width;
 
+  // Clamp scrollX to render-time content width (may differ from state-time
+  // width when pipe/accessible mode removes the gutter)
+  let scrollX: number | undefined;
+  if (state.overflowX === 'scroll') {
+    const maxRenderX = Math.max(0, state.scroll.maxX + (contentWidth < state.width ? 0 : 1));
+    scrollX = Math.min(state.scroll.x, maxRenderX);
+  }
+
   const body = viewport({
     width: contentWidth,
     height: state.height,
     content: state.content,
     scrollY: state.scroll.y,
-    scrollX: state.overflowX === 'scroll' ? state.scroll.x : undefined,
+    scrollX,
     showScrollbar,
   });
 

--- a/packages/bijou-tui/src/focus-area.ts
+++ b/packages/bijou-tui/src/focus-area.ts
@@ -1,0 +1,341 @@
+/**
+ * Focus area building block — a scrollable pane with a colored left gutter.
+ *
+ * Wraps `viewport()` and prepends a styled gutter character (`▎`) to each
+ * line indicating focus state: bright accent when focused, muted when unfocused.
+ *
+ * Follows the building block pattern: immutable state + pure transformers +
+ * pure render + convenience keymap factory.
+ *
+ * ```ts
+ * // In TEA init:
+ * const fa = createFocusAreaState({ content, width: 60, height: 20 });
+ *
+ * // In TEA view:
+ * const output = focusArea(fa, { focused: true, ctx });
+ *
+ * // In TEA update:
+ * case 'scroll-down':
+ *   return [{ ...model, fa: focusAreaScrollBy(model.fa, 1) }, []];
+ * ```
+ */
+
+import type { BijouContext } from '@flyingrobots/bijou';
+import type { TokenValue } from '@flyingrobots/bijou';
+import {
+  type ScrollState,
+  viewport,
+  createScrollState,
+  scrollBy,
+  scrollTo,
+  scrollToTop,
+  scrollToBottom,
+  pageDown,
+  pageUp,
+  scrollByX,
+  scrollToX,
+} from './viewport.js';
+import { createKeyMap, type KeyMap } from './keybindings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Horizontal overflow behavior. */
+export type OverflowX = 'scroll' | 'hidden';
+
+/** Immutable state for the focus area widget. */
+export interface FocusAreaState {
+  /** Full text content displayed in the focus area. */
+  readonly content: string;
+  /** Underlying scroll position state. */
+  readonly scroll: ScrollState;
+  /** Total width in columns (including gutter). */
+  readonly width: number;
+  /** Total height in rows. */
+  readonly height: number;
+  /** Horizontal overflow behavior. */
+  readonly overflowX: OverflowX;
+}
+
+/** Options for creating a new focus area state. */
+export interface FocusAreaOptions {
+  /** Full text content to display. */
+  readonly content: string;
+  /** Total width in columns (including gutter). */
+  readonly width: number;
+  /** Total height in rows. */
+  readonly height: number;
+  /** Horizontal overflow behavior. Default: `'hidden'`. */
+  readonly overflowX?: OverflowX;
+}
+
+/** Options for rendering the focus area view. */
+export interface FocusAreaRenderOptions {
+  /** Whether the pane is currently focused. Default: `true`. */
+  readonly focused?: boolean;
+  /** Token for the focused gutter. Default: `theme.semantic.accent`. */
+  readonly focusedGutterToken?: TokenValue;
+  /** Token for the unfocused gutter. Default: `theme.semantic.muted`. */
+  readonly unfocusedGutterToken?: TokenValue;
+  /** Show a scrollbar track on the right edge. Default: `true`. */
+  readonly showScrollbar?: boolean;
+  /** Bijou context for styling and mode detection. */
+  readonly ctx?: BijouContext;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Gutter character: left one quarter block (U+258E). */
+const GUTTER_CHAR = '▎';
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial focus area state for the given content and dimensions.
+ *
+ * The viewport width is `width - 1` to account for the gutter column.
+ * When `overflowX` is `'scroll'`, horizontal scroll bounds are computed
+ * from the widest content line.
+ *
+ * @param options - Content, width, height, and overflow for the focus area.
+ * @returns Fresh focus area state with scroll at the top-left.
+ */
+export function createFocusAreaState(options: FocusAreaOptions): FocusAreaState {
+  const { content, width, height, overflowX = 'hidden' } = options;
+  // Gutter consumes 1 column
+  const contentWidth = Math.max(1, width - 1);
+  const viewportWidth = overflowX === 'scroll' ? contentWidth : undefined;
+  return {
+    content,
+    scroll: createScrollState(content, height, viewportWidth),
+    width,
+    height,
+    overflowX,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State transformers
+// ---------------------------------------------------------------------------
+
+/**
+ * Scroll vertically by a relative amount.
+ *
+ * @param state - Current focus area state.
+ * @param dy - Relative vertical offset (positive = down).
+ * @returns Updated state with new scroll position.
+ */
+export function focusAreaScrollBy(state: FocusAreaState, dy: number): FocusAreaState {
+  return { ...state, scroll: scrollBy(state.scroll, dy) };
+}
+
+/**
+ * Scroll vertically to an absolute position.
+ *
+ * @param state - Current focus area state.
+ * @param y - Absolute vertical offset (0-based).
+ * @returns Updated state with new scroll position.
+ */
+export function focusAreaScrollTo(state: FocusAreaState, y: number): FocusAreaState {
+  return { ...state, scroll: scrollTo(state.scroll, y) };
+}
+
+/**
+ * Scroll to the first line.
+ *
+ * @param state - Current focus area state.
+ * @returns Updated state scrolled to the top.
+ */
+export function focusAreaScrollToTop(state: FocusAreaState): FocusAreaState {
+  return { ...state, scroll: scrollToTop(state.scroll) };
+}
+
+/**
+ * Scroll to the last line.
+ *
+ * @param state - Current focus area state.
+ * @returns Updated state scrolled to the bottom.
+ */
+export function focusAreaScrollToBottom(state: FocusAreaState): FocusAreaState {
+  return { ...state, scroll: scrollToBottom(state.scroll) };
+}
+
+/**
+ * Page down (one viewport height).
+ *
+ * @param state - Current focus area state.
+ * @returns Updated state advanced by one page.
+ */
+export function focusAreaPageDown(state: FocusAreaState): FocusAreaState {
+  return { ...state, scroll: pageDown(state.scroll) };
+}
+
+/**
+ * Page up (one viewport height).
+ *
+ * @param state - Current focus area state.
+ * @returns Updated state moved back by one page.
+ */
+export function focusAreaPageUp(state: FocusAreaState): FocusAreaState {
+  return { ...state, scroll: pageUp(state.scroll) };
+}
+
+/**
+ * Scroll horizontally by a relative amount.
+ * No-op when `overflowX` is `'hidden'`.
+ *
+ * @param state - Current focus area state.
+ * @param dx - Relative horizontal offset (positive = right).
+ * @returns Updated state with new horizontal scroll position.
+ */
+export function focusAreaScrollByX(state: FocusAreaState, dx: number): FocusAreaState {
+  if (state.overflowX === 'hidden') return state;
+  return { ...state, scroll: scrollByX(state.scroll, dx) };
+}
+
+/**
+ * Scroll horizontally to an absolute position.
+ * No-op when `overflowX` is `'hidden'`.
+ *
+ * @param state - Current focus area state.
+ * @param x - Absolute horizontal offset (0-based).
+ * @returns Updated state with new horizontal scroll position.
+ */
+export function focusAreaScrollToX(state: FocusAreaState, x: number): FocusAreaState {
+  if (state.overflowX === 'hidden') return state;
+  return { ...state, scroll: scrollToX(state.scroll, x) };
+}
+
+/**
+ * Update content while preserving scroll position (clamped).
+ *
+ * @param state - Current focus area state.
+ * @param content - New text content to display.
+ * @returns Updated state with new content and clamped scroll position.
+ */
+export function focusAreaSetContent(state: FocusAreaState, content: string): FocusAreaState {
+  const contentWidth = Math.max(1, state.width - 1);
+  const viewportWidth = state.overflowX === 'scroll' ? contentWidth : undefined;
+  const newScroll = createScrollState(content, state.height, viewportWidth);
+  const clampedY = Math.min(state.scroll.y, newScroll.maxY);
+  const clampedX = Math.min(state.scroll.x, newScroll.maxX);
+  return {
+    ...state,
+    content,
+    scroll: { ...newScroll, y: clampedY, x: clampedX },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the focus area — viewport content with a colored left gutter.
+ *
+ * The gutter character (`▎`) is styled based on focus state:
+ * - Focused: `focusedGutterToken` (default: `theme.semantic.accent`)
+ * - Unfocused: `unfocusedGutterToken` (default: `theme.semantic.muted`)
+ * - Static mode: unstyled gutter
+ * - Pipe / accessible mode: no gutter (full width to content)
+ *
+ * @param state - Current focus area state.
+ * @param options - Rendering options (focus, tokens, scrollbar, ctx).
+ * @returns Rendered focus area string.
+ */
+export function focusArea(state: FocusAreaState, options?: FocusAreaRenderOptions): string {
+  const focused = options?.focused ?? true;
+  const showScrollbar = options?.showScrollbar ?? true;
+  const ctx = options?.ctx;
+  const mode = ctx?.mode ?? 'interactive';
+
+  // Pipe and accessible modes: no gutter, full width to content
+  const hasGutter = mode !== 'pipe' && mode !== 'accessible';
+  const contentWidth = hasGutter ? Math.max(1, state.width - 1) : state.width;
+
+  const body = viewport({
+    width: contentWidth,
+    height: state.height,
+    content: state.content,
+    scrollY: state.scroll.y,
+    scrollX: state.overflowX === 'scroll' ? state.scroll.x : undefined,
+    showScrollbar,
+  });
+
+  if (!hasGutter) return body;
+
+  // Determine gutter string
+  const gutter = resolveGutter(focused, ctx, options);
+
+  // Prepend gutter to each line
+  const lines = body.split('\n');
+  return lines.map((line) => gutter + line).join('\n');
+}
+
+/**
+ * Resolve the styled gutter string based on focus state and context.
+ */
+function resolveGutter(
+  focused: boolean,
+  ctx: BijouContext | undefined,
+  options: FocusAreaRenderOptions | undefined,
+): string {
+  if (!ctx) return GUTTER_CHAR;
+
+  const mode = ctx.mode;
+  if (mode === 'static') return GUTTER_CHAR;
+
+  const token = focused
+    ? (options?.focusedGutterToken ?? ctx.theme.theme.semantic.accent)
+    : (options?.unfocusedGutterToken ?? ctx.theme.theme.semantic.muted);
+
+  return ctx.style.styled(token, GUTTER_CHAR);
+}
+
+// ---------------------------------------------------------------------------
+// Convenience keymap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a preconfigured KeyMap for focus area navigation.
+ *
+ * Arrow keys are intentionally excluded — reserved for content-specific
+ * navigation (e.g., DAG node selection).
+ *
+ * @template Msg - Application message type dispatched by key bindings.
+ * @param actions - Map of navigation actions to message values.
+ * @returns Preconfigured key map with vim-style scroll bindings.
+ */
+export function focusAreaKeyMap<Msg>(actions: {
+  scrollUp: Msg;
+  scrollDown: Msg;
+  pageUp: Msg;
+  pageDown: Msg;
+  top: Msg;
+  bottom: Msg;
+  scrollLeft?: Msg;
+  scrollRight?: Msg;
+}): KeyMap<Msg> {
+  const km = createKeyMap<Msg>()
+    .group('Scroll', (g) => {
+      g.bind('j', 'Down', actions.scrollDown)
+        .bind('k', 'Up', actions.scrollUp)
+        .bind('d', 'Page down', actions.pageDown)
+        .bind('u', 'Page up', actions.pageUp)
+        .bind('g', 'Top', actions.top)
+        .bind('shift+g', 'Bottom', actions.bottom);
+      if (actions.scrollLeft !== undefined) {
+        g.bind('h', 'Scroll left', actions.scrollLeft);
+      }
+      if (actions.scrollRight !== undefined) {
+        g.bind('l', 'Scroll right', actions.scrollRight);
+      }
+      return g;
+    });
+  return km;
+}

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -280,3 +280,47 @@ export {
   commandPalette,
   commandPaletteKeyMap,
 } from './command-palette.js';
+
+// Focus area — scrollable pane with colored gutter
+export {
+  type OverflowX,
+  type FocusAreaState,
+  type FocusAreaOptions,
+  type FocusAreaRenderOptions,
+  createFocusAreaState,
+  focusArea,
+  focusAreaScrollBy,
+  focusAreaScrollTo,
+  focusAreaScrollToTop,
+  focusAreaScrollToBottom,
+  focusAreaPageDown,
+  focusAreaPageUp,
+  focusAreaScrollByX,
+  focusAreaScrollToX,
+  focusAreaSetContent,
+  focusAreaKeyMap,
+} from './focus-area.js';
+
+// DAG pane — interactive DAG viewer
+export {
+  type DagPaneDagOptions,
+  type DagPaneState,
+  type DagPaneOptions,
+  type DagPaneRenderOptions,
+  createDagPaneState,
+  dagPane,
+  dagPaneSelectChild,
+  dagPaneSelectParent,
+  dagPaneSelectLeft,
+  dagPaneSelectRight,
+  dagPaneSelectNode,
+  dagPaneClearSelection,
+  dagPaneScrollBy,
+  dagPaneScrollToTop,
+  dagPaneScrollToBottom,
+  dagPanePageDown,
+  dagPanePageUp,
+  dagPaneScrollByX,
+  dagPaneSetSource,
+  dagPaneKeyMap,
+} from './dag-pane.js';


### PR DESCRIPTION
## Summary

- **`focusArea()`** — new scrollable pane building block with a colored left gutter bar (`▎`) indicating focus state. Wraps `viewport()` with gutter chrome, horizontal overflow support (`overflowX: 'scroll' | 'hidden'`), and a convenience keymap. Degrades gracefully: pipe/accessible modes omit the gutter; static mode renders it unstyled.
- **`dagPane()`** — new interactive DAG viewer building block. Wraps `dagLayout()` in a `focusArea()` with arrow-key node navigation (parent/child/sibling via spatial proximity), auto-highlight-path from root to selected node, and auto-scroll-to-selection. Includes full keymap with vim scroll bindings and arrow-key selection.
- Two new examples (`examples/focus-area/`, `examples/dag-pane/`)
- Documentation updates across root README, bijou-tui README/GUIDE/ARCHITECTURE, docs/ARCHITECTURE, docs/EXAMPLES, docs/CHANGELOG, docs/ROADMAP

## New files

| File | Purpose |
|------|---------|
| `packages/bijou-tui/src/focus-area.ts` | focusArea primitive |
| `packages/bijou-tui/src/focus-area.test.ts` | 39 tests |
| `packages/bijou-tui/src/dag-pane.ts` | dagPane building block |
| `packages/bijou-tui/src/dag-pane.test.ts` | 47 tests |
| `examples/focus-area/main.ts` | TEA app demo |
| `examples/dag-pane/main.ts` | TEA app demo |

## Test plan

- [x] 86 new tests (39 focus-area + 47 dag-pane)
- [x] `tsc --noEmit` passes for all 3 packages (bijou, bijou-node, bijou-tui)
- [x] Full test suite: 89 files, 1603 tests, 0 failures