### PR TITLE
feat: add deterministic runtime clock seam

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Runtime timer-handle cleanup** — interactive runtime renders and shutdown flushes now dispose their scheduled timeout handles after firing, so deterministic clocks do not retain stale timeout bookkeeping after the app exits.
 - **Deterministic Ctrl+C quit guard** — interactive runtime now treats “no prior Ctrl+C” distinctly from “Ctrl+C at time zero,” so injected clocks that start at `0` still forward the first Ctrl+C to the app instead of force-quitting immediately.
 - **Deterministic runtime test lint compliance** — the Ctrl+C-at-time-zero regression test now disposes its timeout handles with a block-bodied loop so it satisfies the repo’s iterable-callback-return lint rule without changing behavior.
+- **Deterministic runtime test helper cleanup** — the tracking clock helper in `runtime.test.ts` now passes timeout callbacks directly to the base clock instead of wrapping them in a no-op forwarding closure.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Surface background metadata parity** — `boxSurface()` now preserves interior background cells even when `ctx` is `noColor`, so the returned `Surface` model stays consistent and render policy decides whether color is emitted.
 - **Pulse-driven TUI timing** — `tick()`, framed-page transitions, runtime render scheduling, and live timer/log/spinner/progress helpers now route through the shared clock/pulse seams instead of mixing raw `Date.now()`, `setTimeout(...)`, and `setInterval(...)` into component logic.
 - **Deterministic test cleanup** — high-signal TUI tests now use `mockClock()`, explicit event-bus idleness, and deterministic temporary paths instead of wall-clock sleeps and random missing-file names.
+- **Deterministic command and timer drains** — event-bus `drain()` now settles even when commands throw synchronously, and `mockClock.runAll()` now fails loudly instead of spinning forever when live intervals remain active.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### ✨ Features
 
 - **Surface-first companion primitives** — added `boxSurface()`, `headerBoxSurface()`, `separatorSurface()`, `alertSurface()`, and `tableSurface()` so V3 apps can keep common layout/status composition on the `Surface` path instead of dropping back through explicit string bridges.
+- **Deterministic clock port and test adapter** — `BijouContext` now supports a shared `clock` port, and the test adapters now ship `mockClock()` so runtime code and component tests can fake wall-clock time without reaching for Node globals.
+- **Idle-aware scripted driver controls** — `runScript()` now supports configurable pulse frequency, and the TUI event bus exposes explicit command-idle tracking so deterministic tests can wait for real command completion instead of sprinkling `setTimeout(...)` heuristics.
 
 ### 🐛 Fixes
 
@@ -25,6 +27,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Surface fixed-width normalization** — `boxSurface()` now normalizes fractional or negative fixed widths before border and blit math runs, so constrained boxes preserve their borders instead of drifting past the actual allocated surface width.
 - **Surface title and table width parity** — `boxSurface()` now widens auto-sized boxes to account for long titles like `box()`, and `tableSurface()` now normalizes explicit column widths before layout math so fractional widths cannot corrupt the underlying `Surface` grid.
 - **Surface background metadata parity** — `boxSurface()` now preserves interior background cells even when `ctx` is `noColor`, so the returned `Surface` model stays consistent and render policy decides whether color is emitted.
+- **Pulse-driven TUI timing** — `tick()`, framed-page transitions, runtime render scheduling, and live timer/log/spinner/progress helpers now route through the shared clock/pulse seams instead of mixing raw `Date.now()`, `setTimeout(...)`, and `setInterval(...)` into component logic.
+- **Deterministic test cleanup** — high-signal TUI tests now use `mockClock()`, explicit event-bus idleness, and deterministic temporary paths instead of wall-clock sleeps and random missing-file names.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Pulse-driven TUI timing** — `tick()`, framed-page transitions, runtime render scheduling, and live timer/log/spinner/progress helpers now route through the shared clock/pulse seams instead of mixing raw `Date.now()`, `setTimeout(...)`, and `setInterval(...)` into component logic.
 - **Deterministic test cleanup** — high-signal TUI tests now use `mockClock()`, explicit event-bus idleness, and deterministic temporary paths instead of wall-clock sleeps and random missing-file names.
 - **Deterministic command and timer drains** — event-bus `drain()` now settles even when commands throw synchronously, and `mockClock.runAll()` now fails loudly instead of spinning forever when live intervals remain active.
+- **Runtime timer-handle cleanup** — interactive runtime renders and shutdown flushes now dispose their scheduled timeout handles after firing, so deterministic clocks do not retain stale timeout bookkeeping after the app exits.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Deterministic command and timer drains** — event-bus `drain()` now settles even when commands throw synchronously, and `mockClock.runAll()` now fails loudly instead of spinning forever when live intervals remain active.
 - **Runtime timer-handle cleanup** — interactive runtime renders and shutdown flushes now dispose their scheduled timeout handles after firing, so deterministic clocks do not retain stale timeout bookkeeping after the app exits.
 - **Deterministic Ctrl+C quit guard** — interactive runtime now treats “no prior Ctrl+C” distinctly from “Ctrl+C at time zero,” so injected clocks that start at `0` still forward the first Ctrl+C to the app instead of force-quitting immediately.
+- **Deterministic runtime test lint compliance** — the Ctrl+C-at-time-zero regression test now disposes its timeout handles with a block-bodied loop so it satisfies the repo’s iterable-callback-return lint rule without changing behavior.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Deterministic test cleanup** — high-signal TUI tests now use `mockClock()`, explicit event-bus idleness, and deterministic temporary paths instead of wall-clock sleeps and random missing-file names.
 - **Deterministic command and timer drains** — event-bus `drain()` now settles even when commands throw synchronously, and `mockClock.runAll()` now fails loudly instead of spinning forever when live intervals remain active.
 - **Runtime timer-handle cleanup** — interactive runtime renders and shutdown flushes now dispose their scheduled timeout handles after firing, so deterministic clocks do not retain stale timeout bookkeeping after the app exits.
+- **Deterministic Ctrl+C quit guard** — interactive runtime now treats “no prior Ctrl+C” distinctly from “Ctrl+C at time zero,” so injected clocks that start at `0` still forward the first Ctrl+C to the app instead of force-quitting immediately.
 
 ## [3.0.0] - 2026-03-12
 

--- a/docs/CODERABBIT_REVIEW_NOTES.md
+++ b/docs/CODERABBIT_REVIEW_NOTES.md
@@ -28,6 +28,11 @@ Track recurring friction in the PR feedback loop and concrete fixes (scripts/pro
   Progress: the file now uses an explicit `15_000ms` budget for the two async proxy-runtime tests, which stabilized the full-suite push.
   Remaining gap: reduce dynamic-import and mock overhead so those tests can move back toward the default timeout budget.
 
+### 2026-03-16
+- **Deterministic clocks are flushing out real runtime edge cases**: once time became injectable, CodeRabbit and local regressions surfaced several legitimate bugs that wall-clock testing had masked: event-bus sync throws could strand `drain()`, `mockClock.runAll()` could spin forever on active intervals, runtime timeout handles were not always disposed after firing, and the interactive Ctrl+C guard treated time `0` as "already pressed once."
+  Progress: PR #47 adds the shared `clock` port/test adapter, event-bus idle tracking, pulse-driven timing, timeout-handle cleanup, and targeted regressions for those failure modes.
+  Remaining gap: finish pushing the remaining time-dependent logic behind explicit seams, share the runtime viewport overlay across main/worker runtimes, and add more fake-time coverage around intervals, microtasks, and startup-time sentinel values.
+
 ## Backlog Candidates
 - Build `scripts/pr-review-threads.ts` to export unresolved threads as JSON/Markdown with severity bucketing and dedupe.
 - Build `scripts/pr-review-resolve.ts` to resolve confirmed-addressed thread IDs in bulk.
@@ -41,3 +46,6 @@ Track recurring friction in the PR feedback loop and concrete fixes (scripts/pro
 - Generalize stale CodeRabbit history handling beyond `rate-limited` comments so older clean/actionable bot chatter is down-ranked as explicitly as rate-limit noise.
 - Add a reusable parity-test helper or pattern for paired string/surface primitives so option-contract regressions are easier to lock down.
 - Reduce the runtime cost of `packages/bijou-node/src/worker/worker.proxy.test.ts` so explicit elevated timeout budgets are no longer needed.
+- Add more defensive fake-time regressions around intervals, microtasks, idle-drain sequencing, and startup-time sentinel values.
+- Finish sharing the runtime viewport overlay/helper across main and worker runtimes so resize bookkeeping and deterministic timing stay aligned.
+- Keep removing remaining direct wall-clock/global-timer uses in runtime and component logic in favor of the shared clock/pulse seams.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,6 +56,7 @@ See [COMPLETED.md](COMPLETED.md) for the full shipped log. Summary:
 | ~~**Sub-App Composition**~~ | ~~bijou-tui~~ | ~~Shipped in v3.0.0. Fractal TEA support via `mount()` and `mapCmds()`.~~ |
 | ~~**Reactive & Semantic Token Graph**~~ | ~~bijou~~ | ~~Shipped in v3.0.0. Reactive graph backend for theming (`createTokenGraph`).~~ |
 | **Shared Runtime Viewport Overlay** | bijou-tui + bijou-node | Extract the mutable runtime-size overlay used by the main runtime and worker runtime into one shared helper so resize-state logic stays consistent across contexts. |
+| **Deterministic Time & Idle Semantics** | bijou + bijou-tui | The first v3.1 hardening slice adds a shared `clock` port, `mockClock()`, event-bus `drain()`, and pulse-driven timing. Backlog now covers the remaining global-timer holdouts, shared runtime overlay cleanup, and more defensive interval/microtask/sentinel regressions. |
 | **Standardized `BijouNode` Protocol** | bijou | Unified node type and `children` prop across all components for true composability. |
 | **Standard Interactive Component & Form System** | bijou-tui | Unified interface for stateful components (Sub-Apps), global focus management, and TEA-native form binding. |
 | **Worker Runtime Hardening & Performance** | bijou-node | `runInWorker()` / `startWorkerApp()` shipped in v3.0.0. Backlog now covers heavier-load scheduling, profiling, and follow-up cleanup beyond the first release. |

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -40,8 +40,9 @@ describe('nodeIO()', () => {
   });
 
   it('readFile() throws for missing file', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bijou-test-'));
     const io = nodeIO();
-    const missingFile = join(tmpdir(), `bijou-missing-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
+    const missingFile = join(tempDir, 'missing.txt');
     expect(() => io.readFile(missingFile)).toThrow();
   });
 
@@ -70,8 +71,9 @@ describe('nodeIO()', () => {
   });
 
   it('readDir() throws for missing directory', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bijou-test-'));
     const io = nodeIO();
-    const missingDir = join(tmpdir(), `bijou-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const missingDir = join(tempDir, 'missing-dir');
     expect(() => io.readDir(missingDir)).toThrow();
   });
 

--- a/packages/bijou-tui-app/src/index.test.ts
+++ b/packages/bijou-tui-app/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { createTestContext, mockClock } from '@flyingrobots/bijou/adapters/test';
 import { runScript, stripAnsi, visibleLength } from '@flyingrobots/bijou-tui';
 import { surfaceToString } from '@flyingrobots/bijou';
 import { createTuiAppSkeleton } from './index.js';
@@ -81,13 +81,18 @@ describe('createTuiAppSkeleton', () => {
   });
 
   it('animates drawer changes via physics commands', async () => {
-    const ctx = createTestContext({ mode: 'interactive' });
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
     const app = createTuiAppSkeleton({ ctx });
 
-    const result = await runScript(app, [
+    const promise = runScript(app, [
       { key: 'o' },
       { key: 'o', delay: 120 },
     ], { ctx });
+    for (let i = 0; i < 80; i++) {
+      await clock.advanceByAsync(25);
+    }
+    const result = await promise;
 
     // Initial frame + key frame + animation frames + second toggle.
     expect(result.frames.length).toBeGreaterThan(3);

--- a/packages/bijou-tui/src/app-frame-actions.ts
+++ b/packages/bijou-tui/src/app-frame-actions.ts
@@ -144,7 +144,7 @@ export function switchTab<PageModel, Msg>(
     transitionProgress: hasTransition ? 0 : 1,
     transitionGeneration: nextGeneration,
     transitionFrame: 0,
-    transitionStartMs: hasTransition ? Date.now() : undefined,
+    transitionStartMs: undefined,
     transitionTimeline: tl,
     transitionTimelineState: tl?.init(),
   }, nextId, pagesById);
@@ -382,14 +382,10 @@ export function syncPageFrameState<PageModel, Msg>(
 }
 
 /**
- * Create a TEA command that drives transition re-renders via `setInterval`.
- *
- * Each tick emits a frame-scoped 'transition' message. The actual progress
- * is computed from wall-clock time in the update handler, not from the
- * interval count. The interval just schedules re-renders.
+ * Create a TEA command that drives transition re-renders from the shared pulse.
  */
 export function createTransitionTickCmd<Msg>(durationMs: number, generation: number): Cmd<Msg> {
-  return (emit) =>
+  return (emit, caps) =>
     new Promise<void>((resolve) => {
       if (durationMs <= 0) {
         emit(wrapFrameMsg({ type: 'transition-complete', generation } as FrameAction) as unknown as Msg);
@@ -397,20 +393,24 @@ export function createTransitionTickCmd<Msg>(durationMs: number, generation: num
         return;
       }
 
-      const startMs = Date.now();
-      const intervalMs = Math.round(1000 / 60);
+      let elapsedMs = 0;
+      const pulse = caps.onPulse((dt) => {
+        elapsedMs = Math.min(durationMs, elapsedMs + Math.max(0, dt * 1000));
+        const rawProgress = Math.min(1, elapsedMs / durationMs);
 
-      const id = setInterval(() => {
-        const elapsed = Date.now() - startMs;
-        const rawProgress = Math.min(1, elapsed / durationMs);
-
-        emit(wrapFrameMsg({ type: 'transition', progress: rawProgress, generation } as FrameAction) as unknown as Msg);
+        emit(wrapFrameMsg({
+          type: 'transition',
+          progress: rawProgress,
+          generation,
+          dt,
+          elapsedMs,
+        } as FrameAction) as unknown as Msg);
 
         if (rawProgress >= 1) {
-          clearInterval(id);
+          pulse.dispose();
           emit(wrapFrameMsg({ type: 'transition-complete', generation } as FrameAction) as unknown as Msg);
           resolve();
         }
-      }, intervalMs);
+      });
     });
 }

--- a/packages/bijou-tui/src/app-frame-types.ts
+++ b/packages/bijou-tui/src/app-frame-types.ts
@@ -81,7 +81,7 @@ export type FrameAction =
   | { type: 'dock-down' }
   | { type: 'dock-left' }
   | { type: 'dock-right' }
-  | { type: 'transition'; progress: number; generation: number }
+  | { type: 'transition'; progress: number; generation: number; dt: number; elapsedMs: number }
   | { type: 'transition-complete'; generation: number };
 
 /** Discriminated union of command palette navigation/selection actions. */

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createTestContext, _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
+import { createTestContext, mockClock, _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
 import { setDefaultContext, stringToSurface, surfaceToString } from '@flyingrobots/bijou';
 import { createKeyMap } from './keybindings.js';
 import { createSplitPaneState } from './split-pane.js';
 import { runScript } from './driver.js';
 import { createFramedApp, type FramePage, type FrameOverlayContext, type PageTransition } from './app-frame.js';
-import type { Cmd, MouseMsg } from './types.js';
+import { QUIT, type Cmd, type MouseMsg } from './types.js';
+import { tick } from './commands.js';
 
 type Msg =
   | { type: 'inc' }
@@ -168,7 +169,29 @@ describe('createFramedApp', () => {
 
     // Manually drive the animation command
     const messages: any[] = [];
-    await switchCmds[0]!((m) => messages.push(m), { onPulse: () => ({ dispose() {} }) });
+    const pulseHandlers = new Set<(dt: number) => void>();
+    let settled = false;
+    const promise = switchCmds[0]!((m) => messages.push(m), {
+      onPulse(handler) {
+        pulseHandlers.add(handler);
+        return {
+          dispose() {
+            pulseHandlers.delete(handler);
+          },
+        };
+      },
+    }).then(() => {
+      settled = true;
+    });
+
+    for (let i = 0; i < 10 && !settled; i++) {
+      for (const handler of [...pulseHandlers]) {
+        handler(0.002);
+      }
+      await Promise.resolve();
+    }
+
+    await promise;
 
     expect(messages.length).toBeGreaterThan(0);
     
@@ -184,6 +207,8 @@ describe('createFramedApp', () => {
   });
 
   it('runs transition animation through runScript', async () => {
+    const clock = mockClock();
+    const ctx = createTestContext({ clock });
     const app = createFramedApp({
       pages: [
         makePage('p1', 'P1', 'm'),
@@ -193,11 +218,11 @@ describe('createFramedApp', () => {
       transitionDuration: 20,
     });
 
-    // Delay must exceed transitionDuration (20ms) with headroom for CI load.
-    const result = await runScript(app, [
+    const promise = runScript(app, [
       { key: ']' },
-      { key: 'noop', delay: 200 },
-    ]);
+    ], { ctx });
+    await clock.advanceByAsync(200);
+    const result = await promise;
 
     expect(result.model.activePageId).toBe('p2');
     expect(result.model.previousPageId).toBeUndefined();
@@ -210,6 +235,8 @@ describe('createFramedApp', () => {
     const transitions: PageTransition[] = ['melt', 'matrix', 'scramble'];
     
     for (const transition of transitions) {
+      const clock = mockClock();
+      const ctx = createTestContext({ clock });
       const app = createFramedApp({
         pages: [
           makePage('p1', 'P1', 'm'),
@@ -219,10 +246,11 @@ describe('createFramedApp', () => {
         transitionDuration: 10,
       });
 
-      const result = await runScript(app, [
+      const promise = runScript(app, [
         { key: ']' },
-        { key: 'noop', delay: 50 },
-      ]);
+      ], { ctx });
+      await clock.advanceByAsync(100);
+      const result = await promise;
 
       expect(result.model.activePageId).toBe('p2');
       expect(result.model.transitionProgress).toBe(1);
@@ -352,11 +380,7 @@ describe('createFramedApp', () => {
       update(msg, model) {
         if (msg.type === 'inc') return [{ ...model, count: model.count + 1 }, []];
         if (msg.type === 'noop') {
-          const delayed: Cmd<Msg> = async () => {
-            await new Promise<void>((resolve) => setTimeout(resolve, 10));
-            return { type: 'inc' };
-          };
-          return [model, [delayed]];
+          return [model, [tick(10, { type: 'inc' })]];
         }
         return [model, []];
       },
@@ -372,15 +396,51 @@ describe('createFramedApp', () => {
       pages: [home, logs],
     });
 
-    const result = await runScript(app, [
-      { key: ']' },
-      { key: 'x' },
-      { key: '[' },
-      { delay: 25, msg: { type: 'noop' } },
-    ]);
+    let [model, initCmds] = app.init();
+    expect(initCmds).toHaveLength(0);
 
-    expect(result.model.pageModels.home?.count).toBe(0);
-    expect(result.model.pageModels.logs?.count).toBe(1);
+    let update = app.update({ type: 'key', key: ']', ctrl: false, alt: false, shift: false }, model);
+    model = update[0];
+    expect(model.activePageId).toBe('logs');
+
+    update = app.update({ type: 'key', key: 'x', ctrl: false, alt: false, shift: false }, model);
+    model = update[0];
+    const noopCmd = update[1][0];
+    expect(noopCmd).toBeDefined();
+
+    const noopResult = await noopCmd!(() => {}, {
+      onPulse: () => ({ dispose() {} }),
+    });
+    expect(noopResult).toBeDefined();
+    expect(noopResult).not.toBe(QUIT);
+
+    update = app.update(noopResult as Msg, model);
+    model = update[0];
+    const delayedCmd = update[1][0];
+    expect(delayedCmd).toBeDefined();
+
+    const emitted: Msg[] = [];
+    const delayedPromise = delayedCmd!((msg) => emitted.push(msg), {
+      onPulse: () => ({ dispose() {} }),
+      sleep: () => Promise.resolve(),
+    });
+
+    update = app.update({ type: 'key', key: '[', ctrl: false, alt: false, shift: false }, model);
+    model = update[0];
+    expect(model.activePageId).toBe('home');
+
+    const returned = await delayedPromise;
+    for (const msg of emitted) {
+      update = app.update(msg, model);
+      model = update[0];
+    }
+    if (returned !== undefined && returned !== QUIT) {
+      update = app.update(returned, model);
+      model = update[0];
+    }
+
+    expect(model.pageModels.home?.count).toBe(0);
+    expect(model.pageModels.logs?.count).toBe(1);
   });
 
   it('supports Shift+G for scroll-to-bottom', async () => {

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -341,12 +341,12 @@ export function createFramedApp<PageModel, Msg>(
         if (action.type === 'transition') {
           // Ignore stale transition ticks from a previous generation
           if (action.generation !== model.transitionGeneration) return [model, []];
-          // Advance timeline using wall-clock elapsed time
-          if (model.transitionTimeline && model.transitionTimelineState && model.transitionStartMs != null) {
-            const elapsedMs = Date.now() - model.transitionStartMs;
-            const elapsedSec = Math.max(0, elapsedMs / 1000);
-            // Step from init to current elapsed time (tweens are deterministic)
-            const state = model.transitionTimeline.step(model.transitionTimeline.init(), elapsedSec);
+          // Advance timeline from deterministic pulse deltas.
+          if (model.transitionTimeline && model.transitionTimelineState) {
+            const state = model.transitionTimeline.step(
+              model.transitionTimelineState,
+              Math.max(0, action.dt),
+            );
             const vals = model.transitionTimeline.values(state);
             const progress = Math.min(1, Math.max(0, vals['progress'] ?? action.progress));
 

--- a/packages/bijou-tui/src/commands.ts
+++ b/packages/bijou-tui/src/commands.ts
@@ -28,10 +28,16 @@ export function quit<M>(): Cmd<M> {
  * @returns A one-shot timer command.
  */
 export function tick<M>(ms: number, msg: M): Cmd<M> {
-  return (_emit, _caps) =>
-    new Promise<M>((resolve) => {
-      setTimeout(() => resolve(msg), ms);
-    });
+  return async (_emit, caps) => {
+    if (caps.sleep) {
+      await caps.sleep(ms);
+    } else {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      });
+    }
+    return msg;
+  };
 }
 
 /**

--- a/packages/bijou-tui/src/driver.test.ts
+++ b/packages/bijou-tui/src/driver.test.ts
@@ -4,7 +4,7 @@ import type { App, Cmd } from './types.js';
 import { quit } from './commands.js';
 import { isKeyMsg, isResizeMsg } from './types.js';
 import { badge, surfaceToString } from '@flyingrobots/bijou';
-import { createTestContext, plainStyle } from '@flyingrobots/bijou/adapters/test';
+import { createTestContext, mockClock, plainStyle } from '@flyingrobots/bijou/adapters/test';
 
 const style = plainStyle();
 
@@ -81,12 +81,17 @@ describe('runScript', () => {
   });
 
   it('supports delays between steps', async () => {
-    const start = Date.now();
-    const result = await runScript(counterApp, [
+    const clock = mockClock({ nowMs: 1_000 });
+    const ctx = createTestContext({ clock });
+    const promise = runScript(counterApp, [
       { key: '\x1b[A', delay: 50 },
       { key: '\x1b[A', delay: 50 },
-    ]);
-    expect(result.elapsed).toBeGreaterThanOrEqual(80); // some margin
+    ], { ctx, pulseFps: false });
+    for (let i = 0; i < 4; i++) {
+      await clock.advanceByAsync(25);
+    }
+    const result = await promise;
+    expect(result.elapsed).toBe(100);
     expect(result.model.count).toBe(2);
   });
 

--- a/packages/bijou-tui/src/driver.ts
+++ b/packages/bijou-tui/src/driver.ts
@@ -20,7 +20,7 @@ import type { App, RunOptions, ResizeMsg } from './types.js';
 import { isResizeMsg } from './types.js';
 import { createEventBus } from './eventbus.js';
 import { parseKey } from './keys.js';
-import { type Surface } from '@flyingrobots/bijou';
+import { type Surface, resolveClock, sleep } from '@flyingrobots/bijou';
 import { installBCSSResolver } from './css/install.js';
 import { normalizeViewOutput } from './view-output.js';
 
@@ -59,6 +59,8 @@ export type ScriptStep<M = never> =
 export interface RunScriptOptions extends RunOptions {
   /** Capture each rendered frame. */
   onFrame?: (frame: Surface, index: number) => void;
+  /** Pulse frequency used to drive animation commands. Set to `false` to disable. */
+  pulseFps?: number | false;
 }
 
 /**
@@ -90,11 +92,8 @@ export interface RunScriptResult<Model> {
  * - A command returns QUIT
  * - All script steps are exhausted (auto-quits)
  *
- * **Limitation:** Between steps the driver yields via `queueMicrotask`,
- * which only settles microtask-based async (e.g. `Promise.resolve()`).
- * Commands that use `setTimeout`, real I/O, or other macrotask-based async
- * may not have completed before the next key is dispatched. Use `delay`
- * on subsequent steps to allow time for macrotask-based commands.
+ * Between steps the driver waits for the event bus to go idle, so command
+ * chains settle deterministically without relying on microtask-only yields.
  *
  * @template Model - The application model type.
  * @template M     - The message (action) type for the TEA update cycle.
@@ -108,9 +107,10 @@ export async function runScript<Model, M>(
   steps: ScriptStep<M>[],
   options?: RunScriptOptions,
 ): Promise<RunScriptResult<Model>> {
-  const start = Date.now();
+  const clock = resolveClock(options?.ctx);
+  const start = clock.now();
   const frames: Surface[] = [];
-  const bus = createEventBus<M>();
+  const bus = createEventBus<M>({ clock });
   const ctx = options?.ctx;
   if (ctx != null) {
     installBCSSResolver(ctx, options?.css);
@@ -124,8 +124,10 @@ export async function runScript<Model, M>(
     height: Math.max(0, Math.floor(ctx?.runtime.rows || 24)),
   };
 
-  // Start heartbeat for animations
-  bus.startPulse();
+  // Start heartbeat for animations when enabled.
+  if (options?.pulseFps !== false) {
+    bus.startPulse(options?.pulseFps ?? ctx?.runtime.refreshRate ?? 60);
+  }
 
   /** Stop the scripted driver event loop. */
   function shutdown(): void {
@@ -166,15 +168,14 @@ export async function runScript<Model, M>(
       bus.runCmd(cmd);
     }
 
-    // Yield so microtask-based init commands can settle
-    await new Promise<void>((r) => queueMicrotask(r));
+    await bus.drain();
 
     // Feed script steps
     for (const step of steps) {
       if (!running) break;
 
       if (step.delay && step.delay > 0) {
-        await new Promise<void>((r) => setTimeout(r, step.delay));
+        await sleep(clock, step.delay);
       }
 
       if (!running) break;
@@ -198,12 +199,10 @@ export async function runScript<Model, M>(
         throw new Error(`runScript: unhandled script step variant: ${JSON.stringify(_exhaustive)}`);
       }
 
-      // Yield to allow async commands to settle
-      await new Promise<void>((r) => queueMicrotask(r));
+      await bus.drain();
     }
 
-    // Final yield so any trailing commands can settle
-    await new Promise<void>((r) => queueMicrotask(r));
+    await bus.drain();
   } finally {
     bus.stopPulse();
     bus.dispose();
@@ -212,6 +211,6 @@ export async function runScript<Model, M>(
   return {
     model,
     frames,
-    elapsed: Date.now() - start,
+    elapsed: clock.now() - start,
   };
 }

--- a/packages/bijou-tui/src/eventbus.test.ts
+++ b/packages/bijou-tui/src/eventbus.test.ts
@@ -335,6 +335,20 @@ describe('runCmd', () => {
     expect(onError.mock.calls[0]?.[1]).toBeInstanceOf(Error);
   });
 
+  it('settles drain when a command throws synchronously', async () => {
+    const onError = vi.fn();
+    const bus = createEventBus<TestMsg>({ onError });
+
+    bus.runCmd(() => {
+      throw new Error('sync boom');
+    });
+
+    await bus.drain();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toContain('[EventBus] Command rejected:');
+    expect(onError.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+  });
+
   it('does not throw unhandled rejection when onError itself throws', async () => {
     const throwingOnError = vi.fn(() => {
       throw new Error('onError blew up');

--- a/packages/bijou-tui/src/eventbus.test.ts
+++ b/packages/bijou-tui/src/eventbus.test.ts
@@ -250,8 +250,7 @@ describe('runCmd', () => {
     const cmd: Cmd<TestMsg> = async () => ({ type: 'custom' as const, value: 99 });
     bus.runCmd(cmd);
 
-    // Wait for promise to resolve
-    await vi.waitFor(() => expect(received).toHaveLength(1));
+    await bus.drain();
     expect(received[0]).toEqual({ type: 'custom', value: 99 });
   });
 
@@ -263,8 +262,7 @@ describe('runCmd', () => {
     const cmd: Cmd<TestMsg> = async () => undefined;
     bus.runCmd(cmd);
 
-    // Give the promise time to resolve
-    await new Promise((r) => setTimeout(r, 10));
+    await bus.drain();
     expect(received).toHaveLength(0);
   });
 
@@ -276,7 +274,8 @@ describe('runCmd', () => {
     const cmd: Cmd<TestMsg> = async () => QUIT;
     bus.runCmd(cmd);
 
-    await vi.waitFor(() => expect(quitCalled).toHaveBeenCalledTimes(1));
+    await bus.drain();
+    expect(quitCalled).toHaveBeenCalledTimes(1);
   });
 
   it('does not emit QUIT as a regular message', async () => {
@@ -288,7 +287,7 @@ describe('runCmd', () => {
     const cmd: Cmd<TestMsg> = async () => QUIT;
     bus.runCmd(cmd);
 
-    await new Promise((r) => setTimeout(r, 10));
+    await bus.drain();
     expect(received).toHaveLength(0);
   });
 
@@ -300,7 +299,8 @@ describe('runCmd', () => {
       throw new Error('boom');
     });
 
-    await vi.waitFor(() => expect(onCommandRejected).toHaveBeenCalledTimes(1));
+    await bus.drain();
+    expect(onCommandRejected).toHaveBeenCalledTimes(1);
     expect(onCommandRejected.mock.calls[0]?.[0]).toBeInstanceOf(Error);
     expect((onCommandRejected.mock.calls[0]?.[0] as Error).message).toBe('boom');
   });
@@ -315,7 +315,8 @@ describe('runCmd', () => {
       throw new Error('boom');
     });
 
-    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(2));
+    await bus.drain();
+    expect(onError).toHaveBeenCalledTimes(2);
     expect(onCommandRejected).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]?.[0]).toContain('[EventBus] onCommandRejected handler threw:');
     expect(onError.mock.calls[1]?.[0]).toContain('[EventBus] Original command rejection:');
@@ -328,7 +329,8 @@ describe('runCmd', () => {
       throw new Error('boom');
     });
 
-    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    await bus.drain();
+    expect(onError).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]?.[0]).toContain('[EventBus] Command rejected:');
     expect(onError.mock.calls[0]?.[1]).toBeInstanceOf(Error);
   });
@@ -342,8 +344,7 @@ describe('runCmd', () => {
       throw new Error('boom');
     });
 
-    // If safeReport is working, the promise settles without unhandled rejection.
-    await new Promise((r) => setTimeout(r, 10));
+    await bus.drain();
     // onError was called but its throw was swallowed
     expect(throwingOnError).toHaveBeenCalled();
   });
@@ -363,7 +364,7 @@ describe('runCmd', () => {
       throw new Error('boom');
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await bus.drain();
     expect(throwingRejected).toHaveBeenCalledTimes(1);
     // safeReport swallowed the throw from onError
     expect(throwingOnError).toHaveBeenCalled();
@@ -377,8 +378,7 @@ describe('runCmd', () => {
         throw new Error('boom');
       });
 
-      // Give the promise time to resolve
-      await new Promise((r) => setTimeout(r, 10));
+      await bus.drain();
       expect(consoleError).not.toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
@@ -400,7 +400,7 @@ describe('onQuit', () => {
     const cmd: Cmd<TestMsg> = async () => QUIT;
     bus.runCmd(cmd);
 
-    await new Promise((r) => setTimeout(r, 10));
+    await bus.drain();
     expect(quitCalled).not.toHaveBeenCalled();
   });
 });
@@ -532,7 +532,7 @@ describe('dispose', () => {
     bus.emit({ type: 'custom', value: 1 });
     bus.runCmd(async () => QUIT);
 
-    await new Promise((r) => setTimeout(r, 10));
+    await bus.drain();
     expect(received).toHaveLength(0);
     expect(quitCalled).not.toHaveBeenCalled();
   });

--- a/packages/bijou-tui/src/eventbus.ts
+++ b/packages/bijou-tui/src/eventbus.ts
@@ -306,7 +306,14 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
         now: () => clock.now(),
       };
 
-      Promise.resolve(cmd(emit, caps)).then((result) => {
+      let commandPromise: Promise<M | typeof QUIT | void>;
+      try {
+        commandPromise = Promise.resolve(cmd(emit, caps));
+      } catch (err: unknown) {
+        commandPromise = Promise.reject(err);
+      }
+
+      commandPromise.then((result) => {
         if (disposed) return;
         if (result === QUIT) {
           for (const handler of quitHandlers) {

--- a/packages/bijou-tui/src/eventbus.ts
+++ b/packages/bijou-tui/src/eventbus.ts
@@ -26,6 +26,7 @@
  */
 
 import type { IOPort } from '@flyingrobots/bijou';
+import { defer, resolveClock, sleep, type ClockPort } from '@flyingrobots/bijou';
 import type { Cmd, KeyMsg, MouseMsg, PulseMsg, ResizeMsg } from './types.js';
 import { QUIT } from './types.js';
 import { parseKey, parseMouse } from './keys.js';
@@ -138,6 +139,9 @@ export interface EventBus<M> {
    */
   use(middleware: Middleware<M>): Disposable;
 
+  /** Resolve once all in-flight commands have settled. */
+  drain(): Promise<void>;
+
   /** Disconnect all sources and remove all subscribers. */
   dispose(): void;
 }
@@ -148,6 +152,8 @@ export interface CreateEventBusOptions {
   onCommandRejected?: (error: unknown) => void;
   /** Called to surface error messages (replaces direct `console.error` usage). */
   onError?: (message: string, error: unknown) => void;
+  /** Clock/scheduler override for deterministic command and pulse timing. */
+  clock?: ClockPort;
 }
 
 /** Handle for unsubscribing or disconnecting a resource. */
@@ -173,13 +179,16 @@ interface Disposable {
  * @returns A new event bus instance.
  */
 export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<M> {
+  const clock = resolveClock(busOptions?.clock);
   const subscribers = new Set<(msg: BusMsg<M>) => void>();
   const quitHandlers = new Set<() => void>();
   const pulseHandlers = new Set<(dt: number) => void>();
   const middlewares: Middleware<M>[] = [];
   const disposables: Disposable[] = [];
   let disposed = false;
-  let pulseTimer: any = null;
+  let pulseTimer: { dispose(): void } | null = null;
+  let pendingCommands = 0;
+  const idleResolvers = new Set<() => void>();
 
   /** Report an error without risking an unhandled rejection. */
   function safeReport(message: string, error: unknown): void {
@@ -220,6 +229,15 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
 
     dispatch(msg);
   }
+
+  function resolveIdleIfNeeded(): void {
+    if (!disposed && pendingCommands !== 0) return;
+    for (const resolve of idleResolvers) {
+      resolve();
+    }
+    idleResolvers.clear();
+  }
+
   return {
     on(handler) {
       subscribers.add(handler);
@@ -279,14 +297,19 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
 
     runCmd(cmd: Cmd<M>): void {
       if (disposed) return;
+      pendingCommands++;
 
       const caps = {
         onPulse: (h: (dt: number) => void) => this.onPulse(h),
+        sleep: (ms: number) => sleep(clock, ms),
+        defer: () => defer(clock),
+        now: () => clock.now(),
       };
 
       Promise.resolve(cmd(emit, caps)).then((result) => {
         if (disposed) return;
-        if (result === QUIT) {          for (const handler of quitHandlers) {
+        if (result === QUIT) {
+          for (const handler of quitHandlers) {
             handler();
           }
           return;
@@ -312,6 +335,11 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
           );
           safeReport('[EventBus] Original command rejection:', err);
         }
+      }).finally(() => {
+        pendingCommands = Math.max(0, pendingCommands - 1);
+        if (!disposed) {
+          resolveIdleIfNeeded();
+        }
       });
     },
 
@@ -328,15 +356,15 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
       if (disposed || pulseTimer) return;
 
       const intervalMs = Math.round(1000 / fps);
-      let lastMs = Date.now();
+      let lastMs = clock.now();
 
-      pulseTimer = setInterval(() => {
+      pulseTimer = clock.setInterval(() => {
         if (disposed) {
-          clearInterval(pulseTimer);
+          pulseTimer?.dispose();
           pulseTimer = null;
           return;
         }
-        const nowMs = Date.now();
+        const nowMs = clock.now();
         const dt = Math.max(0, (nowMs - lastMs) / 1000);
         lastMs = nowMs;
 
@@ -351,7 +379,7 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
 
     stopPulse() {
       if (pulseTimer) {
-        clearInterval(pulseTimer);
+        pulseTimer.dispose();
         pulseTimer = null;
       }
     },
@@ -375,12 +403,22 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
       };
     },
 
+    drain(): Promise<void> {
+      if (disposed || pendingCommands === 0) {
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        idleResolvers.add(resolve);
+      });
+    },
+
     dispose(): void {
       disposed = true;
       if (pulseTimer) {
-        clearInterval(pulseTimer);
+        pulseTimer.dispose();
         pulseTimer = null;
       }
+      resolveIdleIfNeeded();
       for (const d of disposables) {
         d.dispose();
       }

--- a/packages/bijou-tui/src/runtime.test.ts
+++ b/packages/bijou-tui/src/runtime.test.ts
@@ -215,7 +215,9 @@ describe('run', () => {
         ];
         return {
           dispose() {
-            handles.forEach((handle) => handle.dispose());
+            handles.forEach((handle) => {
+              handle.dispose();
+            });
           },
         };
       };

--- a/packages/bijou-tui/src/runtime.test.ts
+++ b/packages/bijou-tui/src/runtime.test.ts
@@ -60,9 +60,7 @@ function createTrackingClock() {
           },
         };
 
-        baseHandle = base.setTimeout(() => {
-          callback();
-        }, ms);
+        baseHandle = base.setTimeout(callback, ms);
         activeTimeouts.add(wrapper);
         return wrapper;
       },

--- a/packages/bijou-tui/src/runtime.test.ts
+++ b/packages/bijou-tui/src/runtime.test.ts
@@ -191,6 +191,43 @@ describe('run', () => {
       expect(received[0]).toMatchObject({ key: 'c', ctrl: true });
     });
 
+    it('does not treat the first Ctrl+C at clock time zero as a double-press', async () => {
+      const clock = mockClock({ nowMs: 0 });
+      const received: KeyMsg[] = [];
+
+      const spyApp: App<null, never> = {
+        init: () => [null, []],
+        update(msg, model) {
+          if (msg.type === 'key') {
+            received.push(msg);
+            if (msg.key === 'q') return [model, [quit()]];
+          }
+          return [model, []];
+        },
+        view: () => 'spy',
+      };
+
+      const ctx = createTestContext({ mode: 'interactive', clock });
+      ctx.io.rawInput = (onKey) => {
+        const handles = [
+          clock.setTimeout(() => onKey('\x03'), 0),
+          clock.setTimeout(() => onKey('q'), 10),
+        ];
+        return {
+          dispose() {
+            handles.forEach((handle) => handle.dispose());
+          },
+        };
+      };
+
+      const promise = run(spyApp, { ctx });
+      await clock.advanceByAsync(20);
+      await promise;
+
+      expect(received[0]).toMatchObject({ key: 'c', ctrl: true });
+      expect(received.some((msg) => msg.key === 'q')).toBe(true);
+    });
+
     it('executes startup commands from init', async () => {
       vi.useFakeTimers();
       type Msg = { type: 'started' };

--- a/packages/bijou-tui/src/runtime.test.ts
+++ b/packages/bijou-tui/src/runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createSurface } from '@flyingrobots/bijou';
-import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { createSurface, type TimerHandle } from '@flyingrobots/bijou';
+import { createTestContext, mockClock } from '@flyingrobots/bijou/adapters/test';
 import { run } from './runtime.js';
 import { quit } from './commands.js';
 import type { App, KeyMsg, Cmd } from './types.js';
@@ -42,6 +42,35 @@ function singleCellSurface(char?: string) {
     surface.set(0, 0, { char, empty: false });
   }
   return surface;
+}
+
+function createTrackingClock() {
+  const base = mockClock();
+  const activeTimeouts = new Set<TimerHandle>();
+
+  return {
+    clock: {
+      ...base,
+      setTimeout(callback: () => void, ms: number): TimerHandle {
+        let baseHandle: TimerHandle | null = null;
+        const wrapper: TimerHandle = {
+          dispose() {
+            if (!activeTimeouts.delete(wrapper)) return;
+            baseHandle?.dispose();
+          },
+        };
+
+        baseHandle = base.setTimeout(() => {
+          callback();
+        }, ms);
+        activeTimeouts.add(wrapper);
+        return wrapper;
+      },
+    },
+    activeTimeoutCount(): number {
+      return activeTimeouts.size;
+    },
+  };
 }
 
 /** What renderFrame produces for a given content string. */
@@ -338,6 +367,22 @@ describe('run', () => {
       expect(ctx.io.written[ctx.io.written.length - 1]).toBe(
         SHOW_CURSOR + WRAP_ENABLE + EXIT_ALT_SCREEN,
       );
+    });
+
+    it('does not leave runtime timeout handles active after shutdown', async () => {
+      const { clock, activeTimeoutCount } = createTrackingClock();
+      const ctx = createTestContext({ mode: 'interactive', clock });
+      const app: App<string, never> = {
+        init: () => ['bye', [quit()]],
+        update: (_msg, model) => [model, []],
+        view: (model) => model,
+      };
+
+      const promise = run(app, { ctx });
+      await clock.advanceByAsync(5);
+      await promise;
+
+      expect(activeTimeoutCount()).toBe(0);
     });
 
     it('does not repeatedly clear the same cell after a surface becomes empty', async () => {

--- a/packages/bijou-tui/src/runtime.ts
+++ b/packages/bijou-tui/src/runtime.ts
@@ -1,5 +1,5 @@
 import { getDefaultContext, createSurface, surfaceToString, resolveClock } from '@flyingrobots/bijou';
-import type { RuntimePort, WritePort, Surface } from '@flyingrobots/bijou';
+import type { RuntimePort, WritePort, Surface, TimerHandle } from '@flyingrobots/bijou';
 import type { App, Cmd, RunOptions, ResizeMsg } from './types.js';
 import { isKeyMsg, isPulseMsg, isResizeMsg } from './types.js';
 import { clearAndHome, enterScreen, exitScreen, renderSurfaceFrame } from './screen.js';
@@ -166,12 +166,14 @@ export async function run<Model, M>(
 
   // Render helper
   let renderRequested = false;
+  let renderHandle: TimerHandle | null = null;
   /** Render the current model's view to the terminal. */
   function render(): void {
     if (!running || renderRequested) return;
     renderRequested = true;
 
-    clock.setTimeout(() => {
+    let scheduledHandle: TimerHandle | null = null;
+    scheduledHandle = clock.setTimeout(() => {
       try {
         const targetSurface = createSurface(
           sanitizeDimension(ctx.runtime.columns),
@@ -197,8 +199,13 @@ export async function run<Model, M>(
         shutdown(error);
       } finally {
         renderRequested = false;
+        scheduledHandle?.dispose();
+        if (renderHandle === scheduledHandle) {
+          renderHandle = null;
+        }
       }
     }, 0);
+    renderHandle = scheduledHandle;
   }
 
   // Execute commands through the bus
@@ -284,11 +291,18 @@ export async function run<Model, M>(
   // Ensure any pending render is flushed before exiting
   if (renderRequested) {
     await new Promise<void>((resolve) => {
-      clock.setTimeout(resolve, 0);
+      let flushHandle: TimerHandle | null = null;
+      flushHandle = clock.setTimeout(() => {
+        flushHandle?.dispose();
+        flushHandle = null;
+        resolve();
+      }, 0);
     });
   }
 
   // Cleanup — bus disposes all I/O connections
+  disposeTimerHandle(renderHandle);
+  renderHandle = null;
   bus.stopPulse();
   bus.dispose();
   if (useMouse) {
@@ -301,6 +315,10 @@ export async function run<Model, M>(
   if (fatalError != null) {
     throw fatalError instanceof Error ? fatalError : new Error(String(fatalError));
   }
+}
+
+function disposeTimerHandle(handle: TimerHandle | null): void {
+  handle?.dispose();
 }
 
 /** Clamp a terminal dimension to a non-negative integer. */

--- a/packages/bijou-tui/src/runtime.ts
+++ b/packages/bijou-tui/src/runtime.ts
@@ -74,7 +74,7 @@ export async function run<Model, M>(
   // Interactive mode
   let model = initModel;
   let running = true;
-  let lastCtrlC = 0;
+  let lastCtrlC: number | null = null;
   let resolveQuit: (() => void) | null = null;
   let currentDt = 0.016; // Default to 60fps for first frame
   let fatalError: unknown = null;
@@ -247,7 +247,7 @@ export async function run<Model, M>(
     // Double Ctrl+C force-quit
     if (isKeyMsg(msg) && msg.key === 'c' && msg.ctrl) {
       const now = clock.now();
-      if (now - lastCtrlC < 1000) {
+      if (lastCtrlC !== null && now - lastCtrlC < 1000) {
         shutdown();
         return;
       }

--- a/packages/bijou-tui/src/runtime.ts
+++ b/packages/bijou-tui/src/runtime.ts
@@ -1,4 +1,4 @@
-import { getDefaultContext, createSurface, surfaceToString } from '@flyingrobots/bijou';
+import { getDefaultContext, createSurface, surfaceToString, resolveClock } from '@flyingrobots/bijou';
 import type { RuntimePort, WritePort, Surface } from '@flyingrobots/bijou';
 import type { App, Cmd, RunOptions, ResizeMsg } from './types.js';
 import { isKeyMsg, isPulseMsg, isResizeMsg } from './types.js';
@@ -45,6 +45,7 @@ export async function run<Model, M>(
   options?: RunOptions<M>,
 ): Promise<void> {
   const ctx = options?.ctx ?? getDefaultContext();
+  const clock = resolveClock(ctx);
   installRuntimeOverlay(ctx);
   const useAltScreen = options?.altScreen ?? true;
   const useHideCursor = options?.hideCursor ?? true;
@@ -85,6 +86,7 @@ export async function run<Model, M>(
   );
 
   const bus = createEventBus<M>({
+    clock,
     onCommandRejected(error) {
       const message = error instanceof Error
         ? `${error.name}: ${error.message}`
@@ -169,7 +171,7 @@ export async function run<Model, M>(
     if (!running || renderRequested) return;
     renderRequested = true;
 
-    setTimeout(() => {
+    clock.setTimeout(() => {
       try {
         const targetSurface = createSurface(
           sanitizeDimension(ctx.runtime.columns),
@@ -237,7 +239,7 @@ export async function run<Model, M>(
 
     // Double Ctrl+C force-quit
     if (isKeyMsg(msg) && msg.key === 'c' && msg.ctrl) {
-      const now = Date.now();
+      const now = clock.now();
       if (now - lastCtrlC < 1000) {
         shutdown();
         return;
@@ -282,7 +284,7 @@ export async function run<Model, M>(
   // Ensure any pending render is flushed before exiting
   if (renderRequested) {
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
+      clock.setTimeout(resolve, 0);
     });
   }
 

--- a/packages/bijou-tui/src/types.ts
+++ b/packages/bijou-tui/src/types.ts
@@ -141,6 +141,12 @@ export interface CmdCapabilities {
    * Returns a dispose function.
    */
   onPulse(handler: (dt: number) => void): { dispose(): void };
+  /** Sleep for a bounded amount of time using the runtime clock. */
+  sleep?(ms: number): Promise<void>;
+  /** Yield to the next microtask using the runtime clock. */
+  defer?(): Promise<void>;
+  /** Read the current wall-clock time from the runtime clock. */
+  now?(): number;
 }
 
 // --- App definition ---

--- a/packages/bijou/src/adapters/test/clock.test.ts
+++ b/packages/bijou/src/adapters/test/clock.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { mockClock } from './clock.js';
+
+describe('mockClock()', () => {
+  it('advances now() deterministically', () => {
+    const clock = mockClock({ nowMs: 100 });
+    expect(clock.now()).toBe(100);
+    clock.advanceBy(25);
+    expect(clock.now()).toBe(125);
+  });
+
+  it('runs queued timeouts when time advances past their deadline', () => {
+    const clock = mockClock();
+    const calls: number[] = [];
+    clock.setTimeout(() => calls.push(clock.now()), 10);
+    clock.advanceBy(9);
+    expect(calls).toEqual([]);
+    clock.advanceBy(1);
+    expect(calls).toEqual([10]);
+  });
+
+  it('runs intervals repeatedly and stops after dispose', () => {
+    const clock = mockClock();
+    const calls: number[] = [];
+    const handle = clock.setInterval(() => calls.push(clock.now()), 5);
+    clock.advanceBy(16);
+    handle.dispose();
+    clock.advanceBy(10);
+    expect(calls).toEqual([5, 10, 15]);
+  });
+
+  it('flushes queued microtasks without advancing wall-clock time', () => {
+    const clock = mockClock({ nowMs: 42 });
+    const calls: number[] = [];
+    clock.queueMicrotask(() => calls.push(clock.now()));
+    clock.flushMicrotasks();
+    expect(calls).toEqual([42]);
+  });
+
+  it('advances async command chains across native Promise boundaries', async () => {
+    const clock = mockClock();
+    const calls: number[] = [];
+    const run = async () => {
+      await new Promise<void>((resolve) => {
+        clock.setTimeout(resolve, 5);
+      });
+      calls.push(clock.now());
+      await new Promise<void>((resolve) => {
+        clock.setTimeout(resolve, 5);
+      });
+      calls.push(clock.now());
+    };
+
+    const promise = run();
+    await clock.advanceByAsync(10);
+    await promise;
+    expect(calls).toEqual([5, 10]);
+  });
+});

--- a/packages/bijou/src/adapters/test/clock.test.ts
+++ b/packages/bijou/src/adapters/test/clock.test.ts
@@ -56,4 +56,24 @@ describe('mockClock()', () => {
     await promise;
     expect(calls).toEqual([5, 10]);
   });
+
+  it('throws when runAll() would loop forever on an active interval', () => {
+    const clock = mockClock();
+    clock.setInterval(() => {}, 5);
+
+    expect(() => clock.runAll()).toThrow(/active interval timers/i);
+  });
+
+  it('still allows runAll() when an interval disposes itself', () => {
+    const clock = mockClock();
+    const calls: number[] = [];
+    let handle: { dispose(): void } | undefined;
+    handle = clock.setInterval(() => {
+      calls.push(clock.now());
+      handle?.dispose();
+    }, 5);
+
+    clock.runAll();
+    expect(calls).toEqual([5]);
+  });
 });

--- a/packages/bijou/src/adapters/test/clock.ts
+++ b/packages/bijou/src/adapters/test/clock.ts
@@ -1,0 +1,174 @@
+import type { ClockPort } from '../../ports/clock.js';
+import type { TimerHandle } from '../../ports/io.js';
+
+/**
+ * Configuration for {@link mockClock}.
+ */
+export interface MockClockOptions {
+  /** Initial wall-clock time in milliseconds since the Unix epoch. */
+  nowMs?: number;
+}
+
+interface ScheduledTask {
+  id: number;
+  at: number;
+  callback: () => void;
+  intervalMs: number | null;
+  disposed: boolean;
+}
+
+/**
+ * Deterministic in-memory clock for tests.
+ *
+ * Supports manual time advancement, interval/timeout scheduling, and queued
+ * microtasks without touching global timers.
+ */
+export interface MockClock extends ClockPort {
+  /** Advance time and run all due timers/microtasks. */
+  advanceBy(ms: number): void;
+  /** Advance time while flushing native Promise continuations between timer chunks. */
+  advanceByAsync(ms: number): Promise<void>;
+  /** Run all queued microtasks without advancing wall-clock time. */
+  flushMicrotasks(): void;
+  /** Run all currently scheduled timers to completion. */
+  runAll(): void;
+}
+
+function normalizeDelay(ms: number): number {
+  if (!Number.isFinite(ms)) return 0;
+  return Math.max(0, Math.floor(ms));
+}
+
+/**
+ * Create a deterministic {@link ClockPort} for unit and integration tests.
+ *
+ * The returned clock is manually driven through `advanceBy()` and `runAll()`.
+ */
+export function mockClock(options: MockClockOptions = {}): MockClock {
+  let nowMs = options.nowMs ?? 0;
+  let nextId = 1;
+  const microtasks: Array<() => void> = [];
+  const tasks: ScheduledTask[] = [];
+
+  function sortTasks(): void {
+    tasks.sort((a, b) => a.at - b.at || a.id - b.id);
+  }
+
+  function disposeTask(id: number): void {
+    const task = tasks.find((candidate) => candidate.id === id);
+    if (task) {
+      task.disposed = true;
+    }
+  }
+
+  function createHandle(id: number): TimerHandle {
+    return {
+      dispose(): void {
+        disposeTask(id);
+      },
+    };
+  }
+
+  function runQueuedMicrotasks(): void {
+    while (microtasks.length > 0) {
+      const pending = microtasks.splice(0, microtasks.length);
+      for (const callback of pending) {
+        callback();
+      }
+    }
+  }
+
+  function runNextTask(targetMs: number): boolean {
+    sortTasks();
+    const next = tasks.find((task) => !task.disposed && task.at <= targetMs);
+    if (next === undefined) return false;
+
+    nowMs = next.at;
+    if (next.intervalMs === null) {
+      next.disposed = true;
+    } else {
+      next.at = nowMs + next.intervalMs;
+    }
+    next.callback();
+    runQueuedMicrotasks();
+    return true;
+  }
+
+  return {
+    now(): number {
+      return nowMs;
+    },
+
+    date(ms?: number): Date {
+      return new Date(ms ?? nowMs);
+    },
+
+    setTimeout(callback: () => void, ms: number): TimerHandle {
+      const id = nextId++;
+      tasks.push({
+        id,
+        at: nowMs + normalizeDelay(ms),
+        callback,
+        intervalMs: null,
+        disposed: false,
+      });
+      sortTasks();
+      return createHandle(id);
+    },
+
+    setInterval(callback: () => void, ms: number): TimerHandle {
+      const intervalMs = Math.max(1, normalizeDelay(ms));
+      const id = nextId++;
+      tasks.push({
+        id,
+        at: nowMs + intervalMs,
+        callback,
+        intervalMs,
+        disposed: false,
+      });
+      sortTasks();
+      return createHandle(id);
+    },
+
+    queueMicrotask(callback: () => void): void {
+      microtasks.push(callback);
+    },
+
+    advanceBy(ms: number): void {
+      const targetMs = nowMs + normalizeDelay(ms);
+      runQueuedMicrotasks();
+      while (runNextTask(targetMs)) {
+        // Keep draining until there are no more timers due at or before targetMs.
+      }
+      nowMs = targetMs;
+      runQueuedMicrotasks();
+    },
+
+    async advanceByAsync(ms: number): Promise<void> {
+      const targetMs = nowMs + normalizeDelay(ms);
+      await Promise.resolve();
+      while (nowMs < targetMs) {
+        sortTasks();
+        const next = tasks.find((task) => !task.disposed && task.at <= targetMs);
+        const nextAt = next?.at ?? Math.min(targetMs, nowMs + 1);
+        this.advanceBy(Math.max(0, nextAt - nowMs));
+        await Promise.resolve();
+      }
+      await Promise.resolve();
+    },
+
+    flushMicrotasks(): void {
+      runQueuedMicrotasks();
+    },
+
+    runAll(): void {
+      runQueuedMicrotasks();
+      while (true) {
+        sortTasks();
+        const next = tasks.find((task) => !task.disposed);
+        if (next === undefined) break;
+        this.advanceBy(Math.max(0, next.at - nowMs));
+      }
+    },
+  };
+}

--- a/packages/bijou/src/adapters/test/clock.ts
+++ b/packages/bijou/src/adapters/test/clock.ts
@@ -30,7 +30,12 @@ export interface MockClock extends ClockPort {
   advanceByAsync(ms: number): Promise<void>;
   /** Run all queued microtasks without advancing wall-clock time. */
   flushMicrotasks(): void;
-  /** Run all currently scheduled timers to completion. */
+  /**
+   * Run all currently scheduled non-recurring timers to completion.
+   *
+   * Throws when an interval remains active after being given a chance to run,
+   * because recurring timers cannot be drained to completion automatically.
+   */
   runAll(): void;
 }
 
@@ -168,6 +173,13 @@ export function mockClock(options: MockClockOptions = {}): MockClock {
         const next = tasks.find((task) => !task.disposed);
         if (next === undefined) break;
         this.advanceBy(Math.max(0, next.at - nowMs));
+        sortTasks();
+        const remaining = tasks.filter((task) => !task.disposed);
+        if (remaining.length > 0 && remaining.every((task) => task.intervalMs !== null)) {
+          throw new Error(
+            'mockClock.runAll() cannot drain active interval timers; dispose them or advance time manually.',
+          );
+        }
       }
     },
   };

--- a/packages/bijou/src/adapters/test/context.test.ts
+++ b/packages/bijou/src/adapters/test/context.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { createTestContext, auditStyle } from './index.js';
+import { createTestContext, auditStyle, mockClock } from './index.js';
 
 describe('createTestContext()', () => {
   it('returns BijouContext with all fields', () => {
     const ctx = createTestContext();
     expect(ctx.runtime.env).toBeTypeOf('function');
     expect(ctx.io.write).toBeTypeOf('function');
+    expect(ctx.clock?.now).toBeTypeOf('function');
     expect(ctx.style.bold).toBeTypeOf('function');
     expect(ctx.theme.noColor).toBeTypeOf('boolean');
     expect(typeof ctx.mode).toBe('string');
@@ -42,6 +43,13 @@ describe('createTestContext()', () => {
   it('forwards io options', async () => {
     const ctx = createTestContext({ io: { answers: ['yes'] } });
     expect(await ctx.io.question('? ')).toBe('yes');
+  });
+
+  it('forwards custom clock options', () => {
+    const clock = mockClock({ nowMs: 1234 });
+    const ctx = createTestContext({ clock });
+    expect(ctx.clock).toBe(clock);
+    expect(ctx.clock?.now()).toBe(1234);
   });
 
   it('theme accessor functions are resolved and functional', () => {

--- a/packages/bijou/src/adapters/test/index.ts
+++ b/packages/bijou/src/adapters/test/index.ts
@@ -11,6 +11,7 @@ import type { BijouContext } from '../../ports/context.js';
 import type { OutputMode, ColorScheme } from '../../core/detect/tty.js';
 import { mockRuntime, type MockRuntimeOptions } from './runtime.js';
 import { mockIO, type MockIOOptions, type MockIO } from './io.js';
+import { mockClock, type MockClockOptions, type MockClock } from './clock.js';
 import type { StylePort } from '../../ports/style.js';
 import { plainStyle } from './style.js';
 import { createResolved } from '../../core/theme/resolve.js';
@@ -19,9 +20,11 @@ import { createThemeAccessors } from '../../core/theme/accessors.js';
 import { createTokenGraph } from '../../core/theme/graph.js';
 import type { TokenDefinitions } from '../../core/theme/graph-types.js';
 import type { Theme } from '../../core/theme/tokens.js';
+import { systemClock } from '../../core/clock.js';
 
 export { mockRuntime, type MockRuntimeOptions } from './runtime.js';
 export { mockIO, type MockIOOptions, type MockIO } from './io.js';
+export { mockClock, type MockClockOptions, type MockClock } from './clock.js';
 export { plainStyle } from './style.js';
 export { auditStyle, type StyledCall, type AuditStylePort } from './audit-style.js';
 export {
@@ -45,6 +48,8 @@ export interface TestContextOptions {
   io?: MockIOOptions;
   /** Theme to resolve. Defaults to `CYAN_MAGENTA`. */
   theme?: Theme;
+  /** Clock override for deterministic time/scheduling. */
+  clock?: MockClockOptions | MockClock;
   /** Output mode. Defaults to `'interactive'`. */
   mode?: OutputMode;
   /** Whether to strip color from the resolved theme. Defaults to `false`. */
@@ -53,6 +58,13 @@ export interface TestContextOptions {
   colorScheme?: ColorScheme;
   /** Style adapter override. Defaults to {@link plainStyle}. */
   style?: StylePort;
+}
+
+function isMockClock(value: MockClockOptions | MockClock | undefined): value is MockClock {
+  return typeof value === 'object'
+    && value !== null
+    && 'now' in value
+    && typeof value.now === 'function';
 }
 
 /**
@@ -77,6 +89,9 @@ export interface TestContext extends BijouContext {
 export function createTestContext(options: TestContextOptions = {}): TestContext {
   const runtime = mockRuntime(options.runtime);
   const io = mockIO(options.io);
+  const clock = options.clock === undefined
+    ? systemClock()
+    : (isMockClock(options.clock) ? options.clock : mockClock(options.clock));
   const style = options.style ?? plainStyle();
   const theme = createResolved(options.theme ?? CYAN_MAGENTA, options.noColor ?? false, options.colorScheme ?? 'dark');
   const tokenGraph = createTokenGraph((options.theme ?? CYAN_MAGENTA) as unknown as TokenDefinitions);
@@ -87,6 +102,7 @@ export function createTestContext(options: TestContextOptions = {}): TestContext
     mode,
     runtime,
     io,
+    clock,
     style,
     tokenGraph,
     resolveBCSS: () => ({}),

--- a/packages/bijou/src/core/clock.ts
+++ b/packages/bijou/src/core/clock.ts
@@ -1,0 +1,67 @@
+import type { ClockPort } from '../ports/clock.js';
+
+/**
+ * Default system-backed clock implementation.
+ *
+ * This remains the runtime default, while tests can inject a deterministic
+ * implementation through `BijouContext.clock`.
+ */
+const SYSTEM_CLOCK: ClockPort = {
+  now(): number {
+    return Date.now();
+  },
+
+  date(ms?: number): Date {
+    return new Date(ms ?? Date.now());
+  },
+
+  setTimeout(callback: () => void, ms: number) {
+    const id = globalThis.setTimeout(callback, ms);
+    return {
+      dispose(): void {
+        globalThis.clearTimeout(id);
+      },
+    };
+  },
+
+  setInterval(callback: () => void, ms: number) {
+    const id = globalThis.setInterval(callback, ms);
+    return {
+      dispose(): void {
+        globalThis.clearInterval(id);
+      },
+    };
+  },
+
+  queueMicrotask(callback: () => void): void {
+    globalThis.queueMicrotask(callback);
+  },
+};
+
+/** Return the shared system-backed clock. */
+export function systemClock(): ClockPort {
+  return SYSTEM_CLOCK;
+}
+
+/** Resolve a clock from an explicit port or a context-like object. */
+export function resolveClock(value?: ClockPort | { clock?: ClockPort }): ClockPort {
+  if (value === undefined) return SYSTEM_CLOCK;
+  if (typeof value === 'object' && value !== null && 'now' in value) {
+    return value as ClockPort;
+  }
+  return value.clock ?? SYSTEM_CLOCK;
+}
+
+/** Sleep for `ms` milliseconds using the provided clock port. */
+export function sleep(clock: ClockPort, ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    clock.setTimeout(resolve, ms);
+  });
+}
+
+/** Yield to the next microtask using the provided clock port. */
+export function defer(clock: ClockPort): Promise<void> {
+  return new Promise<void>((resolve) => {
+    clock.queueMicrotask(resolve);
+  });
+}

--- a/packages/bijou/src/core/components/log.test.ts
+++ b/packages/bijou/src/core/components/log.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { log } from './log.js';
-import { createTestContext } from '../../adapters/test/index.js';
+import { createTestContext, mockClock } from '../../adapters/test/index.js';
 
 describe('log', () => {
   it('debug level uses DBG label', () => {
@@ -69,15 +69,21 @@ describe('log', () => {
   });
 
   it('timestamp: true adds HH:MM:SS timestamp in pipe mode', () => {
-    const ctx = createTestContext({ mode: 'pipe' });
+    const ctx = createTestContext({
+      mode: 'pipe',
+      clock: mockClock({ nowMs: new Date(2024, 0, 1, 12, 34, 56).getTime() }),
+    });
     const result = log('info', 'request', { timestamp: true, ctx });
-    expect(result).toMatch(/^\[\d{2}:\d{2}:\d{2}\] \[INF\] request$/);
+    expect(result).toBe('[12:34:56] [INF] request');
   });
 
   it('timestamp: true adds timestamp in interactive mode', () => {
-    const ctx = createTestContext({ mode: 'interactive' });
+    const ctx = createTestContext({
+      mode: 'interactive',
+      clock: mockClock({ nowMs: new Date(2024, 0, 1, 12, 34, 56).getTime() }),
+    });
     const result = log('info', 'request', { timestamp: true, ctx });
-    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+    expect(result).toContain('12:34:56');
     expect(result).toContain('request');
   });
 

--- a/packages/bijou/src/core/components/log.ts
+++ b/packages/bijou/src/core/components/log.ts
@@ -1,4 +1,5 @@
 import type { BijouContext } from '../../ports/context.js';
+import { resolveClock } from '../clock.js';
 import { resolveSafeCtx as resolveCtx } from '../resolve-ctx.js';
 import { badge } from './badge.js';
 import { renderByMode } from '../mode-render.js';
@@ -49,8 +50,8 @@ const ACCESSIBLE_LABELS: Record<LogLevel, string> = {
  *
  * @returns The formatted timestamp string.
  */
-function formatTimestamp(): string {
-  const d = new Date();
+function formatTimestamp(ctx?: BijouContext): string {
+  const d = resolveClock(ctx).date();
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
   const ss = String(d.getSeconds()).padStart(2, '0');
@@ -77,7 +78,7 @@ export function log(level: LogLevel, message: string, options?: LogOptions): str
   const showPrefix = options?.prefix !== false;  // default true
   const showTimestamp = options?.timestamp === true;  // default false
 
-  const ts = showTimestamp ? formatTimestamp() : '';
+  const ts = showTimestamp ? formatTimestamp(ctx) : '';
 
   if (!ctx) {
     const parts: string[] = [];

--- a/packages/bijou/src/core/components/progress.ts
+++ b/packages/bijou/src/core/components/progress.ts
@@ -2,6 +2,7 @@ import type { BijouContext } from '../../ports/context.js';
 import type { TimerHandle } from '../../ports/io.js';
 import type { GradientStop } from '../theme/tokens.js';
 import { lerp3 } from '../theme/gradient.js';
+import { resolveClock } from '../clock.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
 import { cursorGuard, type CursorHideHandle } from './cursor-guard.js';
@@ -175,6 +176,7 @@ export interface AnimatedProgressBarOptions extends ProgressBarOptions {
  */
 export function createAnimatedProgressBar(options: AnimatedProgressBarOptions = {}): ProgressBarController {
   const ctx = resolveCtx(options.ctx);
+  const clock = resolveClock(ctx);
   const mode = ctx.mode;
   const fps = options.fps ?? 30;
   const duration = options.duration ?? 300;
@@ -195,7 +197,7 @@ export function createAnimatedProgressBar(options: AnimatedProgressBarOptions = 
   /** Start the interpolation timer if it is not already running. */
   function startAnimation(): void {
     if (timer !== null) return;
-    timer = ctx.io.setInterval(() => {
+    timer = clock.setInterval(() => {
       if (Math.abs(targetPct - currentPct) < 0.1) {
         currentPct = targetPct;
         render();

--- a/packages/bijou/src/core/components/spinner.ts
+++ b/packages/bijou/src/core/components/spinner.ts
@@ -1,6 +1,7 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TimerHandle } from '../../ports/io.js';
 import type { OutputMode } from '../detect/tty.js';
+import { resolveClock } from '../clock.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
 import { cursorGuard, type CursorHideHandle } from './cursor-guard.js';
@@ -77,6 +78,7 @@ export interface SpinnerController {
  */
 export function createSpinner(options: SpinnerOptions = {}): SpinnerController {
   const ctx = resolveCtx(options.ctx);
+  const clock = resolveClock(ctx);
   const frames = options.frames ?? DOTS;
   const interval = options.interval ?? 80;
   let label = options.label ?? 'Loading';
@@ -102,7 +104,7 @@ export function createSpinner(options: SpinnerOptions = {}): SpinnerController {
       cursorHandle?.dispose();
       cursorHandle = cursorGuard(ctx.io).hide();
       render();
-      timer = ctx.io.setInterval(render, interval);
+      timer = clock.setInterval(render, interval);
     },
 
     update(newLabel: string) {

--- a/packages/bijou/src/core/components/timer.ts
+++ b/packages/bijou/src/core/components/timer.ts
@@ -1,5 +1,6 @@
 import type { BijouContext } from '../../ports/context.js';
 import type { TimerHandle } from '../../ports/io.js';
+import { resolveClock } from '../clock.js';
 import { resolveCtx } from '../resolve-ctx.js';
 import { renderByMode } from '../mode-render.js';
 import { cursorGuard, type CursorHideHandle } from './cursor-guard.js';
@@ -110,10 +111,10 @@ type TimerState =
       readonly handle: TimerHandle; readonly cursor: CursorHideHandle | null }
   | { readonly kind: 'stopped'; readonly elapsedMs: number };
 
-function computeElapsed(s: TimerState): number {
+function computeElapsed(s: TimerState, nowMs: number): number {
   switch (s.kind) {
     case 'idle':    return 0;
-    case 'running': return s.pausedElapsed + (Date.now() - s.startTime);
+    case 'running': return s.pausedElapsed + (nowMs - s.startTime);
     case 'paused':  return s.pausedElapsed;
     case 'stopped': return s.elapsedMs;
   }
@@ -122,13 +123,14 @@ function computeElapsed(s: TimerState): number {
 /** Shared controller logic for createTimer and createStopwatch. */
 function createLiveController(config: LiveControllerConfig): TimerController {
   const { ctx, interval, timerOpts, displayMs, initialDisplayMs, onTick, onComplete } = config;
+  const clock = resolveClock(ctx);
   const mode = ctx.mode;
 
   let state: TimerState = { kind: 'idle' };
 
   function tick(): void {
     if (state.kind !== 'running') return;
-    const elapsed = state.pausedElapsed + (Date.now() - state.startTime);
+    const elapsed = state.pausedElapsed + (clock.now() - state.startTime);
     if (onTick?.(elapsed)) {
       state.handle.dispose();
       if (mode === 'interactive') {
@@ -170,27 +172,27 @@ function createLiveController(config: LiveControllerConfig): TimerController {
         return;
       }
 
-      const now = Date.now();
+      const now = clock.now();
       const line = timer(displayMs(0), { ...timerOpts, ctx });
       ctx.io.write(`${CLEAR_LINE_RETURN}${line}`);
-      const handle = ctx.io.setInterval(tick, interval);
+      const handle = clock.setInterval(tick, interval);
       state = { kind: 'running', startTime: now, pausedElapsed: 0, handle, cursor };
     },
 
     pause() {
       if (state.kind !== 'running') return;
-      const elapsed = state.pausedElapsed + (Date.now() - state.startTime);
+      const elapsed = state.pausedElapsed + (clock.now() - state.startTime);
       state = { kind: 'paused', pausedElapsed: elapsed, handle: state.handle, cursor: state.cursor };
     },
 
     resume() {
       if (state.kind !== 'paused') return;
-      state = { kind: 'running', startTime: Date.now(), pausedElapsed: state.pausedElapsed,
+      state = { kind: 'running', startTime: clock.now(), pausedElapsed: state.pausedElapsed,
         handle: state.handle, cursor: state.cursor };
     },
 
     stop(finalMessage?: string) {
-      const elapsed = computeElapsed(state);
+      const elapsed = computeElapsed(state, clock.now());
       if (state.kind === 'running' || state.kind === 'paused') {
         state.handle.dispose();
         if (mode === 'interactive') {
@@ -207,7 +209,7 @@ function createLiveController(config: LiveControllerConfig): TimerController {
     },
 
     elapsed() {
-      return computeElapsed(state);
+      return computeElapsed(state, clock.now());
     },
   };
 }

--- a/packages/bijou/src/factory.ts
+++ b/packages/bijou/src/factory.ts
@@ -12,6 +12,8 @@ import { CYAN_MAGENTA } from './core/theme/presets.js';
 import { PRESETS } from './core/theme/presets.js';
 import { fromDTCG, type DTCGDocument } from './core/theme/dtcg.js';
 import { detectOutputMode } from './core/detect/tty.js';
+import { systemClock } from './core/clock.js';
+import type { ClockPort } from './ports/clock.js';
 
 /** Options for {@link createBijou}. */
 export interface CreateBijouOptions {
@@ -19,6 +21,8 @@ export interface CreateBijouOptions {
   runtime: RuntimePort;
   /** I/O adapter (stdin/stdout, filesystem). */
   io: IOPort;
+  /** Clock/scheduler adapter. Defaults to the system clock. */
+  clock?: ClockPort;
   /** Style adapter (chalk, plain-text, etc.). */
   style: StylePort;
   /** Explicit theme object. Defaults to {@link CYAN_MAGENTA}. */
@@ -42,6 +46,7 @@ export interface CreateBijouOptions {
  */
 export function createBijou(options: CreateBijouOptions): BijouContext {
   const { runtime, io, style } = options;
+  const clock = options.clock ?? systemClock();
   const envVar = options.envVar ?? 'BIJOU_THEME';
   const presets = options.presets ?? PRESETS;
   const fallback = options.theme ?? CYAN_MAGENTA;
@@ -76,6 +81,7 @@ export function createBijou(options: CreateBijouOptions): BijouContext {
     mode,
     runtime,
     io,
+    clock,
     style,
     tokenGraph,
     resolveBCSS: () => ({}),

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -13,6 +13,7 @@ export type {
   InteractivePort,
   FilePort,
   IOPort,
+  ClockPort,
   RawInputHandle,
   TimerHandle,
   StylePort,
@@ -38,6 +39,7 @@ export {
 
 // Context resolution helpers
 export { resolveCtx, resolveSafeCtx } from './core/resolve-ctx.js';
+export { systemClock, resolveClock, sleep, defer } from './core/clock.js';
 
 // Mode rendering strategy
 export {

--- a/packages/bijou/src/ports/clock.ts
+++ b/packages/bijou/src/ports/clock.ts
@@ -1,0 +1,33 @@
+import type { TimerHandle } from './io.js';
+
+/**
+ * Abstract time/scheduling port.
+ *
+ * Provides wall-clock reads plus timer and microtask scheduling without
+ * coupling components to Node.js globals.
+ */
+export interface ClockPort {
+  /** Current wall-clock time in milliseconds since the Unix epoch. */
+  now(): number;
+
+  /**
+   * Create a Date object for a specific timestamp or for the current time when
+   * omitted.
+   */
+  date(ms?: number): Date;
+
+  /**
+   * Schedule a one-shot callback.
+   * @returns A handle whose `dispose()` cancels the timeout.
+   */
+  setTimeout(callback: () => void, ms: number): TimerHandle;
+
+  /**
+   * Schedule a repeating callback.
+   * @returns A handle whose `dispose()` cancels the interval.
+   */
+  setInterval(callback: () => void, ms: number): TimerHandle;
+
+  /** Schedule a microtask callback. */
+  queueMicrotask(callback: () => void): void;
+}

--- a/packages/bijou/src/ports/context.ts
+++ b/packages/bijou/src/ports/context.ts
@@ -3,6 +3,7 @@ import type { Theme, TokenValue, GradientStop } from '../core/theme/tokens.js';
 import type { OutputMode } from '../core/detect/tty.js';
 import type { RuntimePort } from './runtime.js';
 import type { IOPort } from './io.js';
+import type { ClockPort } from './clock.js';
 import type { StylePort } from './style.js';
 import type { TokenGraph } from '../core/theme/graph.js';
 
@@ -21,6 +22,8 @@ export interface BijouContext {
   readonly runtime: RuntimePort;
   /** I/O adapter (stdin/stdout, filesystem). */
   readonly io: IOPort;
+  /** Clock/scheduler adapter for deterministic time and timers. */
+  readonly clock?: ClockPort;
   /** Color / text-decoration adapter. */
   readonly style: StylePort;
   /** Reactive and Semantic Token Graph for advanced theming. */

--- a/packages/bijou/src/ports/index.ts
+++ b/packages/bijou/src/ports/index.ts
@@ -6,6 +6,7 @@
 
 export type { RuntimePort } from './runtime.js';
 export type { WritePort, QueryPort, InteractivePort, FilePort, IOPort, RawInputHandle, TimerHandle } from './io.js';
+export type { ClockPort } from './clock.js';
 export type { StylePort } from './style.js';
 export type { BijouContext } from './context.js';
 export { createEnvAccessor, createTTYAccessor } from './env.js';


### PR DESCRIPTION
## Summary
- add a shared clock port and deterministic test clock adapter
- route TUI command timing, scripted-driver settling, and framed transitions through clock/pulse seams
- replace wall-clock sleeps in the highest-signal tests with explicit idle handling and deterministic clock driving

## Verification
- npm run build
- npm run typecheck:test
- npm test
- npm run release:preflight
- npm run smoke:canaries -- --skip-build
- npm run smoke:examples:all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic test clock (mockClock) and test-context clock support
  * Configurable animation heartbeat (pulseFps) for scripted runs
  * Event bus drain() to await in-flight commands and idle state

* **Improvements**
  * Frame/update events include dt and elapsedMs for deterministic transitions
  * Unified clock abstraction replaces ad-hoc wall-clock timing across runtime, UI, drivers

* **Tests**
  * Extensive deterministic clock tests and timing-driven test updates

* **Documentation**
  * Changelog and review notes updated with timing observations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->