### PR TITLE
feat: v1.5.0 — Polish & Patterns

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,12 +2,6 @@
 
 All 77 items from the PR #28 / PR #29 self-review are complete and merged.
 
-The next milestones from `docs/ROADMAP.md` (in suggested order):
+The next milestone is **v1.5.0 — Polish & Patterns** (Phases 5, 6, 7, 7b). See `docs/ROADMAP.md` for details.
 
-1. **Phase 5: Mode rendering strategy (OCP)** — `ModeRenderer<I,O>` dispatcher pattern to replace 22 `if (mode === …)` chains.
-2. **Phase 6: Test suite hardening** — relax whitespace assertions, null/undefined input tests, shared fixtures (partially done).
-3. **Phase 7: Theme access pattern (DIP)** — `ctx.semantic(key)` / `ctx.border(key)` helpers to decouple components from theme shape.
-4. **Phase 8: App shell primitives** — `splitPane()`, `grid()`, scrollable `select()`.
-5. **Phase 9: `appFrame()`** — TEA app shell with tabs, help overlay, focus routing.
-
-Pick a milestone to expand into a detailed checklist.
+Pick a phase to expand into a detailed checklist.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,7 +1,12 @@
-# Next Up
+# v1.5.0 — Polish & Patterns
 
-All 77 items from the PR #28 / PR #29 self-review are complete and merged.
+All tasks complete. Summary moved to `docs/COMPLETED.md`.
 
-The next milestone is **v1.5.0 — Polish & Patterns** (Phases 5, 6, 7, 7b). See `docs/ROADMAP.md` for details.
-
-Pick a phase to expand into a detailed checklist.
+- [x] Add `gradient()` accessor to `BijouContext`
+- [x] Migrate remaining direct theme accesses (textarea-editor, progress, overlay.test)
+- [x] Relax brittle whitespace-sensitive test assertions
+- [x] Style pass: add bg support to alert, kbd, tabs, accordion, table, stepper, breadcrumb
+- [x] Write bg tests for all 7 components (31 new tests)
+- [x] Update ROADMAP — mark Phases 5, 6, 7, 7b complete
+- [x] Version bump to 1.5.0
+- [x] Update CHANGELOG

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/bijou-tui`, `@flyingrobots/bijou-tui-app`, `create-bijou-tui-app`) are versioned in lock-step.
 
+## [Unreleased]
+
+### ✨ Features
+
+- **`gradient()` theme accessor** — `ctx.gradient(key)` returns `GradientStop[]` for any named gradient, completing the theme accessor API (`semantic`, `border`, `surface`, `status`, `ui`, `gradient`).
+
+### ♻️ Refactors
+
+- **Migrated remaining direct theme accesses** — `textarea-editor.ts`, `progress.ts`, and `overlay.test.ts` now use `ctx.semantic()`, `ctx.gradient()`, and `ctx.border()` accessors instead of reaching into `ctx.theme.theme.*` directly. All source-level direct theme access is eliminated.
+
 ## [1.4.0] - 2026-03-07
 
 ### ✨ Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 - **`gradient()` theme accessor** — `ctx.gradient(key)` returns `GradientStop[]` for any named gradient, completing the theme accessor API (`semantic`, `border`, `surface`, `status`, `ui`, `gradient`).
 
+### 🧪 Tests
+
+- **Relaxed brittle multiline assertions** — Replaced exact multiline `toBe()` assertions with `toMatch()`/`toContain()` + per-line checks in `table.test.ts`, `enumerated-list.test.ts`, `tree.test.ts`, and `dag.test.ts`. Tests now verify content and structure without breaking on whitespace changes.
+
 ### ♻️ Refactors
 
 - **Migrated remaining direct theme accesses** — `textarea-editor.ts`, `progress.ts`, and `overlay.test.ts` now use `ctx.semantic()`, `ctx.gradient()`, and `ctx.border()` accessors instead of reaching into `ctx.theme.theme.*` directly. All source-level direct theme access is eliminated.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,15 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### ✨ Features
 
 - **`gradient()` theme accessor** — `ctx.gradient(key)` returns `GradientStop[]` for any named gradient, completing the theme accessor API (`semantic`, `border`, `surface`, `status`, `ui`, `gradient`).
+- **Background color support for 7 components** — Style pass adding `bgToken` / background fill support:
+  - `alert()` — `surface.elevated` bg on interior box (default, overridable via `bgToken`)
+  - `kbd()` — `surface.muted` bg for key-cap effect (default, overridable via `bgToken`)
+  - `tabs()` — `surface.muted` bg on active tab with padding (default, overridable via `activeBgToken`)
+  - `accordion()` — opt-in `headerBgToken` for expanded/collapsed section headers
+  - `table()` — opt-in `headerBgToken` for header row background
+  - `stepper()` — opt-in `activeBgToken` for active step indicator
+  - `breadcrumb()` — opt-in `currentBgToken` for current segment highlight
+  - All bg fills gracefully degrade in pipe/accessible/noColor modes via `shouldApplyBg()`
 
 ### 🧪 Tests
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/bijou-tui`, `@flyingrobots/bijou-tui-app`, `create-bijou-tui-app`) are versioned in lock-step.
 
-## [Unreleased]
+## [1.5.0] - 2026-03-07
 
 ### ✨ Features
 

--- a/docs/COMPLETED.md
+++ b/docs/COMPLETED.md
@@ -4,6 +4,14 @@ Shipped work, newest first. See [CHANGELOG.md](CHANGELOG.md) for detailed releas
 
 ---
 
+## v1.5.0 — Polish & Patterns
+
+- **Completed:** 2026-03-07
+- **Summary:** Completed Phases 5 (mode rendering), 6 (test hardening), 7 (theme accessors), and 7b (style pass). Added `gradient()` accessor to BijouContext, migrated all remaining direct theme accesses to typed accessors, relaxed brittle test assertions, and added background color support to 7 components (alert, kbd, tabs, accordion, table, stepper, breadcrumb).
+- **Ref:** v1.5.0, branch `feat/v1.5.0-polish-and-patterns`
+
+---
+
 ## PR #28 Review Improvements + PR #29 CodeRabbit Fixes
 
 - **Completed:** 2026-03-04

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Tests ARE the Spec.** Every feature is defined by its tests. If it's not tested, it's not guaranteed. Acceptance criteria are written as test descriptions first, implementation second.
 
-Latest: **v1.1.0** — Architecture audit + app shell
+Latest: **v1.5.0** — Polish & Patterns
 
 ---
 
@@ -63,49 +63,49 @@ Phases 8–9: App shell primitives — the layout and framing components needed 
 | ~~**Extract textarea editor**~~ | bijou | Done — `textarea-editor.ts` owns TextareaOptions and interactiveTextarea(). `textarea.ts` is the public facade. |
 | ~~**Extract filter interactive UI**~~ | bijou | Done — `filter-interactive.ts` owns FilterOption, FilterOptions, defaultMatch, interactiveFilter(). `filter.ts` is the public facade. |
 
-### Phase 5: Mode rendering strategy (OCP)
+### Phase 5: Mode rendering strategy (OCP) ✅
 
 **Problem:** ~22 components repeat `if (mode === 'pipe') ... if (mode === 'accessible') ...` chains. Adding a new output mode requires touching every component.
 
 | Task | Package | Notes |
 |------|---------|-------|
-| **Design mode renderer pattern** | bijou | Create a `ModeRenderer<Input, Output>` type and `renderByMode()` dispatcher that selects a handler from a mode→renderer map. Components register per-mode renderers instead of using if/else. |
-| **Migrate pilot components** | bijou | Convert `alert`, `badge`, `box` as proof-of-concept. Validate the pattern before wider rollout. |
-| **Migrate remaining components** | bijou | Convert all ~22 mode-branching components to the registry pattern. |
+| ~~**Design mode renderer pattern**~~ | bijou | ✅ Done — `renderByMode()` dispatcher in `core/mode-render.ts`. |
+| ~~**Migrate pilot components**~~ | bijou | ✅ Done — `alert`, `badge`, `box` converted. |
+| ~~**Migrate remaining components**~~ | bijou | ✅ Done — ~27 of 38 files use `renderByMode()`. Remaining ~11 are boolean guards (`shouldApplyBg`, `canvas` empty return, `formDispatch` TTY routing) that don't benefit from the dispatcher. |
 
-### Phase 6: Test suite hardening
+### Phase 6: Test suite hardening ✅
 
 **Problem:** Some tests are brittle (exact ANSI assertions, whitespace-sensitive `toBe`), and some edge cases are missing.
 
 | Task | Package | Notes |
 |------|---------|-------|
 | ~~**Replace exact ANSI assertions**~~ | bijou | ✅ Done — 12 raw ANSI assertions replaced with `expectNoAnsi()`, `expectHiddenCursor()`, `expectShownCursor()` semantic helpers. |
-| **Relax whitespace-sensitive assertions** | bijou | Audit `toBe` assertions on multi-line component output. Replace with `toContain` / `toMatch` where the test intent is "contains content" not "exact formatting". |
-| **Add null/undefined input tests** | bijou | Add defensive tests for all public component APIs: `box(null as any)`, `table({ columns: [], rows: [] })`, etc. |
-| **Extract shared test fixtures** | bijou | Create `test/fixtures.ts` with shared option arrays (`COLOR_OPTIONS`, `FRUIT_OPTIONS`) and context builders used across form tests. |
+| ~~**Relax whitespace-sensitive assertions**~~ | bijou | ✅ Done — Replaced multiline `toBe()` with `toMatch()`/`toContain()` + per-line checks in table, enumerated-list, tree, and dag tests. Pipe/accessible exact-format tests retained `toBe()`. |
+| ~~**Add null/undefined input tests**~~ | bijou | ✅ Done — Defensive tests for `box(null)`, `table({ columns: [], rows: [] })`, `alert(null)`, etc. already existed. |
+| ~~**Extract shared test fixtures**~~ | bijou | ✅ Done — `fixtures.ts` with `COLOR_OPTIONS`, `FRUIT_OPTIONS`, `MANY_OPTIONS` already existed. |
 | ~~**Create output assertion helpers**~~ | bijou | ✅ Done — 6 helpers: `expectNoAnsi()`, `expectNoAnsiSgr()`, `expectContainsAnsi()`, `expectHiddenCursor()`, `expectShownCursor()`, `expectWritten()`. Test-only, not in main barrel. |
 | ~~**noColor integration test suite**~~ | bijou | ✅ Done — 7 tests covering select, multiselect, filter, textarea, input, confirm with `noColor: true`. Interactive forms use `expectNoAnsiSgr()`, question-based use `expectNoAnsi()`. |
 
-### Phase 7: Theme access pattern (DIP)
+### Phase 7: Theme access pattern (DIP) ✅
 
 **Problem:** Every component hardcodes deep theme paths like `ctx.theme.theme.semantic.primary` and `ctx.theme.theme.border.primary`, coupling them to the exact theme object shape.
 
 | Task | Package | Notes |
 |------|---------|-------|
-| **Add theme query helpers** | bijou | `ctx.semantic(key)`, `ctx.border(key)` convenience accessors that encapsulate the path traversal. |
-| **Migrate components** | bijou | Replace `ctx.theme.theme.semantic.*` with `ctx.semantic()` calls across all components. |
+| ~~**Add theme query helpers**~~ | bijou | ✅ Done — `ctx.semantic(key)`, `ctx.border(key)`, `ctx.surface(key)`, `ctx.status(key)`, `ctx.ui(key)`, `ctx.gradient(key)` accessors on BijouContext. |
+| ~~**Migrate components**~~ | bijou | ✅ Done — All source-level `ctx.theme.theme.*` access replaced with typed accessors. Only test files asserting raw theme shape retain direct access. |
 
-### Phase 7b: Style pass
+### Phase 7b: Style pass ✅
 
 **Problem:** Most components were built function-first and never received a visual design pass. The bg infrastructure from Phase 3 (`surface` tokens, `bgToken`, `bgHex`) exists but only `box()`, `flex()`, `modal()`, `toast()`, and `drawer()` use it. Components like `alert()`, `table()`, `accordion()`, `timeline()`, `stepper()`, and others render with minimal styling — no background fills, inconsistent padding, and bare borders.
 
 | Task | Package | Notes |
 |------|---------|-------|
-| **Audit all components for bg opportunities** | bijou + bijou-tui | Catalog every component, note which ones would benefit from `surface` token backgrounds (e.g., `alert()` with `surface.elevated`, `table()` header rows with `surface.muted`). |
-| **Apply background fills** | bijou + bijou-tui | Add `bgToken` / `bg` support to components identified in audit. Ensure graceful degradation in pipe/accessible/noColor modes. |
-| **Improve spacing and padding** | bijou | Review default padding in `box()`, `alert()`, `headerBox()`, `accordion()`, etc. Ensure consistent internal margins. |
-| **Border treatment polish** | bijou | Audit border styles across components — ensure themed `border.*` tokens are applied consistently and defaults look cohesive. |
-| **Update examples and showcase** | examples | Refresh `examples/showcase/` and other demo scripts to reflect the improved visuals. |
+| ~~**Audit all components for bg opportunities**~~ | bijou + bijou-tui | ✅ Done — Categorized 17 components into high-value (alert, kbd, tabs), medium-value (accordion, table, stepper, breadcrumb), and no-bg (badge, separator, skeleton, tree, dag, etc.). |
+| ~~**Apply background fills**~~ | bijou + bijou-tui | ✅ Done — 7 components gained bg support: alert (surface.elevated), kbd (surface.muted), tabs (surface.muted), accordion/table/stepper/breadcrumb (opt-in). All degrade gracefully. |
+| ~~**Improve spacing and padding**~~ | bijou | ✅ Done — tabs() active tab padded with spaces around bg fill. Existing padding on alert/box already adequate. |
+| ~~**Border treatment polish**~~ | bijou | ✅ Done — All bordered components already use `ctx.border()` helpers consistently. |
+| ~~**Update examples and showcase**~~ | examples | ✅ No changes needed — showcase already uses all 7 components and picks up bg improvements automatically via default tokens. |
 
 ### Phase 8: App shell primitives
 
@@ -136,17 +136,12 @@ Phases 8–9: App shell primitives — the layout and framing components needed 
 
 ### Release targeting (current plan)
 
-**v1.5.0 — Polish & Patterns:**
+**v1.5.0 — Polish & Patterns: ✅ SHIPPED**
 
-- Phase 5: Mode rendering strategy (`ModeRenderer` dispatcher, migrate all ~22 components)
-- Phase 6: Test suite hardening (relax whitespace assertions, null/undefined tests, shared fixtures)
-- Phase 7: Theme access pattern (`ctx.semantic(key)` / `ctx.border(key)` helpers)
-- Style pass: visual polish sweep across all components — background colors, spacing, padding, border treatments
-
-**v1.5.0 stretch (only if low-risk):**
-
-- `drawer()` top/bottom anchors + region-scoped drawers
-- Improve docstring coverage to 80%
+- ~~Phase 5: Mode rendering strategy~~ ✅
+- ~~Phase 6: Test suite hardening~~ ✅
+- ~~Phase 7: Theme access pattern~~ ✅
+- ~~Phase 7b: Style pass~~ ✅
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -592,6 +592,7 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | **CodeRabbit review exclusions** | repo config | Add `CLAUDE.md`, `TASKS.md`, `docs/ROADMAP.md` to `.coderabbit.yaml` path filters to reduce false positives on project instructions and planning artifacts. |
 | **`detectColorScheme` env accessor** | bijou | Refactor inline `runtime ? runtime.env(key) : process.env[key]` to use shared `env()` closure, matching `detectOutputMode` pattern in the same file (`core/detect/tty.ts`). |
 | **Improve docstring coverage to 80%** | bijou | Audit exported functions across all packages and add missing JSDoc to reach the 80% threshold. |
+| **Style pass** | bijou | Visual polish sweep across all components. Audit each component for opportunities to use background colors (via `surface` tokens and `bgToken`/`bgHex`), improve default spacing, padding, and border treatments. Goal: every component should look intentionally designed out of the box, not just functional. Leverage the bg infrastructure from Phase 3 (v1.0.0) that most components don't yet use. |
 | ~~**Fix `k` key asymmetry in `filter-interactive`**~~ | bijou | ✅ Done — resolved via vim-style normal/insert mode switching. `k` navigates in normal mode, is typeable in insert mode. |
 | ~~**Wrap arrow position encoding in functions**~~ | bijou | ✅ Done — `encodeArrowPos()`/`decodeArrowPos()` using bitwise `(row << 16) \| col` encoding. `GRID_COL_MULTIPLIER` removed. |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -95,6 +95,18 @@ Phases 8–9: App shell primitives — the layout and framing components needed 
 | **Add theme query helpers** | bijou | `ctx.semantic(key)`, `ctx.border(key)` convenience accessors that encapsulate the path traversal. |
 | **Migrate components** | bijou | Replace `ctx.theme.theme.semantic.*` with `ctx.semantic()` calls across all components. |
 
+### Phase 7b: Style pass
+
+**Problem:** Most components were built function-first and never received a visual design pass. The bg infrastructure from Phase 3 (`surface` tokens, `bgToken`, `bgHex`) exists but only `box()`, `flex()`, `modal()`, `toast()`, and `drawer()` use it. Components like `alert()`, `table()`, `accordion()`, `timeline()`, `stepper()`, and others render with minimal styling — no background fills, inconsistent padding, and bare borders.
+
+| Task | Package | Notes |
+|------|---------|-------|
+| **Audit all components for bg opportunities** | bijou + bijou-tui | Catalog every component, note which ones would benefit from `surface` token backgrounds (e.g., `alert()` with `surface.elevated`, `table()` header rows with `surface.muted`). |
+| **Apply background fills** | bijou + bijou-tui | Add `bgToken` / `bg` support to components identified in audit. Ensure graceful degradation in pipe/accessible/noColor modes. |
+| **Improve spacing and padding** | bijou | Review default padding in `box()`, `alert()`, `headerBox()`, `accordion()`, etc. Ensure consistent internal margins. |
+| **Border treatment polish** | bijou | Audit border styles across components — ensure themed `border.*` tokens are applied consistently and defaults look cohesive. |
+| **Update examples and showcase** | examples | Refresh `examples/showcase/` and other demo scripts to reflect the improved visuals. |
+
 ### Phase 8: App shell primitives
 
 **Problem:** Building a multi-pane TUI app requires manually composing `flex()`, `focusArea()`, `createPanelGroup()`, `InputStack`, keymaps, and resize handling. Every non-trivial app re-implements the same shell: tabbed pages, help overlay, scroll, gutters, fullscreen layout. We need higher-level primitives so this is a one-liner.
@@ -124,27 +136,17 @@ Phases 8–9: App shell primitives — the layout and framing components needed 
 
 ### Release targeting (current plan)
 
-**v1.3.0 — App Shell Foundations (planned):**
+**v1.5.0 — Polish & Patterns:**
 
-- `splitPane()` v1 (stateful, focus-aware, test-first)
-- `grid()` v1 (fixed + fractional tracks, named areas)
-- `appFrame()` MVP (tabs/help/chrome/global+page keymaps)
-- per-page scroll isolation
-- multi-pane page support
-- panel-scoped overlays + `drawer()` anchor expansion
-- framed-app interaction harness (key replay + resize + frame snapshots)
+- Phase 5: Mode rendering strategy (`ModeRenderer` dispatcher, migrate all ~22 components)
+- Phase 6: Test suite hardening (relax whitespace assertions, null/undefined tests, shared fixtures)
+- Phase 7: Theme access pattern (`ctx.semantic(key)` / `ctx.border(key)` helpers)
+- Style pass: visual polish sweep across all components — background colors, spacing, padding, border treatments
 
-**v1.3.0 stretch (only if low-risk):**
+**v1.5.0 stretch (only if low-risk):**
 
-- scrollable `select()` (`filter()` already done)
-- frame-level command palette (`Ctrl+P`/`:`) for app/page actions
-
-**v1.4.0+ / experimental (after core shell stabilizes):**
-
-- tab/screen transitions (`wipe`/`dissolve`/`grid`/`fade`)
-- dockable panel manager (drag + keyboard move)
-- panel minimize/fold/unfold behaviors
-- layout presets + session restore for pane/dock state
+- `drawer()` top/bottom anchors + region-scoped drawers
+- Improve docstring coverage to 80%
 
 ---
 
@@ -592,7 +594,6 @@ Specs from XYPH for building an interactive roadmap DAG view with 2D panning, no
 | **CodeRabbit review exclusions** | repo config | Add `CLAUDE.md`, `TASKS.md`, `docs/ROADMAP.md` to `.coderabbit.yaml` path filters to reduce false positives on project instructions and planning artifacts. |
 | **`detectColorScheme` env accessor** | bijou | Refactor inline `runtime ? runtime.env(key) : process.env[key]` to use shared `env()` closure, matching `detectOutputMode` pattern in the same file (`core/detect/tty.ts`). |
 | **Improve docstring coverage to 80%** | bijou | Audit exported functions across all packages and add missing JSDoc to reach the 80% threshold. |
-| **Style pass** | bijou | Visual polish sweep across all components. Audit each component for opportunities to use background colors (via `surface` tokens and `bgToken`/`bgHex`), improve default spacing, padding, and border treatments. Goal: every component should look intentionally designed out of the box, not just functional. Leverage the bg infrastructure from Phase 3 (v1.0.0) that most components don't yet use. |
 | ~~**Fix `k` key asymmetry in `filter-interactive`**~~ | bijou | ✅ Done — resolved via vim-style normal/insert mode switching. `k` navigates in normal mode, is typeable in insert mode. |
 | ~~**Wrap arrow position encoding in functions**~~ | bijou | ✅ Done — `encodeArrowPos()`/`decodeArrowPos()` using bitwise `(row << 16) \| col` encoding. `GRID_COL_MULTIPLIER` removed. |
 

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -27,7 +27,7 @@
     "chalk": "^5.6.2"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "1.4.0"
+    "@flyingrobots/bijou": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui-app/package.json
+++ b/packages/bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Batteries-included TUI app skeleton built on bijou-tui createFramedApp().",
   "type": "module",
   "sideEffects": false,
@@ -24,8 +24,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "1.4.0",
-    "@flyingrobots/bijou-tui": "1.4.0"
+    "@flyingrobots/bijou": "1.5.0",
+    "@flyingrobots/bijou-tui": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "1.4.0"
+    "@flyingrobots/bijou": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/src/overlay.test.ts
+++ b/packages/bijou-tui/src/overlay.test.ts
@@ -202,7 +202,7 @@ describe('modal', () => {
       hint: 'hint',
       screenWidth: 40,
       screenHeight: 20,
-      borderToken: ctx.theme.theme.border.primary,
+      borderToken: ctx.border('primary'),
       ctx,
     });
     expect(stripAnsi(content)).toContain('Themed');
@@ -575,7 +575,7 @@ describe('drawer', () => {
       width: 20,
       screenWidth: 80,
       screenHeight: 5,
-      borderToken: ctx.theme.theme.border.primary,
+      borderToken: ctx.border('primary'),
       ctx,
     });
     expect(stripAnsi(d.content)).toContain('themed');
@@ -747,7 +747,7 @@ describe('tooltip', () => {
       ...base,
       row: 10,
       col: 40,
-      borderToken: ctx.theme.theme.border.primary,
+      borderToken: ctx.border('primary'),
       ctx,
     });
     expect(stripAnsi(t.content)).toContain('hint');

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/src/adapters/test/index.ts
+++ b/packages/bijou/src/adapters/test/index.ts
@@ -14,7 +14,7 @@ import { mockIO, type MockIOOptions, type MockIO } from './io.js';
 import { plainStyle } from './style.js';
 import { createResolved } from '../../core/theme/resolve.js';
 import { CYAN_MAGENTA } from '../../core/theme/presets.js';
-import type { Theme, TokenValue } from '../../core/theme/tokens.js';
+import type { Theme, TokenValue, GradientStop } from '../../core/theme/tokens.js';
 
 export { mockRuntime, type MockRuntimeOptions } from './runtime.js';
 export { mockIO, type MockIOOptions, type MockIO } from './io.js';
@@ -85,5 +85,6 @@ export function createTestContext(options: TestContextOptions = {}): TestContext
     surface: (key) => theme.theme.surface[key],
     status: (key) => (theme.theme.status as Record<string, TokenValue>)[key] ?? (theme.theme.status as Record<string, TokenValue>)['muted']!,
     ui: (key) => (theme.theme.ui as Record<string, TokenValue>)[key] ?? theme.theme.semantic.primary,
+    gradient: (key) => (theme.theme.gradient as Record<string, GradientStop[]>)[key] ?? [],
   };
 }

--- a/packages/bijou/src/core/components/accordion.test.ts
+++ b/packages/bijou/src/core/components/accordion.test.ts
@@ -65,4 +65,32 @@ describe('accordion', () => {
     const result = accordion(multi, { ctx });
     expect(result).toContain('  line1\n  line2');
   });
+
+  describe('background fill', () => {
+    it('applies headerBgToken when provided', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = accordion(sections, { headerBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Section A');
+      expect(result).toContain('▼');
+    });
+
+    it('no default bg (opt-in only)', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = accordion(sections, { ctx });
+      expect(result).toContain('Section A');
+      expect(result).toContain('▼');
+    });
+
+    it('skips headerBgToken in pipe mode', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      const result = accordion(sections, { headerBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('# Section A');
+    });
+
+    it('skips headerBgToken when noColor is true', () => {
+      const ctx = createTestContext({ mode: 'interactive', noColor: true });
+      const result = accordion(sections, { headerBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Section A');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/accordion.ts
+++ b/packages/bijou/src/core/components/accordion.ts
@@ -2,6 +2,7 @@ import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
+import { makeBgFill } from '../bg-fill.js';
 
 /** Represent a single collapsible section within an accordion. */
 export interface AccordionSection {
@@ -19,6 +20,8 @@ export interface AccordionOptions {
   indicatorToken?: TokenValue;
   /** Token used to style section titles. */
   titleToken?: TokenValue;
+  /** Background fill token for expanded section headers. No default — opt-in only. */
+  headerBgToken?: TokenValue;
   /** Bijou context for rendering mode and theme resolution. */
   ctx?: BijouContext;
 }
@@ -53,21 +56,24 @@ export function accordion(sections: AccordionSection[], options: AccordionOption
     interactive: () => {
       const indicatorToken = options.indicatorToken ?? ctx.semantic('accent');
       const titleToken = options.titleToken ?? ctx.semantic('primary');
+      const bgFill = makeBgFill(options.headerBgToken, ctx);
 
       return sections
         .map((s) => {
           if (s.expanded) {
             const indicator = ctx.style.styled(indicatorToken, '▼');
             const title = ctx.style.styled(titleToken, s.title);
+            const header = `${indicator} ${title}`;
             const indented = s.content
               .split('\n')
               .map((line) => `  ${line}`)
               .join('\n');
-            return `${indicator} ${title}\n${indented}`;
+            return `${bgFill ? bgFill(header) : header}\n${indented}`;
           }
           const indicator = ctx.style.styled(indicatorToken, '▶');
           const title = ctx.style.styled(titleToken, s.title);
-          return `${indicator} ${title}`;
+          const header = `${indicator} ${title}`;
+          return bgFill ? bgFill(header) : header;
         })
         .join('\n\n');
     },

--- a/packages/bijou/src/core/components/alert.test.ts
+++ b/packages/bijou/src/core/components/alert.test.ts
@@ -40,6 +40,40 @@ describe('alert', () => {
     expect(result).toContain('msg');
   });
 
+  describe('background fill', () => {
+    it('applies default bg (surface.elevated) in interactive mode', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = alert('bg test', { ctx });
+      expect(result).toContain('bg test');
+      expect(result).toContain('─');
+    });
+
+    it('accepts custom bgToken', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = alert('custom', { bgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('custom');
+    });
+
+    it('skips bg in pipe mode', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      const result = alert('piped', { ctx });
+      expect(result).toBe('[INFO] piped');
+    });
+
+    it('skips bg in accessible mode', () => {
+      const ctx = createTestContext({ mode: 'accessible' });
+      const result = alert('a11y', { ctx });
+      expect(result).toBe('Info: a11y');
+    });
+
+    it('skips bg when noColor is true', () => {
+      const ctx = createTestContext({ mode: 'interactive', noColor: true });
+      const result = alert('nocolor', { ctx });
+      expect(result).toContain('nocolor');
+      expect(result).toContain('─');
+    });
+  });
+
   describe('defensive input handling', () => {
     it('handles null/undefined message gracefully', () => {
       const ctx = createTestContext({ mode: 'pipe' });

--- a/packages/bijou/src/core/components/alert.ts
+++ b/packages/bijou/src/core/components/alert.ts
@@ -1,4 +1,5 @@
 import type { BijouContext } from '../../ports/context.js';
+import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { box } from './box.js';
 import { renderByMode } from '../mode-render.js';
@@ -10,6 +11,8 @@ export type AlertVariant = 'success' | 'error' | 'warning' | 'info';
 export interface AlertOptions {
   /** Severity variant (defaults to `'info'`). */
   variant?: AlertVariant;
+  /** Background fill token for the alert box interior. Defaults to `surface.elevated`. */
+  bgToken?: TokenValue;
   /** Bijou context for I/O, styling, and mode detection. */
   ctx?: BijouContext;
 }
@@ -74,6 +77,7 @@ export function alert(message: string, options: AlertOptions = {}): string {
 
       return box(coloredIcon + ' ' + safeMessage, {
         borderToken,
+        bgToken: options.bgToken ?? ctx.surface('elevated'),
         padding: { left: 1, right: 1 },
         ctx,
       });

--- a/packages/bijou/src/core/components/alert.ts
+++ b/packages/bijou/src/core/components/alert.ts
@@ -1,5 +1,5 @@
 import type { BijouContext } from '../../ports/context.js';
-import type { TokenValue } from '../theme/tokens.js';
+import type { Theme, TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { box } from './box.js';
 import { renderByMode } from '../mode-render.js';
@@ -42,7 +42,7 @@ const ACCESSIBLE_LABELS: Record<AlertVariant, string> = {
 };
 
 /** Mapping from alert variant to the corresponding border theme token key. */
-const BORDER_TOKENS: Record<AlertVariant, keyof BijouContext['theme']['theme']['border']> = {
+const BORDER_TOKENS: Record<AlertVariant, keyof Theme['border']> = {
   success: 'success',
   error: 'error',
   warning: 'warning',

--- a/packages/bijou/src/core/components/breadcrumb.test.ts
+++ b/packages/bijou/src/core/components/breadcrumb.test.ts
@@ -50,4 +50,31 @@ describe('breadcrumb', () => {
     const result = breadcrumb(['Home', 'About'], { ctx });
     expect(result).toBe('Home > About');
   });
+
+  describe('background fill', () => {
+    it('applies currentBgToken on last segment', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = breadcrumb(items, { currentBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Profile');
+      expect(result).toContain('›');
+    });
+
+    it('no default bg (opt-in only)', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = breadcrumb(items, { ctx });
+      expect(result).toContain('Profile');
+    });
+
+    it('skips currentBgToken in pipe mode', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      const result = breadcrumb(items, { currentBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toBe('Home > Settings > Profile');
+    });
+
+    it('skips currentBgToken when noColor is true', () => {
+      const ctx = createTestContext({ mode: 'interactive', noColor: true });
+      const result = breadcrumb(items, { currentBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Profile');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/breadcrumb.ts
+++ b/packages/bijou/src/core/components/breadcrumb.ts
@@ -1,11 +1,15 @@
 import type { BijouContext } from '../../ports/context.js';
+import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
+import { makeBgFill } from '../bg-fill.js';
 
 /** Configuration options for the {@link breadcrumb} component. */
 export interface BreadcrumbOptions {
   /** Custom separator between breadcrumb segments. Defaults to `' > '` (pipe) or `' › '` (rich). */
   separator?: string;
+  /** Background fill token for the current (last) breadcrumb segment. No default — opt-in only. */
+  currentBgToken?: TokenValue;
   /** Bijou context for rendering mode and theme resolution. */
   ctx?: BijouContext;
 }
@@ -37,12 +41,14 @@ export function breadcrumb(items: string[], options: BreadcrumbOptions = {}): st
     interactive: () => {
       const sep = options.separator ?? ' › ';
       const last = items.length - 1;
+      const bgFill = makeBgFill(options.currentBgToken, ctx);
       return items
         .map((item, i) => {
           if (i === last) {
             const token = ctx.semantic('primary');
             const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
-            return ctx.style.styled(boldToken, item);
+            const text = ctx.style.styled(boldToken, item);
+            return bgFill ? bgFill(` ${text} `) : text;
           }
           return ctx.style.styled(ctx.semantic('muted'), item);
         })

--- a/packages/bijou/src/core/components/dag.test.ts
+++ b/packages/bijou/src/core/components/dag.test.ts
@@ -873,7 +873,8 @@ describe('DagSource adapter', () => {
       };
       const sliced = dagSlice(custom, 'p', { direction: 'descendants' });
       const result = dag(sliced, { ctx });
-      expect(result).toBe('Parent -> Child\nChild');
+      expect(result).toContain('Parent -> Child');
+      expect(result).toContain('Child');
     });
 
     it('never calls ids() on the unbounded source', () => {

--- a/packages/bijou/src/core/components/dag.test.ts
+++ b/packages/bijou/src/core/components/dag.test.ts
@@ -874,7 +874,9 @@ describe('DagSource adapter', () => {
       const sliced = dagSlice(custom, 'p', { direction: 'descendants' });
       const result = dag(sliced, { ctx });
       expect(result).toContain('Parent -> Child');
-      expect(result).toContain('Child');
+      // Verify the standalone node label appears on its own line
+      const lines = result.split('\n');
+      expect(lines.some(l => l.trim() === 'Child')).toBe(true);
     });
 
     it('never calls ids() on the unbounded source', () => {

--- a/packages/bijou/src/core/components/enumerated-list.test.ts
+++ b/packages/bijou/src/core/components/enumerated-list.test.ts
@@ -47,7 +47,11 @@ describe('enumeratedList', () => {
   it('renders none style with indented items and no prefix', () => {
     const ctx = createTestContext({ mode: 'interactive' });
     const result = enumeratedList(['One', 'Two', 'Three'], { style: 'none', ctx });
-    expect(result).toBe('  One\n  Two\n  Three');
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toMatch(/^\s+One$/);
+    expect(lines[1]).toMatch(/^\s+Two$/);
+    expect(lines[2]).toMatch(/^\s+Three$/);
   });
 
   it('respects start offset', () => {
@@ -116,9 +120,10 @@ describe('enumeratedList', () => {
     const ctx = createTestContext({ mode: 'interactive' });
     const result = enumeratedList(['Line one\nLine two', 'Another'], { ctx });
     const lines = result.split('\n');
-    expect(lines[0]).toBe('  1. Line one');
-    expect(lines[1]).toBe('     Line two');
-    expect(lines[2]).toBe('  2. Another');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toMatch(/1\.\s+Line one$/);
+    expect(lines[1]).toMatch(/^\s+Line two$/);
+    expect(lines[2]).toMatch(/2\.\s+Another$/);
   });
 
   it('works with default options (no options passed)', () => {

--- a/packages/bijou/src/core/components/kbd.test.ts
+++ b/packages/bijou/src/core/components/kbd.test.ts
@@ -29,4 +29,36 @@ describe('kbd', () => {
     const ctx = createTestContext({ mode: 'interactive' });
     expect(kbd('Shift+Alt+F', { ctx })).toBe('[ Shift+Alt+F ]');
   });
+
+  describe('background fill', () => {
+    it('applies default bg (surface.muted) in interactive mode', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = kbd('Enter', { ctx });
+      expect(result).toContain('Enter');
+      expect(result).toContain('[');
+      expect(result).toContain(']');
+    });
+
+    it('accepts custom bgToken', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = kbd('Tab', { bgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Tab');
+    });
+
+    it('skips bg in pipe mode', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      expect(kbd('Esc', { ctx })).toBe('<Esc>');
+    });
+
+    it('skips bg in accessible mode', () => {
+      const ctx = createTestContext({ mode: 'accessible' });
+      expect(kbd('Tab', { ctx })).toBe('Tab');
+    });
+
+    it('skips bg when noColor is true', () => {
+      const ctx = createTestContext({ mode: 'interactive', noColor: true });
+      const result = kbd('Enter', { ctx });
+      expect(result).toContain('Enter');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/kbd.ts
+++ b/packages/bijou/src/core/components/kbd.ts
@@ -1,9 +1,13 @@
 import type { BijouContext } from '../../ports/context.js';
+import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
+import { makeBgFill } from '../bg-fill.js';
 
 /** Configuration for rendering a keyboard shortcut indicator. */
 export interface KbdOptions {
+  /** Background fill token for the key cap. Defaults to `surface.muted`. */
+  bgToken?: TokenValue;
   /** Bijou context for I/O, styling, and mode detection. */
   ctx?: BijouContext;
 }
@@ -29,8 +33,10 @@ export function kbd(key: string, options: KbdOptions = {}): string {
     interactive: () => {
       const borderToken = ctx.border('muted');
       const boldKey = ctx.style.bold(key);
+      const bgFill = makeBgFill(options.bgToken ?? ctx.surface('muted'), ctx);
 
-      return ctx.style.styled(borderToken, '[') + ' ' + boldKey + ' ' + ctx.style.styled(borderToken, ']');
+      const inner = ctx.style.styled(borderToken, '[') + ' ' + boldKey + ' ' + ctx.style.styled(borderToken, ']');
+      return bgFill ? bgFill(inner) : inner;
     },
   }, options);
 }

--- a/packages/bijou/src/core/components/progress.ts
+++ b/packages/bijou/src/core/components/progress.ts
@@ -51,7 +51,7 @@ export function progressBar(percent: number, options: ProgressBarOptions = {}): 
       const filledCount = Math.min(width, Math.max(0, Math.round((pct / 100) * width)));
 
       const noColor = ctx.theme.noColor;
-      const stops = options.gradient ?? ctx.theme.theme.gradient.progress ?? [];
+      const stops = options.gradient ?? ctx.gradient('progress');
 
       let bar = '';
       if (noColor || stops.length === 0) {

--- a/packages/bijou/src/core/components/stepper.test.ts
+++ b/packages/bijou/src/core/components/stepper.test.ts
@@ -56,4 +56,31 @@ describe('stepper', () => {
     expect(result).toContain('● Done');
     expect(result).not.toContain('──');
   });
+
+  describe('background fill', () => {
+    it('applies activeBgToken on current step', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = stepper(steps, { current: 1, activeBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Payment');
+      expect(result).toContain('●');
+    });
+
+    it('no default bg (opt-in only)', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = stepper(steps, { current: 1, ctx });
+      expect(result).toContain('Payment');
+    });
+
+    it('skips activeBgToken in pipe mode', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      const result = stepper(steps, { current: 1, activeBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toBe('[x] Account -- [*] Payment -- [ ] Confirm');
+    });
+
+    it('skips activeBgToken when noColor is true', () => {
+      const ctx = createTestContext({ mode: 'interactive', noColor: true });
+      const result = stepper(steps, { current: 1, activeBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Payment');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/stepper.ts
+++ b/packages/bijou/src/core/components/stepper.ts
@@ -1,6 +1,8 @@
 import type { BijouContext } from '../../ports/context.js';
+import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
+import { makeBgFill } from '../bg-fill.js';
 
 /** Represent a single step in a multi-step process. */
 export interface StepperStep {
@@ -12,6 +14,8 @@ export interface StepperStep {
 export interface StepperOptions {
   /** Zero-based index of the current (active) step. */
   current: number;
+  /** Background fill token for the active step indicator. No default — opt-in only. */
+  activeBgToken?: TokenValue;
   /** Bijou context for rendering mode and theme resolution. */
   ctx?: BijouContext;
 }
@@ -53,6 +57,7 @@ export function stepper(steps: StepperStep[], options: StepperOptions): string {
     interactive: () => {
       // interactive + static
       const connector = ctx.style.styled(ctx.semantic('muted'), '──');
+      const bgFill = makeBgFill(options.activeBgToken, ctx);
       return steps
         .map((step, i) => {
           if (i < current) {
@@ -62,7 +67,8 @@ export function stepper(steps: StepperStep[], options: StepperOptions): string {
           if (i === current) {
             const token = ctx.semantic('primary');
             const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
-            return `${ctx.style.styled(token, '●')} ${ctx.style.styled(boldToken, step.label)}`;
+            const text = `${ctx.style.styled(token, '●')} ${ctx.style.styled(boldToken, step.label)}`;
+            return bgFill ? bgFill(` ${text} `) : text;
           }
           const token = ctx.semantic('muted');
           return `${ctx.style.styled(token, '○')} ${ctx.style.styled(token, step.label)}`;

--- a/packages/bijou/src/core/components/table.test.ts
+++ b/packages/bijou/src/core/components/table.test.ts
@@ -45,6 +45,35 @@ describe('table', () => {
     expect(result).toBe('Name\tStatus\tScore');
   });
 
+  describe('background fill', () => {
+    it('applies headerBgToken in interactive mode', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = table({ columns, rows, headerBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Name');
+      expect(result).toContain('Alice');
+      expect(result).toContain('─');
+    });
+
+    it('no default bg (opt-in only)', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = table({ columns, rows, ctx });
+      expect(result).toContain('Name');
+      expect(result).toContain('─');
+    });
+
+    it('skips headerBgToken in pipe mode', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      const result = table({ columns, rows, headerBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Name\tStatus\tScore');
+    });
+
+    it('skips headerBgToken when noColor is true', () => {
+      const ctx = createTestContext({ mode: 'interactive', noColor: true });
+      const result = table({ columns, rows, headerBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Name');
+    });
+  });
+
   describe('defensive input handling', () => {
     it('handles empty columns gracefully', () => {
       const ctx = createTestContext({ mode: 'pipe' });

--- a/packages/bijou/src/core/components/table.test.ts
+++ b/packages/bijou/src/core/components/table.test.ts
@@ -48,14 +48,20 @@ describe('table', () => {
   describe('defensive input handling', () => {
     it('handles empty columns gracefully', () => {
       const ctx = createTestContext({ mode: 'pipe' });
-      // When columns is empty, pipe mode returns empty header line + data lines
-      expect(table({ columns: [], rows, ctx })).toBe('\nAlice\tactive\t95\nBob\tpending\t72');
+      const result = table({ columns: [], rows, ctx });
+      expect(result).toContain('Alice\tactive\t95');
+      expect(result).toContain('Bob\tpending\t72');
     });
 
     it('handles null/undefined fields in rows gracefully', () => {
       const ctx = createTestContext({ mode: 'pipe' });
       const badRows = [[null as any, undefined as any, 'value']];
-      expect(table({ columns, rows: badRows, ctx })).toBe('Name\tStatus\tScore\n\t\tvalue');
+      const result = table({ columns, rows: badRows, ctx });
+      expect(result).toContain('Name\tStatus\tScore');
+      expect(result).toContain('value');
+      // Null/undefined fields should become empty strings in TSV
+      const dataLine = result.split('\n').find(l => l.includes('value'))!;
+      expect(dataLine).toMatch(/\t\tvalue$/);
     });
   });
 });

--- a/packages/bijou/src/core/components/table.ts
+++ b/packages/bijou/src/core/components/table.ts
@@ -2,6 +2,7 @@ import type { BijouContext } from '../../ports/context.js';
 import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
+import { makeBgFill } from '../bg-fill.js';
 
 /** Definition for a single table column. */
 export interface TableColumn {
@@ -21,6 +22,8 @@ export interface TableOptions {
   headerToken?: TokenValue;
   /** Theme token applied to border characters. */
   borderToken?: TokenValue;
+  /** Background fill token for the header row. No default — opt-in only. */
+  headerBgToken?: TokenValue;
   /** Bijou context for I/O, styling, and mode detection. */
   ctx?: BijouContext;
 }
@@ -116,10 +119,12 @@ export function table(options: TableOptions): string {
       const midSep = hLine('\u251c', '\u253c', '\u2524');
       const bottom = hLine('\u2514', '\u2534', '\u2518');
 
+      const hdrBgFill = makeBgFill(options.headerBgToken, ctx);
       const headerCells = columns.map((col, i) =>
         ' ' + padRight(ctx.style.styled(headerToken, col.header ?? ''), colWidths[i]!) + ' ',
       );
-      const headerRow = bc(v) + headerCells.join(bc(v)) + bc(v);
+      const rawHeaderRow = bc(v) + headerCells.join(bc(v)) + bc(v);
+      const headerRow = hdrBgFill ? hdrBgFill(rawHeaderRow) : rawHeaderRow;
 
       const dataRows = rows.map((row) => {
         const cells = colWidths.map((w, i) => ' ' + padRight(row[i] ?? '', w) + ' ');

--- a/packages/bijou/src/core/components/tabs.test.ts
+++ b/packages/bijou/src/core/components/tabs.test.ts
@@ -56,4 +56,37 @@ describe('tabs', () => {
     const result = tabs([{ label: 'Mail', badge: '12' }], { active: 0, ctx });
     expect(result).toContain('Mail (12)');
   });
+
+  describe('background fill', () => {
+    it('applies default bg (surface.muted) on active tab in interactive mode', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = tabs(items, { active: 0, ctx });
+      expect(result).toContain('Dashboard');
+      expect(result).toContain('●');
+    });
+
+    it('accepts custom activeBgToken', () => {
+      const ctx = createTestContext({ mode: 'interactive' });
+      const result = tabs(items, { active: 1, activeBgToken: { hex: '#ffffff', bg: '#001122' }, ctx });
+      expect(result).toContain('Settings');
+    });
+
+    it('skips bg in pipe mode', () => {
+      const ctx = createTestContext({ mode: 'pipe' });
+      const result = tabs(items, { active: 0, ctx });
+      expect(result).toBe('[Dashboard] | Settings | Users (3)');
+    });
+
+    it('skips bg in accessible mode', () => {
+      const ctx = createTestContext({ mode: 'accessible' });
+      const result = tabs(items, { active: 0, ctx });
+      expect(result).toContain('Tab 1 of 3: Dashboard (active)');
+    });
+
+    it('skips bg when noColor is true', () => {
+      const ctx = createTestContext({ mode: 'interactive', noColor: true });
+      const result = tabs(items, { active: 0, ctx });
+      expect(result).toContain('Dashboard');
+    });
+  });
 });

--- a/packages/bijou/src/core/components/tabs.ts
+++ b/packages/bijou/src/core/components/tabs.ts
@@ -1,6 +1,8 @@
 import type { BijouContext } from '../../ports/context.js';
+import type { TokenValue } from '../theme/tokens.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
+import { makeBgFill } from '../bg-fill.js';
 
 /** Represent a single tab in a tab bar. */
 export interface TabItem {
@@ -16,6 +18,8 @@ export interface TabsOptions {
   active: number;
   /** Custom separator string between tabs. Defaults to `' | '` (pipe) or `' │ '` (rich). */
   separator?: string;
+  /** Background fill token for the active tab. Defaults to `surface.muted`. */
+  activeBgToken?: TokenValue;
   /** Bijou context for rendering mode and theme resolution. */
   ctx?: BijouContext;
 }
@@ -69,13 +73,15 @@ export function tabs(items: TabItem[], options: TabsOptions): string {
     interactive: () => {
       // interactive + static
       const sep = options.separator ?? ' │ ';
+      const bgFill = makeBgFill(options.activeBgToken ?? ctx.surface('muted'), ctx);
       return items
         .map((item, i) => {
           const label = formatLabel(item);
           if (i === active) {
             const token = ctx.semantic('primary');
             const boldToken = { hex: token.hex, modifiers: [...(token.modifiers ?? []), 'bold' as const] };
-            return `${ctx.style.styled(boldToken, '●')} ${ctx.style.styled(boldToken, label)}`;
+            const text = `${ctx.style.styled(boldToken, '●')} ${ctx.style.styled(boldToken, label)}`;
+            return bgFill ? bgFill(` ${text} `) : text;
           }
           return `  ${ctx.style.styled(ctx.semantic('muted'), label)}`;
         })

--- a/packages/bijou/src/core/components/tree.test.ts
+++ b/packages/bijou/src/core/components/tree.test.ts
@@ -27,7 +27,12 @@ describe('tree', () => {
   it('renders indented plain text in pipe mode', () => {
     const ctx = createTestContext({ mode: 'pipe' });
     const result = tree(simple, { ctx });
-    expect(result).toBe('src\n  index.ts\n  utils.ts\nREADME.md');
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toBe('src');
+    expect(lines[1]).toMatch(/^\s+index\.ts$/);
+    expect(lines[2]).toMatch(/^\s+utils\.ts$/);
+    expect(lines[3]).toBe('README.md');
   });
 
   it('renders indented text with item counts in accessible mode', () => {

--- a/packages/bijou/src/core/forms/textarea-editor.ts
+++ b/packages/bijou/src/core/forms/textarea-editor.ts
@@ -40,7 +40,6 @@ export interface TextareaOptions extends FieldOptions<string> {
  * @returns The entered text (newline-joined), or the default value on cancel.
  */
 export async function interactiveTextarea(options: TextareaOptions, ctx: BijouContext): Promise<string> {
-  const t = ctx.theme;
   const styledFn = createStyledFn(ctx);
   const height = options.height ?? 6;
   const renderWidth = options.width ?? 80;
@@ -64,7 +63,7 @@ export async function interactiveTextarea(options: TextareaOptions, ctx: BijouCo
 
   function render(): void {
     const label = formatFormTitle(options.title, ctx);
-    const hint = styledFn(t.theme.semantic.muted, ' (Ctrl+D to submit, Ctrl+C/Esc to cancel)');
+    const hint = styledFn(ctx.semantic('muted'), ' (Ctrl+D to submit, Ctrl+C/Esc to cancel)');
     term.writeLine(`${label}${hint}`);
 
     const vis = visibleLines();
@@ -76,11 +75,11 @@ export async function interactiveTextarea(options: TextareaOptions, ctx: BijouCo
       const rawLine = vis[i] ?? '';
       const line = rawLine.length > contentWidth ? rawLine.slice(0, contentWidth) : rawLine;
       const prefix = showLineNumbers
-        ? styledFn(t.theme.semantic.muted, `${String(lineIdx + 1).padStart(numWidth)} │ `)
+        ? styledFn(ctx.semantic('muted'), `${String(lineIdx + 1).padStart(numWidth)} │ `)
         : '  ';
 
       if (lineIdx === 0 && options.placeholder && lines.length === 1 && lines[0] === '') {
-        ctx.io.write(`\x1b[K${prefix}${styledFn(t.theme.semantic.muted, options.placeholder)}\n`);
+        ctx.io.write(`\x1b[K${prefix}${styledFn(ctx.semantic('muted'), options.placeholder)}\n`);
       } else {
         ctx.io.write(`\x1b[K${prefix}${line}\n`);
       }
@@ -89,7 +88,7 @@ export async function interactiveTextarea(options: TextareaOptions, ctx: BijouCo
     // Status line
     const pos = `Ln ${cursorRow + 1}, Col ${cursorCol + 1}`;
     const lenInfo = options.maxLength != null ? ` | ${totalLength}/${options.maxLength}` : '';
-    ctx.io.write(`\x1b[K${styledFn(t.theme.semantic.muted, pos + lenInfo)}\n`);
+    ctx.io.write(`\x1b[K${styledFn(ctx.semantic('muted'), pos + lenInfo)}\n`);
   }
 
   function clearRender(): void {
@@ -107,7 +106,7 @@ export async function interactiveTextarea(options: TextareaOptions, ctx: BijouCo
       : (value
         ? (value.includes('\n') ? `${value.split('\n').length} lines` : value)
         : '(empty)');
-    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(t.theme.semantic.info, summary);
+    const label = formatFormTitle(options.title, ctx) + ' ' + styledFn(ctx.semantic('info'), summary);
     ctx.io.write(`\x1b[K${label}\n`);
     term.showCursor();
   }

--- a/packages/bijou/src/factory.ts
+++ b/packages/bijou/src/factory.ts
@@ -2,7 +2,7 @@ import type { BijouContext } from './ports/context.js';
 import type { RuntimePort } from './ports/runtime.js';
 import type { IOPort } from './ports/io.js';
 import type { StylePort } from './ports/style.js';
-import type { Theme, TokenValue } from './core/theme/tokens.js';
+import type { Theme, TokenValue, GradientStop } from './core/theme/tokens.js';
 import type { OutputMode } from './core/detect/tty.js';
 import { createResolved, type ResolvedTheme } from './core/theme/resolve.js';
 import { CYAN_MAGENTA } from './core/theme/presets.js';
@@ -76,5 +76,6 @@ export function createBijou(options: CreateBijouOptions): BijouContext {
     surface: (key) => theme.theme.surface[key],
     status: (key) => (theme.theme.status as Record<string, TokenValue>)[key] ?? (theme.theme.status as Record<string, TokenValue>)['muted']!,
     ui: (key) => (theme.theme.ui as Record<string, TokenValue>)[key] ?? theme.theme.semantic.primary,
+    gradient: (key) => (theme.theme.gradient as Record<string, GradientStop[]>)[key] ?? [],
   };
 }

--- a/packages/bijou/src/ports/context.ts
+++ b/packages/bijou/src/ports/context.ts
@@ -1,5 +1,5 @@
 import type { ResolvedTheme } from '../core/theme/resolve.js';
-import type { Theme, TokenValue } from '../core/theme/tokens.js';
+import type { Theme, TokenValue, GradientStop } from '../core/theme/tokens.js';
 import type { OutputMode } from '../core/detect/tty.js';
 import type { RuntimePort } from './runtime.js';
 import type { IOPort } from './io.js';
@@ -33,4 +33,6 @@ export interface BijouContext {
   status(key: string): TokenValue;
   /** Look up a UI element color token. */
   ui(key: string): TokenValue;
+  /** Look up a gradient by key, returning its color stops. */
+  gradient(key: string): GradientStop[];
 }

--- a/packages/create-bijou-tui-app/package.json
+++ b/packages/create-bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bijou-tui-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Scaffold a new Bijou TUI app with batteries-included defaults.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Completes the v1.5.0 milestone — Phases 5, 6, 7, and 7b from the roadmap.

- **Phase 5 (Mode rendering):** Already implemented; confirmed ~27/38 files use `renderByMode()`, remaining ~11 are legitimate boolean guards
- **Phase 6 (Test hardening):** Relaxed brittle multiline `toBe()` assertions with `toMatch()`/`toContain()` + per-line checks
- **Phase 7 (Theme access):** Added `gradient()` accessor to `BijouContext`, migrated last 3 files with direct `ctx.theme.theme.*` access to typed accessors
- **Phase 7b (Style pass):** Added background color support to 7 components:
  - **Default bg:** `alert()` (surface.elevated), `kbd()` (surface.muted), `tabs()` (surface.muted on active tab)
  - **Opt-in bg:** `accordion()`, `table()`, `stepper()`, `breadcrumb()` accept optional bg tokens
  - All degrade gracefully in pipe/accessible/noColor modes via `shouldApplyBg()`

31 new tests, 1823 total passing, 0 type errors.

## Test plan

- [x] `npx vitest run --config vitest.config.ts` — 97 files, 1823 tests pass
- [x] `npx tsc --noEmit -p packages/bijou/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p packages/bijou-tui/tsconfig.json` — clean
- [ ] Visual check: `npx tsx examples/showcase/` — bg colors render on alert, kbd, tabs
- [ ] Pipe mode check: `echo | npx tsx examples/showcase/` — graceful degradation