### PR TITLE
feat: harden release tooling and PTY smoke infra

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,130 @@
+name: Release Dry Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify release candidate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      notes_tag: ${{ steps.meta.outputs.notes_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - run: npm ci
+
+      - name: Compute dry-run metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./packages/bijou/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "notes_tag=dry-run-v${VERSION}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        run: npm run build
+
+      - name: Type check
+        run: npm run lint
+
+      - name: Type check tests
+        run: npm run typecheck:test
+
+      - name: Test
+        run: npm test
+
+      - name: Smoke all examples
+        run: npm run smoke:examples:all
+
+      - name: Smoke canary apps
+        run: npm run smoke:canaries -- --skip-build
+
+      - name: Verify packed files
+        run: |
+          (cd packages/bijou && npm pack --dry-run)
+          (cd packages/bijou-node && npm pack --dry-run)
+          (cd packages/bijou-tui && npm pack --dry-run)
+          (cd packages/bijou-tui-app && npm pack --dry-run)
+          (cd packages/create-bijou-tui-app && npm pack --dry-run)
+
+  npm_publish_dry_run:
+    name: npm publish dry-run
+    runs-on: ubuntu-latest
+    needs: verify
+    strategy:
+      matrix:
+        package: [bijou, bijou-node, bijou-tui, bijou-tui-app, create-bijou-tui-app]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: npm publish dry-run packages/${{ matrix.package }}
+        run: cd packages/${{ matrix.package }} && npm publish --dry-run --access public --tag dry-run
+
+  release_notes_preview:
+    name: Release notes preview
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: read
+    steps:
+      - name: Generate notes preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api \
+            -X POST \
+            "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="${{ needs.verify.outputs.notes_tag }}" \
+            -f target_commitish="${{ github.sha }}" \
+            > GENERATED_RELEASE.json
+
+          node --input-type=module <<'EOF'
+          import { readFileSync, writeFileSync } from 'node:fs';
+
+          const payload = JSON.parse(readFileSync('GENERATED_RELEASE.json', 'utf8'));
+          const body = String(payload.body ?? '').trim();
+          const version = '${{ needs.verify.outputs.version }}';
+          const tag = '${{ needs.verify.outputs.notes_tag }}';
+
+          writeFileSync(
+            'RELEASE_NOTES_PREVIEW.md',
+            [
+              `# Release Dry Run Notes`,
+              ``,
+              `Version: \`${version}\``,
+              `Preview tag: \`${tag}\``,
+              ``,
+              body,
+              ``,
+            ].join('\n'),
+          );
+          EOF
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-preview
+          path: RELEASE_NOTES_PREVIEW.md

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Type check
+      - name: Lint
         run: npm run lint
 
       - name: Type check tests

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -31,6 +31,38 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./packages/bijou/package.json').version")
+          ERRORS=0
+
+          for pkg in packages/*/package.json; do
+            PKG_NAME=$(node -p "require('./$pkg').name")
+            PKG_VERSION=$(node -p "require('./$pkg').version")
+            echo "$PKG_NAME: $PKG_VERSION (dry-run: $VERSION)"
+            if [ "$PKG_VERSION" != "$VERSION" ]; then
+              echo "::error::$PKG_NAME version ($PKG_VERSION) does not match dry-run version ($VERSION)"
+              ERRORS=$((ERRORS+1))
+            fi
+          done
+
+          for pkg in packages/*/package.json; do
+            node -e "
+              const p = require('./$pkg');
+              for (const depType of ['dependencies', 'devDependencies']) {
+                if (!p[depType]) continue;
+                for (const [name, ver] of Object.entries(p[depType])) {
+                  if (name.startsWith('@flyingrobots/bijou') && ver !== '$VERSION') {
+                    console.log('::error::' + p.name + ' has ' + name + '@' + ver + ' in ' + depType + ', expected $VERSION');
+                    process.exitCode = 1;
+                  }
+                }
+              }
+            " || ERRORS=$((ERRORS+1))
+          done
+
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "::error::Workspace version mismatch detected. Run: npm run version $VERSION"
+            exit 1
+          fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "notes_tag=dry-run-v${VERSION}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -46,7 +46,7 @@ jobs:
           for pkg in packages/*/package.json; do
             node -e "
               const p = require('./$pkg');
-              for (const depType of ['dependencies', 'devDependencies']) {
+              for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
                 if (!p[depType]) continue;
                 for (const [name, ver] of Object.entries(p[depType])) {
                   if (name.startsWith('@flyingrobots/bijou') && ver !== '$VERSION') {

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn.lock
 *.tgz
 last-chat.txt
 bijou-tui-app/
+scripts/__pycache__/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 🐛 Fixes
 
 - **Scaffold canary PTY shutdown race** — the PTY driver now treats queued late input/resize steps as no-ops once the child exits, preventing traceback noise from masking the actual canary failure.
+- **PR status helper edge cases** — canceled checks now fail the review-status exit code, nullable review authors fall back safely, and the release dry-run workflow labels its lint step accurately.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Scaffold canary PTY shutdown race** — the PTY driver now treats queued late input/resize steps as no-ops once the child exits, preventing traceback noise from masking the actual canary failure.
 - **PR status helper edge cases** — canceled checks now fail the review-status exit code, nullable review authors fall back safely, and the release dry-run workflow labels its lint step accurately.
 - **Release dry-run peer pin validation** — the dry-run metadata gate now checks internal `peerDependencies` as well, so it matches the lock-step validation performed by the real publish workflow.
+- **Packed scaffold bin test stability** — the packed `create-bijou-tui-app` bin-shim test now disables npm audit/fund/script overhead and uses explicit subprocess timeouts so it stays reliable under full-suite load.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 - **Scaffold canary PTY shutdown race** — the PTY driver now treats queued late input/resize steps as no-ops once the child exits, preventing traceback noise from masking the actual canary failure.
 - **PR status helper edge cases** — canceled checks now fail the review-status exit code, nullable review authors fall back safely, and the release dry-run workflow labels its lint step accurately.
+- **Release dry-run peer pin validation** — the dry-run metadata gate now checks internal `peerDependencies` as well, so it matches the lock-step validation performed by the real publish workflow.
 
 ## [3.0.0] - 2026-03-12
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "smoke:examples": "tsx scripts/smoke-v3-examples.ts",
     "smoke:examples:all": "tsx scripts/smoke-all-examples.ts",
     "smoke:canaries": "tsx scripts/smoke-canaries.ts",
+    "pr:review-status": "tsx scripts/pr-review-status.ts",
     "lint": "npm run lint --workspaces",
     "version": "bash scripts/version.sh"
   },

--- a/packages/create-bijou-tui-app/src/cli.test.ts
+++ b/packages/create-bijou-tui-app/src/cli.test.ts
@@ -144,7 +144,9 @@ describe('create-bijou-tui-app cli', () => {
         cwd: PACKAGE_ROOT,
         encoding: 'utf8',
         maxBuffer: 8 * 1024 * 1024,
+        timeout: 90_000,
       });
+      expect(packed.error).toBeUndefined();
       expect(packed.status).toBe(0);
       const arrayStart = packed.stdout.indexOf('[');
       const arrayEnd = packed.stdout.lastIndexOf(']');
@@ -155,13 +157,24 @@ describe('create-bijou-tui-app cli', () => {
 
       const installed = spawnSync(
         'npm',
-        ['install', '--prefix', runnerDir, '--no-package-lock', '--no-save', `file:${tarball}`],
+        [
+          'install',
+          '--prefix', runnerDir,
+          '--no-package-lock',
+          '--no-save',
+          '--no-audit',
+          '--fund=false',
+          '--ignore-scripts',
+          `file:${tarball}`,
+        ],
         {
           cwd: PACKAGE_ROOT,
           encoding: 'utf8',
           maxBuffer: 8 * 1024 * 1024,
+          timeout: 90_000,
         },
       );
+      expect(installed.error).toBeUndefined();
       expect(installed.status).toBe(0);
 
       const binPath = join(runnerDir, 'node_modules', '.bin', 'create-bijou-tui-app');
@@ -171,12 +184,14 @@ describe('create-bijou-tui-app cli', () => {
         cwd: root,
         encoding: 'utf8',
         maxBuffer: 8 * 1024 * 1024,
+        timeout: 30_000,
       });
+      expect(result.error).toBeUndefined();
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('Created project in');
       expect(existsSync(join(targetDir, 'package.json'))).toBe(true);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  }, 60000);
+  }, 180000);
 });

--- a/scripts/pr-review-status.test.ts
+++ b/scripts/pr-review-status.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { computeExitCode, extractUnresolvedFindings, summarizeChecks } from './pr-review-status.js';
+
+describe('summarizeChecks', () => {
+  it('counts passing, pending, failing, and CodeRabbit checks', () => {
+    const summary = summarizeChecks([
+      { name: 'test (18)', bucket: 'pass', state: 'SUCCESS' },
+      { name: 'CodeRabbit', bucket: 'pending', state: 'PENDING' },
+      { name: 'lint', bucket: 'fail', state: 'FAILURE' },
+    ]);
+
+    expect(summary.counts.pass).toBe(1);
+    expect(summary.counts.pending).toBe(1);
+    expect(summary.counts.fail).toBe(1);
+    expect(summary.codeRabbit?.name).toBe('CodeRabbit');
+    expect(summary.failing).toHaveLength(1);
+    expect(summary.pending).toHaveLength(1);
+  });
+});
+
+describe('extractUnresolvedFindings', () => {
+  it('keeps only unresolved review threads and extracts the first comment summary', () => {
+    const findings = extractUnresolvedFindings([
+      {
+        isResolved: false,
+        comments: {
+          nodes: [{
+            author: { login: 'coderabbitai' },
+            body: '<!-- hidden -->\n\nHandle PTY shutdown race cleanly.',
+            path: 'scripts/pty-driver.py',
+            url: 'https://example.test/thread/1',
+          }],
+        },
+      },
+      {
+        isResolved: true,
+        comments: {
+          nodes: [{
+            author: { login: 'reviewer' },
+            body: 'already handled',
+            path: 'scripts/smoke-canaries.ts',
+            url: 'https://example.test/thread/2',
+          }],
+        },
+      },
+    ]);
+
+    expect(findings).toEqual([{
+      author: 'coderabbitai',
+      path: 'scripts/pty-driver.py',
+      summary: 'Handle PTY shutdown race cleanly.',
+      url: 'https://example.test/thread/1',
+    }]);
+  });
+});
+
+describe('computeExitCode', () => {
+  it('returns success only when checks and threads are clear', () => {
+    const summary = summarizeChecks([{ name: 'test', bucket: 'pass', state: 'SUCCESS' }]);
+    expect(computeExitCode(summary, 0)).toBe(0);
+  });
+
+  it('returns pending when only pending checks remain', () => {
+    const summary = summarizeChecks([{ name: 'CodeRabbit', bucket: 'pending', state: 'PENDING' }]);
+    expect(computeExitCode(summary, 0)).toBe(8);
+  });
+
+  it('returns failure for unresolved threads or failing checks', () => {
+    const passing = summarizeChecks([{ name: 'test', bucket: 'pass', state: 'SUCCESS' }]);
+    const failing = summarizeChecks([{ name: 'lint', bucket: 'fail', state: 'FAILURE' }]);
+
+    expect(computeExitCode(passing, 1)).toBe(1);
+    expect(computeExitCode(failing, 0)).toBe(1);
+  });
+});

--- a/scripts/pr-review-status.test.ts
+++ b/scripts/pr-review-status.test.ts
@@ -2,19 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { computeExitCode, extractUnresolvedFindings, summarizeChecks } from './pr-review-status.js';
 
 describe('summarizeChecks', () => {
-  it('counts passing, pending, failing, and CodeRabbit checks', () => {
+  it('counts passing, pending, failing, canceled, and CodeRabbit checks', () => {
     const summary = summarizeChecks([
       { name: 'test (18)', bucket: 'pass', state: 'SUCCESS' },
       { name: 'CodeRabbit', bucket: 'pending', state: 'PENDING' },
       { name: 'lint', bucket: 'fail', state: 'FAILURE' },
+      { name: 'test (22)', bucket: 'cancel', state: 'CANCELLED' },
     ]);
 
     expect(summary.counts.pass).toBe(1);
     expect(summary.counts.pending).toBe(1);
     expect(summary.counts.fail).toBe(1);
+    expect(summary.counts.cancel).toBe(1);
     expect(summary.codeRabbit?.name).toBe('CodeRabbit');
     expect(summary.failing).toHaveLength(1);
     expect(summary.pending).toHaveLength(1);
+    expect(summary.canceled).toHaveLength(1);
   });
 });
 
@@ -29,6 +32,17 @@ describe('extractUnresolvedFindings', () => {
             body: '<!-- hidden -->\n\nHandle PTY shutdown race cleanly.',
             path: 'scripts/pty-driver.py',
             url: 'https://example.test/thread/1',
+          }],
+        },
+      },
+      {
+        isResolved: false,
+        comments: {
+          nodes: [{
+            author: null,
+            body: 'Anonymous review comment.',
+            path: null,
+            url: 'https://example.test/thread/3',
           }],
         },
       },
@@ -50,6 +64,11 @@ describe('extractUnresolvedFindings', () => {
       path: 'scripts/pty-driver.py',
       summary: 'Handle PTY shutdown race cleanly.',
       url: 'https://example.test/thread/1',
+    }, {
+      author: '(unknown)',
+      path: '(no file)',
+      summary: 'Anonymous review comment.',
+      url: 'https://example.test/thread/3',
     }]);
   });
 });
@@ -65,11 +84,13 @@ describe('computeExitCode', () => {
     expect(computeExitCode(summary, 0)).toBe(8);
   });
 
-  it('returns failure for unresolved threads or failing checks', () => {
+  it('returns failure for unresolved threads, failing checks, or canceled checks', () => {
     const passing = summarizeChecks([{ name: 'test', bucket: 'pass', state: 'SUCCESS' }]);
     const failing = summarizeChecks([{ name: 'lint', bucket: 'fail', state: 'FAILURE' }]);
+    const canceled = summarizeChecks([{ name: 'test (22)', bucket: 'cancel', state: 'CANCELLED' }]);
 
     expect(computeExitCode(passing, 1)).toBe(1);
     expect(computeExitCode(failing, 0)).toBe(1);
+    expect(computeExitCode(canceled, 0)).toBe(1);
   });
 });

--- a/scripts/pr-review-status.ts
+++ b/scripts/pr-review-status.ts
@@ -23,7 +23,7 @@ interface CheckEntry {
 }
 
 interface ReviewThreadComment {
-  readonly author: { readonly login: string };
+  readonly author?: { readonly login: string } | null;
   readonly body: string;
   readonly path?: string | null;
   readonly url: string;
@@ -50,6 +50,7 @@ export interface CheckSummary {
   readonly counts: Readonly<Record<string, number>>;
   readonly failing: readonly CheckEntry[];
   readonly pending: readonly CheckEntry[];
+  readonly canceled: readonly CheckEntry[];
   readonly codeRabbit: CheckEntry | null;
 }
 
@@ -82,6 +83,7 @@ export function summarizeChecks(checks: readonly CheckEntry[]): CheckSummary {
     counts,
     failing: checks.filter((check) => check.bucket === 'fail'),
     pending: checks.filter((check) => check.bucket === 'pending'),
+    canceled: checks.filter((check) => check.bucket === 'cancel'),
     codeRabbit: checks.find((check) => check.name === 'CodeRabbit') ?? null,
   };
 }
@@ -92,7 +94,7 @@ export function extractUnresolvedFindings(threads: readonly ReviewThreadNode[]):
     .map((thread) => thread.comments.nodes[0])
     .filter((comment): comment is ReviewThreadComment => comment != null)
     .map((comment) => ({
-      author: comment.author.login,
+      author: comment.author?.login ?? '(unknown)',
       path: comment.path ?? '(no file)',
       url: comment.url,
       summary: summarizeComment(comment.body),
@@ -100,7 +102,7 @@ export function extractUnresolvedFindings(threads: readonly ReviewThreadNode[]):
 }
 
 export function computeExitCode(summary: CheckSummary, unresolvedCount: number): number {
-  if (summary.failing.length > 0 || unresolvedCount > 0) {
+  if (summary.failing.length > 0 || summary.canceled.length > 0 || unresolvedCount > 0) {
     return 1;
   }
 
@@ -145,6 +147,13 @@ function main(): void {
   if (summary.failing.length > 0) {
     process.stdout.write('\nFailing checks:\n');
     for (const check of summary.failing) {
+      process.stdout.write(`- ${check.name} (${check.state})${check.link ? ` ${check.link}` : ''}\n`);
+    }
+  }
+
+  if (summary.canceled.length > 0) {
+    process.stdout.write('\nCanceled checks:\n');
+    for (const check of summary.canceled) {
       process.stdout.write(`- ${check.name} (${check.state})${check.link ? ` ${check.link}` : ''}\n`);
     }
   }

--- a/scripts/pr-review-status.ts
+++ b/scripts/pr-review-status.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env npx tsx
+
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface PullRequestView {
+  readonly number: number;
+  readonly title: string;
+  readonly state: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly isDraft: boolean;
+  readonly url: string;
+}
+
+interface CheckEntry {
+  readonly name: string;
+  readonly bucket: 'pass' | 'fail' | 'pending' | 'skipping' | 'cancel' | string;
+  readonly state: string;
+  readonly link?: string;
+  readonly workflow?: string;
+}
+
+interface ReviewThreadComment {
+  readonly author: { readonly login: string };
+  readonly body: string;
+  readonly path?: string | null;
+  readonly url: string;
+}
+
+interface ReviewThreadNode {
+  readonly isResolved: boolean;
+  readonly comments: { readonly nodes: readonly ReviewThreadComment[] };
+}
+
+interface ReviewThreadsResponse {
+  readonly data: {
+    readonly repository: {
+      readonly pullRequest: {
+        readonly reviewThreads: {
+          readonly nodes: readonly ReviewThreadNode[];
+        };
+      };
+    };
+  };
+}
+
+export interface CheckSummary {
+  readonly counts: Readonly<Record<string, number>>;
+  readonly failing: readonly CheckEntry[];
+  readonly pending: readonly CheckEntry[];
+  readonly codeRabbit: CheckEntry | null;
+}
+
+export interface UnresolvedFinding {
+  readonly author: string;
+  readonly path: string;
+  readonly url: string;
+  readonly summary: string;
+}
+
+export function summarizeChecks(checks: readonly CheckEntry[]): CheckSummary {
+  const counts: Record<string, number> = {
+    pass: 0,
+    fail: 0,
+    pending: 0,
+    skipping: 0,
+    cancel: 0,
+    other: 0,
+  };
+
+  for (const check of checks) {
+    if (check.bucket in counts) {
+      counts[check.bucket] += 1;
+    } else {
+      counts.other += 1;
+    }
+  }
+
+  return {
+    counts,
+    failing: checks.filter((check) => check.bucket === 'fail'),
+    pending: checks.filter((check) => check.bucket === 'pending'),
+    codeRabbit: checks.find((check) => check.name === 'CodeRabbit') ?? null,
+  };
+}
+
+export function extractUnresolvedFindings(threads: readonly ReviewThreadNode[]): readonly UnresolvedFinding[] {
+  return threads
+    .filter((thread) => !thread.isResolved)
+    .map((thread) => thread.comments.nodes[0])
+    .filter((comment): comment is ReviewThreadComment => comment != null)
+    .map((comment) => ({
+      author: comment.author.login,
+      path: comment.path ?? '(no file)',
+      url: comment.url,
+      summary: summarizeComment(comment.body),
+    }));
+}
+
+export function computeExitCode(summary: CheckSummary, unresolvedCount: number): number {
+  if (summary.failing.length > 0 || unresolvedCount > 0) {
+    return 1;
+  }
+
+  if (summary.pending.length > 0) {
+    return 8;
+  }
+
+  return 0;
+}
+
+function main(): void {
+  const prArg = process.argv[2];
+  const pr = ghJson<PullRequestView>([
+    'pr',
+    'view',
+    ...maybeArg(prArg),
+    '--json',
+    'number,title,state,baseRefName,headRefName,isDraft,url',
+  ]);
+  const checks = ghJson<CheckEntry[]>([
+    'pr',
+    'checks',
+    String(pr.number),
+    '--json',
+    'name,bucket,state,link,workflow',
+  ]);
+  const threads = fetchReviewThreads(pr.number);
+  const unresolved = extractUnresolvedFindings(threads);
+  const summary = summarizeChecks(checks);
+
+  process.stdout.write(`PR #${pr.number}: ${pr.title}\n`);
+  process.stdout.write(`State: ${pr.state}${pr.isDraft ? ' (draft)' : ''}\n`);
+  process.stdout.write(`Branch: ${pr.headRefName} -> ${pr.baseRefName}\n`);
+  process.stdout.write(`URL: ${pr.url}\n\n`);
+
+  process.stdout.write(
+    `Checks: pass=${summary.counts.pass} pending=${summary.counts.pending} fail=${summary.counts.fail} skipping=${summary.counts.skipping} cancel=${summary.counts.cancel}\n`,
+  );
+  process.stdout.write(`Unresolved threads: ${unresolved.length}\n`);
+  process.stdout.write(`CodeRabbit: ${summary.codeRabbit?.bucket ?? 'missing'}\n`);
+
+  if (summary.failing.length > 0) {
+    process.stdout.write('\nFailing checks:\n');
+    for (const check of summary.failing) {
+      process.stdout.write(`- ${check.name} (${check.state})${check.link ? ` ${check.link}` : ''}\n`);
+    }
+  }
+
+  if (summary.pending.length > 0) {
+    process.stdout.write('\nPending checks:\n');
+    for (const check of summary.pending) {
+      process.stdout.write(`- ${check.name} (${check.state})${check.link ? ` ${check.link}` : ''}\n`);
+    }
+  }
+
+  if (unresolved.length > 0) {
+    process.stdout.write('\nUnresolved review threads:\n');
+    for (const finding of unresolved) {
+      process.stdout.write(`- [${finding.author}] ${finding.path}: ${finding.summary}\n  ${finding.url}\n`);
+    }
+  }
+
+  process.exitCode = computeExitCode(summary, unresolved.length);
+}
+
+function fetchReviewThreads(prNumber: number): readonly ReviewThreadNode[] {
+  const query = `
+query($prNumber: Int!) {
+  repository(owner: "flyingrobots", name: "bijou") {
+    pullRequest(number: $prNumber) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 20) {
+            nodes {
+              author { login }
+              body
+              path
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+  const payload = ghGraphql<ReviewThreadsResponse>(query, { prNumber: String(prNumber) });
+  return payload.data.repository.pullRequest.reviewThreads.nodes;
+}
+
+function summarizeComment(body: string): string {
+  const firstLine = body
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !line.startsWith('<!--') && !line.startsWith('<details>') && !line.startsWith('</details>'));
+
+  return firstLine == null ? '(no summary)' : firstLine.slice(0, 140);
+}
+
+function ghJson<T>(args: readonly string[]): T {
+  const output = execFileSync('gh', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GH_PAGER: 'cat',
+    },
+  });
+
+  return JSON.parse(output) as T;
+}
+
+function ghGraphql<T>(query: string, variables: Readonly<Record<string, string>>): T {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    args.push('-F', `${key}=${value}`);
+  }
+
+  const output = execFileSync('gh', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GH_PAGER: 'cat',
+    },
+  });
+
+  return JSON.parse(output) as T;
+}
+
+function maybeArg(value: string | undefined): readonly string[] {
+  return value == null || value === '' ? [] : [value];
+}
+
+if (process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main();
+}

--- a/scripts/pty-driver.py
+++ b/scripts/pty-driver.py
@@ -12,6 +12,8 @@ import fcntl
 import struct
 import termios
 
+sys.dont_write_bytecode = True
+
 MARKER_PREFIX = "__BIJOU_STEP__:"
 
 

--- a/scripts/pty-driver.test.ts
+++ b/scripts/pty-driver.test.ts
@@ -9,6 +9,10 @@ const DRIVER_PATH = resolve(ROOT, 'scripts/pty-driver.py');
 function runPython(source: string) {
   return spawnSync('python3', ['-c', source, DRIVER_PATH], {
     encoding: 'utf8',
+    env: {
+      ...process.env,
+      PYTHONDONTWRITEBYTECODE: '1',
+    },
   });
 }
 
@@ -86,6 +90,76 @@ raise SystemExit(1)
 
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('9');
+    expect(result.stderr).toBe('');
+  });
+
+  it('keeps resize checkpoints safe when the scheduled step runs after process exit', () => {
+    const result = runPython(`
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+
+driver_path = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("pty_driver", driver_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class DeadProc:
+    pid = 123
+
+    def poll(self):
+        return 0
+
+    def wait(self):
+        return 0
+
+    def kill(self):
+        raise AssertionError("kill should not be called")
+
+class FakeSelector:
+    def register(self, *_args, **_kwargs):
+        return None
+
+    def select(self, _timeout):
+        return []
+
+    def close(self):
+        return None
+
+module.os.environ["BIJOU_PTY_SPEC"] = json.dumps({
+    "argv": ["python3", "-c", "print('ignored')"],
+    "cwd": ".",
+    "steps": [{
+        "type": "resize",
+        "rows": 30,
+        "cols": 100,
+        "delayMs": 0,
+        "label": "resize-after-exit",
+    }],
+})
+
+module.os.openpty = lambda: (10, 11)
+module.os.close = lambda _fd: None
+module.os.kill = lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("os.kill should not run"))
+module.os.read = lambda *_args, **_kwargs: b""
+module.subprocess.Popen = lambda *_args, **_kwargs: DeadProc()
+module.selectors.DefaultSelector = lambda: FakeSelector()
+resize_calls = []
+module.set_window_size = lambda fd, rows, cols: resize_calls.append((fd, rows, cols))
+module.capture_until = lambda *_args, **_kwargs: None
+module.flush_ready_output = lambda *_args, **_kwargs: None
+module.time.monotonic = lambda: 0.0
+
+result = module.main()
+assert resize_calls == [(10, 24, 80)], resize_calls
+print(result)
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('__BIJOU_STEP__:resize-after-exit');
+    expect(result.stdout.trim().endsWith('0')).toBe(true);
     expect(result.stderr).toBe('');
   });
 });

--- a/scripts/smoke-all-examples.ts
+++ b/scripts/smoke-all-examples.ts
@@ -233,6 +233,7 @@ function createInteractiveTtyChild(absPath: string, steps: readonly PtyStep[]): 
       env: {
         ...process.env,
         BIJOU_PTY_SPEC: JSON.stringify(spec),
+        PYTHONDONTWRITEBYTECODE: '1',
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     },

--- a/scripts/smoke-canaries.ts
+++ b/scripts/smoke-canaries.ts
@@ -260,6 +260,7 @@ function runPtyScenario(cwd: string, steps: readonly PtyStep[]): string {
       cwd: ROOT,
       env: {
         BIJOU_PTY_SPEC: JSON.stringify(spec),
+        PYTHONDONTWRITEBYTECODE: '1',
       },
       timeoutMs: 20000,
     },


### PR DESCRIPTION
## Summary
- harden PTY smoke tooling against bytecode noise and add a resize/exit lifecycle regression
- add a local PR review status helper for unresolved threads and check summaries
- add a workflow-dispatch release dry run that exercises build, smoke, publish dry-runs, and release notes preview

## Verification
- npm run build
- npm run typecheck:test
- npm test
- npm run pr:review-status -- 41
- npm run smoke:canaries -- --skip-build
- npm run smoke:examples:all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated release dry-run workflow with package dry-run publishing and release-notes preview artifact
  * Added a PR review status CLI tool and an npm script for quick PR health checks

* **Tests**
  * Added unit tests for PR review status logic
  * Expanded PTY-driver tests to cover a resize-after-exit edge case

* **Chores**
  * Disabled Python bytecode generation and updated ignore rules

* **Documentation**
  * Updated changelog with PR status and dry-run notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->