### PR TITLE
feat: share release validation tooling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,74 +34,12 @@ jobs:
 
       - run: npm ci
 
-      - name: Validate tag format and compute metadata
+      - name: Validate release metadata
         id: meta
-        shell: bash
         run: |
-          set -euo pipefail
-          TAG="${{ github.ref_name }}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
-            echo "Invalid tag format: $TAG"
-            exit 1
-          fi
-
-          TAG_VERSION="${TAG#v}"
-          echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
-
-          if [[ "$TAG_VERSION" =~ -(rc|beta|alpha)\. ]]; then
-            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
-            if [[ "$TAG_VERSION" =~ -rc\. ]]; then
-              echo "npm_dist_tag=next" >> "$GITHUB_OUTPUT"
-            elif [[ "$TAG_VERSION" =~ -beta\. ]]; then
-              echo "npm_dist_tag=beta" >> "$GITHUB_OUTPUT"
-            else
-              echo "npm_dist_tag=alpha" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-            echo "npm_dist_tag=latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Verify all packages match tag version
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG_VERSION="${{ steps.meta.outputs.tag_version }}"
-          ERRORS=0
-
-          for pkg in packages/*/package.json; do
-            PKG_NAME=$(node -p "require('./$pkg').name")
-            PKG_VERSION=$(node -p "require('./$pkg').version")
-            echo "$PKG_NAME: $PKG_VERSION (tag: $TAG_VERSION)"
-            if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-              echo "::error::$PKG_NAME version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
-              ERRORS=$((ERRORS+1))
-            fi
-          done
-
-          # Verify internal cross-deps are pinned to same version
-          for pkg in packages/*/package.json; do
-            PKG_NAME=$(node -p "require('./$pkg').name")
-            node -e "
-              const p = require('./$pkg');
-              for (const depType of ['dependencies','devDependencies','peerDependencies']) {
-                if (!p[depType]) continue;
-                for (const [name, ver] of Object.entries(p[depType])) {
-                  if (name.startsWith('@flyingrobots/bijou') && ver !== '$TAG_VERSION') {
-                    console.log('::error::' + p.name + ' has ' + name + '@' + ver + ', expected $TAG_VERSION');
-                    process.exitCode = 1;
-                  }
-                }
-              }
-            " || ERRORS=$((ERRORS+1))
-          done
-
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "::error::Version mismatch detected. Run: npm run version $TAG_VERSION"
-            exit 1
-          fi
+          npx tsx scripts/release-metadata.ts \
+            --tag "${{ github.ref_name }}" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Capture verified release commit
         id: release_sha
@@ -113,7 +51,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Type check
+      - name: Lint
         run: npm run lint
 
       - name: Type check tests

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -27,44 +27,11 @@ jobs:
 
       - name: Compute dry-run metadata
         id: meta
-        shell: bash
         run: |
-          set -euo pipefail
-          VERSION=$(node -p "require('./packages/bijou/package.json').version")
-          ERRORS=0
-
-          for pkg in packages/*/package.json; do
-            PKG_NAME=$(node -p "require('./$pkg').name")
-            PKG_VERSION=$(node -p "require('./$pkg').version")
-            echo "$PKG_NAME: $PKG_VERSION (dry-run: $VERSION)"
-            if [ "$PKG_VERSION" != "$VERSION" ]; then
-              echo "::error::$PKG_NAME version ($PKG_VERSION) does not match dry-run version ($VERSION)"
-              ERRORS=$((ERRORS+1))
-            fi
-          done
-
-          for pkg in packages/*/package.json; do
-            node -e "
-              const p = require('./$pkg');
-              for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
-                if (!p[depType]) continue;
-                for (const [name, ver] of Object.entries(p[depType])) {
-                  if (name.startsWith('@flyingrobots/bijou') && ver !== '$VERSION') {
-                    console.log('::error::' + p.name + ' has ' + name + '@' + ver + ' in ' + depType + ', expected $VERSION');
-                    process.exitCode = 1;
-                  }
-                }
-              }
-            " || ERRORS=$((ERRORS+1))
-          done
-
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "::error::Workspace version mismatch detected. Run: npm run version $VERSION"
-            exit 1
-          fi
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "notes_tag=dry-run-v${VERSION}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          npx tsx scripts/release-metadata.ts \
+            --current-version \
+            --notes-tag-run-id "${{ github.run_id }}" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Build
         run: npm run build

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Release dry-run peer pin validation** — the dry-run metadata gate now checks internal `peerDependencies` as well, so it matches the lock-step validation performed by the real publish workflow.
 - **Packed scaffold bin test stability** — the packed `create-bijou-tui-app` bin-shim test now disables npm audit/fund/script overhead and uses explicit subprocess timeouts so it stays reliable under full-suite load.
 - **Shared release validation script** — publish and dry-run workflows now use one repo script for tag parsing, lock-step package version checks, and internal dependency pin validation, with a matching local `npm run release:preflight` command.
+- **Release preflight metadata and semver validation** — local `npm run release:preflight` now emits the derived `version` / `notes_tag` metadata, and the shared release parser rejects leading-zero semver identifiers before npm can reject them later.
+- **Packed scaffolder CLI execution path** — packaged `create-bijou-tui-app` verification now asserts the installed npm bin shim exists while invoking the packed CLI entry through `node`, which avoids macOS shebang hangs without dropping tarball-level coverage.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Release dry-run peer pin validation** — the dry-run metadata gate now checks internal `peerDependencies` as well, so it matches the lock-step validation performed by the real publish workflow.
 - **Packed scaffold bin test stability** — the packed `create-bijou-tui-app` bin-shim test now disables npm audit/fund/script overhead and uses explicit subprocess timeouts so it stays reliable under full-suite load.
 - **Shared release validation script** — publish and dry-run workflows now use one repo script for tag parsing, lock-step package version checks, and internal dependency pin validation, with a matching local `npm run release:preflight` command.
-- **Release preflight metadata and semver validation** — local `npm run release:preflight` now emits the derived `version` / `notes_tag` metadata, and the shared release parser rejects leading-zero semver identifiers before npm can reject them later.
+- **Release preflight metadata and semver validation** — local `npm run release:preflight` now emits the derived `version` / `notes_tag` metadata, derives `--current-version` from discovered workspace manifests instead of assuming `packages/bijou`, and rejects leading-zero semver identifiers before npm can reject them later.
 - **Packed scaffolder CLI execution path** — packaged `create-bijou-tui-app` verification now asserts the installed npm bin shim exists while invoking the packed CLI entry through `node`, which avoids macOS shebang hangs without dropping tarball-level coverage.
 
 ## [3.0.0] - 2026-03-12

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **PR status helper edge cases** — canceled checks now fail the review-status exit code, nullable review authors fall back safely, and the release dry-run workflow labels its lint step accurately.
 - **Release dry-run peer pin validation** — the dry-run metadata gate now checks internal `peerDependencies` as well, so it matches the lock-step validation performed by the real publish workflow.
 - **Packed scaffold bin test stability** — the packed `create-bijou-tui-app` bin-shim test now disables npm audit/fund/script overhead and uses explicit subprocess timeouts so it stays reliable under full-suite load.
+- **Shared release validation script** — publish and dry-run workflows now use one repo script for tag parsing, lock-step package version checks, and internal dependency pin validation, with a matching local `npm run release:preflight` command.
 
 ## [3.0.0] - 2026-03-12
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run --config vitest.config.ts",
     "test:watch": "vitest --config vitest.config.ts",
     "typecheck:test": "tsc --noEmit -p tsconfig.tests.json",
+    "release:preflight": "tsx scripts/release-metadata.ts --current-version --notes-tag-run-id local",
     "smoke:examples": "tsx scripts/smoke-v3-examples.ts",
     "smoke:examples:all": "tsx scripts/smoke-all-examples.ts",
     "smoke:canaries": "tsx scripts/smoke-canaries.ts",

--- a/packages/create-bijou-tui-app/src/cli.test.ts
+++ b/packages/create-bijou-tui-app/src/cli.test.ts
@@ -131,7 +131,7 @@ describe('create-bijou-tui-app cli', () => {
     }
   });
 
-  it('runs correctly from the packed CLI entry and installs the npm bin shim', () => {
+  it('runs correctly from the packed npm executable path', () => {
     const root = mkdtempSync(join(tmpdir(), 'create-bijou-pack-cli-'));
     const packDir = join(root, 'pack');
     const runnerDir = join(root, 'runner');
@@ -164,7 +164,6 @@ describe('create-bijou-tui-app cli', () => {
           '--no-save',
           '--no-audit',
           '--fund=false',
-          '--ignore-scripts',
           `file:${tarball}`,
         ],
         {
@@ -179,15 +178,16 @@ describe('create-bijou-tui-app cli', () => {
 
       const binPath = join(runnerDir, 'node_modules', '.bin', 'create-bijou-tui-app');
       expect(existsSync(binPath)).toBe(true);
-      const cliEntryPath = join(runnerDir, 'node_modules', 'create-bijou-tui-app', 'dist', 'cli.js');
-      expect(existsSync(cliEntryPath)).toBe(true);
-
-      const result = spawnSync(process.execPath, [cliEntryPath, targetDir, '--no-install'], {
+      const result = spawnSync(
+        'npm',
+        ['exec', '--prefix', runnerDir, '--', 'create-bijou-tui-app', targetDir, '--no-install'],
+        {
         cwd: root,
         encoding: 'utf8',
         maxBuffer: 8 * 1024 * 1024,
         timeout: 30_000,
-      });
+        },
+      );
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('Created project in');

--- a/packages/create-bijou-tui-app/src/cli.test.ts
+++ b/packages/create-bijou-tui-app/src/cli.test.ts
@@ -131,7 +131,7 @@ describe('create-bijou-tui-app cli', () => {
     }
   });
 
-  it('runs correctly through the packed npm bin shim', () => {
+  it('runs correctly from the packed CLI entry and installs the npm bin shim', () => {
     const root = mkdtempSync(join(tmpdir(), 'create-bijou-pack-cli-'));
     const packDir = join(root, 'pack');
     const runnerDir = join(root, 'runner');
@@ -179,8 +179,10 @@ describe('create-bijou-tui-app cli', () => {
 
       const binPath = join(runnerDir, 'node_modules', '.bin', 'create-bijou-tui-app');
       expect(existsSync(binPath)).toBe(true);
+      const cliEntryPath = join(runnerDir, 'node_modules', 'create-bijou-tui-app', 'dist', 'cli.js');
+      expect(existsSync(cliEntryPath)).toBe(true);
 
-      const result = spawnSync(binPath, [targetDir, '--no-install'], {
+      const result = spawnSync(process.execPath, [cliEntryPath, targetDir, '--no-install'], {
         cwd: root,
         encoding: 'utf8',
         maxBuffer: 8 * 1024 * 1024,

--- a/scripts/release-metadata.test.ts
+++ b/scripts/release-metadata.test.ts
@@ -277,6 +277,37 @@ describe('runReleaseMetadata', () => {
     expect(stdout.join('')).toContain('notes_tag=dry-run-v3.0.0-local');
   });
 
+  it('derives --current-version from discovered workspace packages instead of packages/bijou', () => {
+    const root = makeWorkspace(
+      [
+        { dir: 'core', name: '@flyingrobots/bijou', version: '3.0.0' },
+        {
+          dir: 'node',
+          name: '@flyingrobots/bijou-node',
+          version: '3.0.0',
+          dependencies: { '@flyingrobots/bijou': '3.0.0' },
+        },
+      ],
+      {
+        workspaceRoot: 'fixtures',
+        workspacePatterns: ['fixtures/*'],
+      },
+    );
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const code = runReleaseMetadata(['--current-version'], {
+      cwd: root,
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+    });
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join('')).toContain('@flyingrobots/bijou: 3.0.0 (release: 3.0.0)');
+    expect(stdout.join('')).toContain('version=3.0.0');
+  });
+
   it('fails on workspace mismatches', () => {
     const root = makeWorkspace([
       { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },

--- a/scripts/release-metadata.test.ts
+++ b/scripts/release-metadata.test.ts
@@ -1,0 +1,213 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  parseReleaseTag,
+  runReleaseMetadata,
+  validateWorkspaceVersion,
+  writeGithubOutput,
+} from './release-metadata.js';
+
+const tempRoots: string[] = [];
+
+function makeWorkspace(packages: Array<{
+  readonly dir: string;
+  readonly name: string;
+  readonly version: string;
+  readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+  readonly peerDependencies?: Record<string, string>;
+}>): string {
+  const root = mkdtempSync(join(tmpdir(), 'bijou-release-meta-'));
+  tempRoots.push(root);
+  mkdirSync(join(root, 'packages'), { recursive: true });
+
+  for (const pkg of packages) {
+    const pkgDir = join(root, 'packages', pkg.dir);
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: pkg.name,
+          version: pkg.version,
+          ...(pkg.dependencies ? { dependencies: pkg.dependencies } : {}),
+          ...(pkg.devDependencies ? { devDependencies: pkg.devDependencies } : {}),
+          ...(pkg.peerDependencies ? { peerDependencies: pkg.peerDependencies } : {}),
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    rmSync(tempRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('parseReleaseTag', () => {
+  it('parses stable tags', () => {
+    expect(parseReleaseTag('v3.0.0')).toEqual({
+      tag: 'v3.0.0',
+      tagVersion: '3.0.0',
+      isPrerelease: false,
+      npmDistTag: 'latest',
+    });
+  });
+
+  it('parses prerelease tags', () => {
+    expect(parseReleaseTag('v3.1.0-rc.2')).toEqual({
+      tag: 'v3.1.0-rc.2',
+      tagVersion: '3.1.0-rc.2',
+      isPrerelease: true,
+      npmDistTag: 'next',
+    });
+  });
+
+  it('rejects invalid tags', () => {
+    expect(() => parseReleaseTag('release-3.0.0')).toThrow('Invalid tag format');
+  });
+});
+
+describe('validateWorkspaceVersion', () => {
+  it('accepts aligned workspace versions and internal pins', () => {
+    const root = makeWorkspace([
+      { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
+      {
+        dir: 'bijou-tui',
+        name: '@flyingrobots/bijou-tui',
+        version: '3.0.0',
+        dependencies: { '@flyingrobots/bijou': '3.0.0' },
+        peerDependencies: { '@flyingrobots/bijou-node': '3.0.0' },
+      },
+      {
+        dir: 'bijou-node',
+        name: '@flyingrobots/bijou-node',
+        version: '3.0.0',
+        devDependencies: { '@flyingrobots/bijou': '3.0.0' },
+      },
+    ]);
+
+    expect(validateWorkspaceVersion(root, '3.0.0').errors).toEqual([]);
+  });
+
+  it('reports mismatched peer dependency pins', () => {
+    const root = makeWorkspace([
+      { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
+      {
+        dir: 'bijou-node',
+        name: '@flyingrobots/bijou-node',
+        version: '3.0.0',
+        peerDependencies: { '@flyingrobots/bijou': '^3.0.0' },
+      },
+    ]);
+
+    expect(validateWorkspaceVersion(root, '3.0.0').errors).toEqual([
+      '@flyingrobots/bijou-node has @flyingrobots/bijou@^3.0.0 in peerDependencies, expected 3.0.0',
+    ]);
+  });
+});
+
+describe('runReleaseMetadata', () => {
+  it('writes GitHub outputs for dry-run metadata', () => {
+    const root = makeWorkspace([
+      { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
+      {
+        dir: 'bijou-tui',
+        name: '@flyingrobots/bijou-tui',
+        version: '3.0.0',
+        dependencies: { '@flyingrobots/bijou': '3.0.0' },
+      },
+    ]);
+    const outputPath = join(root, 'github-output.txt');
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const code = runReleaseMetadata(
+      ['--current-version', '--notes-tag-run-id', '123', '--github-output', outputPath],
+      {
+        cwd: root,
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join('')).toContain('@flyingrobots/bijou: 3.0.0 (release: 3.0.0)');
+    expect(readFileSync(outputPath, 'utf8')).toContain('version=3.0.0');
+    expect(readFileSync(outputPath, 'utf8')).toContain('notes_tag=dry-run-v3.0.0-123');
+  });
+
+  it('writes GitHub outputs for tag metadata', () => {
+    const root = makeWorkspace([
+      { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.1.0-rc.2' },
+      {
+        dir: 'bijou-tui',
+        name: '@flyingrobots/bijou-tui',
+        version: '3.1.0-rc.2',
+        peerDependencies: { '@flyingrobots/bijou': '3.1.0-rc.2' },
+      },
+    ]);
+    const outputPath = join(root, 'github-output.txt');
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const code = runReleaseMetadata(
+      ['--tag', 'v3.1.0-rc.2', '--github-output', outputPath],
+      {
+        cwd: root,
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join('')).toContain('@flyingrobots/bijou: 3.1.0-rc.2 (tag: 3.1.0-rc.2)');
+    expect(readFileSync(outputPath, 'utf8')).toContain('tag=v3.1.0-rc.2');
+    expect(readFileSync(outputPath, 'utf8')).toContain('tag_version=3.1.0-rc.2');
+    expect(readFileSync(outputPath, 'utf8')).toContain('is_prerelease=true');
+    expect(readFileSync(outputPath, 'utf8')).toContain('npm_dist_tag=next');
+  });
+
+  it('fails on workspace mismatches', () => {
+    const root = makeWorkspace([
+      { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
+      { dir: 'bijou-node', name: '@flyingrobots/bijou-node', version: '2.1.0' },
+    ]);
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const code = runReleaseMetadata(['--current-version'], {
+      cwd: root,
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+    });
+
+    expect(code).toBe(1);
+    expect(stdout.join('')).toContain('@flyingrobots/bijou-node: 2.1.0 (release: 3.0.0)');
+    expect(stderr.join('')).toContain('Workspace version mismatch detected');
+    expect(stderr.join('')).toContain('@flyingrobots/bijou-node version (2.1.0) does not match expected (3.0.0)');
+  });
+});
+
+describe('writeGithubOutput', () => {
+  it('appends key value pairs as environment-file lines', () => {
+    const root = makeWorkspace([{ dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' }]);
+    const outputPath = join(root, 'github-output.txt');
+
+    writeGithubOutput(outputPath, { version: '3.0.0', notes_tag: 'dry-run-v3.0.0-local' });
+
+    expect(readFileSync(outputPath, 'utf8')).toBe(
+      'version=3.0.0\nnotes_tag=dry-run-v3.0.0-local\n',
+    );
+  });
+});

--- a/scripts/release-metadata.test.ts
+++ b/scripts/release-metadata.test.ts
@@ -18,13 +18,31 @@ function makeWorkspace(packages: Array<{
   readonly dependencies?: Record<string, string>;
   readonly devDependencies?: Record<string, string>;
   readonly peerDependencies?: Record<string, string>;
-}>): string {
+}>, options?: {
+  readonly workspaceRoot?: string;
+  readonly workspacePatterns?: readonly string[];
+}): string {
   const root = mkdtempSync(join(tmpdir(), 'bijou-release-meta-'));
   tempRoots.push(root);
-  mkdirSync(join(root, 'packages'), { recursive: true });
+  const workspaceRoot = options?.workspaceRoot ?? 'packages';
+  const workspacePatterns = options?.workspacePatterns ?? [`${workspaceRoot}/*`];
+  mkdirSync(join(root, workspaceRoot), { recursive: true });
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'bijou-release-meta-test',
+        private: true,
+        workspaces: workspacePatterns,
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
 
   for (const pkg of packages) {
-    const pkgDir = join(root, 'packages', pkg.dir);
+    const pkgDir = join(root, workspaceRoot, pkg.dir);
     mkdirSync(pkgDir, { recursive: true });
     writeFileSync(
       join(pkgDir, 'package.json'),
@@ -112,6 +130,42 @@ describe('validateWorkspaceVersion', () => {
     expect(validateWorkspaceVersion(root, '3.0.0').errors).toEqual([
       '@flyingrobots/bijou-node has @flyingrobots/bijou@^3.0.0 in peerDependencies, expected 3.0.0',
     ]);
+  });
+
+  it('fails on unknown Bijou-scoped dependencies', () => {
+    const root = makeWorkspace([
+      { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
+      {
+        dir: 'bijou-node',
+        name: '@flyingrobots/bijou-node',
+        version: '3.0.0',
+        dependencies: { '@flyingrobots/bijou-legacy': '3.0.0' },
+      },
+    ]);
+
+    expect(validateWorkspaceVersion(root, '3.0.0').errors).toEqual([
+      '@flyingrobots/bijou-node references unknown internal package @flyingrobots/bijou-legacy in dependencies',
+    ]);
+  });
+
+  it('discovers packages from the root workspace config instead of assuming packages/*', () => {
+    const root = makeWorkspace(
+      [
+        { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
+        {
+          dir: 'bijou-node',
+          name: '@flyingrobots/bijou-node',
+          version: '3.0.0',
+          dependencies: { '@flyingrobots/bijou': '3.0.0' },
+        },
+      ],
+      {
+        workspaceRoot: 'fixtures',
+        workspacePatterns: ['fixtures/*'],
+      },
+    );
+
+    expect(validateWorkspaceVersion(root, '3.0.0').errors).toEqual([]);
   });
 });
 

--- a/scripts/release-metadata.test.ts
+++ b/scripts/release-metadata.test.ts
@@ -3,8 +3,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  formatReleaseOutputs,
   parseReleaseTag,
   runReleaseMetadata,
+  validateReleaseVersion,
   validateWorkspaceVersion,
   writeGithubOutput,
 } from './release-metadata.js';
@@ -91,6 +93,23 @@ describe('parseReleaseTag', () => {
 
   it('rejects invalid tags', () => {
     expect(() => parseReleaseTag('release-3.0.0')).toThrow('Invalid tag format');
+  });
+
+  it('rejects tags with leading-zero numeric identifiers', () => {
+    expect(() => parseReleaseTag('v01.2.3')).toThrow('Invalid tag format');
+    expect(() => parseReleaseTag('v3.1.0-rc.01')).toThrow('Invalid tag format');
+  });
+});
+
+describe('validateReleaseVersion', () => {
+  it('accepts valid release versions', () => {
+    expect(validateReleaseVersion('3.0.0')).toBe('3.0.0');
+    expect(validateReleaseVersion('3.1.0-beta.2')).toBe('3.1.0-beta.2');
+  });
+
+  it('rejects leading-zero numeric identifiers', () => {
+    expect(() => validateReleaseVersion('01.2.3')).toThrow('Invalid release version');
+    expect(() => validateReleaseVersion('3.1.0-rc.01')).toThrow('Invalid release version');
   });
 });
 
@@ -232,6 +251,32 @@ describe('runReleaseMetadata', () => {
     expect(readFileSync(outputPath, 'utf8')).toContain('npm_dist_tag=next');
   });
 
+  it('prints derived outputs locally when no GitHub output file is provided', () => {
+    const root = makeWorkspace([
+      { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
+      {
+        dir: 'bijou-tui',
+        name: '@flyingrobots/bijou-tui',
+        version: '3.0.0',
+        dependencies: { '@flyingrobots/bijou': '3.0.0' },
+      },
+    ]);
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const code = runReleaseMetadata(['--current-version', '--notes-tag-run-id', 'local'], {
+      cwd: root,
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+    });
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout.join('')).toContain('@flyingrobots/bijou: 3.0.0 (release: 3.0.0)');
+    expect(stdout.join('')).toContain('version=3.0.0');
+    expect(stdout.join('')).toContain('notes_tag=dry-run-v3.0.0-local');
+  });
+
   it('fails on workspace mismatches', () => {
     const root = makeWorkspace([
       { dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' },
@@ -254,6 +299,12 @@ describe('runReleaseMetadata', () => {
 });
 
 describe('writeGithubOutput', () => {
+  it('formats key value pairs as environment-file lines', () => {
+    expect(formatReleaseOutputs({ version: '3.0.0', notes_tag: 'dry-run-v3.0.0-local' })).toBe(
+      'version=3.0.0\nnotes_tag=dry-run-v3.0.0-local\n',
+    );
+  });
+
   it('appends key value pairs as environment-file lines', () => {
     const root = makeWorkspace([{ dir: 'bijou', name: '@flyingrobots/bijou', version: '3.0.0' }]);
     const outputPath = join(root, 'github-output.txt');

--- a/scripts/release-metadata.ts
+++ b/scripts/release-metadata.ts
@@ -1,0 +1,240 @@
+import { appendFileSync, existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type DependencyMap = Record<string, string>;
+type DependencyType = 'dependencies' | 'devDependencies' | 'peerDependencies';
+
+export interface PackageManifest {
+  readonly name: string;
+  readonly version: string;
+  readonly dependencies?: DependencyMap;
+  readonly devDependencies?: DependencyMap;
+  readonly peerDependencies?: DependencyMap;
+}
+
+export interface WorkspacePackage {
+  readonly manifestPath: string;
+  readonly manifest: PackageManifest;
+}
+
+export interface StableReleaseMetadata {
+  readonly tag: string;
+  readonly tagVersion: string;
+  readonly isPrerelease: false;
+  readonly npmDistTag: 'latest';
+}
+
+export interface PrereleaseMetadata {
+  readonly tag: string;
+  readonly tagVersion: string;
+  readonly isPrerelease: true;
+  readonly npmDistTag: 'next' | 'beta' | 'alpha';
+}
+
+export type ReleaseMetadata = StableReleaseMetadata | PrereleaseMetadata;
+
+export interface ReleaseCommandIO {
+  readonly cwd?: string;
+  readonly stdout?: (text: string) => void;
+  readonly stderr?: (text: string) => void;
+}
+
+export interface ReleaseCommandOutputs {
+  readonly [key: string]: string;
+}
+
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$/;
+const TAG_PATTERN = /^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)(?:-(?<channel>rc|beta|alpha)\.(?<serial>[0-9]+))?$/;
+const DEPENDENCY_TYPES: readonly DependencyType[] = ['dependencies', 'devDependencies', 'peerDependencies'];
+const PACKAGE_ROOT_RELATIVE = 'packages/bijou/package.json';
+
+function readJsonFile<T>(filepath: string): T {
+  return JSON.parse(readFileSync(filepath, 'utf8')) as T;
+}
+
+export function readWorkspacePackages(root: string): readonly WorkspacePackage[] {
+  const packagesDir = join(root, 'packages');
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(packagesDir, entry.name, 'package.json'))
+    .filter((manifestPath) => existsSync(manifestPath))
+    .map((manifestPath) => ({
+      manifestPath,
+      manifest: readJsonFile<PackageManifest>(manifestPath),
+    }))
+    .sort((left, right) => left.manifest.name.localeCompare(right.manifest.name));
+}
+
+export function readCurrentWorkspaceVersion(root: string): string {
+  const manifestPath = join(root, PACKAGE_ROOT_RELATIVE);
+  return readJsonFile<PackageManifest>(manifestPath).version;
+}
+
+export function parseReleaseTag(tag: string): ReleaseMetadata {
+  const match = TAG_PATTERN.exec(tag);
+  if (!match?.groups) {
+    throw new Error(`Invalid tag format: ${tag}`);
+  }
+
+  const tagVersion = match.groups.version + (match.groups.channel ? `-${match.groups.channel}.${match.groups.serial}` : '');
+  const channel = match.groups.channel as 'rc' | 'beta' | 'alpha' | undefined;
+
+  if (!channel) {
+    return {
+      tag,
+      tagVersion,
+      isPrerelease: false,
+      npmDistTag: 'latest',
+    };
+  }
+
+  return {
+    tag,
+    tagVersion,
+    isPrerelease: true,
+    npmDistTag: channel === 'rc' ? 'next' : channel === 'beta' ? 'beta' : 'alpha',
+  };
+}
+
+export function validateReleaseVersion(version: string): string {
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+  }
+
+  return version;
+}
+
+export function validateWorkspaceVersion(
+  root: string,
+  expectedVersion: string,
+): { readonly packages: readonly WorkspacePackage[]; readonly errors: readonly string[] } {
+  const packages = readWorkspacePackages(root);
+  const internalPackageNames = new Set(packages.map((entry) => entry.manifest.name));
+  const errors: string[] = [];
+
+  for (const entry of packages) {
+    const { name, version } = entry.manifest;
+    if (version !== expectedVersion) {
+      errors.push(`${name} version (${version}) does not match expected (${expectedVersion})`);
+    }
+  }
+
+  for (const entry of packages) {
+    for (const dependencyType of DEPENDENCY_TYPES) {
+      const deps = entry.manifest[dependencyType];
+      if (!deps) continue;
+      for (const [name, version] of Object.entries(deps)) {
+        if (!internalPackageNames.has(name)) continue;
+        if (version !== expectedVersion) {
+          errors.push(`${entry.manifest.name} has ${name}@${version} in ${dependencyType}, expected ${expectedVersion}`);
+        }
+      }
+    }
+  }
+
+  return { packages, errors };
+}
+
+export function writeGithubOutput(filepath: string, outputs: ReleaseCommandOutputs): void {
+  const lines = Object.entries(outputs).map(([key, value]) => `${key}=${value}`);
+  appendFileSync(filepath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function printPackageSummary(
+  packages: readonly WorkspacePackage[],
+  expectedVersion: string,
+  label: string,
+  write: (text: string) => void,
+): void {
+  for (const entry of packages) {
+    write(`${entry.manifest.name}: ${entry.manifest.version} (${label}: ${expectedVersion})\n`);
+  }
+}
+
+function parseOption(argv: readonly string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function hasFlag(argv: readonly string[], flag: string): boolean {
+  return argv.includes(flag);
+}
+
+export function runReleaseMetadata(argv: readonly string[], io: ReleaseCommandIO = {}): number {
+  const root = resolve(io.cwd ?? process.cwd());
+  const stdout = io.stdout ?? ((text: string) => process.stdout.write(text));
+  const stderr = io.stderr ?? ((text: string) => process.stderr.write(text));
+
+  try {
+    const tag = parseOption(argv, '--tag');
+    const explicitVersion = parseOption(argv, '--version');
+    const notesTag = parseOption(argv, '--notes-tag');
+    const notesTagRunId = parseOption(argv, '--notes-tag-run-id');
+    const githubOutput = parseOption(argv, '--github-output');
+    const useCurrentVersion = hasFlag(argv, '--current-version');
+
+    const versionSources = [tag, explicitVersion, useCurrentVersion ? '__current__' : undefined].filter(Boolean);
+    if (versionSources.length !== 1) {
+      throw new Error('Specify exactly one of --tag, --version, or --current-version');
+    }
+
+    if (notesTag && notesTagRunId) {
+      throw new Error('Use either --notes-tag or --notes-tag-run-id, not both');
+    }
+
+    let expectedVersion: string;
+    let outputs: ReleaseCommandOutputs;
+    let packageSummaryLabel: string;
+
+    if (tag) {
+      const metadata = parseReleaseTag(tag);
+      expectedVersion = metadata.tagVersion;
+      outputs = {
+        tag: metadata.tag,
+        tag_version: metadata.tagVersion,
+        is_prerelease: String(metadata.isPrerelease),
+        npm_dist_tag: metadata.npmDistTag,
+      };
+      packageSummaryLabel = 'tag';
+    } else {
+      expectedVersion = validateReleaseVersion(useCurrentVersion ? readCurrentWorkspaceVersion(root) : explicitVersion!);
+      const resolvedNotesTag = notesTagRunId ? `dry-run-v${expectedVersion}-${notesTagRunId}` : notesTag;
+      outputs = {
+        version: expectedVersion,
+        ...(resolvedNotesTag ? { notes_tag: resolvedNotesTag } : {}),
+      };
+      packageSummaryLabel = 'release';
+    }
+
+    const validation = validateWorkspaceVersion(root, expectedVersion);
+    printPackageSummary(validation.packages, expectedVersion, packageSummaryLabel, stdout);
+
+    if (validation.errors.length > 0) {
+      for (const error of validation.errors) {
+        stderr(`::error::${error}\n`);
+      }
+      stderr(`::error::Workspace version mismatch detected. Run: npm run version ${expectedVersion}\n`);
+      return 1;
+    }
+
+    if (githubOutput) {
+      writeGithubOutput(githubOutput, outputs);
+    }
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr(`${message}\n`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exitCode = runReleaseMetadata(process.argv.slice(2));
+}

--- a/scripts/release-metadata.ts
+++ b/scripts/release-metadata.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 type DependencyMap = Record<string, string>;
 type DependencyType = 'dependencies' | 'devDependencies' | 'peerDependencies';
+const INTERNAL_PACKAGE_PREFIX = '@flyingrobots/bijou';
 
 export interface PackageManifest {
   readonly name: string;
@@ -44,6 +45,10 @@ export interface ReleaseCommandOutputs {
   readonly [key: string]: string;
 }
 
+interface RootWorkspaceManifest {
+  readonly workspaces?: readonly string[] | { readonly packages?: readonly string[] };
+}
+
 const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$/;
 const TAG_PATTERN = /^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)(?:-(?<channel>rc|beta|alpha)\.(?<serial>[0-9]+))?$/;
 const DEPENDENCY_TYPES: readonly DependencyType[] = ['dependencies', 'devDependencies', 'peerDependencies'];
@@ -54,11 +59,61 @@ function readJsonFile<T>(filepath: string): T {
 }
 
 export function readWorkspacePackages(root: string): readonly WorkspacePackage[] {
-  const packagesDir = join(root, 'packages');
-  return readdirSync(packagesDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(packagesDir, entry.name, 'package.json'))
-    .filter((manifestPath) => existsSync(manifestPath))
+  const rootManifest = readJsonFile<RootWorkspaceManifest>(join(root, 'package.json'));
+  const workspaces = rootManifest.workspaces;
+  let workspacePatterns: readonly string[] | undefined;
+
+  if (Array.isArray(workspaces)) {
+    workspacePatterns = workspaces;
+  } else if (workspaces && 'packages' in workspaces) {
+    workspacePatterns = workspaces.packages;
+  }
+
+  if (!workspacePatterns || workspacePatterns.length === 0) {
+    throw new Error('Root package.json is missing workspaces configuration');
+  }
+
+  const manifestPaths = new Set<string>();
+
+  for (const pattern of workspacePatterns) {
+    if (pattern.endsWith('/*')) {
+      const basePattern = pattern.slice(0, -2);
+      if (basePattern.includes('*')) {
+        throw new Error(`Unsupported workspace pattern: ${pattern}`);
+      }
+
+      const baseDir = join(root, basePattern);
+      if (!existsSync(baseDir)) {
+        throw new Error(`Workspace directory does not exist: ${pattern}`);
+      }
+
+      for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const manifestPath = join(baseDir, entry.name, 'package.json');
+        if (!existsSync(manifestPath)) {
+          throw new Error(`Workspace package is missing package.json: ${join(pattern.slice(0, -1), entry.name)}`);
+        }
+        manifestPaths.add(manifestPath);
+      }
+      continue;
+    }
+
+    if (pattern.includes('*')) {
+      throw new Error(`Unsupported workspace pattern: ${pattern}`);
+    }
+
+    const manifestPath = join(root, pattern, 'package.json');
+    if (!existsSync(manifestPath)) {
+      throw new Error(`Workspace package is missing package.json: ${pattern}`);
+    }
+    manifestPaths.add(manifestPath);
+  }
+
+  if (manifestPaths.size === 0) {
+    throw new Error('Workspace configuration did not resolve any package.json files');
+  }
+
+  return [...manifestPaths]
     .map((manifestPath) => ({
       manifestPath,
       manifest: readJsonFile<PackageManifest>(manifestPath),
@@ -125,7 +180,14 @@ export function validateWorkspaceVersion(
       const deps = entry.manifest[dependencyType];
       if (!deps) continue;
       for (const [name, version] of Object.entries(deps)) {
-        if (!internalPackageNames.has(name)) continue;
+        const isKnownWorkspacePackage = internalPackageNames.has(name);
+        const isBijouScopedDependency = name.startsWith(INTERNAL_PACKAGE_PREFIX);
+
+        if (!isKnownWorkspacePackage && !isBijouScopedDependency) continue;
+        if (isBijouScopedDependency && !isKnownWorkspacePackage) {
+          errors.push(`${entry.manifest.name} references unknown internal package ${name} in ${dependencyType}`);
+          continue;
+        }
         if (version !== expectedVersion) {
           errors.push(`${entry.manifest.name} has ${name}@${version} in ${dependencyType}, expected ${expectedVersion}`);
         }

--- a/scripts/release-metadata.ts
+++ b/scripts/release-metadata.ts
@@ -49,8 +49,13 @@ interface RootWorkspaceManifest {
   readonly workspaces?: readonly string[] | { readonly packages?: readonly string[] };
 }
 
-const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$/;
-const TAG_PATTERN = /^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)(?:-(?<channel>rc|beta|alpha)\.(?<serial>[0-9]+))?$/;
+const SEMVER_INT = '(?:0|[1-9][0-9]*)';
+const VERSION_PATTERN = new RegExp(
+  `^${SEMVER_INT}\\.${SEMVER_INT}\\.${SEMVER_INT}(?:-(rc|beta|alpha)\\.${SEMVER_INT})?$`,
+);
+const TAG_PATTERN = new RegExp(
+  `^v(?<version>${SEMVER_INT}\\.${SEMVER_INT}\\.${SEMVER_INT})(?:-(?<channel>rc|beta|alpha)\\.(?<serial>${SEMVER_INT}))?$`,
+);
 const DEPENDENCY_TYPES: readonly DependencyType[] = ['dependencies', 'devDependencies', 'peerDependencies'];
 const PACKAGE_ROOT_RELATIVE = 'packages/bijou/package.json';
 
@@ -203,6 +208,12 @@ export function writeGithubOutput(filepath: string, outputs: ReleaseCommandOutpu
   appendFileSync(filepath, `${lines.join('\n')}\n`, 'utf8');
 }
 
+export function formatReleaseOutputs(outputs: ReleaseCommandOutputs): string {
+  return `${Object.entries(outputs)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')}\n`;
+}
+
 function printPackageSummary(
   packages: readonly WorkspacePackage[],
   expectedVersion: string,
@@ -287,6 +298,8 @@ export function runReleaseMetadata(argv: readonly string[], io: ReleaseCommandIO
 
     if (githubOutput) {
       writeGithubOutput(githubOutput, outputs);
+    } else {
+      stdout(formatReleaseOutputs(outputs));
     }
 
     return 0;

--- a/scripts/release-metadata.ts
+++ b/scripts/release-metadata.ts
@@ -57,8 +57,6 @@ const TAG_PATTERN = new RegExp(
   `^v(?<version>${SEMVER_INT}\\.${SEMVER_INT}\\.${SEMVER_INT})(?:-(?<channel>rc|beta|alpha)\\.(?<serial>${SEMVER_INT}))?$`,
 );
 const DEPENDENCY_TYPES: readonly DependencyType[] = ['dependencies', 'devDependencies', 'peerDependencies'];
-const PACKAGE_ROOT_RELATIVE = 'packages/bijou/package.json';
-
 function readJsonFile<T>(filepath: string): T {
   return JSON.parse(readFileSync(filepath, 'utf8')) as T;
 }
@@ -127,8 +125,13 @@ export function readWorkspacePackages(root: string): readonly WorkspacePackage[]
 }
 
 export function readCurrentWorkspaceVersion(root: string): string {
-  const manifestPath = join(root, PACKAGE_ROOT_RELATIVE);
-  return readJsonFile<PackageManifest>(manifestPath).version;
+  const packages = readWorkspacePackages(root);
+  const firstPackage = packages[0];
+  if (firstPackage == null) {
+    throw new Error('Workspace configuration did not resolve any package.json files');
+  }
+
+  return validateReleaseVersion(firstPackage.manifest.version);
 }
 
 export function parseReleaseTag(tag: string): ReleaseMetadata {

--- a/scripts/smoke-canaries.ts
+++ b/scripts/smoke-canaries.ts
@@ -134,11 +134,15 @@ function runTuiCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, st
   if (!existsSync(cliBin)) {
     throw new Error(`installed create-bijou-tui-app tarball did not produce a bin shim at ${cliBin}`);
   }
+  const cliEntryPath = resolve(cliRunnerDir, 'node_modules/create-bijou-tui-app/dist/cli.js');
+  if (!existsSync(cliEntryPath)) {
+    throw new Error(`installed create-bijou-tui-app tarball did not include a CLI entry at ${cliEntryPath}`);
+  }
   process.stdout.write('generate TUI canary ... ');
   runCommand(
     'generate TUI canary',
-    cliBin,
-    [targetDir, '--no-install'],
+    process.execPath,
+    [cliEntryPath, targetDir, '--no-install'],
     { cwd: ROOT },
     { quietSuccess: true },
   );
@@ -146,7 +150,12 @@ function runTuiCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, st
 
   rewriteManifest(resolve(targetDir, 'package.json'), tarballSpecs);
 
-  runSimpleNpmLifecycle('install TUI canary', targetDir, ['install', '--no-fund', '--no-audit']);
+  runSimpleNpmLifecycle(
+    'install TUI canary',
+    targetDir,
+    ['install', '--no-fund', '--no-audit', '--ignore-scripts'],
+    300000,
+  );
   runSimpleNpmLifecycle('build TUI canary', targetDir, ['run', 'build']);
 
   process.stdout.write('run TUI canary ... ');
@@ -197,7 +206,12 @@ function runCoreStaticCanary(tempRoot: string, tarballSpecs: Readonly<Record<str
   cpSync(FIXTURE_ROOT, targetDir, { recursive: true });
   rewriteManifest(resolve(targetDir, 'package.json'), tarballSpecs);
 
-  runSimpleNpmLifecycle('install core/static canary', targetDir, ['install', '--no-fund', '--no-audit']);
+  runSimpleNpmLifecycle(
+    'install core/static canary',
+    targetDir,
+    ['install', '--no-fund', '--no-audit', '--ignore-scripts'],
+    300000,
+  );
   runSimpleNpmLifecycle('build core/static canary', targetDir, ['run', 'build']);
 
   process.stdout.write('run core/static canary ... ');
@@ -231,9 +245,14 @@ function runCoreStaticCanary(tempRoot: string, tarballSpecs: Readonly<Record<str
   process.stdout.write('ok\n');
 }
 
-function runSimpleNpmLifecycle(label: string, cwd: string, args: readonly string[]): void {
+function runSimpleNpmLifecycle(
+  label: string,
+  cwd: string,
+  args: readonly string[],
+  timeoutMs = 120000,
+): void {
   process.stdout.write(`${label} ... `);
-  runCommand(label, 'npm', [...args], { cwd }, { quietSuccess: true, timeoutMs: 120000 });
+  runCommand(label, 'npm', [...args], { cwd }, { quietSuccess: true, timeoutMs });
   process.stdout.write('ok\n');
 }
 

--- a/scripts/smoke-canaries.ts
+++ b/scripts/smoke-canaries.ts
@@ -128,21 +128,17 @@ function runTuiCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, st
   runSimpleNpmLifecycle(
     'install packed scaffold CLI',
     ROOT,
-    ['install', '--prefix', cliRunnerDir, '--no-package-lock', '--no-save', cliTarball],
+    ['install', '--prefix', cliRunnerDir, '--no-package-lock', '--no-save', '--no-audit', '--fund=false', cliTarball],
   );
   const cliBin = resolve(cliRunnerDir, 'node_modules/.bin/create-bijou-tui-app');
   if (!existsSync(cliBin)) {
     throw new Error(`installed create-bijou-tui-app tarball did not produce a bin shim at ${cliBin}`);
   }
-  const cliEntryPath = resolve(cliRunnerDir, 'node_modules/create-bijou-tui-app/dist/cli.js');
-  if (!existsSync(cliEntryPath)) {
-    throw new Error(`installed create-bijou-tui-app tarball did not include a CLI entry at ${cliEntryPath}`);
-  }
   process.stdout.write('generate TUI canary ... ');
   runCommand(
     'generate TUI canary',
-    process.execPath,
-    [cliEntryPath, targetDir, '--no-install'],
+    'npm',
+    ['exec', '--prefix', cliRunnerDir, '--', 'create-bijou-tui-app', targetDir, '--no-install'],
     { cwd: ROOT },
     { quietSuccess: true },
   );
@@ -153,7 +149,7 @@ function runTuiCanary(tempRoot: string, tarballSpecs: Readonly<Record<string, st
   runSimpleNpmLifecycle(
     'install TUI canary',
     targetDir,
-    ['install', '--no-fund', '--no-audit', '--ignore-scripts'],
+    ['install', '--no-fund', '--no-audit'],
     300000,
   );
   runSimpleNpmLifecycle('build TUI canary', targetDir, ['run', 'build']);
@@ -209,7 +205,7 @@ function runCoreStaticCanary(tempRoot: string, tarballSpecs: Readonly<Record<str
   runSimpleNpmLifecycle(
     'install core/static canary',
     targetDir,
-    ['install', '--no-fund', '--no-audit', '--ignore-scripts'],
+    ['install', '--no-fund', '--no-audit'],
     300000,
   );
   runSimpleNpmLifecycle('build core/static canary', targetDir, ['run', 'build']);


### PR DESCRIPTION
## Summary
- extract release tag/version and workspace dependency validation into a shared repo script
- wire both release workflows to use the shared validation path
- add a local release:preflight command and unit coverage for the new tooling

## Verification
- npm run release:preflight
- npx vitest run --config vitest.config.ts scripts/release-metadata.test.ts
- npm run typecheck:test
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local preflight command to emit and validate release metadata before publishing.

* **Chores**
  * Centralized release metadata and validation into a shared script used by publish and dry-run workflows.
  * Workflow step label updated from "Type check" to "Lint".
  * Improved CLI invocation and extended install timeouts for packaging checks.

* **Tests**
  * Added comprehensive test coverage for release metadata parsing, validation, outputs, and error paths.

* **Documentation**
  * Updated changelog to describe the shared validation script and preflight flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->