### PR TITLE
Architectural Refactor: Phases 5, 6, and 7 (OCP, DIP, and Test Hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All packages are versioned in lock-step.
 - **TEA loop**: `run`, `App`, command-driven update/view flow.
 - **Layout**: `flex`, `vstack`, `hstack`, `viewport`, focus-aware panes.
 - **Input and interaction**: keymaps, layered input stack, command palette, file picker, browsable list, navigable table.
-- **Motion**: spring and tween animation, timeline sequencing, high-fidelity terminal transitions.
+- **Motion**: spring and tween animation, timeline sequencing, high-fidelity terminal transitions (wipe, dissolve, grid, fade).
 
 ### Node Adapter (`@flyingrobots/bijou-node`)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,13 +20,22 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Decentralized theme access (DIP)** — added `semantic()`, `border()`, `surface()`, `status()`, and `ui()` helpers to `BijouContext`; components now look up tokens via these semantic methods instead of reaching into the deep `ctx.theme.theme` object structure.
 - **Form components consistency** — refactored `select()`, `multiselect()`, and `filter()` to use new semantic context helpers and the `renderByMode` dispatcher.
 
+### 🐛 Fixes
+
+- **Transition generation guard (bijou-tui)** — rapid tab switches no longer let stale tween ticks overwrite a newer transition's progress. Each transition carries a monotonic generation counter; mismatched ticks are discarded.
+- **Table column width (bijou core)** — `table()` now uses `visibleLength()` instead of `.length` for auto-calculated column widths, preventing oversized columns when cells contain ANSI styling.
+- **`headerBox()` nullish label handling** — nullish labels with non-empty `detail` no longer leak separators or empty styled spans.
+- **Active tab bullet styling** — the `●` bullet in `tabs()` is now styled with the primary token, matching the active label.
+- **Custom component example** — replaced `as any` mode mutation with immutable context spread pattern.
+
 ### 🧪 Tests
 
 - **Tab transition coverage** — added manual and scripted interaction tests for tab transitions in `app-frame.test.ts`.
-- **Multiselect scrolling coverage** — added `maxVisible` scrolling test cases to `multiselect.test.ts`.
+- **Multiselect scrolling coverage** — added `maxVisible` scrolling test cases to `multiselect.test.ts`, including wrap-around scrolling.
 - **Shared test fixtures** — extracted common form data (colors, fruits, large lists) into `adapters/test/fixtures.ts` for reuse across test suites.
 - **Defensive input hardening** — added comprehensive tests and fixes for `null`/`undefined` input handling in `box()`, `headerBox()`, `alert()`, `table()`, and `markdown()`.
 - **Test suite refactoring** — migrated all form tests to use shared fixtures and updated component tests to leverage new `BijouContext` helpers.
+- **Test isolation** — `app-frame.test.ts` now properly scopes `setDefaultContext()` with `beforeAll`/`afterAll` to prevent singleton leaks.
 
 ## [1.3.0] - 2026-03-06
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/bijou-tui`, `@flyingrobots/bijou-tui-app`, `create-bijou-tui-app`) are versioned in lock-step.
 
+## [Unreleased]
+
+### ♻️ Refactors
+
+- **Mode rendering strategy (OCP)** — implemented `renderByMode` dispatcher pattern to replace repetitive `if (mode === …)` chains; migrated all core components to use the new registry pattern for cleaner mode-specific rendering.
+- **Decentralized theme access (DIP)** — added `semantic()`, `border()`, `surface()`, `status()`, and `ui()` helpers to `BijouContext`; components now look up tokens via these semantic methods instead of reaching into the deep `ctx.theme.theme` object structure.
+
+### 🧪 Tests
+
+- **Shared test fixtures** — extracted common form data (colors, fruits, large lists) into `adapters/test/fixtures.ts` for reuse across test suites.
+- **Defensive input hardening** — added comprehensive tests and fixes for `null`/`undefined` input handling in `box()`, `headerBox()`, `alert()`, `table()`, and `markdown()`.
+- **Test suite refactoring** — migrated all form tests to use shared fixtures and updated component tests to leverage new `BijouContext` helpers.
+
 ## [1.3.0] - 2026-03-06
 
 ### ✨ Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Component showcase app** — full-screen interactive explorer (`examples/showcase/`) with 45 components across 4 categories (Display, Data, Forms, TUI Blocks). Each component shows rendered output in rich, pipe, and accessible modes side-by-side. Features animated welcome drawer, tab transitions, command palette, and full keyboard navigation.
 - **Tab transition animations (bijou-tui)** — implemented `wipe`, `dissolve`, `grid`, `fade`, `melt` (Doom-style), `matrix` (code-leading edge), and `scramble` (noise resolve) transitions in `createFramedApp()`. Transitions are driven by pure TEA state and rendered via high-performance character-grid shaders in `canvas()`.
 - **Scrollable multiselect viewport (bijou core)** — `multiselect()` now supports `maxVisible` in interactive mode with scrolling behavior for long option lists, matching the `select()` and `filter()` components.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,13 +6,21 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **Tab transition animations (bijou-tui)** — implemented `wipe`, `dissolve`, `grid`, and `fade` transitions in `createFramedApp()`. Transitions are driven by pure TEA state and rendered via high-performance character-grid shaders in `canvas()`.
+- **Scrollable multiselect viewport (bijou core)** — `multiselect()` now supports `maxVisible` in interactive mode with scrolling behavior for long option lists, matching the `select()` and `filter()` components.
+
 ### ♻️ Refactors
 
 - **Mode rendering strategy (OCP)** — implemented `renderByMode` dispatcher pattern to replace repetitive `if (mode === …)` chains; migrated all core components to use the new registry pattern for cleaner mode-specific rendering.
 - **Decentralized theme access (DIP)** — added `semantic()`, `border()`, `surface()`, `status()`, and `ui()` helpers to `BijouContext`; components now look up tokens via these semantic methods instead of reaching into the deep `ctx.theme.theme` object structure.
+- **Form components consistency** — refactored `select()`, `multiselect()`, and `filter()` to use new semantic context helpers and the `renderByMode` dispatcher.
 
 ### 🧪 Tests
 
+- **Tab transition coverage** — added manual and scripted interaction tests for tab transitions in `app-frame.test.ts`.
+- **Multiselect scrolling coverage** — added `maxVisible` scrolling test cases to `multiselect.test.ts`.
 - **Shared test fixtures** — extracted common form data (colors, fruits, large lists) into `adapters/test/fixtures.ts` for reuse across test suites.
 - **Defensive input hardening** — added comprehensive tests and fixes for `null`/`undefined` input handling in `box()`, `headerBox()`, `alert()`, `table()`, and `markdown()`.
 - **Test suite refactoring** — migrated all form tests to use shared fixtures and updated component tests to leverage new `BijouContext` helpers.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ♻️ Refactors
 
+- **Transition shader system (bijou-tui)** — extracted 7 hardcoded transition effects from `renderTransition()` into composable pure functions (`TransitionShaderFn`). `PageTransition` now accepts custom shader functions alongside built-in names, enabling user-authored spatial blend algorithms.
 - **Mode rendering strategy (OCP)** — implemented `renderByMode` dispatcher pattern to replace repetitive `if (mode === …)` chains; migrated all core components to use the new registry pattern for cleaner mode-specific rendering.
 - **Decentralized theme access (DIP)** — added `semantic()`, `border()`, `surface()`, `status()`, and `ui()` helpers to `BijouContext`; components now look up tokens via these semantic methods instead of reaching into the deep `ctx.theme.theme` object structure.
 - **Form components consistency** — refactored `select()`, `multiselect()`, and `filter()` to use new semantic context helpers and the `renderByMode` dispatcher.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
-- **Tab transition animations (bijou-tui)** — implemented `wipe`, `dissolve`, `grid`, and `fade` transitions in `createFramedApp()`. Transitions are driven by pure TEA state and rendered via high-performance character-grid shaders in `canvas()`.
+- **Tab transition animations (bijou-tui)** — implemented `wipe`, `dissolve`, `grid`, `fade`, `melt` (Doom-style), `matrix` (code-leading edge), and `scramble` (noise resolve) transitions in `createFramedApp()`. Transitions are driven by pure TEA state and rendered via high-performance character-grid shaders in `canvas()`.
 - **Scrollable multiselect viewport (bijou core)** — `multiselect()` now supports `maxVisible` in interactive mode with scrolling behavior for long option lists, matching the `select()` and `filter()` components.
 
 ### ♻️ Refactors

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### ✨ Features
 
 - **Component showcase app** — full-screen interactive explorer (`examples/showcase/`) with 45 components across 4 categories (Display, Data, Forms, TUI Blocks). Each component shows rendered output in rich, pipe, and accessible modes side-by-side. Features animated welcome drawer, tab transitions, command palette, and full keyboard navigation.
+- **Timeline-driven transitions (bijou-tui)** — `createFramedApp()` now accepts a `transitionTimeline` option: a compiled `timeline()` with a `'progress'` track that drives the transition animation. Users can share custom transition definitions with springs, tweens, and easing curves. Transitions are time-based (wall-clock `Date.now()`), not tick-based.
 - **Tab transition animations (bijou-tui)** — implemented `wipe`, `dissolve`, `grid`, `fade`, `melt` (Doom-style), `matrix` (code-leading edge), and `scramble` (noise resolve) transitions in `createFramedApp()`. Transitions are driven by pure TEA state and rendered via high-performance character-grid shaders in `canvas()`.
 - **Scrollable multiselect viewport (bijou core)** — `multiselect()` now supports `maxVisible` in interactive mode with scrolling behavior for long option lists, matching the `select()` and `filter()` components.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,7 @@
 | [`split-pane`](./split-pane/) | `splitPane()`, `splitPaneResizeBy()` | Stateful split layout with focus and divider resizing |
 | [`grid-layout`](./grid-layout/) | `grid()`, `gridLayout()` | Named-area grid layout with fixed and fractional tracks |
 | [`app-frame`](./app-frame/) | `createFramedApp()` | Tabbed shell with pane focus, help, overlays, and command palette |
+| [`transitions`](./transitions/) | `createFramedApp()`, transitions | Dynamic tab transition animations (melt, matrix, scramble, etc.) |
 | [`release-workbench`](./release-workbench/) | `createFramedApp()`, `grid()`, `splitPane()`, `drawer()` | Canonical multi-view control room with pane-scoped drawers and command palette |
 | [`pager`](./pager/) | `pager()`, `pagerKeyMap()` | Scrollable text viewer with status line |
 | [`navigable-table`](./navigable-table/) | `navigableTable()`, `navTableKeyMap()` | Keyboard-navigable data table with scrolling |

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,9 @@
 | [`dag-fragment`](./dag-fragment/) | `dagSlice()` + `dag()` | DAG slicing with ghost nodes at boundaries |
 | [`dag-stats`](./dag-stats/) | `dagStats()` | Graph statistics with cycle and duplicate detection |
 | [`enumerated-list`](./enumerated-list/) | `enumeratedList()` | Ordered/unordered lists with 6 bullet styles |
+| [`markdown`](./markdown/) | `markdown()` | Terminal markdown with mode degradation |
+| [`logo`](./logo/) | `loadRandomLogo()` | Random ASCII brand logos in 3 sizes |
+| [`custom-component`](./custom-component/) | `renderByMode()` | Custom mode-aware themed components |
 | [`hyperlink`](./hyperlink/) | `hyperlink()` | OSC 8 clickable terminal links with fallback |
 | [`log`](./log/) | `log()` | Leveled styled output (debug through fatal) |
 | [`pipe`](./pipe/) | `detectOutputMode()`, all components | Same components in interactive/pipe/accessible mode |
@@ -59,6 +62,7 @@
 | [`spring`](./spring/) | `animate()`, `springStep()`, `SPRING_PRESETS` | Spring physics comparison (4 presets) |
 | [`timeline-anim`](./timeline-anim/) | `timeline()`, `animate()`, `sequence()` | Orchestrated GSAP-style animation |
 | [`modal`](./modal/) | `createInputStack()`, `viewport()` | Layered modal input dispatch |
+| [`toast`](./toast/) | `toast()`, `composite()` | Anchored notification overlay variants |
 | [`help`](./help/) | `createKeyMap()`, `helpView()`, `helpShort()` | Keybinding manager with help toggle |
 | [`print-key`](./print-key/) | `parseKey()` | Key event inspector with modifier badges |
 | [`fullscreen`](./fullscreen/) | `enterScreen()`, `exitScreen()` | Alternate screen with centered content |

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,16 @@
 > Run any example: `npx tsx examples/<name>/main.ts`
 > Record all GIFs: `../scripts/record-gifs.sh`
 
+## Showcase
+
+Full-screen interactive component explorer with live previews across all output modes:
+
+```sh
+npx tsx examples/showcase/main.ts
+```
+
+Browse 45 components across 4 categories (Display, Data, Forms, TUI Blocks). Each component shows rendered output in rich, pipe, and accessible modes side-by-side.
+
 ## Static Components
 
 | Example | Component | Description |

--- a/examples/_shared/canonical-app.ts
+++ b/examples/_shared/canonical-app.ts
@@ -274,8 +274,8 @@ function renderOpsSummary(width: number, height: number, model: WorkbenchPageMod
 
   return box(fixedLines.join('\n'), {
     width,
-    bgToken: ctx.theme.theme.surface.secondary,
-    borderToken: ctx.theme.theme.border.primary,
+    bgToken: ctx.surface('secondary'),
+    borderToken: ctx.border('primary'),
     ctx,
   });
 }
@@ -331,7 +331,7 @@ function renderIncidentFeed(width: number, model: WorkbenchPageModel, ctx: Bijou
     legend,
   ].join('\n'), {
     width,
-    borderToken: ctx.theme.theme.border.muted,
+    borderToken: ctx.border('muted'),
     ctx,
   });
 }
@@ -384,7 +384,7 @@ function renderBoardTicket(width: number, model: WorkbenchPageModel, ctx: BijouC
     `Hints: ${kbd('tab', { ctx })} pane focus • ${kbd('h/l', { ctx })} horizontal scroll`,
   ].join('\n'), {
     width,
-    borderToken: ctx.theme.theme.border.primary,
+    borderToken: ctx.border('primary'),
     ctx,
   });
 }
@@ -400,7 +400,7 @@ function renderBoardRunbook(width: number, ctx: BijouContext): string {
     timeline(events, { ctx }),
   ].join('\n'), {
     width,
-    bgToken: ctx.theme.theme.surface.secondary,
+    bgToken: ctx.surface('secondary'),
     ctx,
   });
 }
@@ -460,7 +460,7 @@ function renderGraphNotes(width: number, model: WorkbenchPageModel, ctx: BijouCo
     '- per-pane scroll isolation and horizontal overflow',
   ].join('\n'), {
     width,
-    bgToken: ctx.theme.theme.surface.muted,
+    bgToken: ctx.surface('muted'),
     ctx,
   });
 }
@@ -686,8 +686,8 @@ export function createCanonicalWorkbenchApp(
             content,
             screenWidth: frame.screenRect.width,
             screenHeight: frame.screenRect.height,
-            borderToken: ctx.theme.theme.border.primary,
-            bgToken: ctx.theme.theme.surface.elevated,
+            borderToken: ctx.border('primary'),
+            bgToken: ctx.surface('elevated'),
             ctx,
           };
           if (anchor === 'left' || anchor === 'right') {
@@ -714,8 +714,8 @@ export function createCanonicalWorkbenchApp(
           width: 44,
           screenWidth: frame.screenRect.width,
           screenHeight: frame.screenRect.height,
-          borderToken: ctx.theme.theme.border.primary,
-          bgToken: ctx.theme.theme.surface.elevated,
+          borderToken: ctx.border('primary'),
+          bgToken: ctx.surface('elevated'),
           ctx,
         }));
       }

--- a/examples/app-frame/main.ts
+++ b/examples/app-frame/main.ts
@@ -108,6 +108,8 @@ const app = createFramedApp<PageModel, Msg>({
   pages: [editorPage, dashboardPage],
   globalKeys,
   enableCommandPalette: true,
+  transition: 'dissolve',
+  transitionDuration: 400,
   overlayFactory(frame) {
     if (!frame.pageModel.inspector) return [];
 

--- a/examples/app-frame/main.ts
+++ b/examples/app-frame/main.ts
@@ -122,8 +122,8 @@ const app = createFramedApp<PageModel, Msg>({
       screenHeight: frame.screenRect.height,
       title: 'Inspector',
       content: `Active page: ${frame.activePageId}\n\nUse ${kbd('tab')} to change focused pane.\nUse ${kbd('ctrl+p')} for palette.`,
-      borderToken: ctx.theme.theme.border.primary,
-      bgToken: ctx.theme.theme.surface.elevated,
+      borderToken: ctx.border('primary'),
+      bgToken: ctx.surface('elevated'),
       ctx,
     })];
   },

--- a/examples/app-frame/main.ts
+++ b/examples/app-frame/main.ts
@@ -108,8 +108,8 @@ const app = createFramedApp<PageModel, Msg>({
   pages: [editorPage, dashboardPage],
   globalKeys,
   enableCommandPalette: true,
-  transition: 'dissolve',
-  transitionDuration: 400,
+  transition: 'melt',
+  transitionDuration: 600,
   overlayFactory(frame) {
     if (!frame.pageModel.inspector) return [];
 

--- a/examples/background-panels/README.md
+++ b/examples/background-panels/README.md
@@ -15,11 +15,9 @@ import { ctx } from '../_shared/setup.js';
 import { box, separator } from '@flyingrobots/bijou';
 import { flex, modal, toast, composite } from '@flyingrobots/bijou-tui';
 
-const { theme } = ctx.theme;
-
 // 1. box() with bgToken — a colored panel
 console.log(box('This box has a background fill.', {
-  bgToken: theme.surface.primary,
+  bgToken: ctx.surface('primary'),
   padding: { top: 1, bottom: 1, left: 2, right: 2 },
   width: 44,
   ctx,
@@ -27,10 +25,10 @@ console.log(box('This box has a background fill.', {
 
 // 2. flex() with per-child bg — multiple colored regions
 console.log(flex(
-  { direction: 'row', width: 60, height: 5, gap: 1, bgToken: theme.surface.muted, ctx },
-  { basis: 20, bgToken: theme.surface.primary, content: ' Primary' },
-  { basis: 20, bgToken: theme.surface.secondary, content: ' Secondary' },
-  { flex: 1, bgToken: theme.surface.elevated, content: ' Elevated' },
+  { direction: 'row', width: 60, height: 5, gap: 1, bgToken: ctx.surface('muted'), ctx },
+  { basis: 20, bgToken: ctx.surface('primary'), content: ' Primary' },
+  { basis: 20, bgToken: ctx.surface('secondary'), content: ' Secondary' },
+  { flex: 1, bgToken: ctx.surface('elevated'), content: ' Elevated' },
 ));
 
 // 3. modal() with bgToken over dimmed content
@@ -41,8 +39,8 @@ const m = modal({
   hint: 'y/n',
   screenWidth: 64,
   screenHeight: 12,
-  bgToken: theme.surface.overlay,
-  borderToken: theme.border.primary,
+  bgToken: ctx.surface('overlay'),
+  borderToken: ctx.border('primary'),
   ctx,
 });
 console.log(composite(bg, [m], { dim: true }));
@@ -54,7 +52,7 @@ const t = toast({
   variant: 'success',
   screenWidth: 64,
   screenHeight: 6,
-  bgToken: theme.surface.elevated,
+  bgToken: ctx.surface('elevated'),
   ctx,
 });
 console.log(composite(toastBg, [t]));

--- a/examples/custom-component/README.md
+++ b/examples/custom-component/README.md
@@ -1,0 +1,34 @@
+# `renderByMode()`
+
+Custom mode-aware themed components
+
+## Run
+
+```sh
+npx tsx examples/custom-component/main.ts
+```
+
+## Code
+
+```typescript
+import { renderByMode, resolveCtx, type BijouContext } from '@flyingrobots/bijou';
+
+function spark(label: string, value: string, options: { ctx?: BijouContext } = {}) {
+  const ctx = resolveCtx(options.ctx);
+
+  return renderByMode(ctx.mode, {
+    pipe: () => `[\${label.toUpperCase()}] \${value}`,
+    accessible: () => `Status \${label}: \${value}.`,
+    interactive: () => {
+      const accent = ctx.semantic('accent');
+      const muted = ctx.semantic('muted');
+      const sparkIcon = ctx.style.styled(accent, '\u2728');
+      const labelStyled = ctx.style.bold(label);
+      const valueStyled = ctx.style.styled(muted, value);
+      return `\${sparkIcon} \${labelStyled}: \${valueStyled}`;
+    },
+  }, options);
+}
+```
+
+[← Examples](../README.md)

--- a/examples/custom-component/main.ts
+++ b/examples/custom-component/main.ts
@@ -1,0 +1,43 @@
+import { initDefaultContext, createNodeContext } from '@flyingrobots/bijou-node';
+import { renderByMode, resolveCtx, separator, box, type BijouContext } from '@flyingrobots/bijou';
+
+/**
+ * A custom themed component demonstrating renderByMode.
+ * It shows a "status spark" that looks different in each mode.
+ */
+function spark(label: string, value: string, options: { ctx?: BijouContext } = {}) {
+  const ctx = resolveCtx(options.ctx);
+
+  return renderByMode(ctx.mode, {
+    pipe: () => `[\${label.toUpperCase()}] \${value}`,
+    accessible: () => `Status \${label}: \${value}.`,
+    interactive: () => {
+      const accent = ctx.semantic('accent');
+      const muted = ctx.semantic('muted');
+      const sparkIcon = ctx.style.styled(accent, '\u2728');
+      const labelStyled = ctx.style.bold(label);
+      const valueStyled = ctx.style.styled(muted, value);
+      return `\${sparkIcon} \${labelStyled}: \${valueStyled}`;
+    },
+  }, options);
+}
+
+// 1. Interactive mode (default in TTY)
+const ctx = initDefaultContext();
+console.log(separator({ label: 'interactive mode', ctx }));
+console.log(box(spark('Deploy', 'v1.3.0', { ctx }), { padding: { left: 2, right: 2 }, ctx }));
+console.log();
+
+// 2. Simulated pipe mode
+const pipeCtx = createNodeContext();
+// Manually override mode for demonstration
+(pipeCtx as any).mode = 'pipe';
+console.log(separator({ label: 'pipe mode fallback', ctx: pipeCtx }));
+console.log(spark('Deploy', 'v1.3.0', { ctx: pipeCtx }));
+console.log();
+
+// 3. Simulated accessible mode
+const accCtx = createNodeContext();
+(accCtx as any).mode = 'accessible';
+console.log(separator({ label: 'accessible mode fallback', ctx: accCtx }));
+console.log(spark('Deploy', 'v1.3.0', { ctx: accCtx }));

--- a/examples/custom-component/main.ts
+++ b/examples/custom-component/main.ts
@@ -28,16 +28,17 @@ console.log(separator({ label: 'interactive mode', ctx }));
 console.log(box(spark('Deploy', 'v1.3.0', { ctx }), { padding: { left: 2, right: 2 }, ctx }));
 console.log();
 
+function withMode(base: BijouContext, mode: BijouContext['mode']): BijouContext {
+  return { ...base, mode };
+}
+
 // 2. Simulated pipe mode
-const pipeCtx = createNodeContext();
-// Manually override mode for demonstration
-(pipeCtx as any).mode = 'pipe';
+const pipeCtx = withMode(createNodeContext(), 'pipe');
 console.log(separator({ label: 'pipe mode fallback', ctx: pipeCtx }));
 console.log(spark('Deploy', 'v1.3.0', { ctx: pipeCtx }));
 console.log();
 
 // 3. Simulated accessible mode
-const accCtx = createNodeContext();
-(accCtx as any).mode = 'accessible';
+const accCtx = withMode(createNodeContext(), 'accessible');
 console.log(separator({ label: 'accessible mode fallback', ctx: accCtx }));
 console.log(spark('Deploy', 'v1.3.0', { ctx: accCtx }));

--- a/examples/dag-pane/main.ts
+++ b/examples/dag-pane/main.ts
@@ -1,4 +1,5 @@
-import { initDefaultContext, getDefaultContext } from '@flyingrobots/bijou-node';
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { getDefaultContext } from '@flyingrobots/bijou';
 import { separator } from '@flyingrobots/bijou';
 import type { DagNode } from '@flyingrobots/bijou';
 import {

--- a/examples/drawer/main.ts
+++ b/examples/drawer/main.ts
@@ -64,7 +64,7 @@ const app: App<Model, Msg> = {
       screenWidth: cols,
       screenHeight: rows,
       title: 'Info',
-      borderToken: ctx.theme.theme.border.primary,
+      borderToken: ctx.border('primary'),
       ctx,
     });
 

--- a/examples/logo/README.md
+++ b/examples/logo/README.md
@@ -1,0 +1,23 @@
+# `loadRandomLogo()`
+
+Random ASCII brand logos in 3 sizes
+
+## Run
+
+```sh
+npx tsx examples/logo/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { loadRandomLogo, separator, box, headerBox } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+const logo = loadRandomLogo({ size: 'medium' });
+console.log(box(logo.ascii, { padding: { top: 1, bottom: 1, left: 2, right: 2 }, ctx }));
+```
+
+[← Examples](../README.md)

--- a/examples/logo/main.ts
+++ b/examples/logo/main.ts
@@ -1,0 +1,16 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { loadRandomLogo, separator, box, headerBox } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+console.log(separator({ label: 'Bijou Random Logos', ctx }));
+console.log();
+
+const sizes: Array<'small' | 'medium' | 'large'> = ['small', 'medium', 'large'];
+
+for (const size of sizes) {
+  const logo = loadRandomLogo({ size });
+  console.log(headerBox(`Size: \${size}`, { ctx }));
+  console.log(box(logo.ascii, { padding: { top: 1, bottom: 1, left: 2, right: 2 }, ctx }));
+  console.log();
+}

--- a/examples/markdown/README.md
+++ b/examples/markdown/README.md
@@ -1,0 +1,45 @@
+# `markdown()`
+
+Terminal markdown with mode degradation
+
+## Run
+
+```sh
+npx tsx examples/markdown/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { markdown, box } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+const SOURCE = `
+# Bijou Markdown
+
+**Bijou** supports a subset of CommonMark that degrades gracefully across terminal modes.
+
+## Features
+
+- **Inline formatting**: **bold**, *italic*, and `code spans`
+- **Lists**: bulleted and numbered
+- **Links**: [GitHub](https://github.com/flyingrobots/bijou)
+- **Blocks**:
+  > Blockquotes for highlights
+  ```ts
+  console.log("Fenced code blocks");
+  ```
+
+---
+
+### Why use it?
+
+It allows you to ship documentation or help text that looks great in a TTY but remains readable when piped to a file or a screen reader.
+`;
+
+console.log(box(markdown(SOURCE, { ctx }), { padding: { top: 1, bottom: 1, left: 2, right: 2 } }));
+```
+
+[← Examples](../README.md)

--- a/examples/markdown/README.md
+++ b/examples/markdown/README.md
@@ -1,6 +1,11 @@
 # `markdown()`
 
-Terminal markdown with mode degradation
+Renders a subset of CommonMark that adapts to the terminal's output mode — styled in interactive mode, plain in pipe mode, and screen-reader-friendly in accessible mode.
+
+## Prerequisites
+
+- Node.js 18+
+- `pnpm install` from the repo root
 
 ## Run
 
@@ -8,7 +13,15 @@ Terminal markdown with mode degradation
 npx tsx examples/markdown/main.ts
 ```
 
+Pipe mode output (no ANSI styling):
+
+```sh
+npx tsx examples/markdown/main.ts | cat
+```
+
 ## Code
+
+The example initializes a `BijouContext` via `initDefaultContext()` — this detects the terminal's capabilities (TTY, color support, screen reader) and configures the styling engine accordingly. All bijou components accept `ctx` to render mode-appropriate output.
 
 ```typescript
 import { initDefaultContext } from '@flyingrobots/bijou-node';
@@ -23,14 +36,14 @@ const SOURCE = `
 
 ## Features
 
-- **Inline formatting**: **bold**, *italic*, and `code spans`
+- **Inline formatting**: **bold**, *italic*, and \`code spans\`
 - **Lists**: bulleted and numbered
 - **Links**: [GitHub](https://github.com/flyingrobots/bijou)
 - **Blocks**:
   > Blockquotes for highlights
-  ```ts
+  \`\`\`ts
   console.log("Fenced code blocks");
-  ```
+  \`\`\`
 
 ---
 

--- a/examples/markdown/main.ts
+++ b/examples/markdown/main.ts
@@ -10,14 +10,14 @@ const SOURCE = `
 
 ## Features
 
-- **Inline formatting**: **bold**, *italic*, and `code spans`
+- **Inline formatting**: **bold**, *italic*, and \`code spans\`
 - **Lists**: bulleted and numbered
 - **Links**: [GitHub](https://github.com/flyingrobots/bijou)
 - **Blocks**:
   > Blockquotes for highlights
-  ```ts
+  \`\`\`ts
   console.log("Fenced code blocks");
-  ```
+  \`\`\`
 
 ---
 

--- a/examples/markdown/main.ts
+++ b/examples/markdown/main.ts
@@ -1,0 +1,29 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { markdown, box } from '@flyingrobots/bijou';
+
+const ctx = initDefaultContext();
+
+const SOURCE = `
+# Bijou Markdown
+
+**Bijou** supports a subset of CommonMark that degrades gracefully across terminal modes.
+
+## Features
+
+- **Inline formatting**: **bold**, *italic*, and `code spans`
+- **Lists**: bulleted and numbered
+- **Links**: [GitHub](https://github.com/flyingrobots/bijou)
+- **Blocks**:
+  > Blockquotes for highlights
+  ```ts
+  console.log("Fenced code blocks");
+  ```
+
+---
+
+### Why use it?
+
+It allows you to ship documentation or help text that looks great in a TTY but remains readable when piped to a file or a screen reader.
+`;
+
+console.log(box(markdown(SOURCE, { ctx }), { padding: { top: 1, bottom: 1, left: 2, right: 2 } }));

--- a/examples/showcase/app.ts
+++ b/examples/showcase/app.ts
@@ -7,12 +7,14 @@ import {
   createKeyMap,
   createSplitPaneState,
   drawer,
+  EASINGS,
   listFocusNext,
   listFocusPrev,
   listPageDown,
   listPageUp,
   modal,
   quit,
+  timeline,
   type App,
   type FrameLayoutNode,
   type FrameModel,
@@ -286,8 +288,16 @@ export function createShowcaseApp(
     pages,
     defaultPageId: 'display',
     enableCommandPalette: true,
-    transition: 'fade',
-    transitionDuration: 250,
+    transition: 'dissolve',
+    transitionTimeline: timeline()
+      .add('progress', {
+        type: 'tween',
+        from: 0,
+        to: 1,
+        duration: 400,
+        ease: EASINGS.easeInOutCubic,
+      })
+      .build(),
     globalKeys: createKeyMap<ShowcaseMsg>()
       .group('App', (g) => g
         .bind('q', 'Quit (confirm)', { type: 'request-quit' })

--- a/examples/showcase/app.ts
+++ b/examples/showcase/app.ts
@@ -151,11 +151,13 @@ function createCategoryPage(
 
     init() {
       const listState = createBrowsableListState({ items, height: 40 });
+      const gen = 1;
       const model: ShowcasePageModel = {
         listState,
         quitConfirmOpen: false,
         drawerOpen: isFirstPage,
         drawerProgress: 0,
+        drawerAnimGen: gen,
       };
       const cmds: ReturnType<typeof animate<ShowcaseMsg>>[] = [];
       if (isFirstPage) {
@@ -163,7 +165,7 @@ function createCategoryPage(
           from: 0,
           to: 1,
           spring: 'default',
-          onFrame: (value) => ({ type: 'drawer-progress', value }),
+          onFrame: (value) => ({ type: 'drawer-progress', value, gen }),
         }));
       }
       return [model, cmds];
@@ -199,22 +201,37 @@ function createCategoryPage(
         case 'request-quit':
           return [{ ...model, quitConfirmOpen: true }, []];
         case 'cancel-quit':
+          // Close drawer if open, otherwise no-op
+          if (model.drawerOpen) {
+            const nextGen = model.drawerAnimGen + 1;
+            return [{ ...model, drawerOpen: false, drawerAnimGen: nextGen }, [
+              animate<ShowcaseMsg>({
+                from: model.drawerProgress,
+                to: 0,
+                spring: 'default',
+                onFrame: (value) => ({ type: 'drawer-progress', value, gen: nextGen }),
+              }),
+            ]];
+          }
           return [model, []];
         case 'confirm-quit':
           return [model, []];
         case 'toggle-drawer': {
           const drawerOpen = !model.drawerOpen;
           const target = drawerOpen ? 1 : 0;
-          return [{ ...model, drawerOpen }, [
+          const nextGen = model.drawerAnimGen + 1;
+          return [{ ...model, drawerOpen, drawerAnimGen: nextGen }, [
             animate<ShowcaseMsg>({
               from: model.drawerProgress,
               to: target,
               spring: 'default',
-              onFrame: (value) => ({ type: 'drawer-progress', value }),
+              onFrame: (value) => ({ type: 'drawer-progress', value, gen: nextGen }),
             }),
           ]];
         }
         case 'drawer-progress':
+          // Ignore stale frames from superseded animations
+          if (msg.gen !== model.drawerAnimGen) return [model, []];
           return [{ ...model, drawerProgress: clamp01(msg.value) }, []];
         case 'force-quit':
           return [model, [quit()]];
@@ -275,7 +292,7 @@ export function createShowcaseApp(
       .group('App', (g) => g
         .bind('q', 'Quit (confirm)', { type: 'request-quit' })
         .bind('ctrl+c', 'Force quit', { type: 'force-quit' })
-        .bind('escape', 'Cancel / Quit', { type: 'request-quit' })
+        .bind('escape', 'Cancel / Close', { type: 'cancel-quit' })
         .bind('enter', 'Confirm quit', { type: 'confirm-quit' })
         .bind('o', 'Toggle welcome drawer', { type: 'toggle-drawer' }),
       ),

--- a/examples/showcase/app.ts
+++ b/examples/showcase/app.ts
@@ -1,0 +1,358 @@
+import type { BijouContext } from '@flyingrobots/bijou';
+import { badge, box, kbd, markdown } from '@flyingrobots/bijou';
+import {
+  animate,
+  createBrowsableListState,
+  createFramedApp,
+  createKeyMap,
+  createSplitPaneState,
+  drawer,
+  listFocusNext,
+  listFocusPrev,
+  listPageDown,
+  listPageUp,
+  modal,
+  quit,
+  type App,
+  type FrameLayoutNode,
+  type FrameModel,
+  type FramePage,
+  type Overlay,
+} from '@flyingrobots/bijou-tui';
+import type { ShowcaseMsg, ShowcasePageModel } from './types.js';
+import { CATEGORIES, findEntry, type Category } from './registry.js';
+import { triModePreview } from './tri-mode.js';
+
+// ---------------------------------------------------------------------------
+// Detail pane rendering
+// ---------------------------------------------------------------------------
+
+function renderDetail(
+  componentId: string | undefined,
+  width: number,
+  height: number,
+  ctx: BijouContext,
+): string {
+  if (componentId == null) {
+    return renderWelcomeContent(width, height, ctx);
+  }
+  const entry = findEntry(componentId);
+  if (entry == null) {
+    return '  Component not found.';
+  }
+
+  const innerW = Math.max(20, width - 2);
+  const sections: string[] = [];
+
+  // Header
+  sections.push(markdown(entry.description, { width: innerW, ctx }));
+  sections.push('');
+
+  // Tier + package badge
+  const tierBadge = entry.tier === 1
+    ? badge('static', { variant: 'success', ctx })
+    : entry.tier === 2
+      ? badge('embeddable', { variant: 'info', ctx })
+      : badge('standalone', { variant: 'warning', ctx });
+  sections.push(`  ${tierBadge} ${badge(entry.pkg, { variant: 'muted', ctx })}`);
+  sections.push('');
+
+  // Tri-mode preview
+  sections.push(triModePreview(entry.render, innerW, ctx));
+
+  return sections.join('\n');
+}
+
+function renderWelcomeContent(width: number, _height: number, ctx: BijouContext): string {
+  const w = Math.max(20, Math.min(52, width - 4));
+  return [
+    '',
+    '',
+    box([
+      '  Select a component from the sidebar',
+      '  to see its live preview and docs.',
+      '',
+      `  ${kbd('up', { ctx })}/${kbd('down', { ctx })}  Navigate sidebar`,
+      `  ${kbd('[', { ctx })}/${kbd(']', { ctx })}     Switch categories`,
+      `  ${kbd('tab', { ctx })}      Focus pane`,
+      `  ${kbd('j', { ctx })}/${kbd('k', { ctx })}     Scroll content`,
+      `  ${kbd('?', { ctx })}        Help`,
+      `  ${kbd('q', { ctx })}        Quit`,
+    ].join('\n'), {
+      width: w,
+      borderToken: ctx.border('muted'),
+      ctx,
+    }),
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar rendering
+// ---------------------------------------------------------------------------
+
+function renderSidebar(
+  model: ShowcasePageModel,
+  width: number,
+  _height: number,
+  category: Category,
+  ctx: BijouContext,
+): string {
+  const items = model.listState.items;
+  const focus = model.listState.focusIndex;
+  const scrollY = model.listState.scrollY;
+  const visibleCount = model.listState.height;
+  const visible = items.slice(scrollY, scrollY + visibleCount);
+
+  const lines: string[] = [];
+  for (let i = 0; i < visible.length; i++) {
+    const item = visible[i]!;
+    const globalIdx = scrollY + i;
+    const isFocused = globalIdx === focus;
+    const entry = findEntry(item.value);
+    const tier = entry?.tier ?? 1;
+    const tierMark = tier === 3 ? ' *' : '';
+
+    if (isFocused) {
+      const label = ctx.style.styled(ctx.semantic('primary'), `> ${item.label}${tierMark}`);
+      lines.push(label);
+    } else {
+      lines.push(`  ${item.label}${tierMark}`);
+    }
+  }
+
+  // Scroll indicator
+  if (items.length > visibleCount) {
+    const pct = Math.round(((focus + 1) / items.length) * 100);
+    lines.push('');
+    lines.push(` ${focus + 1}/${items.length} (${pct}%)`);
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Page builder
+// ---------------------------------------------------------------------------
+
+function createCategoryPage(
+  category: Category,
+  isFirstPage: boolean,
+  ctx: BijouContext,
+): FramePage<ShowcasePageModel, ShowcaseMsg> {
+  const items = category.entries.map((e) => ({
+    label: e.name,
+    value: e.id,
+    description: e.subtitle,
+  }));
+
+  return {
+    id: category.id,
+    title: category.title,
+
+    init() {
+      const listState = createBrowsableListState({ items, height: 40 });
+      const model: ShowcasePageModel = {
+        listState,
+        quitConfirmOpen: false,
+        drawerOpen: isFirstPage,
+        drawerProgress: 0,
+      };
+      const cmds: ReturnType<typeof animate<ShowcaseMsg>>[] = [];
+      if (isFirstPage) {
+        cmds.push(animate<ShowcaseMsg>({
+          from: 0,
+          to: 1,
+          spring: 'default',
+          onFrame: (value) => ({ type: 'drawer-progress', value }),
+        }));
+      }
+      return [model, cmds];
+    },
+
+    update(msg, model) {
+      // Force quit always works
+      if (msg.type === 'force-quit') {
+        return [model, [quit()]];
+      }
+
+      // Quit confirmation modal intercepts
+      if (model.quitConfirmOpen) {
+        switch (msg.type) {
+          case 'confirm-quit':
+            return [model, [quit()]];
+          case 'cancel-quit':
+            return [{ ...model, quitConfirmOpen: false }, []];
+          default:
+            return [model, []];
+        }
+      }
+
+      switch (msg.type) {
+        case 'nav-next':
+          return [{ ...model, listState: listFocusNext(model.listState) }, []];
+        case 'nav-prev':
+          return [{ ...model, listState: listFocusPrev(model.listState) }, []];
+        case 'nav-page-down':
+          return [{ ...model, listState: listPageDown(model.listState) }, []];
+        case 'nav-page-up':
+          return [{ ...model, listState: listPageUp(model.listState) }, []];
+        case 'request-quit':
+          return [{ ...model, quitConfirmOpen: true }, []];
+        case 'cancel-quit':
+          return [model, []];
+        case 'confirm-quit':
+          return [model, []];
+        case 'toggle-drawer': {
+          const drawerOpen = !model.drawerOpen;
+          const target = drawerOpen ? 1 : 0;
+          return [{ ...model, drawerOpen }, [
+            animate<ShowcaseMsg>({
+              from: model.drawerProgress,
+              to: target,
+              spring: 'default',
+              onFrame: (value) => ({ type: 'drawer-progress', value }),
+            }),
+          ]];
+        }
+        case 'drawer-progress':
+          return [{ ...model, drawerProgress: clamp01(msg.value) }, []];
+        case 'force-quit':
+          return [model, [quit()]];
+      }
+    },
+
+    keyMap: createKeyMap<ShowcaseMsg>()
+      .group('Sidebar', (g) => g
+        .bind('down', 'Next component', { type: 'nav-next' })
+        .bind('up', 'Previous component', { type: 'nav-prev' })
+        .bind('pagedown', 'Page down', { type: 'nav-page-down' })
+        .bind('pageup', 'Page up', { type: 'nav-page-up' }),
+      ),
+
+    layout(model) {
+      const selectedId = model.listState.items[model.listState.focusIndex]?.value;
+
+      return {
+        kind: 'split',
+        splitId: `${category.id}-split`,
+        direction: 'row',
+        state: createSplitPaneState({ ratio: 0.25 }),
+        minA: 18,
+        minB: 30,
+        paneA: {
+          kind: 'pane',
+          paneId: `${category.id}-sidebar`,
+          render: (w, h) => renderSidebar(model, w, h, category, ctx),
+        },
+        paneB: {
+          kind: 'pane',
+          paneId: `${category.id}-detail`,
+          overflowX: 'scroll',
+          render: (w, h) => renderDetail(selectedId, w, h, ctx),
+        },
+      } satisfies FrameLayoutNode;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// App assembly
+// ---------------------------------------------------------------------------
+
+export function createShowcaseApp(
+  ctx: BijouContext,
+): App<FrameModel<ShowcasePageModel>, ShowcaseMsg> {
+  const pages = CATEGORIES.map((cat, idx) => createCategoryPage(cat, idx === 0, ctx));
+
+  return createFramedApp<ShowcasePageModel, ShowcaseMsg>({
+    title: 'Bijou Component Showcase',
+    pages,
+    defaultPageId: 'display',
+    enableCommandPalette: true,
+    transition: 'fade',
+    transitionDuration: 250,
+    globalKeys: createKeyMap<ShowcaseMsg>()
+      .group('App', (g) => g
+        .bind('q', 'Quit (confirm)', { type: 'request-quit' })
+        .bind('ctrl+c', 'Force quit', { type: 'force-quit' })
+        .bind('escape', 'Cancel / Quit', { type: 'request-quit' })
+        .bind('enter', 'Confirm quit', { type: 'confirm-quit' })
+        .bind('o', 'Toggle welcome drawer', { type: 'toggle-drawer' }),
+      ),
+    overlayFactory(frame) {
+      const overlays: Overlay[] = [];
+
+      // Welcome drawer (animated, left side)
+      const progress = clamp01(frame.pageModel.drawerProgress);
+      if (progress > 0.01) {
+        const idealWidth = Math.max(28, Math.floor(frame.screenRect.width * 0.3));
+        const animatedWidth = Math.max(6, Math.round(idealWidth * progress));
+
+        overlays.push(drawer({
+          anchor: 'left',
+          title: 'Welcome',
+          content: renderDrawerContent(ctx),
+          width: animatedWidth,
+          screenWidth: frame.screenRect.width,
+          screenHeight: frame.screenRect.height,
+          borderToken: ctx.border('primary'),
+          bgToken: ctx.surface('elevated'),
+          ctx,
+        }));
+      }
+
+      // Quit confirmation modal
+      if (frame.pageModel.quitConfirmOpen) {
+        overlays.push(modal({
+          title: 'Quit Showcase?',
+          body: 'Exit the component showcase?\n\nEnter = Yes\nEsc = No',
+          hint: 'q request  |  enter confirm  |  esc cancel',
+          width: Math.min(48, Math.max(34, frame.screenRect.width - 4)),
+          screenWidth: frame.screenRect.width,
+          screenHeight: frame.screenRect.height,
+          borderToken: ctx.border('primary'),
+          bgToken: ctx.surface('elevated'),
+          ctx,
+        }));
+      }
+
+      return overlays;
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Drawer content
+// ---------------------------------------------------------------------------
+
+function renderDrawerContent(ctx: BijouContext): string {
+  const total = CATEGORIES.reduce((n, c) => n + c.entries.length, 0);
+  return [
+    'Bijou Component Showcase',
+    '',
+    `${total} components across`,
+    `${CATEGORIES.length} categories.`,
+    '',
+    `${kbd('up', { ctx })}/${kbd('down', { ctx })}  Navigate`,
+    `${kbd('[', { ctx })}/${kbd(']', { ctx })}     Categories`,
+    `${kbd('tab', { ctx })}      Focus pane`,
+    `${kbd('j', { ctx })}/${kbd('k', { ctx })}     Scroll detail`,
+    `${kbd('ctrl+p', { ctx })} Command palette`,
+    `${kbd('?', { ctx })}        Full help`,
+    `${kbd('o', { ctx })}        Close this drawer`,
+    `${kbd('q', { ctx })}        Quit`,
+    '',
+    '* = standalone only',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/examples/showcase/main.ts
+++ b/examples/showcase/main.ts
@@ -1,0 +1,7 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { run } from '@flyingrobots/bijou-tui';
+import { createShowcaseApp } from './app.js';
+
+const ctx = initDefaultContext();
+const app = createShowcaseApp(ctx);
+run(app);

--- a/examples/showcase/registry.ts
+++ b/examples/showcase/registry.ts
@@ -1,0 +1,1089 @@
+import type { BijouContext, DagNode, TreeNode, TimelineEvent } from '@flyingrobots/bijou';
+import {
+  alert,
+  badge,
+  box,
+  headerBox,
+  separator,
+  skeleton,
+  kbd,
+  hyperlink,
+  log,
+  gradientText,
+  progressBar,
+  spinnerFrame,
+  table,
+  tree,
+  accordion,
+  timeline,
+  tabs,
+  breadcrumb,
+  paginator,
+  stepper,
+  dag,
+  enumeratedList,
+  markdown,
+} from '@flyingrobots/bijou';
+import type { ComponentEntry } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const SAMPLE_TREE: TreeNode[] = [
+  {
+    label: 'src',
+    children: [
+      { label: 'index.ts' },
+      {
+        label: 'components',
+        children: [
+          { label: 'box.ts' },
+          { label: 'badge.ts' },
+        ],
+      },
+    ],
+  },
+  { label: 'package.json' },
+  { label: 'tsconfig.json' },
+];
+
+const SAMPLE_TIMELINE: TimelineEvent[] = [
+  { label: 'Planning', status: 'success' },
+  { label: 'Development', status: 'active' },
+  { label: 'Review', status: 'warning' },
+  { label: 'Release', status: 'muted' },
+];
+
+const SAMPLE_DAG: DagNode[] = [
+  { id: 'plan', label: 'Plan', edges: ['dev', 'design'], badge: 'done' },
+  { id: 'design', label: 'Design', edges: ['dev'], badge: 'done' },
+  { id: 'dev', label: 'Develop', edges: ['test'], badge: 'active' },
+  { id: 'test', label: 'Test', edges: ['ship'], badge: 'pending' },
+  { id: 'ship', label: 'Ship', badge: 'pending' },
+];
+
+// ---------------------------------------------------------------------------
+// Display components
+// ---------------------------------------------------------------------------
+
+const DISPLAY: ComponentEntry[] = [
+  {
+    id: 'box',
+    name: 'box() / headerBox()',
+    subtitle: 'Bordered containers',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# box() / headerBox()',
+      '',
+      'Unicode box-drawing containers with optional titles, padding, width override,',
+      'and background surface tokens. `headerBox()` adds a label + detail header.',
+      '',
+      '**Degradation:** Rich shows borders. Pipe returns content only. Accessible returns content only.',
+    ].join('\n'),
+    render: (w, ctx) => [
+      box('A simple bordered box.', { width: Math.min(40, w), ctx }),
+      '',
+      headerBox('Deploy', { detail: 'v1.2.3 -> production', ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'alert',
+    name: 'alert()',
+    subtitle: 'Boxed alerts with icons',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# alert()',
+      '',
+      'Boxed notification alerts with status icons and variant coloring.',
+      'Variants: `info`, `success`, `warning`, `error`.',
+      '',
+      '**Degradation:** Rich shows bordered box with icon. Pipe/accessible show text with prefix.',
+    ].join('\n'),
+    render: (w, ctx) => [
+      alert('Deployment successful.', { variant: 'success', ctx }),
+      '',
+      alert('Check your configuration.', { variant: 'warning', ctx }),
+      '',
+      alert('Connection refused on port 5432.', { variant: 'error', ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'badge',
+    name: 'badge()',
+    subtitle: 'Inline status badges (7 variants)',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# badge()',
+      '',
+      'Compact inline status indicators. Inverse-colored pills.',
+      'Variants: `success`, `error`, `warning`, `info`, `muted`, `accent`, `primary`.',
+      '',
+      '**Degradation:** Rich shows colored pill. Pipe shows plain text. Accessible shows `[TEXT]` brackets.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      [
+        badge('SUCCESS', { variant: 'success', ctx }),
+        badge('ERROR', { variant: 'error', ctx }),
+        badge('WARNING', { variant: 'warning', ctx }),
+      ].join('  '),
+      [
+        badge('INFO', { variant: 'info', ctx }),
+        badge('MUTED', { variant: 'muted', ctx }),
+        badge('ACCENT', { variant: 'accent', ctx }),
+        badge('PRIMARY', { variant: 'primary', ctx }),
+      ].join('  '),
+      '',
+      `Server is ${badge('RUNNING', { variant: 'success', ctx })} on port ${badge('3000', { variant: 'primary', ctx })}`,
+    ].join('\n'),
+  },
+  {
+    id: 'separator',
+    name: 'separator()',
+    subtitle: 'Horizontal dividers with labels',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# separator()',
+      '',
+      'Horizontal rule dividers with optional centered labels.',
+      '',
+      '**Degradation:** Rich shows styled line. Pipe shows dashes. Accessible shows dashes.',
+    ].join('\n'),
+    render: (w, ctx) => [
+      separator({ width: Math.min(40, w), ctx }),
+      '',
+      separator({ label: 'Section Title', width: Math.min(40, w), ctx }),
+      '',
+      separator({ label: 'Another', width: Math.min(40, w), ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'skeleton',
+    name: 'skeleton()',
+    subtitle: 'Loading placeholders',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# skeleton()',
+      '',
+      'Animated shimmer-style loading placeholders for content that has not loaded yet.',
+      '',
+      '**Degradation:** Rich shows shaded blocks. Pipe/accessible show placeholder dashes.',
+    ].join('\n'),
+    render: (w, ctx) => [
+      skeleton({ width: Math.min(30, w), height: 1, ctx }),
+      skeleton({ width: Math.min(20, w), height: 1, ctx }),
+      skeleton({ width: Math.min(25, w), height: 1, ctx }),
+      '',
+      skeleton({ width: Math.min(40, w), height: 3, ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'kbd',
+    name: 'kbd()',
+    subtitle: 'Keyboard shortcut display',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# kbd()',
+      '',
+      'Rendered keyboard shortcut badges, styled like physical key caps.',
+      '',
+      '**Degradation:** Rich shows styled key. Pipe/accessible show `[key]` brackets.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      `${kbd('Ctrl', { ctx })}+${kbd('C', { ctx })} to quit`,
+      `${kbd('Tab', { ctx })} to switch focus`,
+      `${kbd('?', { ctx })} for help`,
+      `${kbd('Esc', { ctx })} to cancel`,
+    ].join('\n'),
+  },
+  {
+    id: 'hyperlink',
+    name: 'hyperlink()',
+    subtitle: 'Clickable terminal links (OSC 8)',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# hyperlink()',
+      '',
+      'Clickable OSC 8 terminal hyperlinks. Falls back to `text (url)` in terminals',
+      'that do not support the protocol.',
+      '',
+      '**Degradation:** Rich shows clickable link. Pipe/accessible show `text (url)`.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      hyperlink('Bijou on GitHub', 'https://github.com/flyingrobots/bijou', { ctx }),
+      hyperlink('Documentation', 'https://bijou.dev/docs', { ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'log',
+    name: 'log()',
+    subtitle: 'Leveled styled output',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# log()',
+      '',
+      'Leveled log output with status-colored prefixes.',
+      'Levels: `debug`, `info`, `warn`, `error`, `fatal`.',
+      '',
+      '**Degradation:** Rich shows colored prefix. Pipe shows `[LEVEL]` prefix. Accessible same as pipe.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      log('debug', 'Connecting to database...', { ctx }),
+      log('info', 'Server started on port 3000', { ctx }),
+      log('warn', 'Deprecated API used in /v1/users', { ctx }),
+      log('error', 'Connection refused: ECONNREFUSED', { ctx }),
+      log('fatal', 'Unrecoverable state — shutting down', { ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'gradient-text',
+    name: 'gradientText()',
+    subtitle: 'Gradient-colored text',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# gradientText()',
+      '',
+      'Apply RGB color gradients to text strings.',
+      '',
+      '**Degradation:** Rich shows gradient. Pipe/accessible return plain text.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      gradientText('Hello, beautiful terminal!', { ctx }),
+      gradientText('Bijou Component Library', { ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'progress-bar',
+    name: 'progressBar()',
+    subtitle: 'Static progress indicators',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# progressBar()',
+      '',
+      'Horizontal progress bar at a given percentage.',
+      '',
+      '**Degradation:** Rich shows colored bar. Pipe shows `[==>  ] 45%`. Accessible shows `Progress: 45%`.',
+    ].join('\n'),
+    render: (w, ctx) => {
+      const barWidth = Math.min(36, w - 2);
+      return [
+        progressBar(25, { width: barWidth, ctx }),
+        progressBar(50, { width: barWidth, ctx }),
+        progressBar(75, { width: barWidth, ctx }),
+        progressBar(100, { width: barWidth, ctx }),
+      ].join('\n');
+    },
+  },
+  {
+    id: 'spinner',
+    name: 'spinnerFrame()',
+    subtitle: 'Animated spinner frames',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# spinnerFrame()',
+      '',
+      'Returns a single frame of a spinner animation. Call with incrementing',
+      'frame index from a `tick()` command for animation.',
+      '',
+      '**Degradation:** Rich shows animated glyph. Pipe/accessible show static text.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      `Frame 0: ${spinnerFrame(0, { ctx })} Loading...`,
+      `Frame 1: ${spinnerFrame(1, { ctx })} Loading...`,
+      `Frame 2: ${spinnerFrame(2, { ctx })} Loading...`,
+      `Frame 3: ${spinnerFrame(3, { ctx })} Loading...`,
+    ].join('\n'),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Data components
+// ---------------------------------------------------------------------------
+
+const DATA: ComponentEntry[] = [
+  {
+    id: 'table',
+    name: 'table()',
+    subtitle: 'Data tables with columns',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# table()',
+      '',
+      'Tabular data display with typed columns, alignment, and width constraints.',
+      '',
+      '**Degradation:** Rich shows bordered table. Pipe shows TSV. Accessible shows row-label format.',
+    ].join('\n'),
+    render: (w, ctx) => table({
+      columns: [
+        { header: 'Name', width: Math.min(14, Math.floor(w / 4)) },
+        { header: 'Role', width: Math.min(12, Math.floor(w / 4)) },
+        { header: 'Status', width: Math.min(10, Math.floor(w / 4)) },
+      ],
+      rows: [
+        ['Alice', 'Engineer', badge('active', { variant: 'success', ctx })],
+        ['Bob', 'Designer', badge('away', { variant: 'warning', ctx })],
+        ['Carol', 'PM', badge('offline', { variant: 'muted', ctx })],
+      ],
+      ctx,
+    }),
+  },
+  {
+    id: 'tree',
+    name: 'tree()',
+    subtitle: 'Hierarchical tree views',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# tree()',
+      '',
+      'Indented tree display with unicode branch characters.',
+      '',
+      '**Degradation:** Rich shows styled tree lines. Pipe shows ASCII tree. Accessible shows indented list.',
+    ].join('\n'),
+    render: (_w, ctx) => tree(SAMPLE_TREE, { ctx }),
+  },
+  {
+    id: 'accordion',
+    name: 'accordion()',
+    subtitle: 'Expandable content sections',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# accordion()',
+      '',
+      'Static expandable/collapsible content sections. For interactive accordion,',
+      'see `interactiveAccordion()` in bijou-tui.',
+      '',
+      '**Degradation:** Rich shows styled headers. Pipe/accessible show text sections.',
+    ].join('\n'),
+    render: (_w, ctx) => accordion([
+      { title: 'Getting Started', content: 'Install with npm install @flyingrobots/bijou', expanded: true },
+      { title: 'Configuration', content: 'Set BIJOU_THEME env var to choose a preset.', expanded: false },
+      { title: 'Advanced', content: 'Use createBijou() for custom port wiring.', expanded: false },
+    ], { ctx }),
+  },
+  {
+    id: 'timeline',
+    name: 'timeline()',
+    subtitle: 'Event timelines with status',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# timeline()',
+      '',
+      'Vertical timeline with status-colored markers.',
+      'Statuses: `success`, `active`, `warning`, `muted`.',
+      '',
+      '**Degradation:** Rich shows colored dots + lines. Pipe shows `[STATUS] label`. Accessible same as pipe.',
+    ].join('\n'),
+    render: (_w, ctx) => timeline(SAMPLE_TIMELINE, { ctx }),
+  },
+  {
+    id: 'tabs',
+    name: 'tabs()',
+    subtitle: 'Tab bar navigation',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# tabs()',
+      '',
+      'Static tab bar with active tab highlighting and optional badge counts.',
+      '',
+      '**Degradation:** Rich shows styled tabs. Pipe shows `[active] inactive`. Accessible shows labeled list.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      tabs([
+        { label: 'Overview', active: true },
+        { label: 'Files', badge: '12' },
+        { label: 'Settings' },
+      ], { ctx }),
+      '',
+      tabs([
+        { label: 'Home' },
+        { label: 'Dashboard', active: true, badge: '3' },
+        { label: 'Logs' },
+      ], { ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'breadcrumb',
+    name: 'breadcrumb()',
+    subtitle: 'Navigation breadcrumb trails',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# breadcrumb()',
+      '',
+      'Horizontal navigation breadcrumb with separator characters.',
+      '',
+      '**Degradation:** Rich shows styled path. Pipe/accessible show slash-separated text.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      breadcrumb(['Home', 'Projects', 'Bijou', 'src'], { ctx }),
+      breadcrumb(['Settings', 'Theme', 'Colors'], { ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'paginator',
+    name: 'paginator()',
+    subtitle: 'Page indicators (dots and text)',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# paginator()',
+      '',
+      'Dot-style or text-style page indicators.',
+      '',
+      '**Degradation:** Rich shows styled dots. Pipe/accessible show `Page X of Y`.',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      paginator({ current: 0, total: 5, ctx }),
+      paginator({ current: 2, total: 5, ctx }),
+      paginator({ current: 4, total: 5, ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'stepper',
+    name: 'stepper()',
+    subtitle: 'Step progress indicators',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# stepper()',
+      '',
+      'Multi-step progress indicator showing completed, active, and pending steps.',
+      '',
+      '**Degradation:** Rich shows styled steps. Pipe/accessible show numbered step list.',
+    ].join('\n'),
+    render: (_w, ctx) => stepper([
+      { label: 'Account', status: 'complete' },
+      { label: 'Profile', status: 'active' },
+      { label: 'Review', status: 'pending' },
+      { label: 'Done', status: 'pending' },
+    ], { ctx }),
+  },
+  {
+    id: 'dag',
+    name: 'dag()',
+    subtitle: 'Directed acyclic graph',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# dag()',
+      '',
+      'ASCII art directed acyclic graph with status badges, edge routing,',
+      'node selection, and highlight paths.',
+      '',
+      '**Degradation:** Rich shows colored graph. Pipe shows ASCII art. Accessible shows dependency list.',
+    ].join('\n'),
+    render: (w, ctx) => dag(SAMPLE_DAG, {
+      selectedId: 'dev',
+      highlightPath: ['plan', 'dev', 'test', 'ship'],
+      maxWidth: Math.max(50, w),
+      ctx,
+    }),
+  },
+  {
+    id: 'enumerated-list',
+    name: 'enumeratedList()',
+    subtitle: 'Ordered/unordered lists',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# enumeratedList()',
+      '',
+      'Numbered or bulleted lists with 6 bullet styles:',
+      '`arabic`, `alpha`, `roman`, `bullet`, `dash`, `none`.',
+      '',
+      '**Degradation:** All modes render similarly (text-based).',
+    ].join('\n'),
+    render: (_w, ctx) => [
+      enumeratedList(['First item', 'Second item', 'Third item'], { style: 'arabic', ctx }),
+      '',
+      enumeratedList(['Alpha one', 'Alpha two', 'Alpha three'], { style: 'alpha', ctx }),
+      '',
+      enumeratedList(['Bullet point', 'Another point'], { style: 'bullet', ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'markdown',
+    name: 'markdown()',
+    subtitle: 'Terminal markdown renderer',
+    pkg: 'bijou',
+    tier: 1,
+    description: [
+      '# markdown()',
+      '',
+      'Renders markdown in the terminal with headings, bold/italic,',
+      'code blocks, blockquotes, links, and lists.',
+      '',
+      '**Degradation:** Rich shows styled markdown. Pipe shows plain text. Accessible shows simplified text.',
+    ].join('\n'),
+    render: (w, ctx) => markdown([
+      '## Hello World',
+      '',
+      'This is **bold** and *italic* text.',
+      '',
+      '> A blockquote with wisdom.',
+      '',
+      '```ts',
+      'const x = 42;',
+      '```',
+      '',
+      '- Item one',
+      '- Item two',
+    ].join('\n'), { width: Math.min(50, w), ctx }),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Form components (TIER 3 — static preview only)
+// ---------------------------------------------------------------------------
+
+const FORMS: ComponentEntry[] = [
+  {
+    id: 'select',
+    name: 'select()',
+    subtitle: 'Single-select menu',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# select()',
+      '',
+      'Interactive single-selection menu with keyboard navigation.',
+      'Arrow keys move the cursor, Enter selects.',
+      '',
+      '**Interactive component** — cannot be embedded in this showcase.',
+      'Run standalone to try it:',
+      '',
+      '```sh',
+      'npx tsx examples/select/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  ? Pick a color',
+      '',
+      '  > Red       (highlighted)',
+      '    Blue',
+      '    Green',
+      '    Yellow',
+      '',
+      '  (arrow keys navigate, enter selects)',
+    ].join('\n'), { width: Math.min(40, w), ctx }),
+  },
+  {
+    id: 'multiselect',
+    name: 'multiselect()',
+    subtitle: 'Checkbox multi-select',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# multiselect()',
+      '',
+      'Interactive multi-selection with checkboxes. Space toggles,',
+      'Enter confirms. Supports `maxVisible` scrolling.',
+      '',
+      '**Interactive component** — run standalone:',
+      '',
+      '```sh',
+      'npx tsx examples/multiselect/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  ? Select toppings',
+      '',
+      '  [x] Cheese',
+      '  [ ] Pepperoni',
+      '  [x] Mushrooms',
+      '  [ ] Olives',
+      '',
+      '  (space toggles, enter confirms)',
+    ].join('\n'), { width: Math.min(40, w), ctx }),
+  },
+  {
+    id: 'confirm',
+    name: 'confirm()',
+    subtitle: 'Yes/no confirmation',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# confirm()',
+      '',
+      'Simple yes/no confirmation prompt with default value support.',
+      '',
+      '**Interactive component** — run standalone:',
+      '',
+      '```sh',
+      'npx tsx examples/confirm/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  ? Continue with deployment? (Y/n)',
+      '',
+      '  (y/n or enter for default)',
+    ].join('\n'), { width: Math.min(42, w), ctx }),
+  },
+  {
+    id: 'input',
+    name: 'input()',
+    subtitle: 'Text input with validation',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# input()',
+      '',
+      'Single-line text input with placeholder, validation, and required mode.',
+      '',
+      '**Interactive component** — run standalone:',
+      '',
+      '```sh',
+      'npx tsx examples/input/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  ? Enter your name',
+      '',
+      '  > Alice_',
+      '',
+      '  (type and press enter)',
+    ].join('\n'), { width: Math.min(40, w), ctx }),
+  },
+  {
+    id: 'filter',
+    name: 'filter()',
+    subtitle: 'Fuzzy-filter select',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# filter()',
+      '',
+      'Type-to-filter selection with fuzzy keyword matching.',
+      'Supports vim-style normal/insert mode switching.',
+      '',
+      '**Interactive component** — run standalone:',
+      '',
+      '```sh',
+      'npx tsx examples/filter/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  ? Search files',
+      '  > src/comp_',
+      '',
+      '  > src/components/box.ts',
+      '    src/components/badge.ts',
+      '    src/components/alert.ts',
+      '',
+      '  3 matches',
+    ].join('\n'), { width: Math.min(42, w), ctx }),
+  },
+  {
+    id: 'textarea',
+    name: 'textarea()',
+    subtitle: 'Multi-line text input',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# textarea()',
+      '',
+      'Multi-line text editor with cursor navigation, line numbers,',
+      'and maxLength enforcement.',
+      '',
+      '**Interactive component** — run standalone:',
+      '',
+      '```sh',
+      'npx tsx examples/textarea/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  ? Describe the issue',
+      '',
+      '  1 | The build fails when',
+      '  2 | running on Node 22_',
+      '  3 |',
+      '',
+      '  (ctrl+d to submit)',
+    ].join('\n'), { width: Math.min(42, w), ctx }),
+  },
+  {
+    id: 'wizard',
+    name: 'wizard()',
+    subtitle: 'Multi-step form orchestration',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# wizard()',
+      '',
+      'Multi-step form with conditional skip logic, back navigation,',
+      'and step progress display.',
+      '',
+      '**Interactive component** — run standalone:',
+      '',
+      '```sh',
+      'npx tsx examples/wizard/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  Step 1 of 3: Account Setup',
+      '',
+      '  ? Enter username',
+      '  > _',
+      '',
+      '  Next: Profile  |  Then: Review',
+    ].join('\n'), { width: Math.min(42, w), ctx }),
+  },
+  {
+    id: 'group',
+    name: 'group()',
+    subtitle: 'Multi-field form group',
+    pkg: 'bijou',
+    tier: 3,
+    description: [
+      '# group()',
+      '',
+      'Collects multiple form fields in sequence and returns all values.',
+      '',
+      '**Interactive component** — run standalone:',
+      '',
+      '```sh',
+      'npx tsx examples/form-group/main.ts',
+      '```',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  Form Group',
+      '',
+      '  name:    Alice',
+      '  email:   alice@example.com',
+      '  role:    Engineer',
+      '',
+      '  (fields collected sequentially)',
+    ].join('\n'), { width: Math.min(42, w), ctx }),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// TUI building blocks (TIER 2 — description + static preview)
+// ---------------------------------------------------------------------------
+
+const TUI: ComponentEntry[] = [
+  {
+    id: 'browsable-list',
+    name: 'browsableList()',
+    subtitle: 'Keyboard-navigable list',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# browsableList()',
+      '',
+      'Scrollable, keyboard-navigable list with focus tracking.',
+      'State transformers for TEA composition. Vim-style keybindings.',
+      '',
+      '**Embeddable** — composable in any TEA app via state transformers.',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  > Item one',
+      '    Item two',
+      '    Item three',
+      '    Item four',
+      '    Item five',
+    ].join('\n'), { width: Math.min(36, w), ctx }),
+  },
+  {
+    id: 'navigable-table',
+    name: 'navigableTable()',
+    subtitle: 'Keyboard-navigable data table',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# navigableTable()',
+      '',
+      'Data table with row focus, keyboard navigation, page scrolling,',
+      'and vim-style keybindings.',
+      '',
+      '**Embeddable** — composable in any TEA app.',
+    ].join('\n'),
+    render: (w, ctx) => table({
+      columns: [
+        { header: 'File', width: Math.min(16, Math.floor(w / 3)) },
+        { header: 'Size', width: 8 },
+        { header: 'Modified', width: 12 },
+      ],
+      rows: [
+        ['> index.ts', '2.4 KB', '2 hours ago'],
+        ['  app.ts', '8.1 KB', '1 day ago'],
+        ['  utils.ts', '1.2 KB', '3 days ago'],
+      ],
+      ctx,
+    }),
+  },
+  {
+    id: 'pager',
+    name: 'pager()',
+    subtitle: 'Scrollable text viewer',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# pager()',
+      '',
+      'Full-page scrollable text viewer with status line showing position.',
+      'Wraps `viewport()` with chrome.',
+      '',
+      '**Embeddable** — composable in any TEA app.',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  Line 1: Lorem ipsum dolor sit amet',
+      '  Line 2: consectetur adipiscing elit',
+      '  Line 3: sed do eiusmod tempor',
+      '  --------- 3/100 lines ---------',
+    ].join('\n'), { width: Math.min(44, w), ctx }),
+  },
+  {
+    id: 'interactive-accordion',
+    name: 'interactiveAccordion()',
+    subtitle: 'Keyboard accordion',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# interactiveAccordion()',
+      '',
+      'Accordion sections with keyboard focus, expand/collapse, and',
+      'expand-all/collapse-all actions.',
+      '',
+      '**Embeddable** — composable in any TEA app.',
+    ].join('\n'),
+    render: (_w, ctx) => accordion([
+      { title: '> Getting Started', content: '  Install and configure bijou.', expanded: true },
+      { title: '  API Reference', content: '', expanded: false },
+      { title: '  Examples', content: '', expanded: false },
+    ], { ctx }),
+  },
+  {
+    id: 'dag-pane',
+    name: 'dagPane()',
+    subtitle: 'Interactive DAG viewer',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# dagPane()',
+      '',
+      '2D DAG viewer with node navigation (parent/child/sibling),',
+      'scroll, and selection tracking. Wraps `dag()` + `focusArea()`.',
+      '',
+      '**Embeddable** — composable in any TEA app.',
+    ].join('\n'),
+    render: (w, ctx) => dag(SAMPLE_DAG, {
+      selectedId: 'dev',
+      maxWidth: Math.max(40, w),
+      ctx,
+    }),
+  },
+  {
+    id: 'command-palette',
+    name: 'commandPalette()',
+    subtitle: 'Filterable action list',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# commandPalette()',
+      '',
+      'Searchable action list with live filtering. Type to filter,',
+      'arrows to navigate, Enter to select.',
+      '',
+      '**Embeddable** — built into `createFramedApp` via ctrl+p.',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  > open fi_',
+      '',
+      '  > Open File         ctrl+o',
+      '    Open Folder       ctrl+shift+o',
+      '    Open Recent       ctrl+r',
+    ].join('\n'), { width: Math.min(44, w), ctx }),
+  },
+  {
+    id: 'canvas',
+    name: 'canvas()',
+    subtitle: 'Shader-based character grid',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# canvas()',
+      '',
+      'Character-grid renderer driven by a shader function.',
+      '`(x, y, cols, rows, time?) => character`. Used for transitions,',
+      'visual effects, and procedural patterns.',
+      '',
+      '**Embeddable** — runs on `tick()` for animation.',
+    ].join('\n'),
+    render: (w, ctx) => {
+      const cols = Math.min(30, w - 4);
+      const rows = 6;
+      const lines: string[] = [];
+      for (let y = 0; y < rows; y++) {
+        let line = '';
+        for (let x = 0; x < cols; x++) {
+          const v = Math.sin(x * 0.3 + y * 0.5) * 0.5 + 0.5;
+          line += v > 0.7 ? '#' : v > 0.4 ? '+' : v > 0.2 ? '.' : ' ';
+        }
+        lines.push(line);
+      }
+      return box(lines.join('\n'), { width: Math.min(cols + 4, w), ctx });
+    },
+  },
+  {
+    id: 'split-pane',
+    name: 'splitPane()',
+    subtitle: 'Resizable split layout',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# splitPane()',
+      '',
+      'Stateful split-pane layout (horizontal or vertical) with',
+      'focus management, resize controls, and min-width/height constraints.',
+      '',
+      '**Embeddable** — composable in `createFramedApp` layouts.',
+    ].join('\n'),
+    render: (w, ctx) => {
+      const hw = Math.min(18, Math.floor((w - 5) / 2));
+      const left = box('Left pane', { width: hw, ctx });
+      const right = box('Right pane', { width: hw, ctx });
+      const lLines = left.split('\n');
+      const rLines = right.split('\n');
+      const maxH = Math.max(lLines.length, rLines.length);
+      const lines: string[] = [];
+      for (let i = 0; i < maxH; i++) {
+        lines.push(`${lLines[i] ?? ''} | ${rLines[i] ?? ''}`);
+      }
+      return lines.join('\n');
+    },
+  },
+  {
+    id: 'modal',
+    name: 'modal()',
+    subtitle: 'Centered dialog overlay',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# modal()',
+      '',
+      'Centered overlay dialog with title, body, hint text,',
+      'themed borders, and background token. Composited via `composite()`.',
+      '',
+      '**Embeddable** — used in `overlayFactory` of `createFramedApp`.',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '         Confirm Action',
+      '',
+      '  Are you sure you want to proceed?',
+      '',
+      '     Enter = Yes   Esc = No',
+    ].join('\n'), {
+      width: Math.min(42, w),
+      borderToken: ctx.border('primary'),
+      ctx,
+    }),
+  },
+  {
+    id: 'toast',
+    name: 'toast()',
+    subtitle: 'Anchored notification overlay',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# toast()',
+      '',
+      'Corner-anchored notification with success/error/info variants.',
+      'Auto-dismissing with configurable duration. 4-corner anchoring.',
+      '',
+      '**Embeddable** — used in `overlayFactory`.',
+    ].join('\n'),
+    render: (w, ctx) => [
+      box('  Saved successfully!', { width: Math.min(30, w), borderToken: ctx.border('primary'), ctx }),
+      box('  Error: connection lost', { width: Math.min(30, w), borderToken: ctx.border('warning'), ctx }),
+    ].join('\n'),
+  },
+  {
+    id: 'drawer',
+    name: 'drawer()',
+    subtitle: 'Slide-in side panel',
+    pkg: 'bijou-tui',
+    tier: 2,
+    description: [
+      '# drawer()',
+      '',
+      'Slide-in panel overlay anchored to left/right/top/bottom edges.',
+      'Configurable width/height. Supports region-scoped attachment to',
+      'individual panes.',
+      '',
+      '**Embeddable** — used in `overlayFactory`.',
+    ].join('\n'),
+    render: (w, ctx) => box([
+      '  Drawer Panel',
+      '',
+      '  - Navigation item 1',
+      '  - Navigation item 2',
+      '  - Navigation item 3',
+      '',
+      '  o toggle  a anchor',
+    ].join('\n'), { width: Math.min(30, w), borderToken: ctx.border('primary'), ctx }),
+  },
+  {
+    id: 'status-bar',
+    name: 'statusBar()',
+    subtitle: 'Left/right justified status',
+    pkg: 'bijou-tui',
+    tier: 1,
+    description: [
+      '# statusBar()',
+      '',
+      'Single-line status bar with left, center, and right segments.',
+      'Fill character customizable.',
+    ].join('\n'),
+    render: (_w, _ctx) => {
+      // statusBar is imported from bijou-tui; use a simple mock render
+      const w2 = 40;
+      const left = ' NORMAL';
+      const right = 'Ln 42, Col 8 ';
+      const gap = w2 - left.length - right.length;
+      return left + ' '.repeat(Math.max(1, gap)) + right;
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Categories
+// ---------------------------------------------------------------------------
+
+export interface Category {
+  readonly id: string;
+  readonly title: string;
+  readonly entries: readonly ComponentEntry[];
+}
+
+export const CATEGORIES: readonly Category[] = [
+  { id: 'display', title: 'Display', entries: DISPLAY },
+  { id: 'data', title: 'Data', entries: DATA },
+  { id: 'forms', title: 'Forms', entries: FORMS },
+  { id: 'tui', title: 'TUI Blocks', entries: TUI },
+];
+
+/** Look up a component entry by ID across all categories. */
+export function findEntry(id: string): ComponentEntry | undefined {
+  for (const cat of CATEGORIES) {
+    const found = cat.entries.find((e) => e.id === id);
+    if (found) return found;
+  }
+  return undefined;
+}

--- a/examples/showcase/tri-mode.ts
+++ b/examples/showcase/tri-mode.ts
@@ -1,0 +1,43 @@
+import type { BijouContext, OutputMode } from '@flyingrobots/bijou';
+import { separator } from '@flyingrobots/bijou';
+
+/**
+ * Create a shallow copy of ctx with a different output mode.
+ * Components that branch on `ctx.mode` will render their alternate output.
+ */
+function withMode(ctx: BijouContext, mode: OutputMode): BijouContext {
+  return { ...ctx, mode };
+}
+
+/**
+ * Render a component in all 3 output modes stacked vertically.
+ * Each section is labeled with a separator.
+ */
+export function triModePreview(
+  renderFn: (width: number, ctx: BijouContext) => string,
+  width: number,
+  ctx: BijouContext,
+): string {
+  const modes: { label: string; mode: OutputMode }[] = [
+    { label: 'Rich (interactive)', mode: 'interactive' },
+    { label: 'Pipe (non-TTY)', mode: 'pipe' },
+    { label: 'Accessible', mode: 'accessible' },
+  ];
+
+  const innerWidth = Math.max(20, width - 2);
+  const sections: string[] = [];
+
+  for (const { label, mode } of modes) {
+    const modeCtx = withMode(ctx, mode);
+    const sep = separator({ label, width: innerWidth, ctx });
+    let rendered: string;
+    try {
+      rendered = renderFn(innerWidth, modeCtx);
+    } catch {
+      rendered = `  (render error in ${mode} mode)`;
+    }
+    sections.push(sep, rendered, '');
+  }
+
+  return sections.join('\n');
+}

--- a/examples/showcase/types.ts
+++ b/examples/showcase/types.ts
@@ -25,6 +25,8 @@ export interface ShowcasePageModel {
   readonly quitConfirmOpen: boolean;
   readonly drawerOpen: boolean;
   readonly drawerProgress: number;
+  /** Monotonic counter — only accept drawer-progress msgs matching the latest gen. */
+  readonly drawerAnimGen: number;
 }
 
 /** Messages dispatched by the showcase app. */
@@ -38,4 +40,4 @@ export type ShowcaseMsg =
   | { type: 'cancel-quit' }
   | { type: 'force-quit' }
   | { type: 'toggle-drawer' }
-  | { type: 'drawer-progress'; value: number };
+  | { type: 'drawer-progress'; value: number; gen: number };

--- a/examples/showcase/types.ts
+++ b/examples/showcase/types.ts
@@ -1,0 +1,41 @@
+import type { BijouContext } from '@flyingrobots/bijou';
+import type { BrowsableListState } from '@flyingrobots/bijou-tui';
+
+/** A single component entry in the showcase registry. */
+export interface ComponentEntry {
+  /** Unique identifier (e.g. 'box', 'badge'). */
+  readonly id: string;
+  /** Display name (e.g. 'box() / headerBox()'). */
+  readonly name: string;
+  /** Short one-line description for the sidebar. */
+  readonly subtitle: string;
+  /** Longer markdown description for the detail pane. */
+  readonly description: string;
+  /** Demoing difficulty: 1=static, 2=embeddable interactive, 3=blocking/standalone. */
+  readonly tier: 1 | 2 | 3;
+  /** Package the component lives in. */
+  readonly pkg: 'bijou' | 'bijou-tui' | 'bijou-tui-app';
+  /** Render a demo of this component. Returns styled string output. */
+  readonly render: (width: number, ctx: BijouContext) => string;
+}
+
+/** Shared page model used by all showcase category pages. */
+export interface ShowcasePageModel {
+  readonly listState: BrowsableListState<string>;
+  readonly quitConfirmOpen: boolean;
+  readonly drawerOpen: boolean;
+  readonly drawerProgress: number;
+}
+
+/** Messages dispatched by the showcase app. */
+export type ShowcaseMsg =
+  | { type: 'nav-next' }
+  | { type: 'nav-prev' }
+  | { type: 'nav-page-down' }
+  | { type: 'nav-page-up' }
+  | { type: 'request-quit' }
+  | { type: 'confirm-quit' }
+  | { type: 'cancel-quit' }
+  | { type: 'force-quit' }
+  | { type: 'toggle-drawer' }
+  | { type: 'drawer-progress'; value: number };

--- a/examples/toast/README.md
+++ b/examples/toast/README.md
@@ -1,0 +1,37 @@
+# `toast()`, `composite()`
+
+Anchored notification overlay variants
+
+## Run
+
+```sh
+npx tsx examples/toast/main.ts
+```
+
+## Code
+
+```typescript
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { badge, separator } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg, type ResizeMsg,
+  composite, toast, type ToastVariant, type ToastAnchor,
+} from '@flyingrobots/bijou-tui';
+
+const ctx = initDefaultContext();
+
+// ... see main.ts for full implementation ...
+
+    const t = toast({
+      message: `Operation \${model.lastToast.variant}!`,
+      variant: model.lastToast.variant,
+      anchor: model.anchor,
+      screenWidth: cols,
+      screenHeight: rows,
+      ctx,
+    });
+
+    return composite(bg, [t]);
+```
+
+[← Examples](../README.md)

--- a/examples/toast/main.ts
+++ b/examples/toast/main.ts
@@ -1,0 +1,90 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { badge, separator } from '@flyingrobots/bijou';
+import {
+  run, quit, type App, type KeyMsg, type ResizeMsg,
+  composite, toast, type ToastVariant, type ToastAnchor,
+} from '@flyingrobots/bijou-tui';
+
+const ctx = initDefaultContext();
+
+type Msg = 
+  | KeyMsg 
+  | ResizeMsg 
+  | { type: 'show-toast', variant: ToastVariant };
+
+interface Model {
+  lastToast?: { variant: ToastVariant, timestamp: number };
+  cols: number;
+  rows: number;
+  anchor: ToastAnchor;
+}
+
+const app: App<Model, Msg> = {
+  init: () => [
+    { 
+      cols: ctx.runtime.columns(), 
+      rows: ctx.runtime.rows(), 
+      anchor: 'bottom-right' 
+    }, 
+    [],
+  ],
+
+  update: (msg, model) => {
+    if (msg.type === 'resize') {
+      return [{ ...model, cols: msg.cols, rows: msg.rows }, []];
+    }
+    if (msg.type === 'key') {
+      if (msg.key === 'q') return [model, [quit()]];
+      if (msg.key === 's') return [model, [{ type: 'show-toast', variant: 'success' }]];
+      if (msg.key === 'e') return [model, [{ type: 'show-toast', variant: 'error' }]];
+      if (msg.key === 'i') return [model, [{ type: 'show-toast', variant: 'info' }]];
+      if (msg.key === 'a') {
+        const anchors: ToastAnchor[] = ['top-left', 'top-right', 'bottom-right', 'bottom-left'];
+        const idx = anchors.indexOf(model.anchor);
+        const next = anchors[(idx + 1) % anchors.length]!;
+        return [{ ...model, anchor: next }, []];
+      }
+    }
+    if ('type' in msg && msg.type === 'show-toast') {
+      return [{ ...model, lastToast: { variant: msg.variant, timestamp: Date.now() } }, []];
+    }
+    return [model, []];
+  },
+
+  view: (model) => {
+    const { cols, rows } = model;
+
+    const header = separator({ label: 'toast demo', width: cols, ctx });
+    const help = [
+      '  Keys:',
+      `    ${badge('s', { ctx })} success toast`,
+      `    ${badge('e', { ctx })} error toast`,
+      `    ${badge('i', { ctx })} info toast`,
+      `    ${badge('a', { ctx })} cycle anchor (${model.anchor})`,
+      `    ${badge('q', { ctx })} quit`,
+    ].join('
+');
+
+    const bgLines = [header, '', help];
+    while (bgLines.length < rows) bgLines.push('');
+    const bg = bgLines.join('
+');
+
+    if (!model.lastToast || Date.now() - model.lastToast.timestamp > 3000) {
+      return bg;
+    }
+
+    const t = toast({
+      message: `Operation \${model.lastToast.variant}!`,
+      variant: model.lastToast.variant,
+      anchor: model.anchor,
+      screenWidth: cols,
+      screenHeight: rows,
+      ctx,
+    });
+
+    return composite(bg, [t]);
+  },
+};
+
+run(app);

--- a/examples/tooltip/main.ts
+++ b/examples/tooltip/main.ts
@@ -68,7 +68,7 @@ const app: App<Model, Msg> = {
       direction: dir,
       screenWidth: cols,
       screenHeight: rows,
-      borderToken: ctx.theme.theme.border.primary,
+      borderToken: ctx.border('primary'),
       ctx,
     });
 

--- a/examples/transitions/README.md
+++ b/examples/transitions/README.md
@@ -1,0 +1,25 @@
+# Transitions
+
+Demonstrates dynamic tab transition animations.
+
+## Run
+
+```sh
+npx tsx examples/transitions/main.ts
+```
+
+## Code
+
+```typescript
+import { createFramedApp } from '@flyingrobots/bijou-tui';
+
+const app = createFramedApp({
+  title: 'Bijou Transitions Demo',
+  pages: [pageA, pageB],
+  transitionDuration: 600,
+  // Select the transition dynamically from the page model
+  transitionOverride: (model) => model.selectedTransition,
+});
+```
+
+[← Examples](../README.md)

--- a/examples/transitions/main.ts
+++ b/examples/transitions/main.ts
@@ -30,27 +30,26 @@ function createPageKeyMap() {
   const km = createKeyMap<Msg>();
   // Bind 1-8 to set transition
   TRANSITIONS.forEach((t, i) => {
-    km.bind((i + 1).toString(), `Use \${t}`, { type: 'set-transition', transition: t });
+    km.bind((i + 1).toString(), `Use ${t}`, { type: 'set-transition', transition: t });
   });
   return km;
 }
 
 function renderContent(pageName: string, model: PageModel, width: number, height: number): string {
   const list = enumeratedList(
-    TRANSITIONS.map(t => t === model.selectedTransition ? `\${t} \${badge('active', { variant: 'success' })}` : t),
+    TRANSITIONS.map(t => t === model.selectedTransition ? `${t} ${badge('active', { variant: 'success' })}` : t),
     { style: 'arabic', indent: 2 }
   );
 
   const content = [
-    `Currently on \${badge(pageName, { variant: 'primary' })}`,
+    `Currently on ${badge(pageName, { variant: 'primary' })}`,
     '',
     'Press 1-8 to select the NEXT transition:',
     '',
     list,
     '',
-    `Press \${kbd('[')} or \${kbd(']')} to switch pages and play the animation.`,
-  ].join('
-');
+    `Press ${kbd('[')} or ${kbd(']')} to switch pages and play the animation.`,
+  ].join('\n');
 
   return box(content, { width: Math.max(40, width - 4), padding: { top: 1, left: 2, right: 2 } });
 }
@@ -64,7 +63,7 @@ function makePage(id: string, title: string): FramePage<PageModel, Msg> {
     keyMap: createPageKeyMap(),
     layout: (model) => ({
       kind: 'pane',
-      paneId: `\${id}-main`,
+      paneId: `${id}-main`,
       render: (w, h) => renderContent(title, model, w, h),
     }),
   };

--- a/examples/transitions/main.ts
+++ b/examples/transitions/main.ts
@@ -1,0 +1,85 @@
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+import { box, badge, enumeratedList, kbd, separator } from '@flyingrobots/bijou';
+import {
+  run,
+  createKeyMap,
+  createFramedApp,
+  type FramePage,
+  type PageTransition,
+} from '@flyingrobots/bijou-tui';
+
+const ctx = initDefaultContext();
+
+type Msg = 
+  | { type: 'set-transition', transition: PageTransition };
+
+interface PageModel {
+  selectedTransition: PageTransition;
+}
+
+const TRANSITIONS: PageTransition[] = ['none', 'wipe', 'dissolve', 'grid', 'fade', 'melt', 'matrix', 'scramble'];
+
+function updatePageModel(msg: Msg, model: PageModel): [PageModel, []] {
+  if (msg.type === 'set-transition') {
+    return [{ ...model, selectedTransition: msg.transition }, []];
+  }
+  return [model, []];
+}
+
+function createPageKeyMap() {
+  const km = createKeyMap<Msg>();
+  // Bind 1-8 to set transition
+  TRANSITIONS.forEach((t, i) => {
+    km.bind((i + 1).toString(), `Use \${t}`, { type: 'set-transition', transition: t });
+  });
+  return km;
+}
+
+function renderContent(pageName: string, model: PageModel, width: number, height: number): string {
+  const list = enumeratedList(
+    TRANSITIONS.map(t => t === model.selectedTransition ? `\${t} \${badge('active', { variant: 'success' })}` : t),
+    { style: 'arabic', indent: 2 }
+  );
+
+  const content = [
+    `Currently on \${badge(pageName, { variant: 'primary' })}`,
+    '',
+    'Press 1-8 to select the NEXT transition:',
+    '',
+    list,
+    '',
+    `Press \${kbd('[')} or \${kbd(']')} to switch pages and play the animation.`,
+  ].join('
+');
+
+  return box(content, { width: Math.max(40, width - 4), padding: { top: 1, left: 2, right: 2 } });
+}
+
+function makePage(id: string, title: string): FramePage<PageModel, Msg> {
+  return {
+    id,
+    title,
+    init: () => [{ selectedTransition: 'melt' }, []],
+    update: updatePageModel,
+    keyMap: createPageKeyMap(),
+    layout: (model) => ({
+      kind: 'pane',
+      paneId: `\${id}-main`,
+      render: (w, h) => renderContent(title, model, w, h),
+    }),
+  };
+}
+
+const app = createFramedApp<PageModel, Msg>({
+  title: 'Bijou Transitions Demo',
+  pages: [
+    makePage('page-a', 'Page A'),
+    makePage('page-b', 'Page B'),
+  ],
+  transition: 'none', // base default
+  transitionDuration: 600,
+  transitionOverride: (model) => model.selectedTransition,
+  enableCommandPalette: true,
+});
+
+run(app);

--- a/packages/bijou-tui/src/animate.ts
+++ b/packages/bijou-tui/src/animate.ts
@@ -148,10 +148,14 @@ function createSpringCmd<M>(
   return (emit) =>
     new Promise<void>((resolve) => {
       let state = createSpringState(from);
-      const dt = 1 / fps;
       const intervalMs = Math.round(1000 / fps);
+      let lastMs = Date.now();
 
       const id = setInterval(() => {
+        const nowMs = Date.now();
+        const dt = Math.max(0, (nowMs - lastMs) / 1000);
+        lastMs = nowMs;
+
         state = springStep(state, to, config, dt);
         emit(onFrame(state.value));
 
@@ -170,6 +174,10 @@ function createSpringCmd<M>(
 
 /**
  * Build a TEA command that runs a tween animation via `setInterval`.
+ *
+ * Uses wall-clock time (`Date.now()`) to compute actual elapsed time
+ * per frame, so animations run at the correct speed regardless of
+ * timer jitter or system load.
  *
  * @template M - The message type emitted into the TEA update cycle.
  * @param from       - Starting value.
@@ -196,9 +204,14 @@ function createTweenCmd<M>(
     new Promise<void>((resolve) => {
       let state = createTweenState(from);
       const intervalMs = Math.round(1000 / fps);
+      let lastMs = Date.now();
 
       const id = setInterval(() => {
-        state = tweenStep(state, config, intervalMs);
+        const nowMs = Date.now();
+        const dtMs = Math.max(0, nowMs - lastMs);
+        lastMs = nowMs;
+
+        state = tweenStep(state, config, dtMs);
         emit(onFrame(state.value));
 
         if (state.done) {

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { setDefaultContext } from '@flyingrobots/bijou';
 import { createKeyMap } from './keybindings.js';
 import { createSplitPaneState } from './split-pane.js';
 import { runScript } from './driver.js';
@@ -43,6 +45,10 @@ function makePage(id: string, title: string, paneId: string): FramePage<PageMode
 }
 
 describe('createFramedApp', () => {
+  // Ensure a context is available for components that resolve it from the singleton
+  const testCtx = createTestContext();
+  setDefaultContext(testCtx);
+
   it('switches tabs with [ and ]', async () => {
     const app = createFramedApp({
       title: 'Test',
@@ -94,6 +100,66 @@ describe('createFramedApp', () => {
     const app = createFramedApp({ pages: [splitPage] });
     const result = await runScript(app, [{ key: KEY_TAB }, { key: KEY_SHIFT_TAB }]);
     expect(result.model.focusedPaneByPage.home).toBe('left');
+  });
+
+  it('triggers transition animation when switching tabs', async () => {
+    const app = createFramedApp({
+      pages: [
+        makePage('p1', 'P1', 'm'),
+        makePage('p2', 'P2', 'm'),
+      ],
+      transition: 'wipe',
+      transitionDuration: 10,
+    });
+
+    const [initModel, initCmds] = app.init();
+    expect(initModel.activePageId).toBe('p1');
+
+    // Trigger tab switch
+    const [switchedModel, switchCmds] = app.update({ type: 'key', key: ']', ctrl: false, alt: false, shift: false }, initModel);
+    expect(switchedModel.activePageId).toBe('p2');
+    expect(switchedModel.previousPageId).toBe('p1');
+    expect(switchedModel.transitionProgress).toBe(0);
+    expect(switchCmds.length).toBe(1);
+
+    // Manually drive the animation command
+    const messages: any[] = [];
+    await switchCmds[0]!((m) => messages.push(m));
+
+    expect(messages.length).toBeGreaterThan(0);
+    
+    let model = switchedModel;
+    for (const m of messages) {
+      const [nextModel] = app.update(m, model);
+      model = nextModel;
+    }
+
+    expect(model.activePageId).toBe('p2');
+    expect(model.previousPageId).toBeUndefined();
+    expect(model.transitionProgress).toBe(1);
+  });
+
+  it('runs transition animation through runScript', async () => {
+    const app = createFramedApp({
+      pages: [
+        makePage('p1', 'P1', 'm'),
+        makePage('p2', 'P2', 'm'),
+      ],
+      transition: 'fade',
+      transitionDuration: 20,
+    });
+
+    // We add a second step with a delay to allow the macrotask (setInterval) to complete.
+    const result = await runScript(app, [
+      { key: ']' },
+      { key: 'noop', delay: 100 },
+    ]);
+
+    expect(result.model.activePageId).toBe('p2');
+    expect(result.model.previousPageId).toBeUndefined();
+    expect(result.model.transitionProgress).toBe(1);
+    // Transition emits frames, so we expect more than just the keypress frame
+    expect(result.frames.length).toBeGreaterThan(1);
   });
 
   it('throws for duplicate pane ids in a page layout', () => {

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -162,6 +162,29 @@ describe('createFramedApp', () => {
     expect(result.frames.length).toBeGreaterThan(1);
   });
 
+  it('renders complex transition styles (melt, matrix, scramble) without error', async () => {
+    const transitions: PageTransition[] = ['melt', 'matrix', 'scramble'];
+    
+    for (const transition of transitions) {
+      const app = createFramedApp({
+        pages: [
+          makePage('p1', 'P1', 'm'),
+          makePage('p2', 'P2', 'm'),
+        ],
+        transition,
+        transitionDuration: 10,
+      });
+
+      const result = await runScript(app, [
+        { key: ']' },
+        { key: 'noop', delay: 50 },
+      ]);
+
+      expect(result.model.activePageId).toBe('p2');
+      expect(result.model.transitionProgress).toBe(1);
+    }
+  });
+
   it('throws for duplicate pane ids in a page layout', () => {
     const app = createFramedApp({
       pages: [{

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createTestContext } from '@flyingrobots/bijou/adapters/test';
-import { setDefaultContext } from '@flyingrobots/bijou';
+import { setDefaultContext, _resetDefaultContextForTesting } from '@flyingrobots/bijou';
 import { createKeyMap } from './keybindings.js';
 import { createSplitPaneState } from './split-pane.js';
 import { runScript } from './driver.js';
@@ -47,7 +47,8 @@ function makePage(id: string, title: string, paneId: string): FramePage<PageMode
 describe('createFramedApp', () => {
   // Ensure a context is available for components that resolve it from the singleton
   const testCtx = createTestContext();
-  setDefaultContext(testCtx);
+  beforeAll(() => setDefaultContext(testCtx));
+  afterAll(() => _resetDefaultContextForTesting());
 
   it('switches tabs with [ and ]', async () => {
     const app = createFramedApp({
@@ -149,10 +150,10 @@ describe('createFramedApp', () => {
       transitionDuration: 20,
     });
 
-    // We add a second step with a delay to allow the macrotask (setInterval) to complete.
+    // Delay must exceed transitionDuration (20ms) with headroom for CI load.
     const result = await runScript(app, [
       { key: ']' },
-      { key: 'noop', delay: 100 },
+      { key: 'noop', delay: 200 },
     ]);
 
     expect(result.model.activePageId).toBe('p2');

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -4,7 +4,7 @@ import { setDefaultContext } from '@flyingrobots/bijou';
 import { createKeyMap } from './keybindings.js';
 import { createSplitPaneState } from './split-pane.js';
 import { runScript } from './driver.js';
-import { createFramedApp, type FramePage, type FrameOverlayContext } from './app-frame.js';
+import { createFramedApp, type FramePage, type FrameOverlayContext, type PageTransition } from './app-frame.js';
 import type { Cmd, MouseMsg } from './types.js';
 
 type Msg =

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -185,6 +185,25 @@ describe('createFramedApp', () => {
     }
   });
 
+  it('respects transitionOverride to select animation dynamically', async () => {
+    const app = createFramedApp({
+      pages: [
+        makePage('p1', 'P1', 'm'),
+        makePage('p2', 'P2', 'm'),
+      ],
+      transition: 'none',
+      transitionOverride: () => 'wipe',
+      transitionDuration: 10,
+    });
+
+    const [initModel] = app.init();
+    const [switchedModel] = app.update({ type: 'key', key: ']', ctrl: false, alt: false, shift: false }, initModel);
+    
+    // Even though transition: 'none' was set, override should win
+    expect(switchedModel.activeTransition).toBe('wipe');
+    expect(switchedModel.transitionProgress).toBe(0);
+  });
+
   it('throws for duplicate pane ids in a page layout', () => {
     const app = createFramedApp({
       pages: [{

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -143,6 +143,8 @@ export interface CreateFramedAppOptions<PageModel, Msg> {
   readonly transition?: PageTransition;
   /** Transition duration in milliseconds. Default: 300. */
   readonly transitionDuration?: number;
+  /** Optional function to determine the transition style dynamically. */
+  readonly transitionOverride?: (model: PageModel) => PageTransition;
 }
 
 /** Stored pane scroll coordinates. */
@@ -177,6 +179,8 @@ export interface FrameModel<PageModel> {
   readonly previousPageId?: string;
   /** Transition progress (0 to 1). */
   readonly transitionProgress: number;
+  /** Currently active transition style. */
+  readonly activeTransition?: PageTransition;
 }
 
 interface InternalFrameModel<PageModel, Msg> extends FrameModel<PageModel> {
@@ -315,7 +319,7 @@ export function createFramedApp<PageModel, Msg>(
           return [{ ...model, transitionProgress: action.progress }, []];
         }
         if (action.type === 'transition-complete') {
-          return [{ ...model, transitionProgress: 1, previousPageId: undefined }, []];
+          return [{ ...model, transitionProgress: 1, previousPageId: undefined, activeTransition: undefined }, []];
         }
         return applyFrameAction(action, model, frameKeys, options, pagesById);
       }
@@ -387,14 +391,15 @@ export function createFramedApp<PageModel, Msg>(
       const activeResult = renderPageContent(model.activePageId, model, bodyRect, pagesById);
       let bodyOutput = activeResult.output;
 
-      if (model.previousPageId != null && model.transitionProgress < 1 && options.transition && options.transition !== 'none') {
+      const activeTransition = model.activeTransition ?? options.transition;
+      if (model.previousPageId != null && model.transitionProgress < 1 && activeTransition && activeTransition !== 'none') {
         const ctx = resolveSafeCtx();
         if (ctx) {
           const prevResult = renderPageContent(model.previousPageId, model, bodyRect, pagesById);
           bodyOutput = renderTransition(
             prevResult.output,
             activeResult.output,
-            options.transition,
+            activeTransition,
             model.transitionProgress,
             bodyRect.width,
             bodyRect.height,
@@ -572,14 +577,20 @@ function switchTab<PageModel, Msg>(
 
   if (nextId === model.activePageId) return [model, []];
 
+  const activePageModel = model.pageModels[model.activePageId]!;
+  const activeTransition = options.transitionOverride
+    ? options.transitionOverride(activePageModel)
+    : options.transition;
+
   const nextModel = syncPageFrameState({
     ...model,
     activePageId: nextId,
     previousPageId: model.activePageId,
-    transitionProgress: options.transition && options.transition !== 'none' ? 0 : 1,
+    activeTransition,
+    transitionProgress: activeTransition && activeTransition !== 'none' ? 0 : 1,
   }, nextId, pagesById);
 
-  if (options.transition && options.transition !== 'none') {
+  if (activeTransition && activeTransition !== 'none') {
     const cmd: Cmd<Msg> = animate({
       type: 'tween',
       from: 0,

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -17,6 +17,8 @@ import type { App, Cmd, KeyMsg } from './types.js';
 import { isKeyMsg, isMouseMsg, isResizeMsg, QUIT } from './types.js';
 import type { Overlay } from './overlay.js';
 import { composite, modal } from './overlay.js';
+import type { TransitionShaderFn } from './transition-shaders.js';
+import { type BuiltinTransition, TRANSITION_SHADERS } from './transition-shaders.js';
 import type { CommandPaletteItem, CommandPaletteState } from './command-palette.js';
 import {
   commandPalette,
@@ -47,8 +49,7 @@ import {
 import { splitPane, splitPaneLayout, type SplitPaneDirection, type SplitPaneState } from './split-pane.js';
 import type { LayoutRect } from './layout-rect.js';
 import { clipToWidth, tokenizeAnsi, visibleLength } from './viewport.js';
-import { animate } from './animate.js';
-import { EASINGS, type EasingFn } from './spring.js';
+import { EASINGS } from './spring.js';
 import { timeline, type Timeline, type TimelineState } from './timeline.js';
 
 /** Page declaration consumed by {@link createFramedApp}. */
@@ -118,8 +119,8 @@ export interface FrameOverlayContext<PageModel> {
   readonly screenRect: LayoutRect;
 }
 
-/** Page transition styles. */
-export type PageTransition = 'none' | 'wipe' | 'dissolve' | 'grid' | 'fade' | 'melt' | 'matrix' | 'scramble';
+/** Page transition styles — a built-in name or a custom shader function. */
+export type PageTransition = BuiltinTransition | TransitionShaderFn;
 
 /** `createFramedApp()` options. */
 export interface CreateFramedAppOptions<PageModel, Msg> {
@@ -353,7 +354,7 @@ export function createFramedApp<PageModel, Msg>(
             // Step from init to current elapsed time (tweens are deterministic)
             const state = model.transitionTimeline.step(model.transitionTimeline.init(), elapsedSec);
             const vals = model.transitionTimeline.values(state);
-            const progress = Math.min(1, Math.max(0, vals.progress ?? action.progress));
+            const progress = Math.min(1, Math.max(0, vals['progress'] ?? action.progress));
 
             if (model.transitionTimeline.done(state) || progress >= 1) {
               return [{
@@ -1333,6 +1334,9 @@ function renderTransition(
   height: number,
   ctx: BijouContext,
 ): string {
+  const shader = typeof style === 'function' ? style : TRANSITION_SHADERS[style];
+  if (!shader) return next;
+
   const prevGrid = stringToGrid(prev, width, height);
   const nextGrid = stringToGrid(next, width, height);
   const lines: string[] = [];
@@ -1344,66 +1348,9 @@ function renderTransition(
       const seed = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
       const rand = seed - Math.floor(seed);
 
-      let showNext = false;
-      let charOverride: string | undefined;
-
-      switch (style) {
-        case 'wipe':
-          showNext = x / width < progress;
-          break;
-
-        case 'dissolve':
-          showNext = rand < progress;
-          break;
-
-        case 'grid': {
-          const gx = Math.floor(x / 8);
-          const gy = Math.floor(y / 4);
-          showNext = ((gx + gy) % 10) / 10 < progress;
-          break;
-        }
-
-        case 'fade':
-          showNext = progress > 0.5;
-          break;
-
-        case 'melt': {
-          const variability = (Math.sin(x * 0.7) * 0.5 + 0.5) * 0.4;
-          const dropStart = progress * 1.4 - variability;
-          showNext = y / height < dropStart;
-          break;
-        }
-
-        case 'matrix': {
-          const threshold = progress;
-          const edge = 0.1;
-          if (rand < threshold) {
-            showNext = true;
-          } else if (rand < threshold + edge) {
-            const chars = '01$#@%&*';
-            const char = chars[Math.floor(rand * 100) % chars.length]!;
-            charOverride = ctx.style.styled(ctx.status('success'), char);
-          } else {
-            showNext = false;
-          }
-          break;
-        }
-
-        case 'scramble': {
-          const scrambleAmount = 1 - Math.abs(progress - 0.5) * 2;
-          if (rand < scrambleAmount * 0.8) {
-            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
-            const char = chars[Math.floor(rand * 1000) % chars.length]!;
-            charOverride = ctx.style.styled(ctx.semantic('muted'), char);
-          } else {
-            showNext = progress > 0.5;
-          }
-          break;
-        }
-
-        default:
-          showNext = progress >= 1;
-      }
+      const result = shader({ x, y, width, height, progress, rand, ctx });
+      const showNext = result.showNext;
+      const charOverride = result.char;
 
       if (charOverride !== undefined) {
         line += charOverride;

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -145,6 +145,30 @@ export interface CreateFramedAppOptions<PageModel, Msg> {
   readonly transitionDuration?: number;
   /** Optional function to determine the transition style dynamically. */
   readonly transitionOverride?: (model: PageModel) => PageTransition;
+  /**
+   * Optional compiled timeline that drives the transition animation.
+   *
+   * Must contain a `'progress'` track that tweens from 0 to 1.
+   * When provided, replaces the default ease/duration with whatever
+   * the timeline defines — springs, multi-track orchestration, etc.
+   *
+   * ```ts
+   * import { timeline, EASINGS } from '@flyingrobots/bijou-tui';
+   *
+   * createFramedApp({
+   *   transition: 'melt',
+   *   transitionTimeline: timeline()
+   *     .add('progress', {
+   *       type: 'tween',
+   *       from: 0, to: 1,
+   *       duration: 600,
+   *       ease: EASINGS.easeInOutCubic,
+   *     })
+   *     .build(),
+   * });
+   * ```
+   */
+  readonly transitionTimeline?: Timeline;
 }
 
 /** Stored pane scroll coordinates. */
@@ -624,21 +648,23 @@ function switchTab<PageModel, Msg>(
     ? options.transitionOverride(activePageModel)
     : options.transition;
 
-  const durationMs = options.transitionDuration ?? 300;
   const hasTransition = activeTransition != null && activeTransition !== 'none';
 
-  // Build a timeline to drive the transition — time-based, not tick-based.
+  // Use the user-supplied timeline if provided, otherwise build a default.
+  // The timeline MUST contain a 'progress' track (0 → 1).
   const tl = hasTransition
-    ? timeline()
+    ? (options.transitionTimeline ?? timeline()
       .add('progress', {
         type: 'tween',
         from: 0,
         to: 1,
-        duration: durationMs,
+        duration: options.transitionDuration ?? 300,
         ease: EASINGS.easeInOutCubic,
       })
-      .build()
+      .build())
     : undefined;
+
+  const durationMs = tl?.estimatedDurationMs ?? options.transitionDuration ?? 300;
 
   const nextModel = syncPageFrameState({
     ...model,

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -119,7 +119,7 @@ export interface FrameOverlayContext<PageModel> {
 }
 
 /** Page transition styles. */
-export type PageTransition = 'none' | 'wipe' | 'dissolve' | 'grid' | 'fade';
+export type PageTransition = 'none' | 'wipe' | 'dissolve' | 'grid' | 'fade' | 'melt' | 'matrix' | 'scramble';
 
 /** `createFramedApp()` options. */
 export interface CreateFramedAppOptions<PageModel, Msg> {
@@ -1220,32 +1220,61 @@ function renderTransition(
   const nextGrid = stringToGrid(next, width, height);
 
   return canvas(width, height, (x, y) => {
-    let showNext = false;
+    // Shared stable-ish pseudo-random seed based on coordinates
+    const seed = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+    const rand = seed - Math.floor(seed);
 
     switch (style) {
       case 'wipe':
-        showNext = x / width < progress;
-        break;
-      case 'dissolve': {
-        // Use a stable-ish pseudo-random seed based on coordinates
-        const seed = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
-        const rand = seed - Math.floor(seed);
-        showNext = rand < progress;
-        break;
-      }
+        return (x / width < progress ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+
+      case 'dissolve':
+        return (rand < progress ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+
       case 'grid': {
         const gx = Math.floor(x / 8);
         const gy = Math.floor(y / 4);
-        showNext = ((gx + gy) % 10) / 10 < progress;
-        break;
+        const showNext = ((gx + gy) % 10) / 10 < progress;
+        return (showNext ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
       }
-      case 'fade':
-        showNext = progress > 0.5;
-        break;
-      default:
-        showNext = progress >= 1;
-    }
 
-    return (showNext ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+      case 'fade':
+        return (progress > 0.5 ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+
+      case 'melt': {
+        // Doom-style melt: columns drop at variable speeds
+        const variability = (Math.sin(x * 0.7) * 0.5 + 0.5) * 0.4;
+        const dropStart = progress * 1.4 - variability;
+        const showNext = y / height < dropStart;
+        return (showNext ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+      }
+
+      case 'matrix': {
+        // Matrix dissolve: leading edge of the flip uses "code" characters
+        const threshold = progress;
+        const edge = 0.1;
+        if (rand < threshold) return nextGrid[y]?.[x] ?? ' ';
+        if (rand < threshold + edge) {
+          const chars = '01$#@%&*';
+          const char = chars[Math.floor(rand * 100) % chars.length]!;
+          return ctx.style.styled(ctx.semantic('success'), char);
+        }
+        return prevGrid[y]?.[x] ?? ' ';
+      }
+
+      case 'scramble': {
+        // Scramble: characters turn to noise then resolve
+        const scrambleAmount = 1 - Math.abs(progress - 0.5) * 2;
+        if (rand < scrambleAmount * 0.8) {
+          const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
+          const char = chars[Math.floor(rand * 1000) % chars.length]!;
+          return ctx.style.styled(ctx.semantic('muted'), char);
+        }
+        return (progress > 0.5 ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+      }
+
+      default:
+        return (progress >= 1 ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+    }
   }, { ctx });
 }

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -5,6 +5,7 @@
  * panel-scoped overlay context, and optional frame-level command palette.
  */
 
+import { resolveSafeCtx, type BijouContext } from '@flyingrobots/bijou';
 import { helpShort, helpView, type BindingSource } from './help.js';
 import {
   createKeyMap,
@@ -43,14 +44,12 @@ import {
   focusAreaScrollToX,
   type OverflowX,
 } from './focus-area.js';
-import {
-  splitPane,
-  splitPaneLayout,
-  type SplitPaneDirection,
-  type SplitPaneState,
-} from './split-pane.js';
+import { splitPane, splitPaneLayout, type SplitPaneDirection, type SplitPaneState } from './split-pane.js';
 import type { LayoutRect } from './layout-rect.js';
-import { clipToWidth, visibleLength } from './viewport.js';
+import { clipToWidth, sliceAnsi, visibleLength } from './viewport.js';
+import { animate } from './animate.js';
+import { EASINGS } from './spring.js';
+import { canvas } from './canvas.js';
 
 /** Page declaration consumed by {@link createFramedApp}. */
 export interface FramePage<PageModel, Msg> {
@@ -119,6 +118,9 @@ export interface FrameOverlayContext<PageModel> {
   readonly screenRect: LayoutRect;
 }
 
+/** Page transition styles. */
+export type PageTransition = 'none' | 'wipe' | 'dissolve' | 'grid' | 'fade';
+
 /** `createFramedApp()` options. */
 export interface CreateFramedAppOptions<PageModel, Msg> {
   /** Registered pages. */
@@ -137,6 +139,10 @@ export interface CreateFramedAppOptions<PageModel, Msg> {
   readonly enableCommandPalette?: boolean;
   /** Optional overlay provider (receives pane rects for panel scoping). */
   readonly overlayFactory?: (ctx: FrameOverlayContext<PageModel>) => readonly Overlay[];
+  /** Optional page transition style. Default: 'none'. */
+  readonly transition?: PageTransition;
+  /** Transition duration in milliseconds. Default: 300. */
+  readonly transitionDuration?: number;
 }
 
 /** Stored pane scroll coordinates. */
@@ -167,6 +173,10 @@ export interface FrameModel<PageModel> {
   readonly helpOpen: boolean;
   /** Command palette state (undefined when closed). */
   readonly commandPalette?: CommandPaletteState;
+  /** ID of the page we are transitioning away from. */
+  readonly previousPageId?: string;
+  /** Transition progress (0 to 1). */
+  readonly transitionProgress: number;
 }
 
 interface InternalFrameModel<PageModel, Msg> extends FrameModel<PageModel> {
@@ -208,7 +218,9 @@ type FrameAction =
   | { type: 'bottom' }
   | { type: 'scroll-left' }
   | { type: 'scroll-right' }
-  | { type: 'open-palette' };
+  | { type: 'open-palette' }
+  | { type: 'transition'; progress: number }
+  | { type: 'transition-complete' };
 
 type PaletteAction =
   | { type: 'cp-next' }
@@ -219,11 +231,17 @@ type PaletteAction =
   | { type: 'cp-close' };
 
 const PAGE_MSG_TOKEN = Symbol('app-frame-page-msg');
+const FRAME_MSG_TOKEN = Symbol('app-frame-frame-msg');
 
 interface PageScopedMsg<Msg> {
   readonly [PAGE_MSG_TOKEN]: true;
   readonly pageId: string;
   readonly msg: Msg;
+}
+
+interface FrameScopedMsg {
+  readonly [FRAME_MSG_TOKEN]: true;
+  readonly action: FrameAction;
 }
 
 /**
@@ -280,6 +298,7 @@ export function createFramedApp<PageModel, Msg>(
         columns: Math.max(1, options.initialColumns ?? 80),
         rows: Math.max(1, options.initialRows ?? 24),
         helpOpen: false,
+        transitionProgress: 1,
       };
 
       for (const pageId of pageOrder) {
@@ -290,6 +309,17 @@ export function createFramedApp<PageModel, Msg>(
     },
 
     update(msg, model) {
+      if (isFrameScopedMsg(msg)) {
+        const action = msg.action;
+        if (action.type === 'transition') {
+          return [{ ...model, transitionProgress: action.progress }, []];
+        }
+        if (action.type === 'transition-complete') {
+          return [{ ...model, transitionProgress: 1, previousPageId: undefined }, []];
+        }
+        return applyFrameAction(action, model, frameKeys, options, pagesById);
+      }
+
       if (isResizeMsg(msg)) {
         return [{
           ...model,
@@ -350,21 +380,30 @@ export function createFramedApp<PageModel, Msg>(
 
     view(model) {
       const activePage = pagesById.get(model.activePageId)!;
-      const activePageModel = model.pageModels[model.activePageId]!;
-
       const header = renderHeaderLine(model, options, pagesById);
       const helpLine = renderHelpLine(model, frameKeys, options, activePage);
       const bodyRect = frameBodyRect(model.columns, model.rows);
 
-      const renderCtx: RenderContext<PageModel, Msg> = {
-        model,
-        pageId: model.activePageId,
-        focusedPaneId: model.focusedPaneByPage[model.activePageId],
-        scrollByPane: model.scrollByPage[model.activePageId] ?? {},
-      };
+      const activeResult = renderPageContent(model.activePageId, model, bodyRect, pagesById);
+      let bodyOutput = activeResult.output;
 
-      const rendered = renderFrameNode(activePage.layout(activePageModel), bodyRect, renderCtx);
-      const bodyLines = fitBlock(rendered.output, bodyRect.width, bodyRect.height);
+      if (model.previousPageId != null && model.transitionProgress < 1 && options.transition && options.transition !== 'none') {
+        const ctx = resolveSafeCtx();
+        if (ctx) {
+          const prevResult = renderPageContent(model.previousPageId, model, bodyRect, pagesById);
+          bodyOutput = renderTransition(
+            prevResult.output,
+            activeResult.output,
+            options.transition,
+            model.transitionProgress,
+            bodyRect.width,
+            bodyRect.height,
+            ctx,
+          );
+        }
+      }
+
+      const bodyLines = fitBlock(bodyOutput, bodyRect.width, bodyRect.height);
       const rows: string[] = [header, helpLine, ...bodyLines];
       while (rows.length < model.rows) rows.push(' '.repeat(Math.max(0, model.columns)));
 
@@ -374,8 +413,8 @@ export function createFramedApp<PageModel, Msg>(
       if (options.overlayFactory != null) {
         overlays.push(...options.overlayFactory({
           activePageId: model.activePageId,
-          pageModel: activePageModel,
-          paneRects: rendered.paneRects,
+          pageModel: model.pageModels[model.activePageId]!,
+          paneRects: activeResult.paneRects,
           screenRect: { row: 0, col: 0, width: model.columns, height: model.rows },
         }));
       }
@@ -495,9 +534,9 @@ function applyFrameAction<PageModel, Msg>(
     case 'toggle-help':
       return [{ ...model, helpOpen: !model.helpOpen }, []];
     case 'prev-tab':
-      return [switchTab(model, -1, pagesById), []];
+      return switchTab(model, -1, pagesById, options);
     case 'next-tab':
-      return [switchTab(model, 1, pagesById), []];
+      return switchTab(model, 1, pagesById, options);
     case 'next-pane':
       return [cyclePane(model, 1, pagesById), []];
     case 'prev-pane':
@@ -514,6 +553,9 @@ function applyFrameAction<PageModel, Msg>(
     case 'scroll-left':
     case 'scroll-right':
       return [scrollFocusedPane(model, action, pagesById), []];
+    case 'transition':
+    case 'transition-complete':
+      return [model, []];
   }
 }
 
@@ -521,12 +563,36 @@ function switchTab<PageModel, Msg>(
   model: InternalFrameModel<PageModel, Msg>,
   delta: number,
   pagesById: Map<string, FramePage<PageModel, Msg>>,
-): InternalFrameModel<PageModel, Msg> {
+  options: CreateFramedAppOptions<PageModel, Msg>,
+): [InternalFrameModel<PageModel, Msg>, Cmd<Msg>[]] {
   const idx = model.pageOrder.indexOf(model.activePageId);
-  if (idx < 0) return model;
+  if (idx < 0) return [model, []];
   const nextIdx = (idx + delta + model.pageOrder.length) % model.pageOrder.length;
   const nextId = model.pageOrder[nextIdx]!;
-  return syncPageFrameState({ ...model, activePageId: nextId }, nextId, pagesById);
+
+  if (nextId === model.activePageId) return [model, []];
+
+  const nextModel = syncPageFrameState({
+    ...model,
+    activePageId: nextId,
+    previousPageId: model.activePageId,
+    transitionProgress: options.transition && options.transition !== 'none' ? 0 : 1,
+  }, nextId, pagesById);
+
+  if (options.transition && options.transition !== 'none') {
+    const cmd: Cmd<Msg> = animate({
+      type: 'tween',
+      from: 0,
+      to: 1,
+      duration: options.transitionDuration ?? 300,
+      ease: EASINGS.easeInOutCubic,
+      onFrame: (v) => wrapFrameMsg({ type: 'transition', progress: v } as FrameAction) as unknown as Msg,
+      onComplete: () => wrapFrameMsg({ type: 'transition-complete' } as FrameAction) as unknown as Msg,
+    });
+    return [nextModel, [cmd]];
+  }
+
+  return [nextModel, []];
 }
 
 function cyclePane<PageModel, Msg>(
@@ -1061,6 +1127,20 @@ function comboToMsg(binding: BindingInfo): KeyMsg {
   };
 }
 
+function isFrameScopedMsg(value: unknown): value is FrameScopedMsg {
+  return typeof value === 'object'
+    && value !== null
+    && FRAME_MSG_TOKEN in value
+    && (value as FrameScopedMsg)[FRAME_MSG_TOKEN] === true;
+}
+
+function wrapFrameMsg(action: FrameAction): FrameScopedMsg {
+  return {
+    [FRAME_MSG_TOKEN]: true,
+    action,
+  };
+}
+
 function emitMsg<Msg>(msg: Msg): Cmd<Msg> {
   return () => Promise.resolve(msg);
 }
@@ -1090,4 +1170,82 @@ function isPageScopedMsg<Msg>(value: unknown): value is PageScopedMsg<Msg> {
     && value !== null
     && PAGE_MSG_TOKEN in value
     && (value as PageScopedMsg<Msg>)[PAGE_MSG_TOKEN] === true;
+}
+
+function renderPageContent<PageModel, Msg>(
+  pageId: string,
+  model: InternalFrameModel<PageModel, Msg>,
+  bodyRect: LayoutRect,
+  pagesById: Map<string, FramePage<PageModel, Msg>>,
+): RenderResult {
+  const page = pagesById.get(pageId)!;
+  const pageModel = model.pageModels[pageId]!;
+  const renderCtx: RenderContext<PageModel, Msg> = {
+    model,
+    pageId,
+    focusedPaneId: model.focusedPaneByPage[pageId],
+    scrollByPane: model.scrollByPage[pageId] ?? {},
+  };
+  return renderFrameNode(page.layout(pageModel), bodyRect, renderCtx);
+}
+
+/**
+ * Split a styled multiline string into a 2D grid of single-column characters.
+ * Each cell is a fully-styled string (including resets).
+ */
+function stringToGrid(str: string, width: number, height: number): string[][] {
+  const lines = str.split('\n');
+  const grid: string[][] = [];
+  for (let y = 0; y < height; y++) {
+    const line = lines[y] ?? '';
+    const row: string[] = [];
+    for (let x = 0; x < width; x++) {
+      row.push(sliceAnsi(line, x, x + 1));
+    }
+    grid.push(row);
+  }
+  return grid;
+}
+
+function renderTransition(
+  prev: string,
+  next: string,
+  style: PageTransition,
+  progress: number,
+  width: number,
+  height: number,
+  ctx: BijouContext,
+): string {
+  const prevGrid = stringToGrid(prev, width, height);
+  const nextGrid = stringToGrid(next, width, height);
+
+  return canvas(width, height, (x, y) => {
+    let showNext = false;
+
+    switch (style) {
+      case 'wipe':
+        showNext = x / width < progress;
+        break;
+      case 'dissolve': {
+        // Use a stable-ish pseudo-random seed based on coordinates
+        const seed = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+        const rand = seed - Math.floor(seed);
+        showNext = rand < progress;
+        break;
+      }
+      case 'grid': {
+        const gx = Math.floor(x / 8);
+        const gy = Math.floor(y / 4);
+        showNext = ((gx + gy) % 10) / 10 < progress;
+        break;
+      }
+      case 'fade':
+        showNext = progress > 0.5;
+        break;
+      default:
+        showNext = progress >= 1;
+    }
+
+    return (showNext ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+  }, { ctx });
 }

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -204,6 +204,8 @@ export interface FrameModel<PageModel> {
   readonly previousPageId?: string;
   /** Transition progress (0 to 1). */
   readonly transitionProgress: number;
+  /** Monotonic counter to discard stale transition ticks. */
+  readonly transitionGeneration: number;
   /** Currently active transition style. */
   readonly activeTransition?: PageTransition;
   /** Wall-clock start time of the active transition (ms since epoch). */
@@ -254,8 +256,8 @@ type FrameAction =
   | { type: 'scroll-left' }
   | { type: 'scroll-right' }
   | { type: 'open-palette' }
-  | { type: 'transition'; progress: number }
-  | { type: 'transition-complete' };
+  | { type: 'transition'; progress: number; generation: number }
+  | { type: 'transition-complete'; generation: number };
 
 type PaletteAction =
   | { type: 'cp-next' }
@@ -334,6 +336,7 @@ export function createFramedApp<PageModel, Msg>(
         rows: Math.max(1, options.initialRows ?? 24),
         helpOpen: false,
         transitionProgress: 1,
+        transitionGeneration: 0,
       };
 
       for (const pageId of pageOrder) {
@@ -347,6 +350,8 @@ export function createFramedApp<PageModel, Msg>(
       if (isFrameScopedMsg(msg)) {
         const action = msg.action;
         if (action.type === 'transition') {
+          // Ignore stale transition ticks from a previous generation
+          if (action.generation !== model.transitionGeneration) return [model, []];
           // Advance timeline using wall-clock elapsed time
           if (model.transitionTimeline && model.transitionTimelineState && model.transitionStartMs != null) {
             const elapsedMs = Date.now() - model.transitionStartMs;
@@ -378,6 +383,7 @@ export function createFramedApp<PageModel, Msg>(
           return [{ ...model, transitionProgress: action.progress }, []];
         }
         if (action.type === 'transition-complete') {
+          if (action.generation !== model.transitionGeneration) return [model, []];
           return [{
             ...model,
             transitionProgress: 1,
@@ -650,6 +656,7 @@ function switchTab<PageModel, Msg>(
     : options.transition;
 
   const hasTransition = activeTransition != null && activeTransition !== 'none';
+  const nextGeneration = model.transitionGeneration + 1;
 
   // Use the user-supplied timeline if provided, otherwise build a default.
   // The timeline MUST contain a 'progress' track (0 → 1).
@@ -673,6 +680,7 @@ function switchTab<PageModel, Msg>(
     previousPageId: model.activePageId,
     activeTransition,
     transitionProgress: hasTransition ? 0 : 1,
+    transitionGeneration: nextGeneration,
     transitionStartMs: hasTransition ? Date.now() : undefined,
     transitionTimeline: tl,
     transitionTimelineState: tl?.init(),
@@ -681,7 +689,7 @@ function switchTab<PageModel, Msg>(
   if (hasTransition) {
     // Schedule render ticks at ~60fps for the duration of the transition.
     // Each tick advances the timeline using wall-clock elapsed time.
-    const cmd: Cmd<Msg> = createTransitionTickCmd(durationMs);
+    const cmd: Cmd<Msg> = createTransitionTickCmd(durationMs, nextGeneration);
     return [nextModel, [cmd]];
   }
 
@@ -1272,7 +1280,7 @@ function isPageScopedMsg<Msg>(value: unknown): value is PageScopedMsg<Msg> {
  * is computed from wall-clock time in the update handler, not from the
  * interval count. The interval just schedules re-renders.
  */
-function createTransitionTickCmd<Msg>(durationMs: number): Cmd<Msg> {
+function createTransitionTickCmd<Msg>(durationMs: number, generation: number): Cmd<Msg> {
   return (emit) =>
     new Promise<void>((resolve) => {
       const startMs = Date.now();
@@ -1282,11 +1290,11 @@ function createTransitionTickCmd<Msg>(durationMs: number): Cmd<Msg> {
         const elapsed = Date.now() - startMs;
         const rawProgress = Math.min(1, elapsed / durationMs);
 
-        emit(wrapFrameMsg({ type: 'transition', progress: rawProgress } as FrameAction) as unknown as Msg);
+        emit(wrapFrameMsg({ type: 'transition', progress: rawProgress, generation } as FrameAction) as unknown as Msg);
 
         if (rawProgress >= 1) {
           clearInterval(id);
-          emit(wrapFrameMsg({ type: 'transition-complete' } as FrameAction) as unknown as Msg);
+          emit(wrapFrameMsg({ type: 'transition-complete', generation } as FrameAction) as unknown as Msg);
           resolve();
         }
       }, intervalMs);

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -46,7 +46,7 @@ import {
 } from './focus-area.js';
 import { splitPane, splitPaneLayout, type SplitPaneDirection, type SplitPaneState } from './split-pane.js';
 import type { LayoutRect } from './layout-rect.js';
-import { clipToWidth, sliceAnsi, visibleLength } from './viewport.js';
+import { clipToWidth, tokenizeAnsi, visibleLength } from './viewport.js';
 import { animate } from './animate.js';
 import { EASINGS } from './spring.js';
 
@@ -1206,19 +1206,10 @@ function renderPageContent<PageModel, Msg>(
 function stringToGrid(str: string, width: number, height: number): string[][] {
   const lines = str.split('\n');
   const grid: string[][] = [];
+
   for (let y = 0; y < height; y++) {
     const line = lines[y] ?? '';
-    const row: string[] = [];
-    const lineVis = visibleLength(line);
-
-    for (let x = 0; x < width; x++) {
-      if (x >= lineVis) {
-        row.push(' ');
-      } else {
-        row.push(sliceAnsi(line, x, x + 1));
-      }
-    }
-    grid.push(row);
+    grid.push(tokenizeAnsi(line, width));
   }
   return grid;
 }

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -49,7 +49,6 @@ import type { LayoutRect } from './layout-rect.js';
 import { clipToWidth, sliceAnsi, visibleLength } from './viewport.js';
 import { animate } from './animate.js';
 import { EASINGS } from './spring.js';
-import { canvas } from './canvas.js';
 
 /** Page declaration consumed by {@link createFramedApp}. */
 export interface FramePage<PageModel, Msg> {
@@ -1210,8 +1209,14 @@ function stringToGrid(str: string, width: number, height: number): string[][] {
   for (let y = 0; y < height; y++) {
     const line = lines[y] ?? '';
     const row: string[] = [];
+    const lineVis = visibleLength(line);
+
     for (let x = 0; x < width; x++) {
-      row.push(sliceAnsi(line, x, x + 1));
+      if (x >= lineVis) {
+        row.push(' ');
+      } else {
+        row.push(sliceAnsi(line, x, x + 1));
+      }
     }
     grid.push(row);
   }
@@ -1229,63 +1234,84 @@ function renderTransition(
 ): string {
   const prevGrid = stringToGrid(prev, width, height);
   const nextGrid = stringToGrid(next, width, height);
+  const lines: string[] = [];
 
-  return canvas(width, height, (x, y) => {
-    // Shared stable-ish pseudo-random seed based on coordinates
-    const seed = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
-    const rand = seed - Math.floor(seed);
+  for (let y = 0; y < height; y++) {
+    let line = '';
+    for (let x = 0; x < width; x++) {
+      // Shared stable-ish pseudo-random seed based on coordinates
+      const seed = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+      const rand = seed - Math.floor(seed);
 
-    switch (style) {
-      case 'wipe':
-        return (x / width < progress ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+      let showNext = false;
+      let charOverride: string | undefined;
 
-      case 'dissolve':
-        return (rand < progress ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+      switch (style) {
+        case 'wipe':
+          showNext = x / width < progress;
+          break;
 
-      case 'grid': {
-        const gx = Math.floor(x / 8);
-        const gy = Math.floor(y / 4);
-        const showNext = ((gx + gy) % 10) / 10 < progress;
-        return (showNext ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
-      }
+        case 'dissolve':
+          showNext = rand < progress;
+          break;
 
-      case 'fade':
-        return (progress > 0.5 ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
-
-      case 'melt': {
-        // Doom-style melt: columns drop at variable speeds
-        const variability = (Math.sin(x * 0.7) * 0.5 + 0.5) * 0.4;
-        const dropStart = progress * 1.4 - variability;
-        const showNext = y / height < dropStart;
-        return (showNext ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
-      }
-
-      case 'matrix': {
-        // Matrix dissolve: leading edge of the flip uses "code" characters
-        const threshold = progress;
-        const edge = 0.1;
-        if (rand < threshold) return nextGrid[y]?.[x] ?? ' ';
-        if (rand < threshold + edge) {
-          const chars = '01$#@%&*';
-          const char = chars[Math.floor(rand * 100) % chars.length]!;
-          return ctx.style.styled(ctx.semantic('success'), char);
+        case 'grid': {
+          const gx = Math.floor(x / 8);
+          const gy = Math.floor(y / 4);
+          showNext = ((gx + gy) % 10) / 10 < progress;
+          break;
         }
-        return prevGrid[y]?.[x] ?? ' ';
-      }
 
-      case 'scramble': {
-        // Scramble: characters turn to noise then resolve
-        const scrambleAmount = 1 - Math.abs(progress - 0.5) * 2;
-        if (rand < scrambleAmount * 0.8) {
-          const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
-          const char = chars[Math.floor(rand * 1000) % chars.length]!;
-          return ctx.style.styled(ctx.semantic('muted'), char);
+        case 'fade':
+          showNext = progress > 0.5;
+          break;
+
+        case 'melt': {
+          const variability = (Math.sin(x * 0.7) * 0.5 + 0.5) * 0.4;
+          const dropStart = progress * 1.4 - variability;
+          showNext = y / height < dropStart;
+          break;
         }
-        return (progress > 0.5 ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+
+        case 'matrix': {
+          const threshold = progress;
+          const edge = 0.1;
+          if (rand < threshold) {
+            showNext = true;
+          } else if (rand < threshold + edge) {
+            const chars = '01$#@%&*';
+            const char = chars[Math.floor(rand * 100) % chars.length]!;
+            charOverride = ctx.style.styled(ctx.status('success'), char);
+          } else {
+            showNext = false;
+          }
+          break;
+        }
+
+        case 'scramble': {
+          const scrambleAmount = 1 - Math.abs(progress - 0.5) * 2;
+          if (rand < scrambleAmount * 0.8) {
+            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
+            const char = chars[Math.floor(rand * 1000) % chars.length]!;
+            charOverride = ctx.style.styled(ctx.semantic('muted'), char);
+          } else {
+            showNext = progress > 0.5;
+          }
+          break;
+        }
+
+        default:
+          showNext = progress >= 1;
       }
 
-      default:
-        return (progress >= 1 ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+      if (charOverride !== undefined) {
+        line += charOverride;
+      } else {
+        line += (showNext ? nextGrid[y]?.[x] : prevGrid[y]?.[x]) ?? ' ';
+      }
     }
-  }, { ctx });
+    lines.push(line);
+  }
+
+  return lines.join('\n');
 }

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -48,7 +48,8 @@ import { splitPane, splitPaneLayout, type SplitPaneDirection, type SplitPaneStat
 import type { LayoutRect } from './layout-rect.js';
 import { clipToWidth, tokenizeAnsi, visibleLength } from './viewport.js';
 import { animate } from './animate.js';
-import { EASINGS } from './spring.js';
+import { EASINGS, type EasingFn } from './spring.js';
+import { timeline, type Timeline, type TimelineState } from './timeline.js';
 
 /** Page declaration consumed by {@link createFramedApp}. */
 export interface FramePage<PageModel, Msg> {
@@ -180,6 +181,12 @@ export interface FrameModel<PageModel> {
   readonly transitionProgress: number;
   /** Currently active transition style. */
   readonly activeTransition?: PageTransition;
+  /** Wall-clock start time of the active transition (ms since epoch). */
+  readonly transitionStartMs?: number;
+  /** Compiled timeline driving the active transition. */
+  readonly transitionTimeline?: Timeline;
+  /** Timeline state for the active transition. */
+  readonly transitionTimelineState?: TimelineState;
 }
 
 interface InternalFrameModel<PageModel, Msg> extends FrameModel<PageModel> {
@@ -315,10 +322,46 @@ export function createFramedApp<PageModel, Msg>(
       if (isFrameScopedMsg(msg)) {
         const action = msg.action;
         if (action.type === 'transition') {
+          // Advance timeline using wall-clock elapsed time
+          if (model.transitionTimeline && model.transitionTimelineState && model.transitionStartMs != null) {
+            const elapsedMs = Date.now() - model.transitionStartMs;
+            const elapsedSec = Math.max(0, elapsedMs / 1000);
+            // Step from init to current elapsed time (tweens are deterministic)
+            const state = model.transitionTimeline.step(model.transitionTimeline.init(), elapsedSec);
+            const vals = model.transitionTimeline.values(state);
+            const progress = Math.min(1, Math.max(0, vals.progress ?? action.progress));
+
+            if (model.transitionTimeline.done(state) || progress >= 1) {
+              return [{
+                ...model,
+                transitionProgress: 1,
+                previousPageId: undefined,
+                activeTransition: undefined,
+                transitionStartMs: undefined,
+                transitionTimeline: undefined,
+                transitionTimelineState: undefined,
+              }, []];
+            }
+
+            return [{
+              ...model,
+              transitionProgress: progress,
+              transitionTimelineState: state,
+            }, []];
+          }
+          // Fallback for non-timeline transitions (backward compat)
           return [{ ...model, transitionProgress: action.progress }, []];
         }
         if (action.type === 'transition-complete') {
-          return [{ ...model, transitionProgress: 1, previousPageId: undefined, activeTransition: undefined }, []];
+          return [{
+            ...model,
+            transitionProgress: 1,
+            previousPageId: undefined,
+            activeTransition: undefined,
+            transitionStartMs: undefined,
+            transitionTimeline: undefined,
+            transitionTimelineState: undefined,
+          }, []];
         }
         return applyFrameAction(action, model, frameKeys, options, pagesById);
       }
@@ -581,24 +624,37 @@ function switchTab<PageModel, Msg>(
     ? options.transitionOverride(activePageModel)
     : options.transition;
 
+  const durationMs = options.transitionDuration ?? 300;
+  const hasTransition = activeTransition != null && activeTransition !== 'none';
+
+  // Build a timeline to drive the transition — time-based, not tick-based.
+  const tl = hasTransition
+    ? timeline()
+      .add('progress', {
+        type: 'tween',
+        from: 0,
+        to: 1,
+        duration: durationMs,
+        ease: EASINGS.easeInOutCubic,
+      })
+      .build()
+    : undefined;
+
   const nextModel = syncPageFrameState({
     ...model,
     activePageId: nextId,
     previousPageId: model.activePageId,
     activeTransition,
-    transitionProgress: activeTransition && activeTransition !== 'none' ? 0 : 1,
+    transitionProgress: hasTransition ? 0 : 1,
+    transitionStartMs: hasTransition ? Date.now() : undefined,
+    transitionTimeline: tl,
+    transitionTimelineState: tl?.init(),
   }, nextId, pagesById);
 
-  if (activeTransition && activeTransition !== 'none') {
-    const cmd: Cmd<Msg> = animate({
-      type: 'tween',
-      from: 0,
-      to: 1,
-      duration: options.transitionDuration ?? 300,
-      ease: EASINGS.easeInOutCubic,
-      onFrame: (v) => wrapFrameMsg({ type: 'transition', progress: v } as FrameAction) as unknown as Msg,
-      onComplete: () => wrapFrameMsg({ type: 'transition-complete' } as FrameAction) as unknown as Msg,
-    });
+  if (hasTransition) {
+    // Schedule render ticks at ~60fps for the duration of the transition.
+    // Each tick advances the timeline using wall-clock elapsed time.
+    const cmd: Cmd<Msg> = createTransitionTickCmd(durationMs);
     return [nextModel, [cmd]];
   }
 
@@ -1180,6 +1236,34 @@ function isPageScopedMsg<Msg>(value: unknown): value is PageScopedMsg<Msg> {
     && value !== null
     && PAGE_MSG_TOKEN in value
     && (value as PageScopedMsg<Msg>)[PAGE_MSG_TOKEN] === true;
+}
+
+/**
+ * Create a TEA command that drives transition re-renders via `setInterval`.
+ *
+ * Each tick emits a frame-scoped 'transition' message. The actual progress
+ * is computed from wall-clock time in the update handler, not from the
+ * interval count. The interval just schedules re-renders.
+ */
+function createTransitionTickCmd<Msg>(durationMs: number): Cmd<Msg> {
+  return (emit) =>
+    new Promise<void>((resolve) => {
+      const startMs = Date.now();
+      const intervalMs = Math.round(1000 / 60);
+
+      const id = setInterval(() => {
+        const elapsed = Date.now() - startMs;
+        const rawProgress = Math.min(1, elapsed / durationMs);
+
+        emit(wrapFrameMsg({ type: 'transition', progress: rawProgress } as FrameAction) as unknown as Msg);
+
+        if (rawProgress >= 1) {
+          clearInterval(id);
+          emit(wrapFrameMsg({ type: 'transition-complete' } as FrameAction) as unknown as Msg);
+          resolve();
+        }
+      }, intervalMs);
+    });
 }
 
 function renderPageContent<PageModel, Msg>(

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -269,7 +269,7 @@ export function commandPalette(
   const indicator = '\u25b8'; // ▸
   const pad = ' ';
   const muted = (text: string) =>
-    ctx ? ctx.style.styled(ctx.theme.theme.semantic.muted, text) : text;
+    ctx ? ctx.style.styled(ctx.semantic('muted'), text) : text;
 
   for (let i = 0; i < visible.length; i++) {
     const item = visible[i]!;

--- a/packages/bijou-tui/src/focus-area.ts
+++ b/packages/bijou-tui/src/focus-area.ts
@@ -21,6 +21,7 @@
  */
 
 import type { BijouContext, TokenValue } from '@flyingrobots/bijou';
+import { renderByMode } from '@flyingrobots/bijou';
 import {
   type ScrollState,
   viewport,
@@ -303,14 +304,16 @@ function resolveGutter(
 ): string {
   if (!ctx) return GUTTER_CHAR;
 
-  const mode = ctx.mode;
-  if (mode === 'static') return GUTTER_CHAR;
+  return renderByMode(ctx.mode, {
+    static: () => GUTTER_CHAR,
+    interactive: () => {
+      const token = focused
+        ? (options?.focusedGutterToken ?? ctx.semantic('accent'))
+        : (options?.unfocusedGutterToken ?? ctx.semantic('muted'));
 
-  const token = focused
-    ? (options?.focusedGutterToken ?? ctx.theme.theme.semantic.accent)
-    : (options?.unfocusedGutterToken ?? ctx.theme.theme.semantic.muted);
-
-  return ctx.style.styled(token, GUTTER_CHAR);
+      return ctx.style.styled(token, GUTTER_CHAR);
+    },
+  }, options);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -83,6 +83,7 @@ export {
   type FrameLayoutNode,
   type FrameOverlayContext,
   type CreateFramedAppOptions,
+  type PageTransition,
   type FramePaneScroll,
   type FrameModel,
   createFramedApp,

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -89,6 +89,22 @@ export {
   createFramedApp,
 } from './app-frame.js';
 
+// Transition shaders
+export {
+  type TransitionCell,
+  type TransitionResult,
+  type TransitionShaderFn,
+  type BuiltinTransition,
+  wipeShader,
+  dissolveShader,
+  gridShader,
+  fadeShader,
+  meltShader,
+  matrixShader,
+  scrambleShader,
+  TRANSITION_SHADERS,
+} from './transition-shaders.js';
+
 // Status bar
 export { statusBar } from './status-bar.js';
 export type { StatusBarOptions } from './status-bar.js';

--- a/packages/bijou-tui/src/overlay.ts
+++ b/packages/bijou-tui/src/overlay.ts
@@ -232,7 +232,7 @@ export function modal(options: ModalOptions): Overlay {
   if (hint != null) {
     contentLines.push('');
     const hintText = ctx
-      ? ctx.style.styled(ctx.theme.theme.semantic.muted, hint)
+      ? ctx.style.styled(ctx.semantic('muted'), hint)
       : hint;
     contentLines.push(hintText);
   }
@@ -308,12 +308,12 @@ export function toast(options: ToastOptions): Overlay {
   let line = icon + ' ' + message;
 
   if (ctx) {
-    line = ctx.style.styled(ctx.theme.theme.semantic[variant], line);
+    line = ctx.style.styled(ctx.semantic(variant), line);
   }
 
   const borderKey = TOAST_BORDER[variant];
   const borderColor = ctx
-    ? (s: string) => ctx.style.styled(ctx.theme.theme.border[borderKey], s)
+    ? (s: string) => ctx.style.styled(ctx.border(borderKey), s)
     : (s: string) => s;
 
   const bgFill = makeBgFill(options.bgToken, ctx);

--- a/packages/bijou-tui/src/panels.ts
+++ b/packages/bijou-tui/src/panels.ts
@@ -191,12 +191,11 @@ export function createPanelGroup<A>(options: PanelGroupOptions<A>): PanelGroup<A
       }
 
       const style = ctx.style;
-      const semantic = ctx.theme.theme.semantic;
 
       if (id === focusedId) {
-        return style.bold(style.styled(semantic.primary, panel.label));
+        return style.bold(style.styled(ctx.semantic('primary'), panel.label));
       }
-      return style.styled(semantic.muted, panel.label);
+      return style.styled(ctx.semantic('muted'), panel.label);
     },
 
     dispose(): void {

--- a/packages/bijou-tui/src/transition-shaders.test.ts
+++ b/packages/bijou-tui/src/transition-shaders.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import {
+  wipeShader,
+  dissolveShader,
+  gridShader,
+  fadeShader,
+  meltShader,
+  matrixShader,
+  scrambleShader,
+  TRANSITION_SHADERS,
+  type TransitionCell,
+  type BuiltinTransition,
+} from './transition-shaders.js';
+
+const ctx = createTestContext({ mode: 'interactive' });
+
+function cell(overrides: Partial<TransitionCell> = {}): TransitionCell {
+  return {
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 24,
+    progress: 0.5,
+    rand: 0.5,
+    ctx,
+    ...overrides,
+  };
+}
+
+describe('wipeShader', () => {
+  it('shows prev at progress=0', () => {
+    expect(wipeShader(cell({ x: 40, progress: 0 })).showNext).toBe(false);
+  });
+
+  it('shows next at progress=1', () => {
+    expect(wipeShader(cell({ x: 79, progress: 1 })).showNext).toBe(true);
+  });
+
+  it('wipes left-to-right based on x/width vs progress', () => {
+    // x=20, width=80 → 0.25 < 0.5 → showNext
+    expect(wipeShader(cell({ x: 20, progress: 0.5 })).showNext).toBe(true);
+    // x=60, width=80 → 0.75 > 0.5 → showPrev
+    expect(wipeShader(cell({ x: 60, progress: 0.5 })).showNext).toBe(false);
+  });
+});
+
+describe('dissolveShader', () => {
+  it('shows prev at progress=0', () => {
+    expect(dissolveShader(cell({ rand: 0.5, progress: 0 })).showNext).toBe(false);
+  });
+
+  it('shows next at progress=1', () => {
+    expect(dissolveShader(cell({ rand: 0.99, progress: 1 })).showNext).toBe(true);
+  });
+
+  it('dissolves based on rand vs progress', () => {
+    expect(dissolveShader(cell({ rand: 0.3, progress: 0.5 })).showNext).toBe(true);
+    expect(dissolveShader(cell({ rand: 0.7, progress: 0.5 })).showNext).toBe(false);
+  });
+});
+
+describe('gridShader', () => {
+  it('shows prev at progress=0', () => {
+    expect(gridShader(cell({ x: 0, y: 0, progress: 0 })).showNext).toBe(false);
+  });
+
+  it('shows next at progress=1', () => {
+    expect(gridShader(cell({ x: 0, y: 0, progress: 1 })).showNext).toBe(true);
+  });
+
+  it('uses 8x4 block grid pattern', () => {
+    // gx=0, gy=0 → (0+0)%10=0, 0/10=0 < 0.5 → showNext
+    expect(gridShader(cell({ x: 0, y: 0, progress: 0.5 })).showNext).toBe(true);
+    // gx=1, gy=1 → (1+1)%10=2, 2/10=0.2 < 0.5 → showNext
+    expect(gridShader(cell({ x: 8, y: 4, progress: 0.5 })).showNext).toBe(true);
+    // gx=5, gy=2 → (5+2)%10=7, 7/10=0.7 > 0.5 → showPrev
+    expect(gridShader(cell({ x: 40, y: 8, progress: 0.5 })).showNext).toBe(false);
+  });
+});
+
+describe('fadeShader', () => {
+  it('shows prev at progress=0', () => {
+    expect(fadeShader(cell({ progress: 0 })).showNext).toBe(false);
+  });
+
+  it('shows next at progress=1', () => {
+    expect(fadeShader(cell({ progress: 1 })).showNext).toBe(true);
+  });
+
+  it('hard-cuts at midpoint', () => {
+    expect(fadeShader(cell({ progress: 0.49 })).showNext).toBe(false);
+    expect(fadeShader(cell({ progress: 0.51 })).showNext).toBe(true);
+  });
+});
+
+describe('meltShader', () => {
+  it('shows prev at progress=0', () => {
+    expect(meltShader(cell({ x: 0, y: 12, height: 24, progress: 0 })).showNext).toBe(false);
+  });
+
+  it('shows next at progress=1 for all rows', () => {
+    // At progress=1, dropStart = 1.4 - variability (max 0.4) = min 1.0
+    // y/height max = 23/24 ≈ 0.958 < 1.0 → showNext
+    for (let y = 0; y < 24; y++) {
+      expect(meltShader(cell({ x: 0, y, height: 24, progress: 1 })).showNext).toBe(true);
+    }
+  });
+
+  it('melts top-down', () => {
+    // Top rows reveal before bottom rows at same x
+    const top = meltShader(cell({ x: 0, y: 0, height: 24, progress: 0.5 }));
+    const bottom = meltShader(cell({ x: 0, y: 23, height: 24, progress: 0.5 }));
+    // If top shows next, bottom may or may not; but top should be at least as advanced
+    expect(top.showNext || !bottom.showNext).toBe(true);
+  });
+});
+
+describe('matrixShader', () => {
+  it('shows prev at progress=0', () => {
+    const result = matrixShader(cell({ rand: 0.5, progress: 0 }));
+    expect(result.showNext).toBe(false);
+  });
+
+  it('shows next at progress=1', () => {
+    const result = matrixShader(cell({ rand: 0.5, progress: 1 }));
+    expect(result.showNext).toBe(true);
+  });
+
+  it('produces char override at the leading edge', () => {
+    // rand just above threshold but within threshold+edge
+    const result = matrixShader(cell({ rand: 0.55, progress: 0.5 }));
+    expect(result.showNext).toBe(false);
+    expect(result.char).toBeDefined();
+  });
+
+  it('shows next when rand < threshold', () => {
+    const result = matrixShader(cell({ rand: 0.3, progress: 0.5 }));
+    expect(result.showNext).toBe(true);
+    expect(result.char).toBeUndefined();
+  });
+});
+
+describe('scrambleShader', () => {
+  it('shows prev at progress=0', () => {
+    const result = scrambleShader(cell({ rand: 0.5, progress: 0 }));
+    expect(result.showNext).toBe(false);
+  });
+
+  it('shows next at progress=1', () => {
+    const result = scrambleShader(cell({ rand: 0.5, progress: 1 }));
+    expect(result.showNext).toBe(true);
+  });
+
+  it('produces char override at peak scramble (midpoint)', () => {
+    // At progress=0.5, scrambleAmount=1, so rand 0.5 < 0.8 → char override
+    const result = scrambleShader(cell({ rand: 0.5, progress: 0.5 }));
+    expect(result.char).toBeDefined();
+  });
+
+  it('resolves to next page past midpoint with high rand', () => {
+    // At progress=0.9, scrambleAmount=0.2, rand 0.5 > 0.16 → no override, showNext true
+    const result = scrambleShader(cell({ rand: 0.5, progress: 0.9 }));
+    expect(result.showNext).toBe(true);
+    expect(result.char).toBeUndefined();
+  });
+});
+
+describe('TRANSITION_SHADERS', () => {
+  it('maps none to undefined', () => {
+    expect(TRANSITION_SHADERS.none).toBeUndefined();
+  });
+
+  it('maps all built-in names to shader functions', () => {
+    const names: BuiltinTransition[] = ['wipe', 'dissolve', 'grid', 'fade', 'melt', 'matrix', 'scramble'];
+    for (const name of names) {
+      expect(typeof TRANSITION_SHADERS[name]).toBe('function');
+    }
+  });
+
+  it('has exactly 8 entries', () => {
+    expect(Object.keys(TRANSITION_SHADERS)).toHaveLength(8);
+  });
+});

--- a/packages/bijou-tui/src/transition-shaders.ts
+++ b/packages/bijou-tui/src/transition-shaders.ts
@@ -1,0 +1,98 @@
+/**
+ * Transition shader system — composable pure functions for page transitions.
+ *
+ * Each shader receives cell metadata (position, dimensions, progress, random)
+ * and returns whether to show the next page or optionally override the character.
+ */
+
+import type { BijouContext } from '@flyingrobots/bijou';
+
+/** Input provided to a transition shader for each cell. */
+export interface TransitionCell {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly progress: number;
+  readonly rand: number;
+  readonly ctx: BijouContext;
+}
+
+/** Output from a transition shader for a single cell. */
+export interface TransitionResult {
+  readonly showNext: boolean;
+  readonly char?: string;
+}
+
+/** A pure function that determines how each cell transitions between pages. */
+export type TransitionShaderFn = (cell: TransitionCell) => TransitionResult;
+
+/** Built-in transition names. */
+export type BuiltinTransition = 'none' | 'wipe' | 'dissolve' | 'grid' | 'fade' | 'melt' | 'matrix' | 'scramble';
+
+/** Left-to-right wipe. */
+export const wipeShader: TransitionShaderFn = ({ x, width, progress }) => ({
+  showNext: x / width < progress,
+});
+
+/** Random pixel dissolve. */
+export const dissolveShader: TransitionShaderFn = ({ rand, progress }) => ({
+  showNext: rand < progress,
+});
+
+/** Checkerboard block reveal. */
+export const gridShader: TransitionShaderFn = ({ x, y, progress }) => {
+  const gx = Math.floor(x / 8);
+  const gy = Math.floor(y / 4);
+  return { showNext: ((gx + gy) % 10) / 10 < progress };
+};
+
+/** Hard cut at midpoint. */
+export const fadeShader: TransitionShaderFn = ({ progress }) => ({
+  showNext: progress > 0.5,
+});
+
+/** Doom-style top-down melt with per-column variation. */
+export const meltShader: TransitionShaderFn = ({ x, y, height, progress }) => {
+  const variability = (Math.sin(x * 0.7) * 0.5 + 0.5) * 0.4;
+  const dropStart = progress * 1.4 - variability;
+  return { showNext: y / height < dropStart };
+};
+
+/** Code rain leading edge with matrix characters. */
+export const matrixShader: TransitionShaderFn = ({ rand, progress, ctx }) => {
+  const threshold = progress;
+  const edge = 0.1;
+  if (rand < threshold) {
+    return { showNext: true };
+  }
+  if (rand < threshold + edge) {
+    const chars = '01$#@%&*';
+    const char = chars[Math.floor(rand * 100) % chars.length]!;
+    return { showNext: false, char: ctx.style.styled(ctx.status('success'), char) };
+  }
+  return { showNext: false };
+};
+
+/** Scramble noise that resolves at midpoint. */
+export const scrambleShader: TransitionShaderFn = ({ rand, progress, ctx }) => {
+  const scrambleAmount = 1 - Math.abs(progress - 0.5) * 2;
+  if (rand < scrambleAmount * 0.8) {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
+    const char = chars[Math.floor(rand * 1000) % chars.length]!;
+    return { showNext: false, char: ctx.style.styled(ctx.semantic('muted'), char) };
+  }
+  return { showNext: progress > 0.5 };
+};
+
+/** Registry mapping built-in transition names to shader functions. `none` maps to `undefined`. */
+export const TRANSITION_SHADERS: Record<BuiltinTransition, TransitionShaderFn | undefined> = {
+  none: undefined,
+  wipe: wipeShader,
+  dissolve: dissolveShader,
+  grid: gridShader,
+  fade: fadeShader,
+  melt: meltShader,
+  matrix: matrixShader,
+  scramble: scrambleShader,
+};

--- a/packages/bijou-tui/src/viewport.ts
+++ b/packages/bijou-tui/src/viewport.ts
@@ -175,6 +175,72 @@ export function sliceAnsi(str: string, startCol: number, endCol: number): string
   return result;
 }
 
+/**
+ * Extract all individual visible character cells from an ANSI-styled string.
+ * Each cell is returned as a fully-styled string (including resets).
+ *
+ * @param str - ANSI-styled input string.
+ * @param width - Number of cells to extract (pads with spaces if shorter).
+ * @returns Array of exactly `width` strings, each a single-column styled character.
+ */
+export function tokenizeAnsi(str: string, width: number): string[] {
+  const stripped = stripAnsi(str);
+  const graphemes = segmentGraphemes(stripped);
+  const result: string[] = [];
+
+  let inEscape = false;
+  let escBuf = '';
+  let activeAnsi = '';
+  let gi = 0;
+  let i = 0;
+  let visibleCount = 0;
+
+  while (i < str.length && visibleCount < width) {
+    const ch = str[i]!;
+
+    if (ch === '\x1b') {
+      inEscape = true;
+      escBuf = ch;
+      i++;
+      continue;
+    }
+
+    if (inEscape) {
+      escBuf += ch;
+      if (ch === 'm') {
+        inEscape = false;
+        activeAnsi += escBuf;
+        escBuf = '';
+      }
+      i++;
+      continue;
+    }
+
+    if (gi >= graphemes.length) break;
+
+    const grapheme = graphemes[gi]!;
+    const gWidth = graphemeClusterWidth(grapheme);
+
+    // If adding this grapheme exceeds width, stop
+    if (visibleCount + gWidth > width) break;
+
+    const styledGrapheme = activeAnsi + grapheme + '\x1b[0m';
+    result.push(styledGrapheme);
+    if (gWidth === 2) result.push(''); // placeholder for wide char
+
+    visibleCount += gWidth;
+    gi++;
+    i += grapheme.length;
+  }
+
+  // Pad with spaces
+  while (result.length < width) {
+    result.push(' ');
+  }
+
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Scrollbar rendering
 // ---------------------------------------------------------------------------

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -102,7 +102,7 @@ BIJOU_THEME=./themes/my-brand.json node my-cli.js
 ### Extending Themes in Code
 
 ```typescript
-import { extendTheme, styled, styledStatus, tv, CYAN_MAGENTA } from '@flyingrobots/bijou';
+import { extendTheme, tv, CYAN_MAGENTA } from '@flyingrobots/bijou';
 
 const myTheme = extendTheme(CYAN_MAGENTA, {
   status: {
@@ -113,6 +113,18 @@ const myTheme = extendTheme(CYAN_MAGENTA, {
     clusterName: tv('#60a5fa', ['bold']),
   },
 });
+```
+
+### Looking Up Tokens
+
+Use semantic helpers on the context to look up tokens without coupling to theme object structure:
+
+```typescript
+const primary = ctx.semantic('primary');
+const border = ctx.border('muted');
+const bg = ctx.surface('secondary');
+const status = ctx.status('success'); // falls back to 'muted' if missing
+const icon = ctx.ui('cursor');
 ```
 
 ### DTCG Interop
@@ -126,6 +138,29 @@ const theme = fromDTCG(jsonDocument);
 // Export back to DTCG format
 const doc = toDTCG(theme);
 ```
+
+## Custom Components
+
+Build your own mode-aware components using the `renderByMode` dispatcher:
+
+```typescript
+import { renderByMode, resolveCtx } from '@flyingrobots/bijou';
+
+export function myComponent(text: string, options = {}) {
+  const ctx = resolveCtx(options.ctx);
+
+  return renderByMode(ctx.mode, {
+    pipe: () => `[${text}]`,
+    accessible: () => `Component: ${text}`,
+    interactive: () => {
+      const token = ctx.semantic('accent');
+      return ctx.style.styled(token, `\u2728 ${text}`);
+    }
+  }, options);
+}
+```
+
+The dispatcher automatically handles mode selection and fallback logic (e.g. `static` falls back to `interactive` by default).
 
 ## Testing
 

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -144,9 +144,13 @@ const doc = toDTCG(theme);
 Build your own mode-aware components using the `renderByMode` dispatcher:
 
 ```typescript
+import type { BijouContext } from '@flyingrobots/bijou';
 import { renderByMode, resolveCtx } from '@flyingrobots/bijou';
 
-export function myComponent(text: string, options = {}) {
+export function myComponent(
+  text: string,
+  options: { ctx?: BijouContext } = {},
+) {
   const ctx = resolveCtx(options.ctx);
 
   return renderByMode(ctx.mode, {

--- a/packages/bijou/src/adapters/test/fixtures.ts
+++ b/packages/bijou/src/adapters/test/fixtures.ts
@@ -1,0 +1,21 @@
+import type { SelectOption } from '../../core/forms/types.js';
+
+/** Standard color options for form tests. */
+export const COLOR_OPTIONS: SelectOption<string>[] = [
+  { label: 'Red', value: 'red' },
+  { label: 'Green', value: 'green' },
+  { label: 'Blue', value: 'blue' },
+];
+
+/** Standard fruit options for form tests. */
+export const FRUIT_OPTIONS: SelectOption<string>[] = [
+  { label: 'Apple', value: 'apple', description: 'Crunchy' },
+  { label: 'Banana', value: 'banana', description: 'Sweet' },
+  { label: 'Cherry', value: 'cherry', description: 'Tart' },
+];
+
+/** A large set of numbered options for scrolling tests. */
+export const MANY_OPTIONS: SelectOption<string>[] = Array.from({ length: 20 }, (_, i) => ({
+  label: `Option ${i + 1}`,
+  value: `v${i + 1}`,
+}));

--- a/packages/bijou/src/adapters/test/index.ts
+++ b/packages/bijou/src/adapters/test/index.ts
@@ -14,7 +14,7 @@ import { mockIO, type MockIOOptions, type MockIO } from './io.js';
 import { plainStyle } from './style.js';
 import { createResolved } from '../../core/theme/resolve.js';
 import { CYAN_MAGENTA } from '../../core/theme/presets.js';
-import type { Theme } from '../../core/theme/tokens.js';
+import type { Theme, TokenValue } from '../../core/theme/tokens.js';
 
 export { mockRuntime, type MockRuntimeOptions } from './runtime.js';
 export { mockIO, type MockIOOptions, type MockIO } from './io.js';
@@ -28,6 +28,7 @@ export {
   expectShownCursor,
   expectWritten,
 } from './assertions.js';
+export { COLOR_OPTIONS, FRUIT_OPTIONS, MANY_OPTIONS } from './fixtures.js';
 
 /**
  * Configuration for {@link createTestContext}.
@@ -73,5 +74,16 @@ export function createTestContext(options: TestContextOptions = {}): TestContext
   const theme = createResolved(options.theme ?? CYAN_MAGENTA, options.noColor ?? false, options.colorScheme ?? 'dark');
   const mode: OutputMode = options.mode ?? 'interactive';
 
-  return { theme, mode, runtime, io, style };
+  return {
+    theme,
+    mode,
+    runtime,
+    io,
+    style,
+    semantic: (key) => theme.theme.semantic[key],
+    border: (key) => theme.theme.border[key],
+    surface: (key) => theme.theme.surface[key],
+    status: (key) => (theme.theme.status as Record<string, TokenValue>)[key] ?? (theme.theme.status as Record<string, TokenValue>)['muted']!,
+    ui: (key) => (theme.theme.ui as Record<string, TokenValue>)[key] ?? theme.theme.semantic.primary,
+  };
 }

--- a/packages/bijou/src/core/components/accordion.ts
+++ b/packages/bijou/src/core/components/accordion.ts
@@ -1,6 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Represent a single collapsible section within an accordion. */
 export interface AccordionSection {
@@ -36,42 +37,39 @@ export interface AccordionOptions {
  */
 export function accordion(sections: AccordionSection[], options: AccordionOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
 
-  if (mode === 'pipe') {
-    return sections
+  return renderByMode(ctx.mode, {
+    pipe: () => sections
       .map((s) => `# ${s.title}\n${s.content}`)
-      .join('\n\n');
-  }
-
-  if (mode === 'accessible') {
-    return sections
+      .join('\n\n'),
+    accessible: () => sections
       .map((s) => {
         if (s.expanded) {
           return `[expanded] ${s.title}: ${s.content}`;
         }
         return `[collapsed] ${s.title}`;
       })
-      .join('\n');
-  }
+      .join('\n'),
+    interactive: () => {
+      const indicatorToken = options.indicatorToken ?? ctx.semantic('accent');
+      const titleToken = options.titleToken ?? ctx.semantic('primary');
 
-  const indicatorToken = options.indicatorToken ?? ctx.theme.theme.semantic.accent;
-  const titleToken = options.titleToken ?? ctx.theme.theme.semantic.primary;
-
-  return sections
-    .map((s) => {
-      if (s.expanded) {
-        const indicator = ctx.style.styled(indicatorToken, '▼');
-        const title = ctx.style.styled(titleToken, s.title);
-        const indented = s.content
-          .split('\n')
-          .map((line) => `  ${line}`)
-          .join('\n');
-        return `${indicator} ${title}\n${indented}`;
-      }
-      const indicator = ctx.style.styled(indicatorToken, '▶');
-      const title = ctx.style.styled(titleToken, s.title);
-      return `${indicator} ${title}`;
-    })
-    .join('\n\n');
+      return sections
+        .map((s) => {
+          if (s.expanded) {
+            const indicator = ctx.style.styled(indicatorToken, '▼');
+            const title = ctx.style.styled(titleToken, s.title);
+            const indented = s.content
+              .split('\n')
+              .map((line) => `  ${line}`)
+              .join('\n');
+            return `${indicator} ${title}\n${indented}`;
+          }
+          const indicator = ctx.style.styled(indicatorToken, '▶');
+          const title = ctx.style.styled(titleToken, s.title);
+          return `${indicator} ${title}`;
+        })
+        .join('\n\n');
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/alert.test.ts
+++ b/packages/bijou/src/core/components/alert.test.ts
@@ -47,8 +47,7 @@ describe('alert', () => {
       expect(alert(undefined as any, { ctx })).toBe('[INFO] ');
     });
 
-    it('handles missing options gracefully', () => {
-      // should not throw, uses default context (or fails if not set, but here we check it doesn't crash on options access)
+    it('renders with explicit context in pipe mode', () => {
       const ctx = createTestContext({ mode: 'pipe' });
       expect(alert('test', { ctx })).toBe('[INFO] test');
     });

--- a/packages/bijou/src/core/components/alert.test.ts
+++ b/packages/bijou/src/core/components/alert.test.ts
@@ -39,4 +39,18 @@ describe('alert', () => {
     expect(result).toContain('\u2717');
     expect(result).toContain('msg');
   });
+
+  describe('defensive input handling', () => {
+    it('handles null/undefined message gracefully', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      expect(alert(null as any, { ctx })).toBe('[INFO] ');
+      expect(alert(undefined as any, { ctx })).toBe('[INFO] ');
+    });
+
+    it('handles missing options gracefully', () => {
+      // should not throw, uses default context (or fails if not set, but here we check it doesn't crash on options access)
+      const ctx = createTestContext({ mode: 'pipe' });
+      expect(alert('test', { ctx })).toBe('[INFO] test');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/alert.ts
+++ b/packages/bijou/src/core/components/alert.ts
@@ -1,7 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
-import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { box } from './box.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Alert severity level. */
 export type AlertVariant = 'success' | 'error' | 'warning' | 'info';
@@ -60,20 +60,23 @@ const BORDER_TOKENS: Record<AlertVariant, keyof BijouContext['theme']['theme']['
  */
 export function alert(message: string, options: AlertOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const variant = options.variant ?? 'info';
+  const safeMessage = message ?? '';
 
-  if (mode === 'pipe') return `[${PIPE_LABELS[variant]}] ${message}`;
-  if (mode === 'accessible') return `${ACCESSIBLE_LABELS[variant]}: ${message}`;
+  return renderByMode(ctx.mode, {
+    pipe: () => `[${PIPE_LABELS[variant]}] ${safeMessage}`,
+    accessible: () => `${ACCESSIBLE_LABELS[variant]}: ${safeMessage}`,
+    interactive: () => {
+      const icon = ICONS[variant];
+      const semanticToken = ctx.semantic(variant === 'info' ? 'info' : variant);
+      const borderToken = ctx.border(BORDER_TOKENS[variant]);
+      const coloredIcon = ctx.style.styled(semanticToken, icon);
 
-  const icon = ICONS[variant];
-  const semanticToken: TokenValue = ctx.theme.theme.semantic[variant === 'info' ? 'info' : variant];
-  const borderToken = ctx.theme.theme.border[BORDER_TOKENS[variant]];
-  const coloredIcon = ctx.style.styled(semanticToken, icon);
-
-  return box(coloredIcon + ' ' + message, {
-    borderToken,
-    padding: { left: 1, right: 1 },
-    ctx,
-  });
+      return box(coloredIcon + ' ' + safeMessage, {
+        borderToken,
+        padding: { left: 1, right: 1 },
+        ctx,
+      });
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/alert.ts
+++ b/packages/bijou/src/core/components/alert.ts
@@ -68,7 +68,7 @@ export function alert(message: string, options: AlertOptions = {}): string {
     accessible: () => `${ACCESSIBLE_LABELS[variant]}: ${safeMessage}`,
     interactive: () => {
       const icon = ICONS[variant];
-      const semanticToken = ctx.semantic(variant === 'info' ? 'info' : variant);
+      const semanticToken = ctx.semantic(variant);
       const borderToken = ctx.border(BORDER_TOKENS[variant]);
       const coloredIcon = ctx.style.styled(semanticToken, icon);
 

--- a/packages/bijou/src/core/components/badge.ts
+++ b/packages/bijou/src/core/components/badge.ts
@@ -1,6 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue, BaseStatusKey } from '../theme/tokens.js';
 import { resolveSafeCtx as resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Badge color variant — any status key, plus `'accent'` and `'primary'`. */
 export type BadgeVariant = BaseStatusKey | 'accent' | 'primary';
@@ -31,27 +32,22 @@ export function badge(text: string, options: BadgeOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
   if (!ctx) return ` ${text} `;
 
-  const mode = ctx.mode;
-  if (mode === 'pipe') return `[${text}]`;
-  if (mode === 'accessible') return text;
-
-  const t = ctx.theme?.theme;
-  if (!t) return ` ${text} `;
-
   const variant = options.variant ?? 'info';
-  const status = (t.status || {}) as any;
-  const semantic = (t.semantic || {}) as any;
-  
-  let baseToken = status[variant] || semantic[variant] || status.info;
 
-  if (!baseToken || typeof baseToken.hex !== 'string') {
-    baseToken = { hex: '#808080' };
-  }
+  return renderByMode(ctx.mode, {
+    pipe: () => `[${text}]`,
+    accessible: () => text,
+    interactive: () => {
+      const baseToken = (variant === 'accent' || variant === 'primary')
+        ? ctx.semantic(variant)
+        : ctx.status(variant);
 
-  const inverseToken: TokenValue = {
-    hex: baseToken.hex,
-    modifiers: [...(baseToken.modifiers ?? []), 'inverse'],
-  };
+      const inverseToken: TokenValue = {
+        hex: baseToken.hex,
+        modifiers: [...(baseToken.modifiers ?? []), 'inverse'],
+      };
 
-  return ctx.style.styled(inverseToken, ` ${text} `);
+      return ctx.style.styled(inverseToken, ` ${text} `);
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/box.test.ts
+++ b/packages/bijou/src/core/components/box.test.ts
@@ -172,17 +172,18 @@ describe('box() with width override', () => {
     }
   });
 
-  describe('defensive input handling', () => {
-    it('handles null/undefined content gracefully', () => {
-      const ctx = createTestContext({ mode: 'pipe' });
-      expect(box(null as any, { ctx })).toBe('');
-      expect(box(undefined as any, { ctx })).toBe('');
-    });
+});
 
-    it('handles null/undefined label in headerBox gracefully', () => {
-      const ctx = createTestContext({ mode: 'pipe' });
-      expect(headerBox(null as any, { ctx })).toBe('');
-      expect(headerBox(undefined as any, { ctx })).toBe('');
-    });
+describe('defensive input handling', () => {
+  it('handles null/undefined content gracefully', () => {
+    const ctx = createTestContext({ mode: 'pipe' });
+    expect(box(null as any, { ctx })).toBe('');
+    expect(box(undefined as any, { ctx })).toBe('');
+  });
+
+  it('handles null/undefined label in headerBox gracefully', () => {
+    const ctx = createTestContext({ mode: 'pipe' });
+    expect(headerBox(null as any, { ctx })).toBe('');
+    expect(headerBox(undefined as any, { ctx })).toBe('');
   });
 });

--- a/packages/bijou/src/core/components/box.test.ts
+++ b/packages/bijou/src/core/components/box.test.ts
@@ -171,4 +171,18 @@ describe('box() with width override', () => {
       expect(graphemeWidth(line)).toBe(30);
     }
   });
+
+  describe('defensive input handling', () => {
+    it('handles null/undefined content gracefully', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      expect(box(null as any, { ctx })).toBe('');
+      expect(box(undefined as any, { ctx })).toBe('');
+    });
+
+    it('handles null/undefined label in headerBox gracefully', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      expect(headerBox(null as any, { ctx })).toBe('');
+      expect(headerBox(undefined as any, { ctx })).toBe('');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/box.ts
+++ b/packages/bijou/src/core/components/box.ts
@@ -152,13 +152,17 @@ export function headerBox(label: string, options: HeaderBoxOptions = {}): string
   const safeLabel = label ?? '';
 
   return renderByMode(ctx.mode, {
-    pipe: () => (detail ? `${safeLabel}  ${detail}` : safeLabel),
-    accessible: () => (detail ? `${safeLabel}: ${detail}` : safeLabel),
+    pipe: () => (safeLabel && detail ? `${safeLabel}  ${detail}` : safeLabel || detail),
+    accessible: () => (safeLabel && detail ? `${safeLabel}: ${detail}` : safeLabel || detail),
     interactive: () => {
       const labelToken = options.labelToken ?? ctx.semantic('primary');
-      const content = detail
+      const content = safeLabel && detail
         ? ctx.style.styled(labelToken, safeLabel) + ctx.style.styled(ctx.semantic('muted'), `  ${detail}`)
-        : ctx.style.styled(labelToken, safeLabel);
+        : safeLabel
+          ? ctx.style.styled(labelToken, safeLabel)
+          : detail
+            ? ctx.style.styled(ctx.semantic('muted'), detail)
+            : '';
 
       return box(content, options);
     },

--- a/packages/bijou/src/core/components/box.ts
+++ b/packages/bijou/src/core/components/box.ts
@@ -4,6 +4,7 @@ import { resolveCtx } from '../resolve-ctx.js';
 import { makeBgFill } from '../bg-fill.js';
 import { graphemeWidth } from '../text/grapheme.js';
 import { clipToWidth } from '../text/clip.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration for rendering a bordered box. */
 export interface BoxOptions {
@@ -104,25 +105,26 @@ function drawBox(
  */
 export function box(content: string, options: BoxOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
+  const safeContent = content ?? '';
 
-  if (mode === 'pipe' || mode === 'accessible') {
-    return content;
-  }
+  return renderByMode(ctx.mode, {
+    pipe: () => safeContent,
+    accessible: () => safeContent,
+    interactive: () => {
+      const borderToken = options.borderToken ?? ctx.border('primary');
+      const padding = {
+        top: options.padding?.top ?? 0,
+        bottom: options.padding?.bottom ?? 0,
+        left: options.padding?.left ?? 1,
+        right: options.padding?.right ?? 1,
+      };
 
-  const borderToken = options.borderToken ?? ctx.theme.theme.border.primary;
-  const padding = {
-    top: options.padding?.top ?? 0,
-    bottom: options.padding?.bottom ?? 0,
-    left: options.padding?.left ?? 1,
-    right: options.padding?.right ?? 1,
-  };
+      const colorize = (s: string): string => ctx.style.styled(borderToken, s);
+      const bgFill = makeBgFill(options.bgToken, ctx);
 
-  const colorize = (s: string): string => ctx.style.styled(borderToken, s);
-
-  const bgFill = makeBgFill(options.bgToken, ctx);
-
-  return drawBox(content, colorize, padding, options.width, bgFill);
+      return drawBox(safeContent, colorize, padding, options.width, bgFill);
+    },
+  }, options);
 }
 
 /** Configuration for {@link headerBox}, extending {@link BoxOptions} with label support. */
@@ -146,20 +148,19 @@ export interface HeaderBoxOptions extends BoxOptions {
  */
 export function headerBox(label: string, options: HeaderBoxOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const detail = options.detail ?? '';
+  const safeLabel = label ?? '';
 
-  if (mode === 'pipe') {
-    return detail ? `${label}  ${detail}` : label;
-  }
-  if (mode === 'accessible') {
-    return detail ? `${label}: ${detail}` : label;
-  }
+  return renderByMode(ctx.mode, {
+    pipe: () => (detail ? `${safeLabel}  ${detail}` : safeLabel),
+    accessible: () => (detail ? `${safeLabel}: ${detail}` : safeLabel),
+    interactive: () => {
+      const labelToken = options.labelToken ?? ctx.semantic('primary');
+      const content = detail
+        ? ctx.style.styled(labelToken, safeLabel) + ctx.style.styled(ctx.semantic('muted'), `  ${detail}`)
+        : ctx.style.styled(labelToken, safeLabel);
 
-  const labelToken = options.labelToken ?? ctx.theme.theme.semantic.primary;
-  const content = detail
-    ? ctx.style.styled(labelToken, label) + ctx.style.styled(ctx.theme.theme.semantic.muted, `  ${detail}`)
-    : ctx.style.styled(labelToken, label);
-
-  return box(content, options);
+      return box(content, options);
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/breadcrumb.ts
+++ b/packages/bijou/src/core/components/breadcrumb.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration options for the {@link breadcrumb} component. */
 export interface BreadcrumbOptions {
@@ -23,29 +24,29 @@ export interface BreadcrumbOptions {
  */
 export function breadcrumb(items: string[], options: BreadcrumbOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
 
-  if (mode === 'pipe') {
-    const sep = options.separator ?? ' > ';
-    return items.join(sep);
-  }
-
-  if (mode === 'accessible') {
-    const path = items.join(' > ');
-    return `Breadcrumb: ${path} (current)`;
-  }
-
-  // interactive + static
-  const sep = options.separator ?? ' › ';
-  const last = items.length - 1;
-  return items
-    .map((item, i) => {
-      if (i === last) {
-        const token = ctx.theme.theme.semantic.primary;
-        const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
-        return ctx.style.styled(boldToken, item);
-      }
-      return ctx.style.styled(ctx.theme.theme.semantic.muted, item);
-    })
-    .join(sep);
+  return renderByMode(ctx.mode, {
+    pipe: () => {
+      const sep = options.separator ?? ' > ';
+      return items.join(sep);
+    },
+    accessible: () => {
+      const path = items.join(' > ');
+      return `Breadcrumb: ${path} (current)`;
+    },
+    interactive: () => {
+      const sep = options.separator ?? ' › ';
+      const last = items.length - 1;
+      return items
+        .map((item, i) => {
+          if (i === last) {
+            const token = ctx.semantic('primary');
+            const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
+            return ctx.style.styled(boldToken, item);
+          }
+          return ctx.style.styled(ctx.semantic('muted'), item);
+        })
+        .join(sep);
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/dag-render.ts
+++ b/packages/bijou/src/core/components/dag-render.ts
@@ -260,7 +260,7 @@ export function renderInteractiveLayout(
   }
 
   const highlightSet = new Set(options.highlightPath ?? []);
-  const edgeToken = options.edgeToken ?? ctx.theme.theme.border.muted;
+  const edgeToken = options.edgeToken ?? ctx.border('muted');
   const hlToken = options.highlightToken;
 
   const positions = new Map<string, DagNodePosition>();
@@ -279,13 +279,13 @@ export function renderInteractiveLayout(
 
     let nToken: TokenValue;
     if (options.selectedId === n.id) {
-      nToken = options.selectedToken ?? ctx.theme.theme.ui.cursor;
+      nToken = options.selectedToken ?? ctx.ui('cursor');
     } else if (highlightSet.has(n.id) && hlToken) {
       nToken = hlToken;
     } else if (n.token) {
       nToken = n.token;
     } else {
-      nToken = options.nodeToken ?? ctx.theme.theme.border.primary;
+      nToken = options.nodeToken ?? ctx.border('primary');
     }
 
     // Expand grapheme arrays to column-aligned arrays so cellAt can

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -5,6 +5,7 @@ import { isDagSource, isSlicedDagSource, arraySource, materialize, sliceSource }
 import type { DagSource, SlicedDagSource, DagSliceOptions } from './dag-source.js';
 import { assignLayers } from './dag-layout.js';
 import { renderInteractiveLayout, renderPipe, renderAccessible } from './dag-render.js';
+import { renderByMode } from '../mode-render.js';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -193,19 +194,16 @@ export function dag(
     );
   }
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const nodes = isSlicedDagSource(input) ? materialize(input) : [...input];
 
   if (nodes.length === 0) return '';
 
-  if (mode === 'pipe') {
-    return renderPipe(nodes);
-  }
-
-  if (mode === 'accessible') {
-    const layerMap = assignLayers(nodes);
-    return renderAccessible(nodes, layerMap);
-  }
-
-  return renderInteractiveLayout(nodes, options, ctx).output;
+  return renderByMode(ctx.mode, {
+    pipe: () => renderPipe(nodes),
+    accessible: () => {
+      const layerMap = assignLayers(nodes);
+      return renderAccessible(nodes, layerMap);
+    },
+    interactive: () => renderInteractiveLayout(nodes, options, ctx).output,
+  }, options);
 }

--- a/packages/bijou/src/core/components/enumerated-list.ts
+++ b/packages/bijou/src/core/components/enumerated-list.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveSafeCtx as resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /**
  * Enumeration style for list item prefixes.
@@ -142,28 +143,11 @@ export function enumeratedList(items: readonly string[], options?: EnumeratedLis
   const indent = options?.indent ?? 2;
   const start = options?.start ?? 1;
   const ctx = resolveCtx(options?.ctx);
-  const mode = ctx?.mode;
 
   const indentStr = ' '.repeat(indent);
 
-  // Accessible mode: simple numbering regardless of style
-  if (mode === 'accessible') {
-    return items
-      .map((item, i) => {
-        const num = start + i;
-        const prefix = `${num}.`;
-        const lines = item.split('\n');
-        const firstLine = `${indentStr}${prefix} ${lines[0]}`;
-        if (lines.length === 1) return firstLine;
-        const contIndent = ' '.repeat(indent + prefix.length + 1);
-        return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
-      })
-      .join('\n');
-  }
-
-  // Pipe mode: ASCII fallbacks
-  if (mode === 'pipe') {
-    const prefixes = items.map((_, i) => generatePipePrefix(style, start + i));
+  if (!ctx) {
+    const prefixes = items.map((_, i) => generatePrefix(style, start + i));
     const maxPrefixLen = isOrderedStyle(style)
       ? Math.max(...prefixes.map(p => p.length))
       : 0;
@@ -191,31 +175,75 @@ export function enumeratedList(items: readonly string[], options?: EnumeratedLis
       .join('\n');
   }
 
-  // Interactive / static mode (or no context): full rendering
-  const prefixes = items.map((_, i) => generatePrefix(style, start + i));
-  const maxPrefixLen = isOrderedStyle(style)
-    ? Math.max(...prefixes.map(p => p.length))
-    : 0;
+  return renderByMode(ctx.mode, {
+    accessible: () => {
+      return items
+        .map((item, i) => {
+          const num = start + i;
+          const prefix = `${num}.`;
+          const lines = item.split('\n');
+          const firstLine = `${indentStr}${prefix} ${lines[0]}`;
+          if (lines.length === 1) return firstLine;
+          const contIndent = ' '.repeat(indent + prefix.length + 1);
+          return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
+        })
+        .join('\n');
+    },
+    pipe: () => {
+      const prefixes = items.map((_, i) => generatePipePrefix(style, start + i));
+      const maxPrefixLen = isOrderedStyle(style)
+        ? Math.max(...prefixes.map(p => p.length))
+        : 0;
 
-  return items
-    .map((item, i) => {
-      const prefix = prefixes[i]!;
-      const lines = item.split('\n');
+      return items
+        .map((item, i) => {
+          const prefix = prefixes[i]!;
+          const lines = item.split('\n');
 
-      if (style === 'none') {
-        const firstLine = `${indentStr}${lines[0]}`;
-        if (lines.length === 1) return firstLine;
-        const contIndent = indentStr;
-        return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
-      }
+          if (style === 'none') {
+            const firstLine = `${indentStr}${lines[0]}`;
+            if (lines.length === 1) return firstLine;
+            const contIndent = indentStr;
+            return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
+          }
 
-      const paddedPrefix = isOrderedStyle(style)
-        ? prefix.padStart(maxPrefixLen)
-        : prefix;
-      const firstLine = `${indentStr}${paddedPrefix} ${lines[0]}`;
-      if (lines.length === 1) return firstLine;
-      const contIndent = ' '.repeat(indent + paddedPrefix.length + 1);
-      return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
-    })
-    .join('\n');
+          const paddedPrefix = isOrderedStyle(style)
+            ? prefix.padStart(maxPrefixLen)
+            : prefix;
+          const firstLine = `${indentStr}${paddedPrefix} ${lines[0]}`;
+          if (lines.length === 1) return firstLine;
+          const contIndent = ' '.repeat(indent + paddedPrefix.length + 1);
+          return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
+        })
+        .join('\n');
+    },
+    interactive: () => {
+      const prefixes = items.map((_, i) => generatePrefix(style, start + i));
+      const maxPrefixLen = isOrderedStyle(style)
+        ? Math.max(...prefixes.map(p => p.length))
+        : 0;
+
+      return items
+        .map((item, i) => {
+          const prefix = prefixes[i]!;
+          const lines = item.split('\n');
+
+          if (style === 'none') {
+            const firstLine = `${indentStr}${lines[0]}`;
+            if (lines.length === 1) return firstLine;
+            const contIndent = indentStr;
+            return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
+          }
+
+          const paddedPrefix = isOrderedStyle(style)
+            ? prefix.padStart(maxPrefixLen)
+            : prefix;
+          const firstLine = `${indentStr}${paddedPrefix} ${lines[0]}`;
+          if (lines.length === 1) return firstLine;
+          const contIndent = ' '.repeat(indent + paddedPrefix.length + 1);
+          return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
+        })
+        .join('\n');
+    },
+  }, options ?? {});
 }

--- a/packages/bijou/src/core/components/enumerated-list.ts
+++ b/packages/bijou/src/core/components/enumerated-list.ts
@@ -121,6 +121,42 @@ function isOrderedStyle(style: BulletStyle): boolean {
   return style === 'arabic' || style === 'alpha' || style === 'roman';
 }
 
+function renderItems(
+  items: readonly string[],
+  style: BulletStyle,
+  start: number,
+  indent: number,
+  indentStr: string,
+  prefixFn: (style: BulletStyle, index: number) => string,
+): string {
+  const prefixes = items.map((_, i) => prefixFn(style, start + i));
+  const maxPrefixLen = isOrderedStyle(style)
+    ? Math.max(...prefixes.map(p => p.length))
+    : 0;
+
+  return items
+    .map((item, i) => {
+      const prefix = prefixes[i]!;
+      const lines = item.split('\n');
+
+      if (style === 'none') {
+        const firstLine = `${indentStr}${lines[0]}`;
+        if (lines.length === 1) return firstLine;
+        const contIndent = indentStr;
+        return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
+      }
+
+      const paddedPrefix = isOrderedStyle(style)
+        ? prefix.padStart(maxPrefixLen)
+        : prefix;
+      const firstLine = `${indentStr}${paddedPrefix} ${lines[0]}`;
+      if (lines.length === 1) return firstLine;
+      const contIndent = ' '.repeat(indent + paddedPrefix.length + 1);
+      return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
+    })
+    .join('\n');
+}
+
 /**
  * Render a formatted list with configurable numbering or bullet styles.
  *
@@ -189,61 +225,7 @@ export function enumeratedList(items: readonly string[], options?: EnumeratedLis
         })
         .join('\n');
     },
-    pipe: () => {
-      const prefixes = items.map((_, i) => generatePipePrefix(style, start + i));
-      const maxPrefixLen = isOrderedStyle(style)
-        ? Math.max(...prefixes.map(p => p.length))
-        : 0;
-
-      return items
-        .map((item, i) => {
-          const prefix = prefixes[i]!;
-          const lines = item.split('\n');
-
-          if (style === 'none') {
-            const firstLine = `${indentStr}${lines[0]}`;
-            if (lines.length === 1) return firstLine;
-            const contIndent = indentStr;
-            return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
-          }
-
-          const paddedPrefix = isOrderedStyle(style)
-            ? prefix.padStart(maxPrefixLen)
-            : prefix;
-          const firstLine = `${indentStr}${paddedPrefix} ${lines[0]}`;
-          if (lines.length === 1) return firstLine;
-          const contIndent = ' '.repeat(indent + paddedPrefix.length + 1);
-          return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
-        })
-        .join('\n');
-    },
-    interactive: () => {
-      const prefixes = items.map((_, i) => generatePrefix(style, start + i));
-      const maxPrefixLen = isOrderedStyle(style)
-        ? Math.max(...prefixes.map(p => p.length))
-        : 0;
-
-      return items
-        .map((item, i) => {
-          const prefix = prefixes[i]!;
-          const lines = item.split('\n');
-
-          if (style === 'none') {
-            const firstLine = `${indentStr}${lines[0]}`;
-            if (lines.length === 1) return firstLine;
-            const contIndent = indentStr;
-            return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
-          }
-
-          const paddedPrefix = isOrderedStyle(style)
-            ? prefix.padStart(maxPrefixLen)
-            : prefix;
-          const firstLine = `${indentStr}${paddedPrefix} ${lines[0]}`;
-          if (lines.length === 1) return firstLine;
-          const contIndent = ' '.repeat(indent + paddedPrefix.length + 1);
-          return [firstLine, ...lines.slice(1).map(l => `${contIndent}${l}`)].join('\n');
-        })
-        .join('\n');
-    },
+    pipe: () => renderItems(items, style, start, indent, indentStr, generatePipePrefix),
+    interactive: () => renderItems(items, style, start, indent, indentStr, generatePrefix),
   }, options ?? {});
 }

--- a/packages/bijou/src/core/components/hyperlink.ts
+++ b/packages/bijou/src/core/components/hyperlink.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveSafeCtx as resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration options for the {@link hyperlink} component. */
 export interface HyperlinkOptions {
@@ -29,20 +30,11 @@ export function hyperlink(text: string, url: string, options?: HyperlinkOptions)
   // No context → use fallback format
   if (!ctx) return formatFallback(text, url, fallback);
 
-  const mode = ctx.mode;
-
-  // Interactive/static: OSC 8 clickable link
-  if (mode === 'interactive' || mode === 'static') {
-    return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
-  }
-
-  // Pipe: use fallback format
-  if (mode === 'pipe') return formatFallback(text, url, fallback);
-
-  // Accessible: always text (url) for screen readers
-  if (mode === 'accessible') return `${text} (${url})`;
-
-  return formatFallback(text, url, fallback);
+  return renderByMode(ctx.mode, {
+    interactive: () => `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`,
+    pipe: () => formatFallback(text, url, fallback),
+    accessible: () => `${text} (${url})`,
+  }, options ?? {});
 }
 
 /**

--- a/packages/bijou/src/core/components/kbd.ts
+++ b/packages/bijou/src/core/components/kbd.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration for rendering a keyboard shortcut indicator. */
 export interface KbdOptions {
@@ -21,13 +22,15 @@ export interface KbdOptions {
  */
 export function kbd(key: string, options: KbdOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
 
-  if (mode === 'pipe') return `<${key}>`;
-  if (mode === 'accessible') return key;
+  return renderByMode(ctx.mode, {
+    pipe: () => `<${key}>`,
+    accessible: () => key,
+    interactive: () => {
+      const borderToken = ctx.border('muted');
+      const boldKey = ctx.style.bold(key);
 
-  const borderToken = ctx.theme.theme.border.muted;
-  const boldKey = ctx.style.bold(key);
-
-  return ctx.style.styled(borderToken, '[') + ' ' + boldKey + ' ' + ctx.style.styled(borderToken, ']');
+      return ctx.style.styled(borderToken, '[') + ' ' + boldKey + ' ' + ctx.style.styled(borderToken, ']');
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/log.ts
+++ b/packages/bijou/src/core/components/log.ts
@@ -1,6 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveSafeCtx as resolveCtx } from '../resolve-ctx.js';
 import { badge } from './badge.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Severity levels for structured log messages. */
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
@@ -85,34 +86,34 @@ export function log(level: LogLevel, message: string, options?: LogOptions): str
     return parts.join(' ');
   }
 
-  const mode = ctx.mode;
-
-  if (mode === 'pipe') {
-    const parts: string[] = [];
-    if (ts) parts.push(`[${ts}]`);
-    if (showPrefix) parts.push(`[${LABELS[level]}]`);
-    parts.push(message);
-    return parts.join(' ');
-  }
-
-  if (mode === 'accessible') {
-    const parts: string[] = [];
-    if (ts) parts.push(ts);
-    if (showPrefix) parts.push(`${ACCESSIBLE_LABELS[level]}:`);
-    parts.push(message);
-    return parts.join(' ');
-  }
-
-  // Interactive/static: use badge + styled message
-  const parts: string[] = [];
-  if (ts) {
-    const tsStyled = ctx.style.styled(ctx.theme.theme.semantic.muted, ts);
-    parts.push(tsStyled);
-  }
-  if (showPrefix) {
-    const variant = BADGE_VARIANTS[level] as any;
-    parts.push(badge(LABELS[level], { variant, ctx }));
-  }
-  parts.push(message);
-  return parts.join(' ');
+  return renderByMode(ctx.mode, {
+    pipe: () => {
+      const parts: string[] = [];
+      if (ts) parts.push(`[${ts}]`);
+      if (showPrefix) parts.push(`[${LABELS[level]}]`);
+      parts.push(message);
+      return parts.join(' ');
+    },
+    accessible: () => {
+      const parts: string[] = [];
+      if (ts) parts.push(ts);
+      if (showPrefix) parts.push(`${ACCESSIBLE_LABELS[level]}:`);
+      parts.push(message);
+      return parts.join(' ');
+    },
+    interactive: () => {
+      // Interactive/static: use badge + styled message
+      const parts: string[] = [];
+      if (ts) {
+        const tsStyled = ctx.style.styled(ctx.semantic('muted'), ts);
+        parts.push(tsStyled);
+      }
+      if (showPrefix) {
+        const variant = BADGE_VARIANTS[level] as any;
+        parts.push(badge(LABELS[level], { variant, ctx }));
+      }
+      parts.push(message);
+      return parts.join(' ');
+    },
+  }, options ?? {});
 }

--- a/packages/bijou/src/core/components/markdown-parse.ts
+++ b/packages/bijou/src/core/components/markdown-parse.ts
@@ -8,6 +8,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import { hyperlink } from './hyperlink.js';
 import { graphemeWidth } from '../text/grapheme.js';
+import { renderByMode } from '../mode-render.js';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -156,15 +157,14 @@ function isBlockStart(line: string): boolean {
  *
  * @param text - The inline text to parse.
  * @param ctx - Bijou context for styling.
- * @param mode - Current rendering mode.
  * @returns The rendered inline text.
  */
-export function parseInline(text: string, ctx: BijouContext, mode: string): string {
-  if (mode === 'accessible') return parseInlineAccessible(text, ctx);
-  if (mode === 'pipe') return parseInlinePlain(text);
-  // `static` mode intentionally falls through to styled rendering here,
-  // same as `interactive`. Only `pipe` and `accessible` are special-cased.
-  return parseInlineStyled(text, ctx);
+export function parseInline(text: string, ctx: BijouContext): string {
+  return renderByMode(ctx.mode, {
+    accessible: () => parseInlineAccessible(text, ctx),
+    pipe: () => parseInlinePlain(text),
+    interactive: () => parseInlineStyled(text, ctx),
+  }, text);
 }
 
 /**
@@ -189,7 +189,7 @@ function parseInlineStyled(text: string, ctx: BijouContext): string {
   const codeSpans: string[] = [];
   result = result.replace(/`([^`]+)`/g, (_m, code: string) => {
     const idx = codeSpans.length;
-    codeSpans.push(ctx.style.styled(ctx.theme.theme.semantic.warning, code));
+    codeSpans.push(ctx.style.styled(ctx.semantic('warning'), code));
     return `\x00\x01BIJOU_CS${idx}\x01\x00`;
   });
 
@@ -201,7 +201,7 @@ function parseInlineStyled(text: string, ctx: BijouContext): string {
   // Italic: *text* — runs after bold removal, so `**bold**` won't false-match.
   // The negative lookahead/lookbehind prevents matching the `**` delimiter itself.
   result = result.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, (_m, italic: string) => {
-    return ctx.style.styled(ctx.theme.theme.semantic.muted, italic);
+    return ctx.style.styled(ctx.semantic('muted'), italic);
   });
 
   // Restore code spans

--- a/packages/bijou/src/core/components/markdown-render.ts
+++ b/packages/bijou/src/core/components/markdown-render.ts
@@ -9,6 +9,7 @@ import type { BijouContext } from '../../ports/context.js';
 import type { BlockType } from './markdown-parse.js';
 import { parseInline, wordWrap } from './markdown-parse.js';
 import { separator } from './separator.js';
+import { renderByMode } from '../mode-render.js';
 
 /**
  * Render an array of parsed block elements into a final terminal string.
@@ -37,21 +38,18 @@ export function renderBlocks(
         break;
 
       case 'heading': {
-        const text = parseInline(block.text, ctx, mode);
-        if (mode === 'accessible') {
-          lines.push(`Heading level ${block.level}: ${text}`);
-        } else if (mode === 'pipe') {
-          lines.push('#'.repeat(block.level) + ' ' + text);
-        } else {
-          // Interactive: bold, h1 uses primary color
-          const styled = ctx.style.bold(text);
-          if (block.level === 1) {
-            lines.push(ctx.style.styled(ctx.theme.theme.border.primary, styled));
-          } else {
-            lines.push(styled);
-          }
-        }
-        lines.push('');
+        const text = parseInline(block.text, ctx);
+        const headingLine = renderByMode(ctx.mode, {
+          accessible: () => `Heading level ${block.level}: ${text}`,
+          pipe: () => '#'.repeat(block.level) + ' ' + text,
+          interactive: () => {
+            const styled = ctx.style.bold(text);
+            return block.level === 1
+              ? ctx.style.styled(ctx.border('primary'), styled)
+              : styled;
+          },
+        }, block);
+        lines.push(headingLine, '');
         break;
       }
 
@@ -63,7 +61,7 @@ export function renderBlocks(
         // requires strip-for-measurement then wrap-raw then parse-after,
         // which is complex due to cross-word-boundary formatting spans.
         const wrapped = wordWrap(block.text, width);
-        lines.push(...wrapped.map(line => parseInline(line, ctx, mode)));
+        lines.push(...wrapped.map(line => parseInline(line, ctx)));
         lines.push('');
         break;
       }
@@ -73,9 +71,9 @@ export function renderBlocks(
           const bullet = mode === 'pipe' ? '- ' : '  \u2022 ';
           const indentWidth = width - bullet.length;
           const wrapped = wordWrap(item, indentWidth > 0 ? indentWidth : width);
-          lines.push(bullet + parseInline(wrapped[0]!, ctx, mode));
+          lines.push(bullet + parseInline(wrapped[0]!, ctx));
           for (let i = 1; i < wrapped.length; i++) {
-            lines.push(' '.repeat(bullet.length) + parseInline(wrapped[i]!, ctx, mode));
+            lines.push(' '.repeat(bullet.length) + parseInline(wrapped[i]!, ctx));
           }
         }
         lines.push('');
@@ -92,9 +90,9 @@ export function renderBlocks(
           const paddedPrefix = prefix.padEnd(uniformIndent);
           const indentWidth = width - uniformIndent;
           const wrapped = wordWrap(block.items[n]!, indentWidth > 0 ? indentWidth : width);
-          lines.push(paddedPrefix + parseInline(wrapped[0]!, ctx, mode));
+          lines.push(paddedPrefix + parseInline(wrapped[0]!, ctx));
           for (let i = 1; i < wrapped.length; i++) {
-            lines.push(' '.repeat(uniformIndent) + parseInline(wrapped[i]!, ctx, mode));
+            lines.push(' '.repeat(uniformIndent) + parseInline(wrapped[i]!, ctx));
           }
         }
         lines.push('');
@@ -102,29 +100,27 @@ export function renderBlocks(
       }
 
       case 'code-block': {
-        if (mode === 'pipe' || mode === 'accessible') {
-          lines.push('```' + block.lang);
-          lines.push(...block.lines);
-          lines.push('```');
-        } else {
-          // Interactive: dim styling
-          for (const codeLine of block.lines) {
-            lines.push(ctx.style.styled(ctx.theme.theme.semantic.muted, '  ' + codeLine));
-          }
-        }
-        lines.push('');
+        const cbLines = renderByMode(ctx.mode, {
+          pipe: () => ['```' + block.lang, ...block.lines, '```'],
+          accessible: () => ['```' + block.lang, ...block.lines, '```'],
+          interactive: () => block.lines.map(cl => ctx.style.styled(ctx.semantic('muted'), '  ' + cl)),
+        }, block);
+        lines.push(...cbLines, '');
         break;
       }
 
       case 'blockquote': {
         for (const ql of block.lines) {
-          const inlined = parseInline(ql, ctx, mode);
-          if (mode === 'pipe' || mode === 'accessible') {
-            lines.push('> ' + inlined);
-          } else {
-            const prefix = ctx.style.styled(ctx.theme.theme.border.muted, '\u2502 ');
-            lines.push(prefix + ctx.style.styled(ctx.theme.theme.semantic.muted, inlined));
-          }
+          const inlined = parseInline(ql, ctx);
+          const bqLine = renderByMode(ctx.mode, {
+            pipe: () => '> ' + inlined,
+            accessible: () => '> ' + inlined,
+            interactive: () => {
+              const prefix = ctx.style.styled(ctx.border('muted'), '\u2502 ');
+              return prefix + ctx.style.styled(ctx.semantic('muted'), inlined);
+            },
+          }, block);
+          lines.push(bqLine);
         }
         lines.push('');
         break;

--- a/packages/bijou/src/core/components/markdown.test.ts
+++ b/packages/bijou/src/core/components/markdown.test.ts
@@ -292,6 +292,11 @@ describe('markdown()', () => {
       const result = markdown('This has **bold and `code`** inside.', { ctx: ctx('pipe') });
       expect(result).toContain('bold and code');
     });
+
+    it('handles null/undefined input gracefully', () => {
+      expect(markdown(null as any, { ctx: ctx() })).toBe('');
+      expect(markdown(undefined as any, { ctx: ctx() })).toBe('');
+    });
   });
 
   describe('static mode', () => {

--- a/packages/bijou/src/core/components/markdown.ts
+++ b/packages/bijou/src/core/components/markdown.ts
@@ -10,7 +10,7 @@
  */
 
 import type { BijouContext } from '../../ports/context.js';
-import { getDefaultContext } from '../../context.js';
+import { resolveCtx } from '../resolve-ctx.js';
 import { parseBlocks } from './markdown-parse.js';
 import { renderBlocks } from './markdown-render.js';
 
@@ -42,12 +42,13 @@ export interface MarkdownOptions {
  * @returns The rendered terminal string.
  */
 export function markdown(source: string, options?: MarkdownOptions): string {
-  if (source.trim() === '') return '';
+  const safeSource = source ?? '';
+  if (safeSource.trim() === '') return '';
 
-  const ctx = options?.ctx ?? getDefaultContext();
+  const ctx = resolveCtx(options?.ctx);
   const rawWidth = options?.width ?? ctx.runtime.columns;
   const width = Math.max(1, Number.isFinite(rawWidth) ? rawWidth : ctx.runtime.columns);
 
-  const blocks = parseBlocks(source);
+  const blocks = parseBlocks(safeSource);
   return renderBlocks(blocks, ctx, width);
 }

--- a/packages/bijou/src/core/components/paginator.ts
+++ b/packages/bijou/src/core/components/paginator.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration options for the {@link paginator} component. */
 export interface PaginatorOptions {
@@ -26,26 +27,28 @@ export interface PaginatorOptions {
  */
 export function paginator(options: PaginatorOptions): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const page = options.current + 1; // convert 0-indexed to 1-indexed for display
   const total = options.total;
 
-  if (mode === 'pipe') return `[${page}/${total}]`;
-  if (mode === 'accessible') return `Page ${page} of ${total}`;
+  return renderByMode(ctx.mode, {
+    pipe: () => `[${page}/${total}]`,
+    accessible: () => `Page ${page} of ${total}`,
+    interactive: () => {
+      // interactive + static
+      const style = options.style ?? 'dots';
 
-  // interactive + static
-  const style = options.style ?? 'dots';
+      if (style === 'text') return `Page ${page} of ${total}`;
 
-  if (style === 'text') return `Page ${page} of ${total}`;
-
-  // dots style
-  const dots: string[] = [];
-  for (let i = 0; i < total; i++) {
-    if (i === options.current) {
-      dots.push(ctx.style.styled(ctx.theme.theme.semantic.primary, '●'));
-    } else {
-      dots.push(ctx.style.styled(ctx.theme.theme.semantic.muted, '○'));
-    }
-  }
-  return dots.join(' ');
+      // dots style
+      const dots: string[] = [];
+      for (let i = 0; i < total; i++) {
+        if (i === options.current) {
+          dots.push(ctx.style.styled(ctx.semantic('primary'), '●'));
+        } else {
+          dots.push(ctx.style.styled(ctx.semantic('muted'), '○'));
+        }
+      }
+      return dots.join(' ');
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/progress.ts
+++ b/packages/bijou/src/core/components/progress.ts
@@ -3,6 +3,7 @@ import type { TimerHandle } from '../../ports/io.js';
 import type { GradientStop } from '../theme/tokens.js';
 import { lerp3 } from '../theme/gradient.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration for rendering a progress bar. */
 export interface ProgressBarOptions {
@@ -38,40 +39,37 @@ export interface ProgressBarOptions {
 export function progressBar(percent: number, options: ProgressBarOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
   const pct = Math.max(0, Math.min(100, percent));
-  const mode = ctx.mode;
 
-  if (mode === 'pipe') {
-    return `Progress: ${Math.round(pct)}%`;
-  }
-  if (mode === 'accessible') {
-    return `${Math.round(pct)} percent complete.`;
-  }
+  return renderByMode(ctx.mode, {
+    pipe: () => `Progress: ${Math.round(pct)}%`,
+    accessible: () => `${Math.round(pct)} percent complete.`,
+    interactive: () => {
+      const width = options.width ?? 20;
+      const filledChar = options.filled ?? '\u2588';
+      const emptyChar = options.empty ?? '\u2810';
+      const showPercent = options.showPercent ?? true;
+      const filledCount = Math.min(width, Math.max(0, Math.round((pct / 100) * width)));
 
-  const width = options.width ?? 20;
-  const filledChar = options.filled ?? '\u2588';
-  const emptyChar = options.empty ?? '\u2810';
-  const showPercent = options.showPercent ?? true;
-  const filledCount = Math.min(width, Math.max(0, Math.round((pct / 100) * width)));
+      const noColor = ctx.theme.noColor;
+      const stops = options.gradient ?? ctx.theme.theme.gradient.progress ?? [];
 
-  const noColor = ctx.theme.noColor;
-  const theme = ctx.theme.theme;
-  const stops = options.gradient ?? theme.gradient.progress ?? [];
+      let bar = '';
+      if (noColor || stops.length === 0) {
+        bar = filledChar.repeat(filledCount) + emptyChar.repeat(width - filledCount);
+      } else {
+        for (let i = 0; i < filledCount; i++) {
+          const t_val = filledCount <= 1 ? 0 : i / (filledCount - 1);
+          const [r, g, b] = lerp3(stops, t_val * (pct / 100));
+          bar += ctx.style.rgb(r, g, b, filledChar);
+        }
+        const emptyToken = ctx.ui('trackEmpty');
+        bar += ctx.style.hex(emptyToken.hex, emptyChar.repeat(width - filledCount));
+      }
 
-  let bar = '';
-  if (noColor || stops.length === 0) {
-    bar = filledChar.repeat(filledCount) + emptyChar.repeat(width - filledCount);
-  } else {
-    for (let i = 0; i < filledCount; i++) {
-      const t_val = filledCount <= 1 ? 0 : i / (filledCount - 1);
-      const [r, g, b] = lerp3(stops, t_val * (pct / 100));
-      bar += ctx.style.rgb(r, g, b, filledChar);
-    }
-    const emptyToken = theme.ui.trackEmpty;
-    bar += ctx.style.hex(emptyToken.hex, emptyChar.repeat(width - filledCount));
-  }
-
-  const label = showPercent ? `${Math.round(pct)}%` : '';
-  return label ? `${label.padStart(4)} ${bar}` : bar;
+      const label = showPercent ? `${Math.round(pct)}%` : '';
+      return label ? `${label.padStart(4)} ${bar}` : bar;
+    },
+  }, options);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/bijou/src/core/components/separator.ts
+++ b/packages/bijou/src/core/components/separator.ts
@@ -1,6 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration for rendering a horizontal separator line. */
 export interface SeparatorOptions {
@@ -27,29 +28,30 @@ export interface SeparatorOptions {
  */
 export function separator(options: SeparatorOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const label = options.label;
   const width = options.width ?? ctx.runtime.columns;
 
-  if (mode === 'pipe') {
-    if (label) return `--- ${label} ---`;
-    return '---';
-  }
+  return renderByMode(ctx.mode, {
+    pipe: () => {
+      if (label) return `--- ${label} ---`;
+      return '---';
+    },
+    accessible: () => {
+      if (label) return `--- ${label} ---`;
+      return '';
+    },
+    interactive: () => {
+      const token = options.borderToken ?? ctx.border('muted');
 
-  if (mode === 'accessible') {
-    if (label) return `--- ${label} ---`;
-    return '';
-  }
+      if (label) {
+        const labelWithSpaces = ` ${label} `;
+        const remaining = Math.max(0, width - labelWithSpaces.length);
+        const left = Math.floor(remaining / 2);
+        const right = remaining - left;
+        return ctx.style.styled(token, '\u2500'.repeat(left)) + labelWithSpaces + ctx.style.styled(token, '\u2500'.repeat(right));
+      }
 
-  const token = options.borderToken ?? ctx.theme.theme.border.muted;
-
-  if (label) {
-    const labelWithSpaces = ` ${label} `;
-    const remaining = Math.max(0, width - labelWithSpaces.length);
-    const left = Math.floor(remaining / 2);
-    const right = remaining - left;
-    return ctx.style.styled(token, '\u2500'.repeat(left)) + labelWithSpaces + ctx.style.styled(token, '\u2500'.repeat(right));
-  }
-
-  return ctx.style.styled(token, '\u2500'.repeat(width));
+      return ctx.style.styled(token, '\u2500'.repeat(width));
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/skeleton.ts
+++ b/packages/bijou/src/core/components/skeleton.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration for rendering a skeleton placeholder. */
 export interface SkeletonOptions {
@@ -24,15 +25,17 @@ export interface SkeletonOptions {
  */
 export function skeleton(options: SkeletonOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
 
-  if (mode === 'pipe') return '';
-  if (mode === 'accessible') return 'Loading...';
+  return renderByMode(ctx.mode, {
+    pipe: () => '',
+    accessible: () => 'Loading...',
+    interactive: () => {
+      const width = options.width ?? 20;
+      const lines = options.lines ?? 1;
+      const token = ctx.semantic('muted');
+      const line = ctx.style.styled(token, '\u2591'.repeat(width));
 
-  const width = options.width ?? 20;
-  const lines = options.lines ?? 1;
-  const token = ctx.theme.theme.semantic.muted;
-  const line = ctx.style.styled(token, '\u2591'.repeat(width));
-
-  return Array.from({ length: lines }, () => line).join('\n');
+      return Array.from({ length: lines }, () => line).join('\n');
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/spinner.ts
+++ b/packages/bijou/src/core/components/spinner.ts
@@ -2,6 +2,7 @@ import type { BijouContext } from '../../ports/context.js';
 import type { TimerHandle } from '../../ports/io.js';
 import type { OutputMode } from '../detect/tty.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Configuration for spinner rendering and behavior. */
 export interface SpinnerOptions {
@@ -35,20 +36,16 @@ export function spinnerFrame(tick: number, options: SpinnerOptions = {}): string
   const ctx = resolveCtx(options.ctx);
   const frames = options.frames ?? DOTS;
   const label = options.label ?? 'Loading';
-  const mode: OutputMode = ctx.mode;
 
-  switch (mode) {
-    case 'interactive': {
+  return renderByMode(ctx.mode, {
+    interactive: () => {
       const frame = frames[tick % frames.length] ?? frames[0] ?? '\u280b';
       return `${frame} ${label}`;
-    }
-    case 'static':
-      return `... ${label}`;
-    case 'pipe':
-      return `${label}...`;
-    case 'accessible':
-      return `${label}. Please wait.`;
-  }
+    },
+    static: () => `... ${label}`,
+    pipe: () => `${label}...`,
+    accessible: () => `${label}. Please wait.`,
+  }, options);
 }
 
 /** Controller returned by {@link createSpinner} for managing a live spinner. */

--- a/packages/bijou/src/core/components/stepper.ts
+++ b/packages/bijou/src/core/components/stepper.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Represent a single step in a multi-step process. */
 export interface StepperStep {
@@ -32,42 +33,41 @@ export interface StepperOptions {
  */
 export function stepper(steps: StepperStep[], options: StepperOptions): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const current = options.current;
 
-  if (mode === 'pipe') {
-    return steps
+  return renderByMode(ctx.mode, {
+    pipe: () => steps
       .map((step, i) => {
         const marker = i < current ? '[x]' : i === current ? '[*]' : '[ ]';
         return `${marker} ${step.label}`;
       })
-      .join(' -- ');
-  }
-
-  if (mode === 'accessible') {
-    const total = steps.length;
-    const parts = steps.map((step, i) => {
-      const state = i < current ? 'complete' : i === current ? 'current' : 'pending';
-      return `${step.label} (${state})`;
-    });
-    return `Step ${current + 1} of ${total}: ${parts.join(', ')}`;
-  }
-
-  // interactive + static
-  const connector = ctx.style.styled(ctx.theme.theme.semantic.muted, '──');
-  return steps
-    .map((step, i) => {
-      if (i < current) {
-        const token = ctx.theme.theme.status.success;
-        return `${ctx.style.styled(token, '✓')} ${ctx.style.styled(token, step.label)}`;
-      }
-      if (i === current) {
-        const token = ctx.theme.theme.semantic.primary;
-        const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
-        return `${ctx.style.styled(token, '●')} ${ctx.style.styled(boldToken, step.label)}`;
-      }
-      const token = ctx.theme.theme.semantic.muted;
-      return `${ctx.style.styled(token, '○')} ${ctx.style.styled(token, step.label)}`;
-    })
-    .join(` ${connector} `);
+      .join(' -- '),
+    accessible: () => {
+      const total = steps.length;
+      const parts = steps.map((step, i) => {
+        const state = i < current ? 'complete' : i === current ? 'current' : 'pending';
+        return `${step.label} (${state})`;
+      });
+      return `Step ${current + 1} of ${total}: ${parts.join(', ')}`;
+    },
+    interactive: () => {
+      // interactive + static
+      const connector = ctx.style.styled(ctx.semantic('muted'), '──');
+      return steps
+        .map((step, i) => {
+          if (i < current) {
+            const token = ctx.status('success');
+            return `${ctx.style.styled(token, '✓')} ${ctx.style.styled(token, step.label)}`;
+          }
+          if (i === current) {
+            const token = ctx.semantic('primary');
+            const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
+            return `${ctx.style.styled(token, '●')} ${ctx.style.styled(boldToken, step.label)}`;
+          }
+          const token = ctx.semantic('muted');
+          return `${ctx.style.styled(token, '○')} ${ctx.style.styled(token, step.label)}`;
+        })
+        .join(` ${connector} `);
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/table.test.ts
+++ b/packages/bijou/src/core/components/table.test.ts
@@ -44,4 +44,18 @@ describe('table', () => {
     const result = table({ columns, rows: [], ctx });
     expect(result).toBe('Name\tStatus\tScore');
   });
+
+  describe('defensive input handling', () => {
+    it('handles empty columns gracefully', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      // When columns is empty, pipe mode returns empty header line + data lines
+      expect(table({ columns: [], rows, ctx })).toBe('\nAlice\tactive\t95\nBob\tpending\t72');
+    });
+
+    it('handles null/undefined fields in rows gracefully', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      const badRows = [[null as any, undefined as any, 'value']];
+      expect(table({ columns, rows: badRows, ctx })).toBe('Name\tStatus\tScore\n\t\tvalue');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/table.ts
+++ b/packages/bijou/src/core/components/table.ts
@@ -1,6 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Definition for a single table column. */
 export interface TableColumn {
@@ -70,60 +71,63 @@ function padRight(str: string, width: number): string {
  */
 export function table(options: TableOptions): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
+  const columns = options.columns ?? [];
+  const rows = (options.rows ?? []).map(row => (row ?? []).map(cell => cell ?? ''));
 
-  if (mode === 'pipe') {
-    const headerLine = options.columns.map((c) => c.header).join('\t');
-    const dataLines = options.rows.map((row) => row.join('\t'));
-    return [headerLine, ...dataLines].join('\n');
-  }
+  return renderByMode(ctx.mode, {
+    pipe: () => {
+      const headerLine = columns.map((c) => c.header ?? '').join('\t');
+      const dataLines = rows.map((row) => row.join('\t'));
+      return [headerLine, ...dataLines].join('\n');
+    },
+    accessible: () => {
+      const lines: string[] = [];
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i]!;
+        const pairs = columns.map((col, j) => `${col.header ?? ''}=${row[j] ?? ''}`);
+        lines.push(`Row ${i + 1}: ${pairs.join(', ')}`);
+      }
+      return lines.join('\n');
+    },
+    interactive: () => {
+      const headerToken = options.headerToken ?? ctx.ui('tableHeader');
+      const borderToken = options.borderToken ?? ctx.border('muted');
+      const bc = (s: string): string => ctx.style.styled(borderToken, s);
 
-  if (mode === 'accessible') {
-    const lines: string[] = [];
-    for (let i = 0; i < options.rows.length; i++) {
-      const row = options.rows[i]!;
-      const pairs = options.columns.map((col, j) => `${col.header}=${row[j] ?? ''}`);
-      lines.push(`Row ${i + 1}: ${pairs.join(', ')}`);
-    }
-    return lines.join('\n');
-  }
+      const colWidths = columns.map((col, i) => {
+        if (col.width !== undefined) return col.width;
+        let max = (col.header ?? '').length;
+        for (const row of rows) {
+          const cell = row[i] ?? '';
+          max = Math.max(max, cell.length);
+        }
+        return max;
+      });
 
-  const headerToken = options.headerToken ?? ctx.theme.theme.ui.tableHeader;
-  const borderToken = options.borderToken ?? ctx.theme.theme.border.muted;
-  const bc = (s: string): string => ctx.style.styled(borderToken, s);
+      const h = '\u2500';
+      const v = '\u2502';
 
-  const colWidths = options.columns.map((col, i) => {
-    if (col.width !== undefined) return col.width;
-    let max = col.header.length;
-    for (const row of options.rows) {
-      const cell = row[i] ?? '';
-      max = Math.max(max, cell.length);
-    }
-    return max;
-  });
+      const hLine = (left: string, mid: string, right: string): string => {
+        const segments = colWidths.map((w) => h.repeat(w + 2));
+        return bc(left + segments.join(mid) + right);
+      };
 
-  const h = '\u2500';
-  const v = '\u2502';
+      const top    = hLine('\u250c', '\u252c', '\u2510');
+      const midSep = hLine('\u251c', '\u253c', '\u2524');
+      const bottom = hLine('\u2514', '\u2534', '\u2518');
 
-  const hLine = (left: string, mid: string, right: string): string => {
-    const segments = colWidths.map((w) => h.repeat(w + 2));
-    return bc(left + segments.join(mid) + right);
-  };
+      const headerCells = columns.map((col, i) =>
+        ' ' + padRight(ctx.style.styled(headerToken, col.header ?? ''), colWidths[i]!) + ' ',
+      );
+      const headerRow = bc(v) + headerCells.join(bc(v)) + bc(v);
 
-  const top    = hLine('\u250c', '\u252c', '\u2510');
-  const midSep = hLine('\u251c', '\u253c', '\u2524');
-  const bottom = hLine('\u2514', '\u2534', '\u2518');
+      const dataRows = rows.map((row) => {
+        const cells = colWidths.map((w, i) => ' ' + padRight(row[i] ?? '', w) + ' ');
+        return bc(v) + cells.join(bc(v)) + bc(v);
+      });
 
-  const headerCells = options.columns.map((col, i) =>
-    ' ' + padRight(ctx.style.styled(headerToken, col.header), colWidths[i]!) + ' ',
-  );
-  const headerRow = bc(v) + headerCells.join(bc(v)) + bc(v);
-
-  const dataRows = options.rows.map((row) => {
-    const cells = colWidths.map((w, i) => ' ' + padRight(row[i] ?? '', w) + ' ');
-    return bc(v) + cells.join(bc(v)) + bc(v);
-  });
-
-  const lines = [top, headerRow, midSep, ...dataRows, bottom];
-  return lines.join('\n');
+      const lines = [top, headerRow, midSep, ...dataRows, bottom];
+      return lines.join('\n');
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/table.ts
+++ b/packages/bijou/src/core/components/table.ts
@@ -96,10 +96,10 @@ export function table(options: TableOptions): string {
 
       const colWidths = columns.map((col, i) => {
         if (col.width !== undefined) return col.width;
-        let max = (col.header ?? '').length;
+        let max = visibleLength(col.header ?? '');
         for (const row of rows) {
           const cell = row[i] ?? '';
-          max = Math.max(max, cell.length);
+          max = Math.max(max, visibleLength(cell));
         }
         return max;
       });

--- a/packages/bijou/src/core/components/tabs.ts
+++ b/packages/bijou/src/core/components/tabs.ts
@@ -75,7 +75,7 @@ export function tabs(items: TabItem[], options: TabsOptions): string {
           if (i === active) {
             const token = ctx.semantic('primary');
             const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
-            return `● ${ctx.style.styled(boldToken, label)}`;
+            return `${ctx.style.styled(boldToken, '●')} ${ctx.style.styled(boldToken, label)}`;
           }
           return `  ${ctx.style.styled(ctx.semantic('muted'), label)}`;
         })

--- a/packages/bijou/src/core/components/tabs.ts
+++ b/packages/bijou/src/core/components/tabs.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Represent a single tab in a tab bar. */
 export interface TabItem {
@@ -43,41 +44,42 @@ function formatLabel(item: TabItem): string {
  */
 export function tabs(items: TabItem[], options: TabsOptions): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const active = options.active;
 
-  if (mode === 'pipe') {
-    const sep = options.separator ?? ' | ';
-    return items
-      .map((item, i) => {
-        const label = formatLabel(item);
-        return i === active ? `[${label}]` : label;
-      })
-      .join(sep);
-  }
-
-  if (mode === 'accessible') {
-    const total = items.length;
-    return items
-      .map((item, i) => {
-        const label = formatLabel(item);
-        const tag = i === active ? ' (active)' : '';
-        return `Tab ${i + 1} of ${total}: ${label}${tag}`;
-      })
-      .join(' | ');
-  }
-
-  // interactive + static
-  const sep = options.separator ?? ' │ ';
-  return items
-    .map((item, i) => {
-      const label = formatLabel(item);
-      if (i === active) {
-        const token = ctx.theme.theme.semantic.primary;
-        const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
-        return `● ${ctx.style.styled(boldToken, label)}`;
-      }
-      return `  ${ctx.style.styled(ctx.theme.theme.semantic.muted, label)}`;
-    })
-    .join(sep);
+  return renderByMode(ctx.mode, {
+    pipe: () => {
+      const sep = options.separator ?? ' | ';
+      return items
+        .map((item, i) => {
+          const label = formatLabel(item);
+          return i === active ? `[${label}]` : label;
+        })
+        .join(sep);
+    },
+    accessible: () => {
+      const total = items.length;
+      return items
+        .map((item, i) => {
+          const label = formatLabel(item);
+          const tag = i === active ? ' (active)' : '';
+          return `Tab ${i + 1} of ${total}: ${label}${tag}`;
+        })
+        .join(' | ');
+    },
+    interactive: () => {
+      // interactive + static
+      const sep = options.separator ?? ' │ ';
+      return items
+        .map((item, i) => {
+          const label = formatLabel(item);
+          if (i === active) {
+            const token = ctx.semantic('primary');
+            const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
+            return `● ${ctx.style.styled(boldToken, label)}`;
+          }
+          return `  ${ctx.style.styled(ctx.semantic('muted'), label)}`;
+        })
+        .join(sep);
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/timeline.ts
+++ b/packages/bijou/src/core/components/timeline.ts
@@ -2,6 +2,7 @@ import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import type { BaseStatusKey } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Represent a single event on a vertical timeline. */
 export interface TimelineEvent {
@@ -48,43 +49,40 @@ function statusLabel(status: BaseStatusKey): string {
  */
 export function timeline(events: TimelineEvent[], options: TimelineOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
 
-  if (mode === 'pipe') {
-    return events
+  return renderByMode(ctx.mode, {
+    pipe: () => events
       .map((e) => {
         const status = (e.status ?? 'muted').toUpperCase();
         const desc = e.description ? ` - ${e.description}` : '';
         return `[${status}] ${e.label}${desc}`;
       })
-      .join('\n');
-  }
-
-  if (mode === 'accessible') {
-    return events
+      .join('\n'),
+    accessible: () => events
       .map((e) => {
         const label = statusLabel(e.status ?? 'muted');
         const desc = e.description ? `. ${e.description}` : '';
         return `${label}: ${e.label}${desc}`;
       })
-      .join('\n');
-  }
+      .join('\n'),
+    interactive: () => {
+      const lineToken = options.lineToken ?? ctx.border('muted');
 
-  const lineToken = options.lineToken ?? ctx.theme.theme.border.muted;
+      const lines: string[] = [];
+      for (const [i, event] of events.entries()) {
+        const status = event.status ?? 'muted';
+        const dotChar = FILLED_STATUSES.has(status) ? '●' : '○';
+        const statusToken = ctx.status(status);
 
-  const lines: string[] = [];
-  for (const [i, event] of events.entries()) {
-    const status = event.status ?? 'muted';
-    const dotChar = FILLED_STATUSES.has(status) ? '●' : '○';
-    const statusToken = ctx.theme.theme.status[status];
+        const dot = ctx.style.styled(statusToken, dotChar);
+        const desc = event.description ? ` ${event.description}` : '';
+        lines.push(`${dot} ${event.label}${desc}`);
 
-    const dot = ctx.style.styled(statusToken, dotChar);
-    const desc = event.description ? ` ${event.description}` : '';
-    lines.push(`${dot} ${event.label}${desc}`);
-
-    if (i < events.length - 1) {
-      lines.push(ctx.style.styled(lineToken, '│'));
-    }
-  }
-  return lines.join('\n');
+        if (i < events.length - 1) {
+          lines.push(ctx.style.styled(lineToken, '│'));
+        }
+      }
+      return lines.join('\n');
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/components/tree.ts
+++ b/packages/bijou/src/core/components/tree.ts
@@ -1,6 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
+import { renderByMode } from '../mode-render.js';
 
 /** Represent a single node in a tree hierarchy. */
 export interface TreeNode {
@@ -34,19 +35,16 @@ export interface TreeOptions {
  */
 export function tree(nodes: TreeNode[], options: TreeOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
 
-  if (mode === 'pipe') {
-    return renderPlain(nodes, 0);
-  }
-
-  if (mode === 'accessible') {
-    return renderAccessible(nodes, 0);
-  }
-
-  const guideToken = options.guideToken ?? ctx.theme.theme.border.muted;
-  const labelToken = options.labelToken;
-  return renderRich(nodes, '', true, guideToken, labelToken, ctx);
+  return renderByMode(ctx.mode, {
+    pipe: () => renderPlain(nodes, 0),
+    accessible: () => renderAccessible(nodes, 0),
+    interactive: () => {
+      const guideToken = options.guideToken ?? ctx.border('muted');
+      const labelToken = options.labelToken;
+      return renderRich(nodes, '', true, guideToken, labelToken, ctx);
+    },
+  }, options);
 }
 
 /**

--- a/packages/bijou/src/core/environment.test.ts
+++ b/packages/bijou/src/core/environment.test.ts
@@ -18,8 +18,8 @@ describe('environment integration', () => {
   describe('NO_COLOR compliance', () => {
     it('theme.ink() returns undefined for all tokens', () => {
       const ctx = createTestContext({ noColor: true, mode: 'interactive' });
-      expect(ctx.theme.ink(ctx.theme.theme.semantic.primary)).toBeUndefined();
-      expect(ctx.theme.ink(ctx.theme.theme.status.success)).toBeUndefined();
+      expect(ctx.theme.ink(ctx.semantic('primary'))).toBeUndefined();
+      expect(ctx.theme.ink(ctx.status('success'))).toBeUndefined();
     });
 
     it('gradientText() returns plain text', () => {

--- a/packages/bijou/src/core/forms/confirm.ts
+++ b/packages/bijou/src/core/forms/confirm.ts
@@ -2,6 +2,7 @@ import type { ConfirmFieldOptions } from './types.js';
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { formatFormTitle } from './form-utils.js';
+import { renderByMode } from '../mode-render.js';
 
 /**
  * Options for the yes/no confirmation prompt.
@@ -23,22 +24,21 @@ export interface ConfirmOptions extends ConfirmFieldOptions {
  */
 export async function confirm(options: ConfirmOptions): Promise<boolean> {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const noColor = ctx.theme.noColor;
   const defaultYes = options.defaultValue !== false;
   const hint = defaultYes ? 'Y/n' : 'y/N';
 
-  let prompt: string;
-  if (mode === 'accessible') {
-    prompt = `${options.title} Type yes or no (default: ${defaultYes ? 'yes' : 'no'}): `;
-  } else if (mode === 'pipe' || noColor) {
-    prompt = mode === 'pipe'
-      ? `${options.title} ${hint}? `
-      : `${formatFormTitle(options.title, ctx)} [${hint}] `;
-  } else {
-    prompt = formatFormTitle(options.title, ctx)
-      + ctx.style.styled(ctx.theme.theme.semantic.muted, ` [${hint}]`) + ' ';
-  }
+  const prompt = renderByMode(ctx.mode, {
+    accessible: () => `${options.title} Type yes or no (default: ${defaultYes ? 'yes' : 'no'}): `,
+    pipe: () => `${options.title} ${hint}? `,
+    interactive: () => {
+      if (noColor) {
+        return `${formatFormTitle(options.title, ctx)} [${hint}] `;
+      }
+      return formatFormTitle(options.title, ctx)
+        + ctx.style.styled(ctx.semantic('muted'), ` [${hint}]`) + ' ';
+    },
+  }, options);
 
   const answer = await ctx.io.question(prompt);
   const trimmed = answer.trim().toLowerCase();

--- a/packages/bijou/src/core/forms/filter-interactive.ts
+++ b/packages/bijou/src/core/forms/filter-interactive.ts
@@ -80,7 +80,6 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
     throw new Error('[bijou] filter(): options array must contain at least one option');
   }
   const noColor = ctx.theme.noColor;
-  const t = ctx.theme;
   const styledFn = createStyledFn(ctx);
   const boldFn = createBoldFn(ctx);
   const matchFn = options.match ?? defaultMatch;
@@ -126,8 +125,8 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
 
     // Filter input with mode indicator (: normal, / insert)
     const indicator = mode === 'insert' ? '/' : ':';
-    const filterDisplay = query || (options.placeholder ? styledFn(t.theme.semantic.muted, options.placeholder) : '');
-    ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.info, indicator)} ${filterDisplay}\n`);
+    const filterDisplay = query || (options.placeholder ? styledFn(ctx.semantic('muted'), options.placeholder) : '');
+    ctx.io.write(`\x1b[K  ${styledFn(ctx.semantic('info'), indicator)} ${filterDisplay}\n`);
 
     // Visible items
     const vis = visibleItems();
@@ -136,7 +135,7 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
       const isCurrent = scrollOffset + i === cursor;
       const prefix = isCurrent ? '❯' : ' ';
       if (isCurrent && !noColor) {
-        ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.info, prefix)} ${boldFn(opt.label)}\n`);
+        ctx.io.write(`\x1b[K  ${styledFn(ctx.semantic('info'), prefix)} ${boldFn(opt.label)}\n`);
       } else {
         ctx.io.write(`\x1b[K  ${prefix} ${opt.label}\n`);
       }
@@ -144,7 +143,7 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
 
     // Status
     const status = `${filtered.length}/${options.options.length} items`;
-    ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.muted, status)}\n`);
+    ctx.io.write(`\x1b[K  ${styledFn(ctx.semantic('muted'), status)}\n`);
   }
 
   function clearRender(lineCount: number): void {
@@ -164,7 +163,7 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
 
     const selected = filtered[cursor];
     const selectedLabel = selected ? selected.label : '(none)';
-    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(t.theme.semantic.info, selectedLabel);
+    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(ctx.semantic('info'), selectedLabel);
     ctx.io.write(`\x1b[K${label}\n`);
     term.showCursor();
   }

--- a/packages/bijou/src/core/forms/filter.test.ts
+++ b/packages/bijou/src/core/forms/filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { filter } from './filter.js';
-import { createTestContext } from '../../adapters/test/index.js';
+import { createTestContext, MANY_OPTIONS } from '../../adapters/test/index.js';
 
 const OPTIONS = [
   { label: 'Apple', value: 'apple', keywords: ['fruit', 'red'] },
@@ -296,39 +296,26 @@ describe('filter()', () => {
   });
 
   describe('viewport scrolling', () => {
-    const MANY_OPTIONS = [
-      { label: 'A1', value: 'a1' },
-      { label: 'A2', value: 'a2' },
-      { label: 'A3', value: 'a3' },
-      { label: 'A4', value: 'a4' },
-      { label: 'A5', value: 'a5' },
-      { label: 'A6', value: 'a6' },
-      { label: 'A7', value: 'a7' },
-      { label: 'A8', value: 'a8' },
-      { label: 'A9', value: 'a9' },
-      { label: 'A10', value: 'a10' },
-    ];
-
     it('cursor past maxVisible still shows cursor indicator', async () => {
       // maxVisible=3. Navigate down 8 times → cursor at index 8 = A9.
       // The viewport must scroll so A9 is visible WITH the cursor indicator.
       const keys = Array.from({ length: 8 }, () => '\x1b[B').concat(['\r']);
       const ctx = createTestContext({ mode: 'interactive', io: { keys } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 3, ctx });
-      expect(result).toBe('a9');
-      // Strip ANSI codes and verify a line contains both ❯ and A9
+      expect(result).toBe('v9');
+      // Strip ANSI codes and verify a line contains both ❯ and Option 9
       const stripped = ctx.io.written.join('').replace(/\x1b\[[0-9;]*m/g, '');
-      expect(stripped).toMatch(/❯.*A9/);
+      expect(stripped).toMatch(/❯.*Option 9/);
     });
 
     it('cursor wraps up past maxVisible and is visible', async () => {
-      // Navigate up from index 0 wraps to last (A10, index 9).
-      // Viewport must scroll to show A10 with cursor indicator.
+      // Navigate up from index 0 wraps to last (Option 20, index 19).
+      // Viewport must scroll to show Option 20 with cursor indicator.
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[A', '\r'] } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 3, ctx });
-      expect(result).toBe('a10');
+      expect(result).toBe('v20');
       const stripped = ctx.io.written.join('').replace(/\x1b\[[0-9;]*m/g, '');
-      expect(stripped).toMatch(/❯.*A10/);
+      expect(stripped).toMatch(/❯.*Option 20/);
     });
 
     it('scroll down then back up tracks correctly', async () => {
@@ -336,7 +323,7 @@ describe('filter()', () => {
       const keys = ['\x1b[B', '\x1b[B', '\x1b[B', '\x1b[B', '\x1b[A', '\x1b[A', '\r'];
       const ctx = createTestContext({ mode: 'interactive', io: { keys } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 3, ctx });
-      expect(result).toBe('a3');
+      expect(result).toBe('v3');
     });
 
     it('filter query resets scroll offset', async () => {
@@ -344,20 +331,20 @@ describe('filter()', () => {
       const keys = ['\x1b[B', '\x1b[B', '\x1b[B', '\x1b[B', '\x1b[B', '1', '0', '\r'];
       const ctx = createTestContext({ mode: 'interactive', io: { keys } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 3, ctx });
-      // "10" matches A10
-      expect(result).toBe('a10');
+      // "10" matches Option 10
+      expect(result).toBe('v10');
     });
 
     it('maxVisible=1 shows single item with cursor', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[B', '\r'] } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 1, ctx });
-      expect(result).toBe('a2');
+      expect(result).toBe('v2');
     });
 
     it('maxVisible >= option count needs no scrolling', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[B', '\r'] } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 20, ctx });
-      expect(result).toBe('a2');
+      expect(result).toBe('v2');
     });
   });
 

--- a/packages/bijou/src/core/forms/filter.test.ts
+++ b/packages/bijou/src/core/forms/filter.test.ts
@@ -303,9 +303,8 @@ describe('filter()', () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 3, ctx });
       expect(result).toBe('v9');
-      // Strip ANSI codes and verify a line contains both ❯ and Option 9
-      const stripped = ctx.io.written.join('').replace(/\x1b\[[0-9;]*m/g, '');
-      expect(stripped).toMatch(/❯.*Option 9/);
+      const output = ctx.io.written.join('');
+      expect(output).toMatch(/❯.*Option 9/);
     });
 
     it('cursor wraps up past maxVisible and is visible', async () => {
@@ -314,8 +313,8 @@ describe('filter()', () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[A', '\r'] } });
       const result = await filter({ title: 'Pick', options: MANY_OPTIONS, maxVisible: 3, ctx });
       expect(result).toBe('v20');
-      const stripped = ctx.io.written.join('').replace(/\x1b\[[0-9;]*m/g, '');
-      expect(stripped).toMatch(/❯.*Option 20/);
+      const output = ctx.io.written.join('');
+      expect(output).toMatch(/❯.*Option 20/);
     });
 
     it('scroll down then back up tracks correctly', async () => {

--- a/packages/bijou/src/core/forms/form-utils.test.ts
+++ b/packages/bijou/src/core/forms/form-utils.test.ts
@@ -190,7 +190,7 @@ describe('createStyledFn', () => {
   it('returns identity function when noColor is true', () => {
     const ctx = createTestContext({ noColor: true });
     const styledFn = createStyledFn(ctx);
-    const result = styledFn(ctx.theme.theme.semantic.info, 'hello');
+    const result = styledFn(ctx.semantic('info'), 'hello');
     expect(result).toBe('hello');
   });
 
@@ -200,8 +200,8 @@ describe('createStyledFn', () => {
     // Replace style with audit style to track calls
     const ctxWithAudit = { ...ctx, style };
     const styledFn = createStyledFn(ctxWithAudit);
-    styledFn(ctx.theme.theme.semantic.info, 'hello');
-    expect(style.wasStyled(ctx.theme.theme.semantic.info, 'hello')).toBe(true);
+    styledFn(ctx.semantic('info'), 'hello');
+    expect(style.wasStyled(ctx.semantic('info'), 'hello')).toBe(true);
   });
 
   it('does not call styled() when noColor is true', () => {
@@ -209,7 +209,7 @@ describe('createStyledFn', () => {
     const ctx = createTestContext({ noColor: true });
     const ctxWithAudit = { ...ctx, style };
     const styledFn = createStyledFn(ctxWithAudit);
-    styledFn(ctx.theme.theme.semantic.info, 'hello');
+    styledFn(ctx.semantic('info'), 'hello');
     expect(style.calls).toHaveLength(0);
   });
 });

--- a/packages/bijou/src/core/forms/form-utils.ts
+++ b/packages/bijou/src/core/forms/form-utils.ts
@@ -25,7 +25,7 @@ export function formatFormTitle(title: string, ctx: BijouContext): string {
   if (ctx.theme.noColor || ctx.mode === 'accessible') {
     return `? ${title}`;
   }
-  return ctx.style.styled(ctx.theme.theme.semantic.info, '? ') + ctx.style.bold(title);
+  return ctx.style.styled(ctx.semantic('info'), '? ') + ctx.style.bold(title);
 }
 
 /**
@@ -41,7 +41,7 @@ export function writeValidationError(message: string, ctx: BijouContext): void {
   if (ctx.theme.noColor || ctx.mode === 'accessible') {
     ctx.io.write(message + '\n');
   } else {
-    ctx.io.write(ctx.style.styled(ctx.theme.theme.semantic.error, message) + '\n');
+    ctx.io.write(ctx.style.styled(ctx.semantic('error'), message) + '\n');
   }
 }
 

--- a/packages/bijou/src/core/forms/input.ts
+++ b/packages/bijou/src/core/forms/input.ts
@@ -2,6 +2,7 @@ import type { FieldOptions, ValidationResult } from './types.js';
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { formatFormTitle, writeValidationError } from './form-utils.js';
+import { renderByMode } from '../mode-render.js';
 
 /**
  * Options for the text input field.
@@ -27,10 +28,9 @@ export interface InputOptions extends FieldOptions<string> {
  */
 export async function input(options: InputOptions): Promise<string> {
   const ctx = resolveCtx(options.ctx);
-  const mode = ctx.mode;
   const noColor = ctx.theme.noColor;
 
-  const prompt = buildPrompt(options, mode, noColor, ctx);
+  const prompt = buildPrompt(options, noColor, ctx);
   const answer = await ctx.io.question(prompt);
   const value = answer.trim() || options.defaultValue || '';
 
@@ -57,14 +57,17 @@ export async function input(options: InputOptions): Promise<string> {
  * @param ctx - Bijou context for styling.
  * @returns Formatted prompt string.
  */
-function buildPrompt(options: InputOptions, mode: string, noColor: boolean, ctx: BijouContext): string {
+function buildPrompt(options: InputOptions, noColor: boolean, ctx: BijouContext): string {
   const defaultHint = options.defaultValue ? ` (${options.defaultValue})` : '';
 
-  if (mode === 'accessible') return `Enter ${options.title.toLowerCase()}${defaultHint}: `;
-  if (mode === 'pipe') return `${options.title}${defaultHint}: `;
-  if (noColor) return `${options.title}${defaultHint}: `;
-
-  const label = formatFormTitle(options.title, ctx);
-  const hint = options.defaultValue ? ctx.style.styled(ctx.theme.theme.semantic.muted, ` (${options.defaultValue})`) : '';
-  return `${label}${hint} `;
+  return renderByMode(ctx.mode, {
+    accessible: () => `Enter ${options.title.toLowerCase()}${defaultHint}: `,
+    pipe: () => `${options.title}${defaultHint}: `,
+    interactive: () => {
+      if (noColor) return `${options.title}${defaultHint}: `;
+      const label = formatFormTitle(options.title, ctx);
+      const hint = options.defaultValue ? ctx.style.styled(ctx.semantic('muted'), ` (${options.defaultValue})`) : '';
+      return `${label}${hint} `;
+    },
+  }, options);
 }

--- a/packages/bijou/src/core/forms/input.ts
+++ b/packages/bijou/src/core/forms/input.ts
@@ -51,10 +51,11 @@ export async function input(options: InputOptions): Promise<string> {
 /**
  * Build a mode-appropriate prompt string for the input field.
  *
+ * Mode is derived from `ctx`.
+ *
  * @param options - Input field configuration.
- * @param mode - Current output mode (interactive, accessible, pipe).
  * @param noColor - Whether color output is disabled.
- * @param ctx - Bijou context for styling.
+ * @param ctx - Bijou context for styling and mode.
  * @returns Formatted prompt string.
  */
 function buildPrompt(options: InputOptions, noColor: boolean, ctx: BijouContext): string {

--- a/packages/bijou/src/core/forms/multiselect.test.ts
+++ b/packages/bijou/src/core/forms/multiselect.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { multiselect } from './multiselect.js';
-import { createTestContext, COLOR_OPTIONS } from '../../adapters/test/index.js';
+import { createTestContext, COLOR_OPTIONS, MANY_OPTIONS } from '../../adapters/test/index.js';
 
 describe('multiselect()', () => {
   it('returns empty array when options list is empty', async () => {
@@ -107,6 +107,41 @@ describe('multiselect()', () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[B', '\x1b[B', ' ', '\r'] } });
       const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual(['blue']);
+    });
+
+    it('supports maxVisible scrolling for long option lists', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['\x1b[B', '\x1b[B', '\x1b[B', ' ', '\r'] },
+      });
+      const result = await multiselect({
+        title: 'Pick',
+        options: MANY_OPTIONS,
+        maxVisible: 3,
+        ctx,
+      });
+      const output = ctx.io.written.join('');
+
+      expect(result).toEqual(['v4']);
+      expect(output).toContain('\x1b[4A');
+      expect(output).toContain('Option 4');
+      expect(output).not.toContain('Option 10');
+    });
+
+    it('sanitizes non-finite maxVisible values', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: [' ', '\r'] },
+      });
+      const result = await multiselect({
+        title: 'Pick',
+        options: MANY_OPTIONS,
+        maxVisible: Number.NaN,
+        ctx,
+      });
+
+      expect(result).toEqual(['v1']);
+      expect(ctx.io.written.join('')).not.toContain('[NaN');
     });
   });
 

--- a/packages/bijou/src/core/forms/multiselect.test.ts
+++ b/packages/bijou/src/core/forms/multiselect.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { multiselect } from './multiselect.js';
-import { createTestContext } from '../../adapters/test/index.js';
-
-const OPTIONS = [
-  { label: 'Red', value: 'red' },
-  { label: 'Green', value: 'green' },
-  { label: 'Blue', value: 'blue' },
-];
+import { createTestContext, COLOR_OPTIONS } from '../../adapters/test/index.js';
 
 describe('multiselect()', () => {
   it('returns empty array when options list is empty', async () => {
@@ -17,7 +11,7 @@ describe('multiselect()', () => {
   describe('numbered fallback (non-interactive)', () => {
     it('renders numbered list', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['1,2'] } });
-      await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       const output = ctx.io.written.join('');
       expect(output).toContain('1.');
       expect(output).toContain('Red');
@@ -27,19 +21,19 @@ describe('multiselect()', () => {
 
     it('accepts comma-separated numbers', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['1,3'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual(['red', 'blue']);
     });
 
     it('filters out invalid numbers', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['1,99,2'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual(['red', 'green']);
     });
 
     it('returns empty array when input is empty', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: [''] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual([]);
     });
   });
@@ -47,13 +41,13 @@ describe('multiselect()', () => {
   describe('pipe mode', () => {
     it('accepts comma-separated numbers from stdin', async () => {
       const ctx = createTestContext({ mode: 'pipe', io: { answers: ['2, 3'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual(['green', 'blue']);
     });
 
     it('returns empty array when stdin is empty', async () => {
       const ctx = createTestContext({ mode: 'pipe', io: { answers: [''] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual([]);
     });
   });
@@ -61,7 +55,7 @@ describe('multiselect()', () => {
   describe('accessible mode', () => {
     it('prompt says "Enter numbers separated by commas"', async () => {
       const ctx = createTestContext({ mode: 'accessible', io: { answers: ['1'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       const output = ctx.io.written.join('');
       expect(output).toContain('Enter numbers separated by commas');
       expect(result).toEqual(['red']);
@@ -71,7 +65,7 @@ describe('multiselect()', () => {
   describe('interactive mode', () => {
     it('renders with checkboxes', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\r'] } });
-      await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       const output = ctx.io.written.join('');
       expect(output).toContain('○');
       expect(output).toContain('Red');
@@ -81,57 +75,57 @@ describe('multiselect()', () => {
 
     it('Space toggles first, Enter confirms', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: [' ', '\r'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual(['red']);
     });
 
     it('navigate + toggle multiple items', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: [' ', '\x1b[B', ' ', '\r'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual(['red', 'green']);
     });
 
     it('Ctrl+C returns empty array', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x03'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual([]);
     });
 
     it('Escape returns empty array', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual([]);
     });
 
     it('toggle on and off deselects item', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: [' ', ' ', '\r'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual([]);
     });
 
     it('navigate to last item and select', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[B', '\x1b[B', ' ', '\r'] } });
-      const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+      const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
       expect(result).toEqual(['blue']);
     });
   });
 
   it('accepts ctx parameter', async () => {
     const ctx = createTestContext({ mode: 'pipe', io: { answers: ['1'] } });
-    const result = await multiselect({ title: 'X', options: OPTIONS, ctx });
+    const result = await multiselect({ title: 'X', options: COLOR_OPTIONS, ctx });
     expect(result).toEqual(['red']);
     expect(ctx.io.written.length).toBeGreaterThan(0);
   });
 
   it('single selection works', async () => {
     const ctx = createTestContext({ mode: 'static', io: { answers: ['2'] } });
-    const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+    const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
     expect(result).toEqual(['green']);
   });
 
   it('all selections work', async () => {
     const ctx = createTestContext({ mode: 'static', io: { answers: ['1,2,3'] } });
-    const result = await multiselect({ title: 'Colors', options: OPTIONS, ctx });
+    const result = await multiselect({ title: 'Colors', options: COLOR_OPTIONS, ctx });
     expect(result).toEqual(['red', 'green', 'blue']);
   });
 });

--- a/packages/bijou/src/core/forms/multiselect.test.ts
+++ b/packages/bijou/src/core/forms/multiselect.test.ts
@@ -122,10 +122,27 @@ describe('multiselect()', () => {
       });
       const output = ctx.io.written.join('');
 
-      expect(result).toEqual(['v4']);
+      expect(result).toEqual([MANY_OPTIONS[3]!.value]);
       expect(output).toContain('\x1b[4A');
-      expect(output).toContain('Option 4');
-      expect(output).not.toContain('Option 10');
+      expect(output).toContain(MANY_OPTIONS[3]!.label);
+      expect(output).not.toContain(MANY_OPTIONS[9]!.label);
+    });
+
+    it('wrap-around scrolling from first to last item', async () => {
+      const ctx = createTestContext({
+        mode: 'interactive',
+        io: { keys: ['\x1b[A', ' ', '\r'] },
+      });
+      const result = await multiselect({
+        title: 'Pick',
+        options: MANY_OPTIONS,
+        maxVisible: 3,
+        ctx,
+      });
+      const output = ctx.io.written.join('');
+
+      expect(result).toEqual([MANY_OPTIONS[MANY_OPTIONS.length - 1]!.value]);
+      expect(output).toContain(MANY_OPTIONS[MANY_OPTIONS.length - 1]!.label);
     });
 
     it('sanitizes non-finite maxVisible values', async () => {

--- a/packages/bijou/src/core/forms/multiselect.ts
+++ b/packages/bijou/src/core/forms/multiselect.ts
@@ -93,7 +93,7 @@ async function interactiveMultiselect<T>(options: MultiselectOptions<T>, ctx: Bi
   }
 
   function visibleOptions(): SelectOption<T>[] {
-    return options.options.slice(scrollOffset, scrollOffset + maxVisible) as SelectOption<T>[];
+    return options.options.slice(scrollOffset, scrollOffset + maxVisible);
   }
 
   function renderLineCount(): number {

--- a/packages/bijou/src/core/forms/multiselect.ts
+++ b/packages/bijou/src/core/forms/multiselect.ts
@@ -1,4 +1,4 @@
-import type { SelectFieldOptions } from './types.js';
+import type { SelectFieldOptions, SelectOption } from './types.js';
 import type { BijouContext } from '../../ports/context.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { formatFormTitle, renderNumberedOptions, terminalRenderer, formDispatch, createStyledFn, createBoldFn } from './form-utils.js';
@@ -71,33 +71,56 @@ async function numberedMultiselect<T>(options: MultiselectOptions<T>, ctx: Bijou
  */
 async function interactiveMultiselect<T>(options: MultiselectOptions<T>, ctx: BijouContext): Promise<T[]> {
   const noColor = ctx.theme.noColor;
-  const t = ctx.theme;
   const styledFn = createStyledFn(ctx);
   const boldFn = createBoldFn(ctx);
   const term = terminalRenderer(ctx);
+  const rawMaxVisible = options.maxVisible ?? 7;
+  const maxVisible = Number.isFinite(rawMaxVisible)
+    ? Math.max(1, Math.floor(rawMaxVisible))
+    : 7;
 
   let cursor = 0;
+  let scrollOffset = 0;
   const selected = new Set<number>();
+
+  function clampScroll(): void {
+    if (cursor < scrollOffset) {
+      scrollOffset = cursor;
+    } else if (cursor >= scrollOffset + maxVisible) {
+      scrollOffset = cursor - maxVisible + 1;
+    }
+    scrollOffset = Math.max(0, Math.min(scrollOffset, Math.max(0, options.options.length - maxVisible)));
+  }
+
+  function visibleOptions(): SelectOption<T>[] {
+    return options.options.slice(scrollOffset, scrollOffset + maxVisible) as SelectOption<T>[];
+  }
+
+  function renderLineCount(): number {
+    return 1 + Math.min(options.options.length, maxVisible);
+  }
 
   function render(): void {
     const label = formatFormTitle(options.title, ctx);
     term.hideCursor();
-    const hint = styledFn(t.theme.semantic.muted, '(space to toggle, enter to confirm)');
+    const hint = styledFn(ctx.semantic('muted'), '(space to toggle, enter to confirm)');
     term.writeLine(`${label}  ${hint}`);
 
-    for (let i = 0; i < options.options.length; i++) {
-      const opt = options.options[i]!;
-      const isCurrent = i === cursor;
-      const isSelected = selected.has(i);
+    const visible = visibleOptions();
+    for (let i = 0; i < visible.length; i++) {
+      const globalIndex = scrollOffset + i;
+      const opt = visible[i]!;
+      const isCurrent = globalIndex === cursor;
+      const isSelected = selected.has(globalIndex);
       const prefix = isCurrent ? '\u276f' : ' ';
       const check = isSelected ? '\u25c9' : '\u25cb';
       const desc = opt.description
-        ? styledFn(t.theme.semantic.muted, ` \u2014 ${opt.description}`)
+        ? styledFn(ctx.semantic('muted'), ` \u2014 ${opt.description}`)
         : '';
       if (isCurrent && !noColor) {
-        ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.info, prefix)} ${styledFn(t.theme.semantic.info, check)} ${boldFn(opt.label)}${desc}\n`);
+        ctx.io.write(`\x1b[K  ${styledFn(ctx.semantic('info'), prefix)} ${styledFn(ctx.semantic('info'), check)} ${boldFn(opt.label)}${desc}\n`);
       } else if (isSelected && !noColor) {
-        ctx.io.write(`\x1b[K  ${prefix} ${styledFn(t.theme.semantic.success, check)} ${opt.label}${desc}\n`);
+        ctx.io.write(`\x1b[K  ${prefix} ${styledFn(ctx.status('success'), check)} ${opt.label}${desc}\n`);
       } else {
         ctx.io.write(`\x1b[K  ${prefix} ${check} ${opt.label}${desc}\n`);
       }
@@ -105,16 +128,16 @@ async function interactiveMultiselect<T>(options: MultiselectOptions<T>, ctx: Bi
   }
 
   function clearRender(): void {
-    const totalLines = options.options.length + 1;
+    const totalLines = renderLineCount();
     term.moveUp(totalLines);
   }
 
   function cleanup(): void {
     clearRender();
-    const totalLines = options.options.length + 1;
+    const totalLines = renderLineCount();
     term.clearBlock(totalLines);
     const selectedLabels = [...selected].sort().map((i) => options.options[i]!.label).join(', ');
-    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(t.theme.semantic.info, selectedLabels);
+    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(ctx.semantic('info'), selectedLabels);
     ctx.io.write(`\x1b[K${label}\n`);
     term.showCursor();
   }
@@ -125,9 +148,11 @@ async function interactiveMultiselect<T>(options: MultiselectOptions<T>, ctx: Bi
     const handle = ctx.io.rawInput((key: string) => {
       if (key === '\x1b[A' || key === 'k') {
         cursor = (cursor - 1 + options.options.length) % options.options.length;
+        clampScroll();
         clearRender(); render();
       } else if (key === '\x1b[B' || key === 'j') {
         cursor = (cursor + 1) % options.options.length;
+        clampScroll();
         clearRender(); render();
       } else if (key === ' ') {
         if (selected.has(cursor)) selected.delete(cursor); else selected.add(cursor);

--- a/packages/bijou/src/core/forms/select.test.ts
+++ b/packages/bijou/src/core/forms/select.test.ts
@@ -1,18 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { select } from './select.js';
-import { createTestContext } from '../../adapters/test/index.js';
-
-const OPTIONS = [
-  { label: 'Red', value: 'red' },
-  { label: 'Green', value: 'green' },
-  { label: 'Blue', value: 'blue' },
-];
+import { createTestContext, COLOR_OPTIONS, MANY_OPTIONS } from '../../adapters/test/index.js';
 
 describe('select()', () => {
   describe('numbered fallback (non-interactive)', () => {
     it('renders numbered list', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['1'] } });
-      await select({ title: 'Color', options: OPTIONS, ctx });
+      await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       const output = ctx.io.written.join('');
       expect(output).toContain('1.');
       expect(output).toContain('Red');
@@ -24,25 +18,25 @@ describe('select()', () => {
 
     it('accepts number and returns corresponding value', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['2'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('green');
     });
 
     it('invalid number returns default or first option', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['99'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('red'); // falls back to first
     });
 
     it('returns defaultValue when invalid input and default is set', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: [''] } });
-      const result = await select({ title: 'Color', options: OPTIONS, defaultValue: 'blue', ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, defaultValue: 'blue', ctx });
       expect(result).toBe('blue');
     });
 
     it('valid input overrides defaultValue', async () => {
       const ctx = createTestContext({ mode: 'static', io: { answers: ['1'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, defaultValue: 'blue', ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, defaultValue: 'blue', ctx });
       expect(result).toBe('red');
     });
   });
@@ -50,13 +44,13 @@ describe('select()', () => {
   describe('pipe mode', () => {
     it('accepts number from stdin', async () => {
       const ctx = createTestContext({ mode: 'pipe', io: { answers: ['3'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('blue');
     });
 
     it('returns first option when stdin is empty', async () => {
       const ctx = createTestContext({ mode: 'pipe', io: { answers: [''] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('red');
     });
   });
@@ -64,7 +58,7 @@ describe('select()', () => {
   describe('accessible mode', () => {
     it('prompt says "Enter number:"', async () => {
       const ctx = createTestContext({ mode: 'accessible', io: { answers: ['1'] } });
-      await select({ title: 'Color', options: OPTIONS, ctx });
+      await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       const output = ctx.io.written.join('');
       expect(output).toContain('Enter number:');
     });
@@ -84,7 +78,7 @@ describe('select()', () => {
   describe('interactive mode', () => {
     it('renders list with cursor on first item', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\r'] } });
-      await select({ title: 'Color', options: OPTIONS, ctx });
+      await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       const output = ctx.io.written.join('');
       expect(output).toContain('❯');
       expect(output).toContain('Red');
@@ -94,47 +88,42 @@ describe('select()', () => {
 
     it('down arrow + Enter selects second option', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[B', '\r'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('green');
     });
 
     it('up arrow wraps to last item', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b[A', '\r'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('blue');
     });
 
     it('Ctrl+C returns default/first value', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x03'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('red');
     });
 
     it('Escape returns default/first value', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, ctx });
       expect(result).toBe('red');
     });
 
     it('Escape returns defaultValue when set', async () => {
       const ctx = createTestContext({ mode: 'interactive', io: { keys: ['\x1b'] } });
-      const result = await select({ title: 'Color', options: OPTIONS, defaultValue: 'blue', ctx });
+      const result = await select({ title: 'Color', options: COLOR_OPTIONS, defaultValue: 'blue', ctx });
       expect(result).toBe('blue');
     });
 
     it('supports maxVisible scrolling for long option lists', async () => {
-      const many = Array.from({ length: 10 }, (_, i) => ({
-        label: `Option ${i + 1}`,
-        value: `v${i + 1}`,
-      }));
-
       const ctx = createTestContext({
         mode: 'interactive',
         io: { keys: ['\x1b[B', '\x1b[B', '\x1b[B', '\x1b[B', '\r'] },
       });
       const result = await select({
         title: 'Pick',
-        options: many,
+        options: MANY_OPTIONS,
         maxVisible: 3,
         ctx,
       });
@@ -148,17 +137,13 @@ describe('select()', () => {
     });
 
     it('sanitizes non-finite maxVisible values', async () => {
-      const many = Array.from({ length: 10 }, (_, i) => ({
-        label: `Option ${i + 1}`,
-        value: `v${i + 1}`,
-      }));
       const ctx = createTestContext({
         mode: 'interactive',
         io: { keys: ['\x1b[B', '\x1b[B', '\r'] },
       });
       const result = await select({
         title: 'Pick',
-        options: many,
+        options: MANY_OPTIONS,
         maxVisible: Number.NaN,
         ctx,
       });
@@ -170,7 +155,7 @@ describe('select()', () => {
 
   it('accepts ctx parameter', async () => {
     const ctx = createTestContext({ mode: 'pipe', io: { answers: ['1'] } });
-    const result = await select({ title: 'X', options: OPTIONS, ctx });
+    const result = await select({ title: 'X', options: COLOR_OPTIONS, ctx });
     expect(result).toBe('red');
     expect(ctx.io.written.length).toBeGreaterThan(0);
   });

--- a/packages/bijou/src/core/forms/select.ts
+++ b/packages/bijou/src/core/forms/select.ts
@@ -73,7 +73,6 @@ async function numberedSelect<T>(options: SelectOptions<T>, ctx: BijouContext): 
  */
 async function interactiveSelect<T>(options: SelectOptions<T>, ctx: BijouContext): Promise<T> {
   const noColor = ctx.theme.noColor;
-  const t = ctx.theme;
   const styledFn = createStyledFn(ctx);
   const boldFn = createBoldFn(ctx);
   const term = terminalRenderer(ctx);
@@ -113,9 +112,9 @@ async function interactiveSelect<T>(options: SelectOptions<T>, ctx: BijouContext
       const opt = visible[i]!;
       const isCurrent = globalIndex === cursor;
       const prefix = isCurrent ? '\u276f' : ' ';
-      const desc = opt.description ? styledFn(t.theme.semantic.muted, ` \u2014 ${opt.description}`) : '';
+      const desc = opt.description ? styledFn(ctx.semantic('muted'), ` \u2014 ${opt.description}`) : '';
       if (isCurrent && !noColor) {
-        ctx.io.write(`\x1b[K  ${styledFn(t.theme.semantic.info, prefix)} ${boldFn(opt.label)}${desc}\n`);
+        ctx.io.write(`\x1b[K  ${styledFn(ctx.semantic('info'), prefix)} ${boldFn(opt.label)}${desc}\n`);
       } else {
         ctx.io.write(`\x1b[K  ${prefix} ${opt.label}${desc}\n`);
       }
@@ -132,7 +131,7 @@ async function interactiveSelect<T>(options: SelectOptions<T>, ctx: BijouContext
     const totalLines = renderLineCount();
     term.clearBlock(totalLines);
     const selected = options.options[cursor] as SelectOption<T>;
-    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(t.theme.semantic.info, selected.label);
+    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(ctx.semantic('info'), selected.label);
     ctx.io.write(`\x1b[K${label}\n`);
     term.showCursor();
   }

--- a/packages/bijou/src/core/mode-render.ts
+++ b/packages/bijou/src/core/mode-render.ts
@@ -21,9 +21,12 @@ export type ModeMap<I, O> = {
 /**
  * Dispatch rendering to a mode-specific handler.
  *
- * If no handler is defined for the requested mode, it falls back to
- * `'pipe'`, then to `'accessible'`, then to `'static'`, and finally
- * to the first available handler in the map.
+ * If no handler is defined for the requested mode, it falls back to a
+ * sibling in the same visual group first: visual modes (`interactive`,
+ * `static`) fall back to each other, then to `pipe` → `accessible`;
+ * non-visual modes (`pipe`, `accessible`) fall back to each other, then
+ * to `interactive` → `static`. Finally falls back to the first available
+ * handler in the map.
  *
  * @template I - Input options type.
  * @template O - Output type.

--- a/packages/bijou/src/core/mode-render.ts
+++ b/packages/bijou/src/core/mode-render.ts
@@ -1,0 +1,63 @@
+import type { OutputMode } from './detect/tty.js';
+
+/**
+ * A renderer function for a specific output mode.
+ *
+ * @template I - Input options type.
+ * @template O - Output type (usually `string`).
+ */
+export type ModeHandler<I, O> = (options: I) => O;
+
+/**
+ * A map of renderers for each supported output mode.
+ *
+ * @template I - Input options type.
+ * @template O - Output type.
+ */
+export type ModeMap<I, O> = {
+  readonly [K in OutputMode]?: ModeHandler<I, O>;
+};
+
+/**
+ * Dispatch rendering to a mode-specific handler.
+ *
+ * If no handler is defined for the requested mode, it falls back to
+ * `'pipe'`, then to `'accessible'`, then to `'static'`, and finally
+ * to the first available handler in the map.
+ *
+ * @template I - Input options type.
+ * @template O - Output type.
+ * @param mode - The current output mode to dispatch for.
+ * @param map - Map of mode-specific renderer handlers.
+ * @param options - Options to pass to the selected handler.
+ * @returns The output from the selected handler.
+ * @throws {Error} If the map is empty.
+ */
+export function renderByMode<I, O>(
+  mode: OutputMode,
+  map: ModeMap<I, O>,
+  options: I,
+): O {
+  // 1. Direct match
+  const direct = map[mode];
+  if (direct) return direct(options);
+
+  // 2. Fallback chain
+  // - visual modes (interactive, static) fall back to each other first.
+  // - fallback modes (pipe, accessible) fall back to each other first.
+  const visual = mode === 'interactive' || mode === 'static';
+  const fallbacks: OutputMode[] = visual
+    ? ['interactive', 'static', 'pipe', 'accessible']
+    : ['pipe', 'accessible', 'interactive', 'static'];
+
+  for (const f of fallbacks) {
+    const handler = map[f];
+    if (handler) return handler(options);
+  }
+
+  // 3. First available
+  const first = Object.values(map)[0];
+  if (first) return (first as ModeHandler<I, O>)(options);
+
+  throw new Error(`renderByMode: no handlers defined in map for mode "${mode}"`);
+}

--- a/packages/bijou/src/factory.ts
+++ b/packages/bijou/src/factory.ts
@@ -2,7 +2,7 @@ import type { BijouContext } from './ports/context.js';
 import type { RuntimePort } from './ports/runtime.js';
 import type { IOPort } from './ports/io.js';
 import type { StylePort } from './ports/style.js';
-import type { Theme } from './core/theme/tokens.js';
+import type { Theme, TokenValue } from './core/theme/tokens.js';
 import type { OutputMode } from './core/detect/tty.js';
 import { createResolved, type ResolvedTheme } from './core/theme/resolve.js';
 import { CYAN_MAGENTA } from './core/theme/presets.js';
@@ -65,5 +65,16 @@ export function createBijou(options: CreateBijouOptions): BijouContext {
   const theme: ResolvedTheme = createResolved(themeObj, noColor);
   const mode: OutputMode = detectOutputMode(runtime);
 
-  return { theme, mode, runtime, io, style };
+  return {
+    theme,
+    mode,
+    runtime,
+    io,
+    style,
+    semantic: (key) => theme.theme.semantic[key],
+    border: (key) => theme.theme.border[key],
+    surface: (key) => theme.theme.surface[key],
+    status: (key) => (theme.theme.status as Record<string, TokenValue>)[key] ?? (theme.theme.status as Record<string, TokenValue>)['muted']!,
+    ui: (key) => (theme.theme.ui as Record<string, TokenValue>)[key] ?? theme.theme.semantic.primary,
+  };
 }

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -29,6 +29,13 @@ export {
 // Context resolution helpers
 export { resolveCtx, resolveSafeCtx } from './core/resolve-ctx.js';
 
+// Mode rendering strategy
+export {
+  renderByMode,
+  type ModeHandler,
+  type ModeMap,
+} from './core/mode-render.js';
+
 // Background fill utilities
 export { shouldApplyBg, makeBgFill } from './core/bg-fill.js';
 

--- a/packages/bijou/src/ports/context.ts
+++ b/packages/bijou/src/ports/context.ts
@@ -1,4 +1,5 @@
 import type { ResolvedTheme } from '../core/theme/resolve.js';
+import type { Theme, TokenValue } from '../core/theme/tokens.js';
 import type { OutputMode } from '../core/detect/tty.js';
 import type { RuntimePort } from './runtime.js';
 import type { IOPort } from './io.js';
@@ -21,4 +22,15 @@ export interface BijouContext {
   readonly io: IOPort;
   /** Color / text-decoration adapter. */
   readonly style: StylePort;
+
+  /** Look up a semantic color token. */
+  semantic(key: keyof Theme['semantic']): TokenValue;
+  /** Look up a border color token. */
+  border(key: keyof Theme['border']): TokenValue;
+  /** Look up a surface color token. */
+  surface(key: keyof Theme['surface']): TokenValue;
+  /** Look up a status color token with fallback to 'muted'. */
+  status(key: string): TokenValue;
+  /** Look up a UI element color token. */
+  ui(key: string): TokenValue;
 }


### PR DESCRIPTION
This PR implements three major milestones from the roadmap:

### Phase 5: Mode rendering strategy (OCP)
- Implemented `renderByMode` dispatcher in `packages/bijou/src/core/mode-render.ts`.
- Migrated all core components to use this dispatcher, eliminating repetitive `if (mode === ...)` chains.
- Improved `static` mode behavior to correctly fall back to rich rendering when possible.

### Phase 7: Theme access pattern (DIP)
- Added semantic lookup helpers to `BijouContext`: `semantic()`, `border()`, `surface()`, `status()`, and `ui()`.
- Refactored all components and examples to use these helpers, decoupling them from the internal theme object structure.

### Phase 6: Test suite hardening
- Extracted shared test fixtures (`MANY_OPTIONS`, `COLOR_OPTIONS`, etc.) into `adapters/test/fixtures.ts`.
- Added defensive null/undefined input handling and corresponding tests for `box()`, `headerBox()`, `alert()`, `table()`, and `markdown()`.
- Relaxed multiline string assertions to use `toContain` where appropriate.

### Documentation
- Updated `CHANGELOG.md` and package `GUIDE.md` files.
- Refactored example source code and READMEs to use the new architectural patterns.

Verified with 1,764 passing tests.