### PR TITLE
feat: add scaffold canary smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
       - name: Smoke all examples
         if: matrix.node-version == 22
         run: npm run smoke:examples:all
+      - name: Smoke canary apps
+        if: matrix.node-version == 22
+        run: npm run smoke:canaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: npm run smoke:examples:all
       - name: Smoke canary apps
         if: matrix.node-version == 22
-        run: npm run smoke:canaries
+        run: npm run smoke:canaries -- --skip-build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Smoke all examples
         run: npm run smoke:examples:all
 
+      - name: Smoke canary apps
+        run: npm run smoke:canaries
+
       - name: Verify published files
         run: |
           (cd packages/bijou && npm pack --dry-run)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,7 +126,7 @@ jobs:
         run: npm run smoke:examples:all
 
       - name: Smoke canary apps
-        run: npm run smoke:canaries
+        run: npm run smoke:canaries -- --skip-build
 
       - name: Verify published files
         run: |

--- a/README.md
+++ b/README.md
@@ -186,9 +186,12 @@ npm run build:watch  # Incremental watch mode
 npm test             # Vitest suite
 npm run typecheck:test
 npm run smoke:examples:all
+npm run smoke:canaries
 npm run lint         # Typecheck each workspace package
 npm run clean        # Remove build outputs
 ```
+
+`npm run smoke:canaries` packs the current workspace packages, generates a stock `create-bijou-tui-app` app from the local CLI, installs both that TUI app and an internal core/static fixture from local tarballs, then smoke-runs both downstream canaries.
 
 Node.js version: `>=18`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### 🐛 Fixes
+
+- **Scaffold canary PTY shutdown race** — the PTY driver now treats queued late input/resize steps as no-ops once the child exits, preventing traceback noise from masking the actual canary failure.
+
 ## [3.0.0] - 2026-03-12
 
 ### BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck:test": "tsc --noEmit -p tsconfig.tests.json",
     "smoke:examples": "tsx scripts/smoke-v3-examples.ts",
     "smoke:examples:all": "tsx scripts/smoke-all-examples.ts",
+    "smoke:canaries": "tsx scripts/smoke-canaries.ts",
     "lint": "npm run lint --workspaces",
     "version": "bash scripts/version.sh"
   },

--- a/packages/create-bijou-tui-app/README.md
+++ b/packages/create-bijou-tui-app/README.md
@@ -48,6 +48,9 @@ From the repository root:
 # Run scaffolder unit tests
 npx vitest run --config vitest.config.ts packages/create-bijou-tui-app/src/index.test.ts
 
+# Validate the stock generated scaffold end-to-end from packed local tarballs
+npm run smoke:canaries
+
 # Smoke-test generated files without installing dependencies
 TMP="$(mktemp -d /tmp/bijou-scaffold-XXXXXX)"
 TARGET="$TMP/my-app"
@@ -59,5 +62,7 @@ cd "$TARGET"
 npm install
 npm run dev
 ```
+
+The canary smoke run is the strongest downstream check: it generates the stock scaffold, rewrites only the Bijou dependency specs to local tarballs, builds the app, and drives the shipped shell through tab switches, drawer toggles, resizes, and quit-confirm flows under a PTY.
 
 For upgrade notes and architecture context, see [`../../docs/MIGRATING_TO_V3.md`](../../docs/MIGRATING_TO_V3.md) and [`../../docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).

--- a/packages/create-bijou-tui-app/src/cli.test.ts
+++ b/packages/create-bijou-tui-app/src/cli.test.ts
@@ -1,8 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { runCli } from './cli.js';
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 function chunkToString(chunk: unknown): string {
   if (typeof chunk === 'string') return chunk;
@@ -126,4 +130,53 @@ describe('create-bijou-tui-app cli', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('runs correctly through the packed npm bin shim', () => {
+    const root = mkdtempSync(join(tmpdir(), 'create-bijou-pack-cli-'));
+    const packDir = join(root, 'pack');
+    const runnerDir = join(root, 'runner');
+    const targetDir = join(root, 'generated-app');
+    mkdirSync(packDir, { recursive: true });
+    mkdirSync(runnerDir, { recursive: true });
+
+    try {
+      const packed = spawnSync('npm', ['pack', '--json', '--pack-destination', packDir], {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf8',
+        maxBuffer: 8 * 1024 * 1024,
+      });
+      expect(packed.status).toBe(0);
+      const arrayStart = packed.stdout.indexOf('[');
+      const arrayEnd = packed.stdout.lastIndexOf(']');
+      expect(arrayStart).toBeGreaterThanOrEqual(0);
+      expect(arrayEnd).toBeGreaterThan(arrayStart);
+      const packOutput = JSON.parse(packed.stdout.slice(arrayStart, arrayEnd + 1)) as Array<{ filename?: string }>;
+      const tarball = resolve(packDir, packOutput[0]!.filename!);
+
+      const installed = spawnSync(
+        'npm',
+        ['install', '--prefix', runnerDir, '--no-package-lock', '--no-save', `file:${tarball}`],
+        {
+          cwd: PACKAGE_ROOT,
+          encoding: 'utf8',
+          maxBuffer: 8 * 1024 * 1024,
+        },
+      );
+      expect(installed.status).toBe(0);
+
+      const binPath = join(runnerDir, 'node_modules', '.bin', 'create-bijou-tui-app');
+      expect(existsSync(binPath)).toBe(true);
+
+      const result = spawnSync(binPath, [targetDir, '--no-install'], {
+        cwd: root,
+        encoding: 'utf8',
+        maxBuffer: 8 * 1024 * 1024,
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Created project in');
+      expect(existsSync(join(targetDir, 'package.json'))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 60000);
 });

--- a/packages/create-bijou-tui-app/src/cli.ts
+++ b/packages/create-bijou-tui-app/src/cli.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { realpathSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   type PackageManager,
   parseArgs,
@@ -106,5 +107,9 @@ if (isEntrypoint()) {
 /** Check if this module is being run as the CLI entrypoint. */
 function isEntrypoint(): boolean {
   if (process.argv[1] === undefined) return false;
-  return import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+  try {
+    return realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+  }
 }

--- a/scripts/canary-fixtures/core-static/package.json
+++ b/scripts/canary-fixtures/core-static/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bijou-core-static-canary",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "@flyingrobots/bijou": "latest",
+    "@flyingrobots/bijou-node": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/scripts/canary-fixtures/core-static/src/main.ts
+++ b/scripts/canary-fixtures/core-static/src/main.ts
@@ -1,0 +1,37 @@
+import {
+  alert,
+  badge,
+  headerBox,
+  progressBar,
+  separator,
+  surfaceToString,
+  table,
+} from '@flyingrobots/bijou';
+import { initDefaultContext } from '@flyingrobots/bijou-node';
+
+const ctx = initDefaultContext();
+const statusBadge = surfaceToString(badge('READY', { variant: 'success', ctx }), ctx.style);
+
+const lines = [
+  headerBox('Static Core Canary', { detail: 'downstream fixture', ctx }),
+  separator({ label: 'Compatibility seam', ctx }),
+  `Surface status: ${statusBadge}`,
+  alert('One-shot report rendered cleanly.', { variant: 'success', ctx }),
+  separator({ label: 'Progress', ctx }),
+  progressBar(72, { width: 24, showPercent: true, ctx }),
+  separator({ label: 'Packages', ctx }),
+  table({
+    columns: [
+      { header: 'package' },
+      { header: 'status' },
+    ],
+    rows: [
+      ['@flyingrobots/bijou', 'ready'],
+      ['@flyingrobots/bijou-node', 'ready'],
+    ],
+    ctx,
+  }),
+  'CANARY_STATIC_OK',
+];
+
+process.stdout.write(`${lines.join('\n')}\n`);

--- a/scripts/canary-fixtures/core-static/tsconfig.json
+++ b/scripts/canary-fixtures/core-static/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/scripts/pty-driver.py
+++ b/scripts/pty-driver.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import errno
 import json
 import os
 import selectors
@@ -20,11 +21,18 @@ def set_window_size(fd: int, rows: int, cols: int) -> None:
 
 
 def apply_step(master_fd: int, proc: subprocess.Popen[bytes], step: dict) -> None:
+    if proc.poll() is not None:
+        return
+
     step_type = step.get("type", "input")
 
     if step_type == "input":
         payload = step["input"].encode("utf-8", "surrogatepass")
-        os.write(master_fd, payload)
+        try:
+            os.write(master_fd, payload)
+        except OSError as exc:
+            if exc.errno not in (errno.EPIPE, errno.EIO):
+                raise
         return
 
     if step_type == "resize":
@@ -33,7 +41,11 @@ def apply_step(master_fd: int, proc: subprocess.Popen[bytes], step: dict) -> Non
         if rows <= 0 or cols <= 0:
             raise RuntimeError("resize step requires positive rows and cols")
         set_window_size(master_fd, rows, cols)
-        os.kill(proc.pid, signal.SIGWINCH)
+        try:
+            os.kill(proc.pid, signal.SIGWINCH)
+        except OSError as exc:
+            if exc.errno != errno.ESRCH:
+                raise
         return
 
     raise RuntimeError(f"Unsupported PTY step type: {step_type}")

--- a/scripts/pty-driver.py
+++ b/scripts/pty-driver.py
@@ -3,9 +3,38 @@
 import json
 import os
 import selectors
+import signal
 import subprocess
 import sys
 import time
+import fcntl
+import struct
+import termios
+
+
+def set_window_size(fd: int, rows: int, cols: int) -> None:
+    packed = struct.pack("HHHH", rows, cols, 0, 0)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, packed)
+
+
+def apply_step(master_fd: int, proc: subprocess.Popen[bytes], step: dict) -> None:
+    step_type = step.get("type", "input")
+
+    if step_type == "input":
+        payload = step["input"].encode("utf-8", "surrogatepass")
+        os.write(master_fd, payload)
+        return
+
+    if step_type == "resize":
+        rows = int(step["rows"])
+        cols = int(step["cols"])
+        if rows <= 0 or cols <= 0:
+            raise RuntimeError("resize step requires positive rows and cols")
+        set_window_size(master_fd, rows, cols)
+        os.kill(proc.pid, signal.SIGWINCH)
+        return
+
+    raise RuntimeError(f"Unsupported PTY step type: {step_type}")
 
 
 def main() -> int:
@@ -17,16 +46,20 @@ def main() -> int:
     argv = spec["argv"]
     cwd = spec["cwd"]
     steps = spec.get("steps", [])
+    proc = None
 
     env = os.environ.copy()
     for key, value in spec.get("env", {}).items():
-      if value is None:
-        env.pop(key, None)
-      else:
-        env[key] = str(value)
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = str(value)
 
     master_fd, slave_fd = os.openpty()
     try:
+        rows = int(spec.get("rows", 24))
+        cols = int(spec.get("cols", 80))
+        set_window_size(master_fd, rows, cols)
         proc = subprocess.Popen(
             argv,
             cwd=cwd,
@@ -51,8 +84,7 @@ def main() -> int:
         while True:
             now = time.monotonic()
             while next_step_index < len(steps) and now >= next_deadline:
-                payload = steps[next_step_index]["input"].encode("utf-8", "surrogatepass")
-                os.write(master_fd, payload)
+                apply_step(master_fd, proc, steps[next_step_index])
                 next_step_index += 1
                 if next_step_index < len(steps):
                     next_deadline = now + (steps[next_step_index].get("delayMs", 0) / 1000)
@@ -83,6 +115,8 @@ def main() -> int:
             sys.stdout.buffer.write(chunk)
             sys.stdout.buffer.flush()
     finally:
+        if proc is not None and proc.poll() is None:
+            proc.kill()
         selector.close()
         os.close(master_fd)
 

--- a/scripts/pty-driver.py
+++ b/scripts/pty-driver.py
@@ -11,6 +11,8 @@ import fcntl
 import struct
 import termios
 
+MARKER_PREFIX = "__BIJOU_STEP__:"
+
 
 def set_window_size(fd: int, rows: int, cols: int) -> None:
     packed = struct.pack("HHHH", rows, cols, 0, 0)
@@ -35,6 +37,27 @@ def apply_step(master_fd: int, proc: subprocess.Popen[bytes], step: dict) -> Non
         return
 
     raise RuntimeError(f"Unsupported PTY step type: {step_type}")
+
+
+def flush_ready_output(selector: selectors.BaseSelector, master_fd: int, timeout: float) -> None:
+    events = selector.select(timeout)
+    for _key, _mask in events:
+        try:
+            chunk = os.read(master_fd, 4096)
+        except OSError:
+            chunk = b""
+        if chunk:
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+
+
+def capture_until(selector: selectors.BaseSelector, master_fd: int, deadline: float) -> None:
+    while True:
+        now = time.monotonic()
+        if now >= deadline:
+            break
+        flush_ready_output(selector, master_fd, max(0.0, min(0.05, deadline - now)))
+    flush_ready_output(selector, master_fd, 0.0)
 
 
 def main() -> int:
@@ -84,23 +107,22 @@ def main() -> int:
         while True:
             now = time.monotonic()
             while next_step_index < len(steps) and now >= next_deadline:
-                apply_step(master_fd, proc, steps[next_step_index])
+                step = steps[next_step_index]
+                apply_step(master_fd, proc, step)
+                label = step.get("label")
+                if label:
+                    capture_ms = max(0, int(step.get("captureMs", 250)))
+                    capture_until(selector, master_fd, time.monotonic() + (capture_ms / 1000))
+                    sys.stdout.write(f"\n{MARKER_PREFIX}{label}\n")
+                    sys.stdout.flush()
                 next_step_index += 1
                 if next_step_index < len(steps):
-                    next_deadline = now + (steps[next_step_index].get("delayMs", 0) / 1000)
+                    next_deadline = time.monotonic() + (steps[next_step_index].get("delayMs", 0) / 1000)
                 else:
-                    next_deadline = now + 3600
+                    next_deadline = time.monotonic() + 3600
 
             timeout = max(0.0, min(0.05, next_deadline - now))
-            events = selector.select(timeout)
-            for _key, _mask in events:
-                try:
-                    chunk = os.read(master_fd, 4096)
-                except OSError:
-                    chunk = b""
-                if chunk:
-                    sys.stdout.buffer.write(chunk)
-                    sys.stdout.buffer.flush()
+            flush_ready_output(selector, master_fd, timeout)
 
             if proc.poll() is not None:
                 break

--- a/scripts/pty-driver.test.ts
+++ b/scripts/pty-driver.test.ts
@@ -1,0 +1,91 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DRIVER_PATH = resolve(ROOT, 'scripts/pty-driver.py');
+
+function runPython(source: string) {
+  return spawnSync('python3', ['-c', source, DRIVER_PATH], {
+    encoding: 'utf8',
+  });
+}
+
+describe('pty-driver apply_step', () => {
+  it('ignores late steps once the child has exited and tolerates expected shutdown races', () => {
+    const result = runPython(`
+import errno
+import importlib.util
+import pathlib
+import sys
+
+driver_path = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("pty_driver", driver_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class DeadProc:
+    pid = 999999
+
+    def poll(self):
+        return 0
+
+module.apply_step(-1, DeadProc(), {"type": "input", "input": "x"})
+module.apply_step(-1, DeadProc(), {"type": "resize", "rows": 24, "cols": 80})
+
+class LiveProc:
+    pid = 123
+
+    def poll(self):
+        return None
+
+module.os.write = lambda _fd, _payload: (_ for _ in ()).throw(OSError(errno.EPIPE, "broken pipe"))
+module.os.kill = lambda _pid, _sig: (_ for _ in ()).throw(OSError(errno.ESRCH, "gone"))
+module.set_window_size = lambda _fd, _rows, _cols: None
+
+module.apply_step(1, LiveProc(), {"type": "input", "input": "x"})
+module.apply_step(1, LiveProc(), {"type": "resize", "rows": 24, "cols": 80})
+
+print("ok")
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('ok');
+    expect(result.stderr).toBe('');
+  });
+
+  it('re-raises unexpected PTY write errors', () => {
+    const result = runPython(`
+import errno
+import importlib.util
+import pathlib
+import sys
+
+driver_path = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("pty_driver", driver_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class LiveProc:
+    pid = 123
+
+    def poll(self):
+        return None
+
+module.os.write = lambda _fd, _payload: (_ for _ in ()).throw(OSError(errno.EBADF, "bad fd"))
+
+try:
+    module.apply_step(1, LiveProc(), {"type": "input", "input": "x"})
+except OSError as exc:
+    print(exc.errno)
+    raise SystemExit(0)
+
+raise SystemExit(1)
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('9');
+    expect(result.stderr).toBe('');
+  });
+});

--- a/scripts/smoke-all-examples.ts
+++ b/scripts/smoke-all-examples.ts
@@ -4,6 +4,7 @@ import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { detectGarbage, inputStep, stripAnsi, type PtyStep } from './smoke-utils.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -21,11 +22,6 @@ const EXAMPLES = execSync('find examples -maxdepth 2 -name main.ts | sort', {
   .filter(Boolean);
 
 const TARGETS = [...TOP_LEVEL, ...EXAMPLES];
-
-interface ScriptStep {
-  input: string;
-  delayMs?: number;
-}
 
 const PLAIN_INPUTS: Readonly<Record<string, string>> = {
   'demo.ts': '2\n',
@@ -49,71 +45,55 @@ const DEFAULT_INPUT = [
   '',
 ].join('\n').repeat(8);
 
-const INTERACTIVE_FORM_SCRIPTS: Readonly<Record<string, readonly ScriptStep[]>> = {
+const INTERACTIVE_FORM_SCRIPTS: Readonly<Record<string, readonly PtyStep[]>> = {
   'demo.ts': [
-    { input: '\x1b[B', delayMs: 250 },
-    { input: '\r', delayMs: 120 },
+    inputStep('\x1b[B', 250),
+    inputStep('\r', 120),
   ],
   'examples/select/main.ts': [
-    { input: '\x1b[B', delayMs: 250 },
-    { input: '\r', delayMs: 120 },
+    inputStep('\x1b[B', 250),
+    inputStep('\r', 120),
   ],
   'examples/multiselect/main.ts': [
-    { input: ' ', delayMs: 250 },
-    { input: '\x1b[B', delayMs: 120 },
-    { input: ' ', delayMs: 120 },
-    { input: '\r', delayMs: 120 },
+    inputStep(' ', 250),
+    inputStep('\x1b[B', 120),
+    inputStep(' ', 120),
+    inputStep('\r', 120),
   ],
   'examples/filter/main.ts': [
-    { input: '/', delayMs: 250 },
-    { input: 'r', delayMs: 80 },
-    { input: 'u', delayMs: 60 },
-    { input: 's', delayMs: 60 },
-    { input: 't', delayMs: 60 },
-    { input: '\r', delayMs: 120 },
+    inputStep('/', 250),
+    inputStep('r', 80),
+    inputStep('u', 60),
+    inputStep('s', 60),
+    inputStep('t', 60),
+    inputStep('\r', 120),
   ],
   'examples/input/main.ts': [
-    { input: 'my-app\n', delayMs: 250 },
-    { input: 'A short description\n', delayMs: 250 },
+    inputStep('my-app\n', 250),
+    inputStep('A short description\n', 250),
   ],
   'examples/textarea/main.ts': [
-    { input: 'feat: smoke test', delayMs: 250 },
-    { input: '\x04', delayMs: 120 },
+    inputStep('feat: smoke test', 250),
+    inputStep('\x04', 120),
   ],
   'examples/confirm/main.ts': [
-    { input: 'y\n', delayMs: 250 },
+    inputStep('y\n', 250),
   ],
   'examples/form-group/main.ts': [
-    { input: 'my-app\n', delayMs: 250 },
-    { input: '\r', delayMs: 250 },
-    { input: ' ', delayMs: 250 },
-    { input: '\x1b[B', delayMs: 120 },
-    { input: ' ', delayMs: 120 },
-    { input: '\r', delayMs: 120 },
-    { input: 'y\n', delayMs: 250 },
+    inputStep('my-app\n', 250),
+    inputStep('\r', 250),
+    inputStep(' ', 250),
+    inputStep('\x1b[B', 120),
+    inputStep(' ', 120),
+    inputStep('\r', 120),
+    inputStep('y\n', 250),
   ],
   'examples/wizard/main.ts': [
-    { input: '\r', delayMs: 250 },
-    { input: 'aws\n', delayMs: 250 },
-    { input: 'y\n', delayMs: 250 },
+    inputStep('\r', 250),
+    inputStep('aws\n', 250),
+    inputStep('y\n', 250),
   ],
 };
-
-const RAW_SURFACE_PATTERNS = [
-  /cells:\s*\[/,
-  /clear:\s*\[Function:/,
-  /transform:\s*\[Function:/,
-  /width:\s*\d+,\s*\n\s*height:\s*\d+/,
-  /\[object Object\]/,
-];
-
-const ERROR_PATTERNS = [
-  /\[Pipeline Error\]/,
-  /\bTypeError:/,
-  /\bReferenceError:/,
-  /\bSyntaxError:/,
-  /\bUnhandled\b/i,
-];
 
 interface Result {
   path: string;
@@ -126,34 +106,13 @@ interface Result {
 interface Scenario {
   path: string;
   mode: Result['mode'];
-  steps?: readonly ScriptStep[];
+  steps?: readonly PtyStep[];
 }
 
 function isTuiTarget(relativePath: string): boolean {
   if (relativePath === 'demo-tui.ts') return true;
   const source = readFileSync(resolve(ROOT, relativePath), 'utf8');
   return source.includes('@flyingrobots/bijou-tui');
-}
-
-function stripAnsi(text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
-}
-
-function detectGarbage(cleanOutput: string): string | null {
-  for (const pattern of RAW_SURFACE_PATTERNS) {
-    if (pattern.test(cleanOutput)) {
-      return `raw Surface dump matched ${pattern}`;
-    }
-  }
-
-  for (const pattern of ERROR_PATTERNS) {
-    if (pattern.test(cleanOutput)) {
-      return `error output matched ${pattern}`;
-    }
-  }
-
-  return null;
 }
 
 async function runScenarioWithTimeout(scenario: Scenario): Promise<Result> {
@@ -253,7 +212,7 @@ function createStaticTtyChild(absPath: string): ChildProcess {
   );
 }
 
-function createInteractiveTtyChild(absPath: string, steps: readonly ScriptStep[]): ChildProcess {
+function createInteractiveTtyChild(absPath: string, steps: readonly PtyStep[]): ChildProcess {
   const spec = {
     argv: [process.execPath, '--import', 'tsx', absPath],
     cwd: ROOT,

--- a/scripts/smoke-canaries.ts
+++ b/scripts/smoke-canaries.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env npx tsx
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   detectGarbage,
   inputStep,
+  PTY_MARKER_PREFIX,
   resizeStep,
   rewritePackageManifestToTarballs,
   stripAnsi,
@@ -17,6 +18,7 @@ import {
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const FIXTURE_ROOT = resolve(ROOT, 'scripts/canary-fixtures/core-static');
 const KEEP_TEMP = process.env['BIJOU_KEEP_CANARY_TMP'] === '1';
+const SKIP_BUILD = process.argv.includes('--skip-build');
 
 interface PublishableUnit {
   readonly name: string;
@@ -35,23 +37,27 @@ interface CommandOptions {
 }
 
 const TUI_CANARY_STEPS: readonly PtyStep[] = [
-  inputStep(']', 500),
-  inputStep('[', 350),
-  inputStep('o', 350),
-  inputStep('o', 550),
-  resizeStep(120, 36, 700),
-  resizeStep(92, 24, 700),
-  inputStep('q', 400),
-  inputStep('n', 250),
-  inputStep('q', 350),
+  inputStep('', 600, 'initial', 150),
+  inputStep(']', 200, 'split', 650),
+  inputStep('[', 200, 'home-return', 500),
+  inputStep('o', 200, 'drawer-closed', 1200),
+  resizeStep(120, 36, 200, 'resize-large', 700),
+  resizeStep(92, 24, 200, 'resize-small', 700),
+  inputStep('q', 200, 'quit-open', 450),
+  inputStep('n', 200, 'quit-cancel', 450),
+  inputStep('q', 200, 'quit-reopen', 450),
   inputStep('y', 250),
 ];
 
 function main(): void {
   try {
-    process.stdout.write('smoke-canaries: building workspace artifacts ... ');
-    runCommand('workspace build', 'npm', ['run', 'build'], { cwd: ROOT }, { quietSuccess: true });
-    process.stdout.write('ok\n');
+    if (SKIP_BUILD) {
+      process.stdout.write('smoke-canaries: skipping workspace build (--skip-build)\n');
+    } else {
+      process.stdout.write('smoke-canaries: building workspace artifacts ... ');
+      runCommand('workspace build', 'npm', ['run', 'build'], { cwd: ROOT }, { quietSuccess: true });
+      process.stdout.write('ok\n');
+    }
 
     const tempRoot = mkdtempSync(join(tmpdir(), 'bijou-canaries-'));
 
@@ -113,11 +119,26 @@ function packPublishableUnits(tempRoot: string): Readonly<Record<string, string>
 
 function runTuiCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, string>>): void {
   const targetDir = resolve(tempRoot, 'generated-tui');
+  const cliTarball = tarballSpecs['create-bijou-tui-app'];
+  if (cliTarball == null) {
+    throw new Error('missing packed create-bijou-tui-app tarball');
+  }
+  const cliRunnerDir = resolve(tempRoot, 'cli-runner');
+  mkdirSync(cliRunnerDir, { recursive: true });
+  runSimpleNpmLifecycle(
+    'install packed scaffold CLI',
+    ROOT,
+    ['install', '--prefix', cliRunnerDir, '--no-package-lock', '--no-save', cliTarball],
+  );
+  const cliBin = resolve(cliRunnerDir, 'node_modules/.bin/create-bijou-tui-app');
+  if (!existsSync(cliBin)) {
+    throw new Error(`installed create-bijou-tui-app tarball did not produce a bin shim at ${cliBin}`);
+  }
   process.stdout.write('generate TUI canary ... ');
   runCommand(
     'generate TUI canary',
-    process.execPath,
-    ['--import', 'tsx', resolve(ROOT, 'packages/create-bijou-tui-app/src/cli.ts'), targetDir, '--no-install'],
+    cliBin,
+    [targetDir, '--no-install'],
     { cwd: ROOT },
     { quietSuccess: true },
   );
@@ -130,21 +151,44 @@ function runTuiCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, st
 
   process.stdout.write('run TUI canary ... ');
   const output = runPtyScenario(targetDir, TUI_CANARY_STEPS);
-  assertOutput(
-    'TUI canary',
-    output,
-    [
-      'My Bijou App',
-      'Home',
-      'Split',
-      'Home ready',
-      'Split ready',
-      'Panel drawer',
-      '1/3',
-      'Right pane',
-      'Quit App?',
-    ],
-  );
+  assertOutputFreeOfGarbage('TUI canary', output);
+  const checkpoints = parseCheckpointSegments(output);
+  assertCheckpointContains(checkpoints, 'initial', [
+    'My Bijou App',
+    'Home',
+    'Split',
+    'Home ready',
+    'Panel drawer',
+  ]);
+  assertCheckpointContains(checkpoints, 'split', [
+    'Split ready',
+    '1/3',
+    'Right pane',
+  ]);
+  assertCheckpointContains(checkpoints, 'home-return', [
+    'Home ready',
+    'Panel drawer',
+  ]);
+  assertCheckpointContains(checkpoints, 'drawer-closed', [
+    'Open: no',
+  ]);
+  assertCheckpointContains(checkpoints, 'resize-large', [
+    'Home ready',
+    'Home',
+  ]);
+  assertCheckpointContains(checkpoints, 'resize-small', [
+    'Home ready',
+    'Home',
+  ]);
+  assertCheckpointContains(checkpoints, 'quit-open', [
+    'Quit App?',
+  ]);
+  assertCheckpointAbsent(checkpoints, 'quit-cancel', [
+    'Quit App?',
+  ]);
+  assertCheckpointContains(checkpoints, 'quit-reopen', [
+    'Quit App?',
+  ]);
   process.stdout.write('ok\n');
 }
 
@@ -172,7 +216,8 @@ function runCoreStaticCanary(tempRoot: string, tarballSpecs: Readonly<Record<str
     { quietSuccess: true, timeoutMs: 10000 },
   );
   const output = `${result.stdout}${result.stderr}`;
-  assertOutput(
+  assertOutputFreeOfGarbage('core/static canary', output);
+  assertOutputContains(
     'core/static canary',
     output,
     [
@@ -247,16 +292,70 @@ function parsePackResult(stdout: string, packageName: string): { filename: strin
   return { filename };
 }
 
-function assertOutput(label: string, output: string, expected: readonly string[]): void {
+function assertOutputFreeOfGarbage(label: string, output: string): void {
   const clean = stripAnsi(output);
   const garbage = detectGarbage(clean);
   if (garbage != null) {
     throw new Error(`${label} produced garbage output: ${garbage}\n${tail(clean)}`);
   }
+}
 
+function assertOutputContains(label: string, output: string, expected: readonly string[]): void {
+  const clean = stripAnsi(output);
   const missing = expected.filter((needle) => !clean.includes(needle));
   if (missing.length > 0) {
     throw new Error(`${label} output missing expected text: ${missing.join(', ')}\n${tail(clean)}`);
+  }
+}
+
+function parseCheckpointSegments(output: string): ReadonlyMap<string, string> {
+  const clean = stripAnsi(output);
+  const lines = clean.split('\n');
+  const checkpoints = new Map<string, string>();
+  const buffer: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith(PTY_MARKER_PREFIX)) {
+      const label = line.slice(PTY_MARKER_PREFIX.length).trim();
+      checkpoints.set(label, buffer.join('\n'));
+      buffer.length = 0;
+      continue;
+    }
+    buffer.push(line);
+  }
+
+  return checkpoints;
+}
+
+function assertCheckpointContains(
+  checkpoints: ReadonlyMap<string, string>,
+  label: string,
+  expected: readonly string[],
+): void {
+  const segment = checkpoints.get(label);
+  if (segment == null) {
+    throw new Error(`missing PTY checkpoint "${label}"`);
+  }
+
+  const missing = expected.filter((needle) => !segment.includes(needle));
+  if (missing.length > 0) {
+    throw new Error(`checkpoint "${label}" missing expected text: ${missing.join(', ')}\n${tail(segment)}`);
+  }
+}
+
+function assertCheckpointAbsent(
+  checkpoints: ReadonlyMap<string, string>,
+  label: string,
+  forbidden: readonly string[],
+): void {
+  const segment = checkpoints.get(label);
+  if (segment == null) {
+    throw new Error(`missing PTY checkpoint "${label}"`);
+  }
+
+  const present = forbidden.filter((needle) => segment.includes(needle));
+  if (present.length > 0) {
+    throw new Error(`checkpoint "${label}" unexpectedly contained: ${present.join(', ')}\n${tail(segment)}`);
   }
 }
 

--- a/scripts/smoke-canaries.ts
+++ b/scripts/smoke-canaries.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env npx tsx
+
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  detectGarbage,
+  inputStep,
+  resizeStep,
+  rewritePackageManifestToTarballs,
+  stripAnsi,
+  type PtyStep,
+} from './smoke-utils.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const FIXTURE_ROOT = resolve(ROOT, 'scripts/canary-fixtures/core-static');
+const KEEP_TEMP = process.env['BIJOU_KEEP_CANARY_TMP'] === '1';
+
+interface PublishableUnit {
+  readonly name: string;
+  readonly dir: string;
+}
+
+interface CommandResult {
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface CommandOptions {
+  readonly cwd: string;
+  readonly env?: Record<string, string | null | undefined>;
+  readonly timeoutMs?: number;
+}
+
+const TUI_CANARY_STEPS: readonly PtyStep[] = [
+  inputStep(']', 500),
+  inputStep('[', 350),
+  inputStep('o', 350),
+  inputStep('o', 550),
+  resizeStep(120, 36, 700),
+  resizeStep(92, 24, 700),
+  inputStep('q', 400),
+  inputStep('n', 250),
+  inputStep('q', 350),
+  inputStep('y', 250),
+];
+
+function main(): void {
+  try {
+    process.stdout.write('smoke-canaries: building workspace artifacts ... ');
+    runCommand('workspace build', 'npm', ['run', 'build'], { cwd: ROOT }, { quietSuccess: true });
+    process.stdout.write('ok\n');
+
+    const tempRoot = mkdtempSync(join(tmpdir(), 'bijou-canaries-'));
+
+    try {
+      const tarballSpecs = packPublishableUnits(tempRoot);
+      runTuiCanary(tempRoot, tarballSpecs);
+      runCoreStaticCanary(tempRoot, tarballSpecs);
+      process.stdout.write('smoke-canaries: all canaries passed\n');
+    } finally {
+      if (!KEEP_TEMP) {
+        rmSync(tempRoot, { recursive: true, force: true });
+      } else {
+        process.stdout.write(`smoke-canaries: kept temp workspace at ${tempRoot}\n`);
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`smoke-canaries: FAIL\n${message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function discoverPublishableUnits(): readonly PublishableUnit[] {
+  const packagesDir = resolve(ROOT, 'packages');
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => resolve(packagesDir, entry.name))
+    .sort()
+    .map((dir) => {
+      const packageJsonPath = resolve(dir, 'package.json');
+      const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { name: string; private?: boolean };
+      return { name: manifest.name, dir, private: manifest.private === true };
+    })
+    .filter((entry) => !entry.private)
+    .map(({ name, dir }) => ({ name, dir }));
+}
+
+function packPublishableUnits(tempRoot: string): Readonly<Record<string, string>> {
+  const tarballDir = resolve(tempRoot, 'tarballs');
+  mkdirSync(tarballDir, { recursive: true });
+  const tarballSpecs: Record<string, string> = {};
+
+  for (const unit of discoverPublishableUnits()) {
+    process.stdout.write(`pack ${unit.name} ... `);
+    const result = runCommand(
+      `pack ${unit.name}`,
+      'npm',
+      ['pack', '--json', '--pack-destination', tarballDir],
+      { cwd: unit.dir },
+      { quietSuccess: true },
+    );
+    const packed = parsePackResult(result.stdout, unit.name);
+    tarballSpecs[unit.name] = `file:${resolve(tarballDir, packed.filename)}`;
+    process.stdout.write('ok\n');
+  }
+
+  return tarballSpecs;
+}
+
+function runTuiCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, string>>): void {
+  const targetDir = resolve(tempRoot, 'generated-tui');
+  process.stdout.write('generate TUI canary ... ');
+  runCommand(
+    'generate TUI canary',
+    process.execPath,
+    ['--import', 'tsx', resolve(ROOT, 'packages/create-bijou-tui-app/src/cli.ts'), targetDir, '--no-install'],
+    { cwd: ROOT },
+    { quietSuccess: true },
+  );
+  process.stdout.write('ok\n');
+
+  rewriteManifest(resolve(targetDir, 'package.json'), tarballSpecs);
+
+  runSimpleNpmLifecycle('install TUI canary', targetDir, ['install', '--no-fund', '--no-audit']);
+  runSimpleNpmLifecycle('build TUI canary', targetDir, ['run', 'build']);
+
+  process.stdout.write('run TUI canary ... ');
+  const output = runPtyScenario(targetDir, TUI_CANARY_STEPS);
+  assertOutput(
+    'TUI canary',
+    output,
+    [
+      'My Bijou App',
+      'Home',
+      'Split',
+      'Home ready',
+      'Split ready',
+      'Panel drawer',
+      '1/3',
+      'Right pane',
+      'Quit App?',
+    ],
+  );
+  process.stdout.write('ok\n');
+}
+
+function runCoreStaticCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, string>>): void {
+  const targetDir = resolve(tempRoot, 'core-static');
+  cpSync(FIXTURE_ROOT, targetDir, { recursive: true });
+  rewriteManifest(resolve(targetDir, 'package.json'), tarballSpecs);
+
+  runSimpleNpmLifecycle('install core/static canary', targetDir, ['install', '--no-fund', '--no-audit']);
+  runSimpleNpmLifecycle('build core/static canary', targetDir, ['run', 'build']);
+
+  process.stdout.write('run core/static canary ... ');
+  const result = runCommand(
+    'run core/static canary',
+    process.execPath,
+    ['dist/main.js'],
+    {
+      cwd: targetDir,
+      env: {
+        TERM: 'dumb',
+        NO_COLOR: '1',
+        CI: null,
+      },
+    },
+    { quietSuccess: true, timeoutMs: 10000 },
+  );
+  const output = `${result.stdout}${result.stderr}`;
+  assertOutput(
+    'core/static canary',
+    output,
+    [
+      'Static Core Canary',
+      'Compatibility seam',
+      'Surface status:',
+      'One-shot report rendered cleanly.',
+      'CANARY_STATIC_OK',
+    ],
+  );
+  process.stdout.write('ok\n');
+}
+
+function runSimpleNpmLifecycle(label: string, cwd: string, args: readonly string[]): void {
+  process.stdout.write(`${label} ... `);
+  runCommand(label, 'npm', [...args], { cwd }, { quietSuccess: true, timeoutMs: 120000 });
+  process.stdout.write('ok\n');
+}
+
+function runPtyScenario(cwd: string, steps: readonly PtyStep[]): string {
+  const spec = {
+    argv: [process.execPath, 'dist/main.js'],
+    cwd,
+    cols: 100,
+    rows: 30,
+    env: {
+      TERM: 'xterm-256color',
+      CI: null,
+      NO_COLOR: null,
+      BIJOU_ACCESSIBLE: null,
+    },
+    steps,
+  };
+
+  const result = runCommand(
+    'run TUI canary',
+    'python3',
+    [resolve(ROOT, 'scripts/pty-driver.py')],
+    {
+      cwd: ROOT,
+      env: {
+        BIJOU_PTY_SPEC: JSON.stringify(spec),
+      },
+      timeoutMs: 20000,
+    },
+    { quietSuccess: true },
+  );
+
+  return `${result.stdout}${result.stderr}`;
+}
+
+function rewriteManifest(packageJsonPath: string, tarballSpecs: Readonly<Record<string, string>>): void {
+  const source = readFileSync(packageJsonPath, 'utf8');
+  const rewritten = rewritePackageManifestToTarballs(source, tarballSpecs);
+  writeFileSync(packageJsonPath, rewritten, 'utf8');
+}
+
+function parsePackResult(stdout: string, packageName: string): { filename: string } {
+  const trimmed = stdout.trim();
+  const arrayStart = trimmed.indexOf('[');
+  const arrayEnd = trimmed.lastIndexOf(']');
+  if (arrayStart === -1 || arrayEnd === -1 || arrayEnd < arrayStart) {
+    throw new Error(`could not parse npm pack output for ${packageName}\n${trimmed}`);
+  }
+
+  const parsed = JSON.parse(trimmed.slice(arrayStart, arrayEnd + 1)) as Array<{ filename?: string }>;
+  const filename = parsed[0]?.filename;
+  if (filename == null || filename === '') {
+    throw new Error(`npm pack did not report a filename for ${packageName}\n${trimmed}`);
+  }
+
+  return { filename };
+}
+
+function assertOutput(label: string, output: string, expected: readonly string[]): void {
+  const clean = stripAnsi(output);
+  const garbage = detectGarbage(clean);
+  if (garbage != null) {
+    throw new Error(`${label} produced garbage output: ${garbage}\n${tail(clean)}`);
+  }
+
+  const missing = expected.filter((needle) => !clean.includes(needle));
+  if (missing.length > 0) {
+    throw new Error(`${label} output missing expected text: ${missing.join(', ')}\n${tail(clean)}`);
+  }
+}
+
+function tail(text: string, lineCount = 80): string {
+  const lines = text.trim().split('\n');
+  return lines.slice(-lineCount).join('\n');
+}
+
+function runCommand(
+  label: string,
+  command: string,
+  args: readonly string[],
+  options: CommandOptions,
+  behavior: { quietSuccess?: boolean; timeoutMs?: number } = {},
+): CommandResult {
+  const result = spawnSync(command, [...args], {
+    cwd: options.cwd,
+    env: mergeEnv(process.env, options.env),
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    timeout: behavior.timeoutMs ?? options.timeoutMs,
+  });
+
+  if (result.error != null) {
+    throw new Error(`${label} failed to start: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(formatFailure(label, command, args, result.stdout, result.stderr, result.status));
+  }
+
+  if (!behavior.quietSuccess) {
+    process.stdout.write(result.stdout);
+    process.stdout.write(result.stderr);
+  }
+
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function formatFailure(
+  label: string,
+  command: string,
+  args: readonly string[],
+  stdout: string,
+  stderr: string,
+  status: number | null,
+): string {
+  const combined = [stdout.trim(), stderr.trim()].filter(Boolean).join('\n');
+  return [
+    `${label} failed (${status ?? 'null'})`,
+    `command: ${command} ${args.join(' ')}`,
+    tail(stripAnsi(combined), 120),
+  ].filter(Boolean).join('\n');
+}
+
+function mergeEnv(
+  base: NodeJS.ProcessEnv,
+  overrides: Record<string, string | null | undefined> | undefined,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...base };
+  if (overrides == null) return env;
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value == null) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+main();

--- a/scripts/smoke-utils.test.ts
+++ b/scripts/smoke-utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { detectGarbage, rewritePackageManifestToTarballs } from './smoke-utils.js';
+
+describe('rewritePackageManifestToTarballs', () => {
+  it('rewrites matching workspace dependencies to tarball specs', () => {
+    const source = JSON.stringify({
+      name: 'canary-app',
+      dependencies: {
+        '@flyingrobots/bijou': 'latest',
+        '@flyingrobots/bijou-node': 'latest',
+        chalk: '^5.0.0',
+      },
+      devDependencies: {
+        '@flyingrobots/bijou-tui': 'latest',
+      },
+      peerDependencies: {
+        '@flyingrobots/bijou-tui-app': 'latest',
+      },
+    });
+
+    const rewritten = JSON.parse(rewritePackageManifestToTarballs(source, {
+      '@flyingrobots/bijou': 'file:/tmp/bijou.tgz',
+      '@flyingrobots/bijou-node': 'file:/tmp/bijou-node.tgz',
+      '@flyingrobots/bijou-tui': 'file:/tmp/bijou-tui.tgz',
+      '@flyingrobots/bijou-tui-app': 'file:/tmp/bijou-tui-app.tgz',
+    })) as Record<string, Record<string, string>>;
+
+    expect(rewritten.dependencies?.['@flyingrobots/bijou']).toBe('file:/tmp/bijou.tgz');
+    expect(rewritten.dependencies?.['@flyingrobots/bijou-node']).toBe('file:/tmp/bijou-node.tgz');
+    expect(rewritten.dependencies?.['chalk']).toBe('^5.0.0');
+    expect(rewritten.devDependencies?.['@flyingrobots/bijou-tui']).toBe('file:/tmp/bijou-tui.tgz');
+    expect(rewritten.peerDependencies?.['@flyingrobots/bijou-tui-app']).toBe('file:/tmp/bijou-tui-app.tgz');
+  });
+
+  it('leaves unrelated manifests unchanged when no tarball exists', () => {
+    const source = JSON.stringify({
+      name: 'core-canary',
+      dependencies: {
+        '@flyingrobots/bijou': 'latest',
+        picocolors: '^1.1.0',
+      },
+    });
+
+    const rewritten = JSON.parse(rewritePackageManifestToTarballs(source, {
+      '@flyingrobots/bijou-node': 'file:/tmp/bijou-node.tgz',
+    })) as Record<string, Record<string, string>>;
+
+    expect(rewritten.dependencies?.['@flyingrobots/bijou']).toBe('latest');
+    expect(rewritten.dependencies?.['picocolors']).toBe('^1.1.0');
+  });
+});
+
+describe('detectGarbage', () => {
+  it('flags raw surface dumps and runtime errors', () => {
+    expect(detectGarbage('width: 10,\nheight: 1,\ncells: [')).toMatch(/raw Surface dump/);
+    expect(detectGarbage('[Pipeline Error] TypeError: nope')).toMatch(/error output/);
+  });
+
+  it('allows normal smoke output', () => {
+    expect(detectGarbage('My Bijou App\nHome ready\nSplit ready')).toBeNull();
+  });
+});

--- a/scripts/smoke-utils.ts
+++ b/scripts/smoke-utils.ts
@@ -1,0 +1,102 @@
+export interface InputStep {
+  readonly type: 'input';
+  readonly input: string;
+  readonly delayMs?: number;
+}
+
+export interface ResizeStep {
+  readonly type: 'resize';
+  readonly cols: number;
+  readonly rows: number;
+  readonly delayMs?: number;
+}
+
+export type PtyStep = InputStep | ResizeStep;
+
+interface PackageManifest {
+  readonly name?: string;
+  readonly version?: string;
+  readonly private?: boolean;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+type DependencySection =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'peerDependencies'
+  | 'optionalDependencies';
+
+const RAW_SURFACE_PATTERNS = [
+  /cells:\s*\[/,
+  /clear:\s*\[Function:/,
+  /transform:\s*\[Function:/,
+  /width:\s*\d+,\s*\n\s*height:\s*\d+/,
+  /\[object Object\]/,
+];
+
+const ERROR_PATTERNS = [
+  /\[Pipeline Error\]/,
+  /\bTypeError:/,
+  /\bReferenceError:/,
+  /\bSyntaxError:/,
+  /\bUnhandled\b/i,
+];
+
+export function inputStep(input: string, delayMs?: number): InputStep {
+  return { type: 'input', input, delayMs };
+}
+
+export function resizeStep(cols: number, rows: number, delayMs?: number): ResizeStep {
+  return { type: 'resize', cols, rows, delayMs };
+}
+
+export function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+}
+
+export function detectGarbage(cleanOutput: string): string | null {
+  for (const pattern of RAW_SURFACE_PATTERNS) {
+    if (pattern.test(cleanOutput)) {
+      return `raw Surface dump matched ${pattern}`;
+    }
+  }
+
+  for (const pattern of ERROR_PATTERNS) {
+    if (pattern.test(cleanOutput)) {
+      return `error output matched ${pattern}`;
+    }
+  }
+
+  return null;
+}
+
+export function rewritePackageManifestToTarballs(
+  packageJsonSource: string,
+  tarballSpecs: Readonly<Record<string, string>>,
+): string {
+  const manifest = JSON.parse(packageJsonSource) as PackageManifest;
+  const sections: readonly DependencySection[] = [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ];
+
+  for (const section of sections) {
+    const deps = manifest[section];
+    if (deps == null) continue;
+    for (const [name, spec] of Object.entries(deps)) {
+      const tarballSpec = tarballSpecs[name];
+      if (tarballSpec == null) continue;
+      if (spec !== tarballSpec) {
+        deps[name] = tarballSpec;
+      }
+    }
+  }
+
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}

--- a/scripts/smoke-utils.ts
+++ b/scripts/smoke-utils.ts
@@ -1,17 +1,22 @@
-export interface InputStep {
-  readonly type: 'input';
-  readonly input: string;
+interface PtyStepBase {
   readonly delayMs?: number;
+  readonly label?: string;
+  readonly captureMs?: number;
 }
 
-export interface ResizeStep {
+export interface InputStep extends PtyStepBase {
+  readonly type: 'input';
+  readonly input: string;
+}
+
+export interface ResizeStep extends PtyStepBase {
   readonly type: 'resize';
   readonly cols: number;
   readonly rows: number;
-  readonly delayMs?: number;
 }
 
 export type PtyStep = InputStep | ResizeStep;
+export const PTY_MARKER_PREFIX = '__BIJOU_STEP__:';
 
 interface PackageManifest {
   readonly name?: string;
@@ -45,12 +50,23 @@ const ERROR_PATTERNS = [
   /\bUnhandled\b/i,
 ];
 
-export function inputStep(input: string, delayMs?: number): InputStep {
-  return { type: 'input', input, delayMs };
+export function inputStep(
+  input: string,
+  delayMs?: number,
+  label?: string,
+  captureMs?: number,
+): InputStep {
+  return { type: 'input', input, delayMs, label, captureMs };
 }
 
-export function resizeStep(cols: number, rows: number, delayMs?: number): ResizeStep {
-  return { type: 'resize', cols, rows, delayMs };
+export function resizeStep(
+  cols: number,
+  rows: number,
+  delayMs?: number,
+  label?: string,
+  captureMs?: number,
+): ResizeStep {
+  return { type: 'resize', cols, rows, delayMs, label, captureMs };
 }
 
 export function stripAnsi(text: string): string {

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -9,5 +9,5 @@
     "noEmit": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["packages/*/src/**/*.test.ts", "packages/*/src/**/*.d.ts"]
+  "include": ["packages/*/src/**/*.test.ts", "packages/*/src/**/*.d.ts", "scripts/**/*.test.ts", "scripts/**/*.d.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/*/src/**/*.test.ts'],
+    include: ['packages/*/src/**/*.test.ts', 'scripts/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- add a dedicated tarball-based canary smoke harness for a generated TUI app and an internal core/static fixture
- extend the PTY driver and shared smoke utilities to support typed input/resize steps
- run the new canary gate in CI and release verification, and document the local workflow

## Verification
- npm run typecheck:test
- npm test
- npm run smoke:canaries
- npm run smoke:examples:all
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end "smoke canaries" workflow to package, install, and smoke-test scaffolded apps and a static core canary.

* **Documentation**
  * README and scaffold docs updated with smoke canaries usage and Node version notes; changelog notes a PTY shutdown race fix.

* **Chores**
  * CI now runs smoke canaries during verification; test discovery expanded to include new smoke tests.

* **Tests**
  * New unit and integration tests covering manifest rewrites, output validation, and PTY-driven scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->