### PR TITLE
feat: share runtime viewport overlay

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Deterministic runtime test lint compliance** — the Ctrl+C-at-time-zero regression test now disposes its timeout handles with a block-bodied loop so it satisfies the repo’s iterable-callback-return lint rule without changing behavior.
 - **Deterministic runtime test helper cleanup** — the tracking clock helper in `runtime.test.ts` now passes timeout callbacks directly to the base clock instead of wrapping them in a no-op forwarding closure.
 - **Shared runtime viewport overlay** — the main TUI runtime and the worker host/proxy now share one viewport overlay helper, so dimension sanitization and mutable resize state stay consistent across scripted runs, interactive resizes, and worker handoff.
+- **Clock-driven test scheduling** — the remaining timer-sensitive runtime, command, component, and I/O adapter tests now use injected `mockClock()` instances instead of Vitest fake timers, and the Node/test I/O adapters accept clock injection so those tests never have to touch wall-clock scheduling.
 
 ### 🧪 Tests
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Deterministic Ctrl+C quit guard** — interactive runtime now treats “no prior Ctrl+C” distinctly from “Ctrl+C at time zero,” so injected clocks that start at `0` still forward the first Ctrl+C to the app instead of force-quitting immediately.
 - **Deterministic runtime test lint compliance** — the Ctrl+C-at-time-zero regression test now disposes its timeout handles with a block-bodied loop so it satisfies the repo’s iterable-callback-return lint rule without changing behavior.
 - **Deterministic runtime test helper cleanup** — the tracking clock helper in `runtime.test.ts` now passes timeout callbacks directly to the base clock instead of wrapping them in a no-op forwarding closure.
+- **Shared runtime viewport overlay** — the main TUI runtime and the worker host/proxy now share one viewport overlay helper, so dimension sanitization and mutable resize state stay consistent across scripted runs, interactive resizes, and worker handoff.
 
 ### 🧪 Tests
 

--- a/packages/bijou-node/src/io.test.ts
+++ b/packages/bijou-node/src/io.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mockClock } from '@flyingrobots/bijou/adapters/test';
 import { nodeIO } from './io.js';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
@@ -83,19 +84,17 @@ describe('nodeIO()', () => {
   });
 
   it('setInterval() fires periodically and stops on dispose', () => {
-    vi.useFakeTimers();
-    try {
-      const spy = vi.fn();
-      const io = nodeIO();
-      const handle = io.setInterval(spy, 50);
-      vi.advanceTimersByTime(150);
-      expect(spy).toHaveBeenCalledTimes(3);
-      handle.dispose();
-      vi.advanceTimersByTime(100);
-      expect(spy).toHaveBeenCalledTimes(3); // no more calls after dispose
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const spy = vi.fn();
+    const io = nodeIO({ clock });
+    const handle = io.setInterval(spy, 50);
+
+    clock.advanceBy(150);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    handle.dispose();
+    clock.advanceBy(100);
+    expect(spy).toHaveBeenCalledTimes(3); // no more calls after dispose
   });
 
   // question() and rawInput() require a TTY stdin and are not unit-testable.

--- a/packages/bijou-node/src/io.ts
+++ b/packages/bijou-node/src/io.ts
@@ -1,7 +1,13 @@
 import * as readline from 'readline';
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
-import type { IOPort, RawInputHandle, TimerHandle } from '@flyingrobots/bijou';
+import { resolveClock, type ClockPort, type IOPort, type RawInputHandle, type TimerHandle } from '@flyingrobots/bijou';
+
+/** Optional overrides for {@link nodeIO}. */
+export interface NodeIOOptions {
+  /** Clock override for deterministic timer scheduling in tests. */
+  clock?: ClockPort;
+}
 
 /**
  * Create an {@link IOPort} backed by Node.js I/O primitives.
@@ -11,9 +17,11 @@ import type { IOPort, RawInputHandle, TimerHandle } from '@flyingrobots/bijou';
  * `rawInput`, `onResize`, and `setInterval` clean up their underlying
  * resources when `dispose()` is called.
  *
+ * @param options - Optional runtime overrides such as a deterministic clock for tests.
  * @returns An {@link IOPort} bound to the current Node.js process.
  */
-export function nodeIO(): IOPort {
+export function nodeIO(options: NodeIOOptions = {}): IOPort {
+  const clock = resolveClock(options.clock);
   return {
     /**
      * Write a string directly to `process.stdout`.
@@ -116,13 +124,7 @@ export function nodeIO(): IOPort {
      * @returns A {@link TimerHandle} that cancels the timer on disposal.
      */
     setInterval(callback: () => void, ms: number): TimerHandle {
-      const id = globalThis.setInterval(callback, ms);
-      return {
-        /** Cancel the repeating timer. */
-        dispose() {
-          clearInterval(id);
-        },
-      };
+      return clock.setInterval(callback, ms);
     },
 
     /**

--- a/packages/bijou-node/src/worker/worker.ts
+++ b/packages/bijou-node/src/worker/worker.ts
@@ -1,6 +1,11 @@
 import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads';
 import { resolve as resolvePath } from 'node:path';
-import type { BijouContext, RuntimePort } from '@flyingrobots/bijou';
+import {
+  installRuntimeViewportOverlay,
+  readRuntimeViewport,
+  updateRuntimeViewport,
+  type BijouContext,
+} from '@flyingrobots/bijou';
 import type { App, RunOptions } from '@flyingrobots/bijou-tui';
 import { run } from '@flyingrobots/bijou-tui';
 import { createNodeContext } from '../index.js';
@@ -110,7 +115,7 @@ export function runInWorker(options: RunWorkerOptions): WorkerHandle {
   }
 
   const ctx = options.ctx ?? createNodeContext();
-  installRuntimeOverlay(ctx);
+  installRuntimeViewportOverlay(ctx);
   const useAltScreen = options.altScreen ?? true;
   const useHideCursor = options.hideCursor ?? true;
   const useMouse = options.mouse ?? false;
@@ -136,10 +141,7 @@ export function runInWorker(options: RunWorkerOptions): WorkerHandle {
     workerData: {
       isBijouWorker: true,
       options: serializableOptions,
-      runtime: {
-        columns: sanitizeDimension(ctx.runtime.columns),
-        rows: sanitizeDimension(ctx.runtime.rows),
-      },
+      runtime: readRuntimeViewport(ctx.runtime),
     } satisfies BijouWorkerData,
     execArgv: options.execArgv,
     // Pipe stdout/stderr so we can capture logs if needed, but primarily use IPC
@@ -151,11 +153,8 @@ export function runInWorker(options: RunWorkerOptions): WorkerHandle {
   });
 
   const resizeHandle = ctx.io.onResize((columns: number, rows: number) => {
-    const nextColumns = sanitizeDimension(columns);
-    const nextRows = sanitizeDimension(rows);
-    ctx.runtime.columns = nextColumns;
-    ctx.runtime.rows = nextRows;
-    worker.postMessage({ type: 'io:resize', columns: nextColumns, rows: nextRows } satisfies WorkerMessage);
+    const nextViewport = updateRuntimeViewport(ctx.runtime, columns, rows);
+    worker.postMessage({ type: 'io:resize', ...nextViewport } satisfies WorkerMessage);
   });
 
   const onExit = new Promise<void>((resolve, reject) => {
@@ -239,11 +238,14 @@ export async function startWorkerApp<Model, M>(app: App<Model, M>): Promise<void
 
   // Create a proxy Context that speaks IPC instead of true I/O
   const proxyCtx = createNodeContext();
-  installRuntimeOverlay(proxyCtx);
+  installRuntimeViewportOverlay(proxyCtx);
   const { setDefaultContext } = await import('@flyingrobots/bijou');
   setDefaultContext(proxyCtx);
-  proxyCtx.runtime.columns = sanitizeDimension(initData.runtime?.columns ?? proxyCtx.runtime.columns);
-  proxyCtx.runtime.rows = sanitizeDimension(initData.runtime?.rows ?? proxyCtx.runtime.rows);
+  updateRuntimeViewport(
+    proxyCtx.runtime,
+    initData.runtime?.columns ?? proxyCtx.runtime.columns,
+    initData.runtime?.rows ?? proxyCtx.runtime.rows,
+  );
   
   // Hijack the WritePort to send frames back to main thread
   proxyCtx.io.write = (data: string) => {
@@ -277,9 +279,8 @@ export async function startWorkerApp<Model, M>(app: App<Model, M>): Promise<void
   proxyCtx.io.onResize = (handler) => {
     const listener = (msg: WorkerMessage) => {
       if (msg.type === 'io:resize') {
-        proxyCtx.runtime.columns = sanitizeDimension(msg.columns);
-        proxyCtx.runtime.rows = sanitizeDimension(msg.rows);
-        handler(proxyCtx.runtime.columns, proxyCtx.runtime.rows);
+        const nextViewport = updateRuntimeViewport(proxyCtx.runtime, msg.columns, msg.rows);
+        handler(nextViewport.columns, nextViewport.rows);
       }
     };
     parentPort!.on('message', listener);
@@ -303,46 +304,4 @@ export async function startWorkerApp<Model, M>(app: App<Model, M>): Promise<void
 
   // Signal main thread to shut down
   parentPort.postMessage({ type: 'quit' } satisfies MainMessage);
-}
-
-function sanitizeDimension(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.max(0, Math.floor(value));
-}
-
-function installRuntimeOverlay(ctx: BijouContext): RuntimePort {
-  const baseRuntime = ctx.runtime;
-  const state = {
-    columns: sanitizeDimension(baseRuntime.columns),
-    rows: sanitizeDimension(baseRuntime.rows),
-  };
-  const runtime: RuntimePort = {
-    env(key: string): string | undefined {
-      return baseRuntime.env(key);
-    },
-    get stdoutIsTTY(): boolean {
-      return baseRuntime.stdoutIsTTY;
-    },
-    get stdinIsTTY(): boolean {
-      return baseRuntime.stdinIsTTY;
-    },
-    get columns(): number {
-      return state.columns;
-    },
-    set columns(value: number) {
-      state.columns = sanitizeDimension(value);
-    },
-    get rows(): number {
-      return state.rows;
-    },
-    set rows(value: number) {
-      state.rows = sanitizeDimension(value);
-    },
-    get refreshRate(): number {
-      return baseRuntime.refreshRate;
-    },
-  };
-
-  (ctx as { runtime: RuntimePort }).runtime = runtime;
-  return runtime;
 }

--- a/packages/bijou-tui/src/commands.test.ts
+++ b/packages/bijou-tui/src/commands.test.ts
@@ -1,6 +1,22 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { mockClock } from '@flyingrobots/bijou/adapters/test';
 import { quit, tick, batch } from './commands.js';
 import { QUIT } from './types.js';
+
+function createClockCapabilities() {
+  const clock = mockClock();
+  return {
+    clock,
+    caps: {
+      onPulse: () => ({ dispose() {} }),
+      sleep(ms: number) {
+        return new Promise<void>((resolve) => {
+          clock.setTimeout(resolve, ms);
+        });
+      },
+    },
+  };
+}
 
 describe('commands', () => {
   describe('quit', () => {
@@ -13,30 +29,26 @@ describe('commands', () => {
 
   describe('tick', () => {
     it('resolves with the message after the delay', async () => {
-      vi.useFakeTimers();
+      const { clock, caps } = createClockCapabilities();
       const msg = { type: 'tick' as const };
       const cmd = tick(100, msg);
-      const promise = cmd(() => {}, { onPulse: () => ({ dispose() {} }) });
-      vi.advanceTimersByTime(100);
+      const promise = cmd(() => {}, caps);
+      await clock.advanceByAsync(100);
       const result = await promise;
       expect(result).toBe(msg);
-      vi.useRealTimers();
     });
 
     it('does not resolve before the delay', async () => {
-      vi.useFakeTimers();
+      const { clock, caps } = createClockCapabilities();
       const cmd = tick(500, 'done');
       let resolved = false;
-      void cmd(() => {}, { onPulse: () => ({ dispose() {} }) }).then(() => {
+      void cmd(() => {}, caps).then(() => {
         resolved = true;
       });
-      vi.advanceTimersByTime(499);
-      await vi.advanceTimersByTimeAsync(0);
+      await clock.advanceByAsync(499);
       expect(resolved).toBe(false);
-      vi.advanceTimersByTime(1);
-      await vi.advanceTimersByTimeAsync(0);
+      await clock.advanceByAsync(1);
       expect(resolved).toBe(true);
-      vi.useRealTimers();
     });
   });
 

--- a/packages/bijou-tui/src/runtime.test.ts
+++ b/packages/bijou-tui/src/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createSurface, type TimerHandle } from '@flyingrobots/bijou';
 import { createTestContext, mockClock } from '@flyingrobots/bijou/adapters/test';
 import { run } from './runtime.js';
@@ -16,10 +16,6 @@ import {
   SHOW_CURSOR,
   EXIT_ALT_SCREEN,
 } from './screen.js';
-
-afterEach(() => {
-  vi.useRealTimers();
-});
 
 function counterApp(quitKey = 'q'): App<number, never> {
   return {
@@ -77,6 +73,48 @@ function frame(content: string): string {
   return HOME + lines.map((line) => line + CLEAR_LINE_TO_END).join('\n') + CLEAR_TO_END;
 }
 
+function createInteractiveContext(options: Parameters<typeof createTestContext>[0] = {}) {
+  const clock = mockClock();
+  const ctx = createTestContext({ ...options, mode: 'interactive', clock });
+  return { clock, ctx };
+}
+
+function scheduleKeys(
+  ctx: ReturnType<typeof createTestContext>,
+  clock: ReturnType<typeof mockClock>,
+  events: Array<{ at: number; key: string }>,
+): void {
+  ctx.io.rawInput = (onKey) => {
+    const handles = events.map(({ at, key }) => clock.setTimeout(() => onKey(key), at));
+    return {
+      dispose() {
+        handles.forEach((handle) => {
+          handle.dispose();
+        });
+      },
+    };
+  };
+}
+
+function scheduleResizes(
+  ctx: ReturnType<typeof createTestContext>,
+  clock: ReturnType<typeof mockClock>,
+  events: Array<{ at: number; columns: number; rows: number }>,
+): void {
+  ctx.io.onResize = (onResize) => {
+    const handles = events.map(({ at, columns, rows }) =>
+      clock.setTimeout(() => onResize(columns, rows), at)
+    );
+    return {
+      dispose() {
+        handles.forEach((handle) => {
+          handle.dispose();
+        });
+      },
+    };
+  };
+}
+
 describe('run', () => {
   describe('non-interactive mode', () => {
     it('renders once in pipe mode and returns', async () => {
@@ -100,10 +138,9 @@ describe('run', () => {
 
   describe('interactive mode', () => {
     it('enters alt screen and renders initial view', async () => {
-      vi.useFakeTimers();
-      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['q'] } });
+      const { clock, ctx } = createInteractiveContext({ io: { keys: ['q'] } });
       const promise = run(counterApp(), { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       // First write: enterScreen (alt + hide cursor + wrap disable + clear + home)
@@ -114,10 +151,9 @@ describe('run', () => {
     });
 
     it('exits alt screen on quit', async () => {
-      vi.useFakeTimers();
-      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['q'] } });
+      const { clock, ctx } = createInteractiveContext({ io: { keys: ['q'] } });
       const promise = run(counterApp(), { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       const lastWrite = ctx.io.written[ctx.io.written.length - 1]!;
@@ -125,23 +161,37 @@ describe('run', () => {
     });
 
     it('updates model on key input', async () => {
-      vi.useFakeTimers();
-      const ctx = createTestContext({
-        mode: 'interactive',
-        io: { keys: ['\x1b[A', '\x1b[A', 'q'] }, // up, up, quit
-      });
-      const promise = run(counterApp(), { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      const seen: number[] = [];
+      const app: App<number, never> = {
+        init: () => [0, []],
+        update(msg, model) {
+          if (msg.type === 'key') {
+            if (msg.key === 'q') return [model, [quit()]];
+            if (msg.key === 'up') {
+              const next = model + 1;
+              seen.push(next);
+              return [next, []];
+            }
+          }
+          return [model, []];
+        },
+        view: (model) => `count: ${model}`,
+      };
+
+      const { clock, ctx } = createInteractiveContext();
+      scheduleKeys(ctx, clock, [
+        { at: 5, key: '\x1b[A' },
+        { at: 10, key: '\x1b[A' },
+        { at: 20, key: 'q' },
+      ]);
+      const promise = run(app, { ctx });
+      await clock.advanceByAsync(50);
       await promise;
 
-      // After two 'up' presses, the rendered frame should contain 'count: 2'
-      const hasCount2 = ctx.io.written.some((w) => w.includes('count: 2'));
-      expect(hasCount2).toBe(true);
+      expect(seen).toEqual([1, 2]);
     });
 
     it('handles double Ctrl+C force-quit', async () => {
-      vi.useFakeTimers();
-
       // App that ignores Ctrl+C (doesn't quit on it)
       const stubbornApp: App<string, never> = {
         init: () => ['running', []],
@@ -150,12 +200,11 @@ describe('run', () => {
       };
 
       // Two Ctrl+C in rapid succession
-      const ctx = createTestContext({
-        mode: 'interactive',
+      const { clock, ctx } = createInteractiveContext({
         io: { keys: ['\x03', '\x03'] },
       });
       const promise = run(stubbornApp, { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       // Should have exited despite app not issuing quit
@@ -164,7 +213,6 @@ describe('run', () => {
     });
 
     it('sends first Ctrl+C to app as KeyMsg', async () => {
-      vi.useFakeTimers();
       const received: KeyMsg[] = [];
 
       const spyApp: App<null, never> = {
@@ -178,12 +226,11 @@ describe('run', () => {
       };
 
       // Ctrl+C then q to quit normally
-      const ctx = createTestContext({
-        mode: 'interactive',
+      const { clock, ctx } = createInteractiveContext({
         io: { keys: ['\x03', 'q'] },
       });
       const promise = run(spyApp, { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       expect(received[0]).toMatchObject({ key: 'c', ctrl: true });
@@ -229,7 +276,6 @@ describe('run', () => {
     });
 
     it('executes startup commands from init', async () => {
-      vi.useFakeTimers();
       type Msg = { type: 'started' };
 
       const startupApp: App<string, Msg> = {
@@ -244,9 +290,9 @@ describe('run', () => {
         view: (model) => model,
       };
 
-      const ctx = createTestContext({ mode: 'interactive' });
+      const { clock, ctx } = createInteractiveContext();
       const promise = run(startupApp, { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       const hasReady = ctx.io.written.some((w) => w.includes('ready'));
@@ -254,7 +300,6 @@ describe('run', () => {
     });
 
     it('runs init commands before startup resize commands', async () => {
-      vi.useFakeTimers();
       type Msg = { type: 'init-cmd' } | { type: 'resize-cmd' };
       const order: string[] = [];
 
@@ -276,19 +321,18 @@ describe('run', () => {
         view: () => 'ordering',
       };
 
-      const ctx = createTestContext({ mode: 'interactive' });
+      const { clock, ctx } = createInteractiveContext();
       const promise = run(orderingApp, { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       expect(order).toEqual(['init', 'resize']);
     });
 
     it('skips alt screen when altScreen is false', async () => {
-      vi.useFakeTimers();
-      const ctx = createTestContext({ mode: 'interactive', io: { keys: ['q'] } });
+      const { clock, ctx } = createInteractiveContext({ io: { keys: ['q'] } });
       const promise = run(counterApp(), { ctx, altScreen: false, hideCursor: false });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       const hasAltScreen = ctx.io.written.some((w) => w.includes(ENTER_ALT_SCREEN));
@@ -296,9 +340,7 @@ describe('run', () => {
     });
 
     it('allows callers to extend the render pipeline', async () => {
-      vi.useFakeTimers();
-
-      const ctx = createTestContext({ mode: 'interactive' });
+      const { clock, ctx } = createInteractiveContext();
       const app: App<null, never> = {
         init: () => [null, [quit()]],
         update: (_msg, model) => [model, []],
@@ -319,36 +361,26 @@ describe('run', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       expect(ctx.io.written.some((chunk) => chunk.includes('X'))).toBe(true);
     });
 
     it('forces a clean redraw when the terminal resizes', async () => {
-      vi.useFakeTimers();
-
-      const ctx = createTestContext({ mode: 'interactive' });
-      ctx.io.rawInput = (onKey) => {
-        const id = globalThis.setTimeout(() => onKey('q'), 30);
-        return { dispose() { clearTimeout(id); } };
-      };
-      ctx.io.onResize = (onResize) => {
-        const id = globalThis.setTimeout(() => onResize(100, 30), 10);
-        return { dispose() { clearTimeout(id); } };
-      };
+      const { clock, ctx } = createInteractiveContext();
+      scheduleKeys(ctx, clock, [{ at: 30, key: 'q' }]);
+      scheduleResizes(ctx, clock, [{ at: 10, columns: 100, rows: 30 }]);
 
       const promise = run(counterApp(), { ctx });
-      await vi.advanceTimersByTimeAsync(80);
+      await clock.advanceByAsync(80);
       await promise;
 
       expect(ctx.io.written.some((chunk) => chunk === CLEAR_SCREEN + HOME)).toBe(true);
     });
 
     it('updates runtime dimensions before rerendering after resize', async () => {
-      vi.useFakeTimers();
-
-      const ctx = createTestContext({ mode: 'interactive' });
+      const { clock, ctx } = createInteractiveContext();
       const app: App<number, never> = {
         init: () => [0, []],
         update(msg, model) {
@@ -358,17 +390,11 @@ describe('run', () => {
         view: () => `size:${ctx.runtime.columns}x${ctx.runtime.rows}`,
       };
 
-      ctx.io.rawInput = (onKey) => {
-        const id = globalThis.setTimeout(() => onKey('q'), 30);
-        return { dispose() { clearTimeout(id); } };
-      };
-      ctx.io.onResize = (onResize) => {
-        const id = globalThis.setTimeout(() => onResize(100, 30), 10);
-        return { dispose() { clearTimeout(id); } };
-      };
+      scheduleKeys(ctx, clock, [{ at: 30, key: 'q' }]);
+      scheduleResizes(ctx, clock, [{ at: 10, columns: 100, rows: 30 }]);
 
       const promise = run(app, { ctx });
-      await vi.advanceTimersByTimeAsync(80);
+      await clock.advanceByAsync(80);
       await promise;
 
       expect(ctx.runtime.columns).toBe(100);
@@ -377,9 +403,7 @@ describe('run', () => {
     });
 
     it('restores the terminal before rejecting when a scheduled render fails', async () => {
-      vi.useFakeTimers();
-
-      const ctx = createTestContext({ mode: 'interactive' });
+      const { clock, ctx } = createInteractiveContext();
       const promise = run(counterApp(), { ctx });
       const rejection = promise.then(
         () => null,
@@ -397,7 +421,7 @@ describe('run', () => {
         },
       });
 
-      await vi.advanceTimersByTimeAsync(10);
+      await clock.advanceByAsync(10);
       await expect(rejection).resolves.toBeInstanceOf(Error);
       await expect(promise).rejects.toThrow('render exploded');
       expect(columns).toBe(80);
@@ -423,8 +447,6 @@ describe('run', () => {
     });
 
     it('does not repeatedly clear the same cell after a surface becomes empty', async () => {
-      vi.useFakeTimers();
-
       const app: App<boolean, never> = {
         init: () => [true, []],
         update(msg, model) {
@@ -437,22 +459,15 @@ describe('run', () => {
         view: (model) => (model ? singleCellSurface('X') : singleCellSurface()),
       };
 
-      const ctx = createTestContext({ mode: 'interactive' });
-      ctx.io.rawInput = (onKey) => {
-        const ids = [
-          globalThis.setTimeout(() => onKey('x'), 10),
-          globalThis.setTimeout(() => onKey('x'), 20),
-          globalThis.setTimeout(() => onKey('q'), 30),
-        ];
-        return {
-          dispose() {
-            ids.forEach(clearTimeout);
-          },
-        };
-      };
+      const { clock, ctx } = createInteractiveContext();
+      scheduleKeys(ctx, clock, [
+        { at: 10, key: 'x' },
+        { at: 20, key: 'x' },
+        { at: 30, key: 'q' },
+      ]);
 
       const promise = run(app, { ctx });
-      await vi.advanceTimersByTimeAsync(50);
+      await clock.advanceByAsync(50);
       await promise;
 
       const clearWrites = ctx.io.written.filter((chunk) => chunk === '\x1b[1;1H ');

--- a/packages/bijou-tui/src/runtime.ts
+++ b/packages/bijou-tui/src/runtime.ts
@@ -1,5 +1,13 @@
-import { getDefaultContext, createSurface, surfaceToString, resolveClock } from '@flyingrobots/bijou';
-import type { RuntimePort, WritePort, Surface, TimerHandle } from '@flyingrobots/bijou';
+import {
+  getDefaultContext,
+  createSurface,
+  surfaceToString,
+  resolveClock,
+  installRuntimeViewportOverlay,
+  readRuntimeViewport,
+  updateRuntimeViewport,
+} from '@flyingrobots/bijou';
+import type { WritePort, Surface, TimerHandle } from '@flyingrobots/bijou';
 import type { App, Cmd, RunOptions, ResizeMsg } from './types.js';
 import { isKeyMsg, isPulseMsg, isResizeMsg } from './types.js';
 import { clearAndHome, enterScreen, exitScreen, renderSurfaceFrame } from './screen.js';
@@ -46,11 +54,12 @@ export async function run<Model, M>(
 ): Promise<void> {
   const ctx = options?.ctx ?? getDefaultContext();
   const clock = resolveClock(ctx);
-  installRuntimeOverlay(ctx);
+  installRuntimeViewportOverlay(ctx);
   const useAltScreen = options?.altScreen ?? true;
   const useHideCursor = options?.hideCursor ?? true;
   const useMouse = options?.mouse ?? false;
   installBCSSResolver(ctx, options?.css);
+  const runtimeViewport = () => readRuntimeViewport(ctx.runtime);
 
   const [initModel, initCmds] = app.init();
 
@@ -61,9 +70,10 @@ export async function run<Model, M>(
     if (typeof viewOutput === 'string') {
       output = viewOutput;
     } else {
+      const viewport = runtimeViewport();
       const normalized = normalizeViewOutput(viewOutput, {
-        width: sanitizeDimension(ctx.runtime.columns),
-        height: sanitizeDimension(ctx.runtime.rows),
+        width: viewport.columns,
+        height: viewport.rows,
       });
       output = surfaceToString(normalized.surface, ctx.style);
     }
@@ -80,10 +90,8 @@ export async function run<Model, M>(
   let fatalError: unknown = null;
 
   // Double Buffering: track what is currently on screen
-  let currentSurface: Surface = createSurface(
-    sanitizeDimension(ctx.runtime.columns),
-    sanitizeDimension(ctx.runtime.rows),
-  );
+  const initialViewport = runtimeViewport();
+  let currentSurface: Surface = createSurface(initialViewport.columns, initialViewport.rows);
 
   const bus = createEventBus<M>({
     clock,
@@ -101,9 +109,10 @@ export async function run<Model, M>(
   // 1. Layout Logic Stage
   pipeline.use('Layout', (state, next) => {
     const viewOutput = app.view(state.model);
+    const viewport = runtimeViewport();
     (state as any).layoutRoot = wrapViewOutputAsLayoutRoot(viewOutput, {
-      width: sanitizeDimension(ctx.runtime.columns),
-      height: sanitizeDimension(ctx.runtime.rows),
+      width: viewport.columns,
+      height: viewport.rows,
     });
     next();
   });
@@ -175,9 +184,10 @@ export async function run<Model, M>(
     let scheduledHandle: TimerHandle | null = null;
     scheduledHandle = clock.setTimeout(() => {
       try {
+        const viewport = runtimeViewport();
         const targetSurface = createSurface(
-          sanitizeDimension(ctx.runtime.columns),
-          sanitizeDimension(ctx.runtime.rows),
+          viewport.columns,
+          viewport.rows,
         );
 
         const renderState: RenderState = {
@@ -235,11 +245,10 @@ export async function run<Model, M>(
     }
 
     if (isResizeMsg(msg)) {
-      ctx.runtime.columns = sanitizeDimension(msg.columns);
-      ctx.runtime.rows = sanitizeDimension(msg.rows);
+      const viewport = updateRuntimeViewport(ctx.runtime, msg.columns, msg.rows);
       currentSurface = createSurface(
-        ctx.runtime.columns,
-        ctx.runtime.rows,
+        viewport.columns,
+        viewport.rows,
       );
       clearAndHome(ctx.io);
     }
@@ -262,20 +271,19 @@ export async function run<Model, M>(
 
   // Apply an initial runtime-size sync before first render.
   // This keeps framed apps sized from ports instead of process globals.
+  const syncedViewport = runtimeViewport();
   const initialResize: ResizeMsg = {
     type: 'resize',
-    columns: sanitizeDimension(ctx.runtime.columns),
-    rows: sanitizeDimension(ctx.runtime.rows),
+    columns: syncedViewport.columns,
+    rows: syncedViewport.rows,
   };
   const [resizedModel, resizeCmds] = app.update(initialResize, model);
   model = resizedModel;
 
   // After a potential resize in update, ensure currentSurface matches size
   // to avoid diffing mismatched grids.
-  currentSurface = createSurface(
-    sanitizeDimension(ctx.runtime.columns),
-    sanitizeDimension(ctx.runtime.rows),
-  );
+  const postResizeViewport = runtimeViewport();
+  currentSurface = createSurface(postResizeViewport.columns, postResizeViewport.rows);
 
   // Initial render + startup commands
   render();
@@ -319,49 +327,6 @@ export async function run<Model, M>(
 
 function disposeTimerHandle(handle: TimerHandle | null): void {
   handle?.dispose();
-}
-
-/** Clamp a terminal dimension to a non-negative integer. */
-function sanitizeDimension(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.max(0, Math.floor(value));
-}
-
-function installRuntimeOverlay(ctx: { runtime: RuntimePort }): RuntimePort {
-  const baseRuntime = ctx.runtime;
-  const state = {
-    columns: sanitizeDimension(baseRuntime.columns),
-    rows: sanitizeDimension(baseRuntime.rows),
-  };
-  const runtime: RuntimePort = {
-    env(key: string): string | undefined {
-      return baseRuntime.env(key);
-    },
-    get stdoutIsTTY(): boolean {
-      return baseRuntime.stdoutIsTTY;
-    },
-    get stdinIsTTY(): boolean {
-      return baseRuntime.stdinIsTTY;
-    },
-    get columns(): number {
-      return state.columns;
-    },
-    set columns(value: number) {
-      state.columns = sanitizeDimension(value);
-    },
-    get rows(): number {
-      return state.rows;
-    },
-    set rows(value: number) {
-      state.rows = sanitizeDimension(value);
-    },
-    get refreshRate(): number {
-      return baseRuntime.refreshRate;
-    },
-  };
-
-  (ctx as { runtime: RuntimePort }).runtime = runtime;
-  return runtime;
 }
 
 /** Write an error message to stderr if available, otherwise stdout. */

--- a/packages/bijou/src/adapters/test/context.test.ts
+++ b/packages/bijou/src/adapters/test/context.test.ts
@@ -52,6 +52,20 @@ describe('createTestContext()', () => {
     expect(ctx.clock?.now()).toBe(1234);
   });
 
+  it('shares the provided clock with mock I/O scheduling', () => {
+    const clock = mockClock();
+    const ctx = createTestContext({ clock });
+    const calls: number[] = [];
+    const handle = ctx.io.setInterval(() => {
+      calls.push(clock.now());
+    }, 10);
+
+    clock.advanceBy(25);
+    handle.dispose();
+
+    expect(calls).toEqual([10, 20]);
+  });
+
   it('theme accessor functions are resolved and functional', () => {
     const ctx = createTestContext();
     expect(ctx.semantic('primary').hex).toBeTypeOf('string');

--- a/packages/bijou/src/adapters/test/index.ts
+++ b/packages/bijou/src/adapters/test/index.ts
@@ -12,6 +12,7 @@ import type { OutputMode, ColorScheme } from '../../core/detect/tty.js';
 import { mockRuntime, type MockRuntimeOptions } from './runtime.js';
 import { mockIO, type MockIOOptions, type MockIO } from './io.js';
 import { mockClock, type MockClockOptions, type MockClock } from './clock.js';
+import type { ClockPort } from '../../ports/clock.js';
 import type { StylePort } from '../../ports/style.js';
 import { plainStyle } from './style.js';
 import { createResolved } from '../../core/theme/resolve.js';
@@ -49,7 +50,7 @@ export interface TestContextOptions {
   /** Theme to resolve. Defaults to `CYAN_MAGENTA`. */
   theme?: Theme;
   /** Clock override for deterministic time/scheduling. */
-  clock?: MockClockOptions | MockClock;
+  clock?: MockClockOptions | MockClock | ClockPort;
   /** Output mode. Defaults to `'interactive'`. */
   mode?: OutputMode;
   /** Whether to strip color from the resolved theme. Defaults to `false`. */
@@ -60,7 +61,7 @@ export interface TestContextOptions {
   style?: StylePort;
 }
 
-function isMockClock(value: MockClockOptions | MockClock | undefined): value is MockClock {
+function isClockPort(value: MockClockOptions | MockClock | ClockPort | undefined): value is ClockPort {
   return typeof value === 'object'
     && value !== null
     && 'now' in value
@@ -81,17 +82,22 @@ export interface TestContext extends BijouContext {
  *
  * Assemble a {@link mockRuntime}, {@link mockIO}, and {@link plainStyle}
  * together with a resolved theme so tests can exercise bijou components
- * without touching real terminals or filesystems.
+ * without touching real terminals or filesystems. When a clock override is
+ * provided, the same scheduler is threaded through the mock I/O adapter so
+ * interactive runtime tests can stay fully deterministic.
  *
  * @param options - Optional overrides for runtime, I/O, theme, mode, and color.
  * @returns A {@link TestContext} ready for use in tests.
  */
 export function createTestContext(options: TestContextOptions = {}): TestContext {
   const runtime = mockRuntime(options.runtime);
-  const io = mockIO(options.io);
-  const clock = options.clock === undefined
+  const requestedClock = options.clock ?? options.io?.clock;
+  const clock = requestedClock === undefined
     ? systemClock()
-    : (isMockClock(options.clock) ? options.clock : mockClock(options.clock));
+    : (isClockPort(requestedClock) ? requestedClock : mockClock(requestedClock));
+  const io = mockIO(options.io?.clock === undefined
+    ? { ...(options.io ?? {}), clock }
+    : options.io);
   const style = options.style ?? plainStyle();
   const theme = createResolved(options.theme ?? CYAN_MAGENTA, options.noColor ?? false, options.colorScheme ?? 'dark');
   const tokenGraph = createTokenGraph((options.theme ?? CYAN_MAGENTA) as unknown as TokenDefinitions);

--- a/packages/bijou/src/adapters/test/io.test.ts
+++ b/packages/bijou/src/adapters/test/io.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mockIO } from './io.js';
+import { mockClock } from './clock.js';
 
 describe('mockIO()', () => {
   it('write() captures output to written buffer', () => {
@@ -60,14 +61,18 @@ describe('mockIO()', () => {
   });
 
   it('setInterval() returns a disposable handle', () => {
-    vi.useFakeTimers();
-    try {
-      const io = mockIO();
-      const handle = io.setInterval(() => {}, 1000);
-      expect(handle.dispose).toBeTypeOf('function');
-      handle.dispose();
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const calls: number[] = [];
+    const io = mockIO({ clock });
+    const handle = io.setInterval(() => {
+      calls.push(clock.now());
+    }, 1000);
+
+    clock.advanceBy(3_000);
+    expect(calls).toEqual([1_000, 2_000, 3_000]);
+
+    handle.dispose();
+    clock.advanceBy(2_000);
+    expect(calls).toEqual([1_000, 2_000, 3_000]);
   });
 });

--- a/packages/bijou/src/adapters/test/io.ts
+++ b/packages/bijou/src/adapters/test/io.ts
@@ -1,4 +1,6 @@
+import type { ClockPort } from '../../ports/clock.js';
 import type { IOPort, RawInputHandle, TimerHandle } from '../../ports/io.js';
+import { resolveClock } from '../../core/clock.js';
 import { join } from 'path';
 
 /**
@@ -9,6 +11,8 @@ export interface MockIOOptions {
   answers?: string[];
   /** Pre-loaded keypress strings delivered by {@link MockIO.rawInput} via microtasks. */
   keys?: string[];
+  /** Clock override for deterministic timer and microtask scheduling in tests. */
+  clock?: ClockPort;
   /** Virtual filesystem entries (path to content) for {@link MockIO.readFile}. */
   files?: Record<string, string>;
   /** Virtual directory listings (path to entries) for {@link MockIO.readDir}. */
@@ -50,6 +54,7 @@ export function mockIO(options: MockIOOptions = {}): MockIO {
   const answerQueue = [...(options.answers ?? [])];
   const files = { ...(options.files ?? {}) };
   const dirs = { ...(options.dirs ?? {}) };
+  const clock = resolveClock(options.clock);
 
   return {
     written,
@@ -101,9 +106,9 @@ export function mockIO(options: MockIOOptions = {}): MockIO {
         if (disposed || keyQueue.length === 0) return;
         const key = keyQueue.shift()!;
         onKey(key);
-        if (keyQueue.length > 0) queueMicrotask(deliver);
+        if (keyQueue.length > 0) clock.queueMicrotask(deliver);
       }
-      queueMicrotask(deliver);
+      clock.queueMicrotask(deliver);
       return { dispose() { disposed = true; } };
     },
 
@@ -123,8 +128,7 @@ export function mockIO(options: MockIOOptions = {}): MockIO {
      * @returns A handle whose `dispose()` cancels the timer.
      */
     setInterval(callback: () => void, ms: number): TimerHandle {
-      const id = globalThis.setInterval(callback, ms);
-      return { dispose() { clearInterval(id); } };
+      return clock.setInterval(callback, ms);
     },
 
     /**

--- a/packages/bijou/src/core/components/progress.test.ts
+++ b/packages/bijou/src/core/components/progress.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { progressBar, createProgressBar, createAnimatedProgressBar } from './progress.js';
-import { createTestContext } from '../../adapters/test/index.js';
+import { createTestContext, mockClock } from '../../adapters/test/index.js';
 
 describe('progressBar', () => {
   it('renders progress bar at 0% in static mode', () => {
@@ -126,8 +126,8 @@ describe('createAnimatedProgressBar', () => {
   });
 
   it('update() triggers interpolation frames', async () => {
-    vi.useFakeTimers();
-    const ctx = createTestContext({ mode: 'interactive' });
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
     const bar = createAnimatedProgressBar({ width: 10, fps: 30, duration: 300, ctx });
     bar.start();
     const writesBeforeUpdate = ctx.io.written.length;
@@ -135,7 +135,7 @@ describe('createAnimatedProgressBar', () => {
     bar.update(100);
 
     // Advance several frames
-    vi.advanceTimersByTime(200);
+    clock.advanceBy(200);
     expect(ctx.io.written.length).toBeGreaterThan(writesBeforeUpdate);
 
     // Some intermediate frames should have values between 0 and 100
@@ -143,16 +143,15 @@ describe('createAnimatedProgressBar', () => {
     expect(intermediateWrites.length).toBeGreaterThan(1);
 
     bar.stop();
-    vi.useRealTimers();
   });
 
   it('stop() clears interval and restores cursor', () => {
-    vi.useFakeTimers();
-    const ctx = createTestContext({ mode: 'interactive' });
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
     const bar = createAnimatedProgressBar({ width: 10, ctx });
     bar.start();
     bar.update(50);
-    vi.advanceTimersByTime(100);
+    clock.advanceBy(100);
 
     bar.stop('All done');
     const writes = ctx.io.written;
@@ -161,10 +160,8 @@ describe('createAnimatedProgressBar', () => {
 
     // No more writes after stop
     const countAfterStop = writes.length;
-    vi.advanceTimersByTime(200);
+    clock.advanceBy(200);
     expect(writes.length).toBe(countAfterStop);
-
-    vi.useRealTimers();
   });
 
   it('non-interactive mode produces static output', () => {
@@ -185,19 +182,18 @@ describe('createAnimatedProgressBar', () => {
   });
 
   it('animation converges to target value', () => {
-    vi.useFakeTimers();
-    const ctx = createTestContext({ mode: 'interactive' });
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
     const bar = createAnimatedProgressBar({ width: 10, fps: 30, duration: 300, ctx });
     bar.start();
     bar.update(100);
 
     // Advance enough time for animation to complete
-    vi.advanceTimersByTime(500);
+    clock.advanceBy(500);
 
     const lastRenderWrite = ctx.io.written.filter(w => w.includes('%')).at(-1);
     expect(lastRenderWrite).toContain('100%');
 
     bar.stop();
-    vi.useRealTimers();
   });
 });

--- a/packages/bijou/src/core/components/timer.test.ts
+++ b/packages/bijou/src/core/components/timer.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { timer, createTimer, createStopwatch } from './timer.js';
-import { createTestContext } from '../../adapters/test/index.js';
+import { createTestContext, mockClock } from '../../adapters/test/index.js';
 
 describe('timer (static)', () => {
   it('formats MM:SS in interactive mode', () => {
@@ -60,10 +60,6 @@ describe('timer (static)', () => {
 });
 
 describe('createTimer', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('emits a single line in non-interactive mode', () => {
     const ctx = createTestContext({ mode: 'pipe' });
     const t = createTimer({ duration: 60_000, ctx });
@@ -91,40 +87,32 @@ describe('createTimer', () => {
   });
 
   it('restores cursor on natural completion in interactive mode', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      let completed = false;
-      const t = createTimer({ duration: 1000, interval: 100, ctx, onComplete: () => { completed = true; } });
-      t.start();
-      vi.advanceTimersByTime(1100);
-      const output = ctx.io.written.join('');
-      expect(completed).toBe(true);
-      expect(output).toContain('\x1b[?25h');
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    let completed = false;
+    const t = createTimer({ duration: 1000, interval: 100, ctx, onComplete: () => { completed = true; } });
+    t.start();
+    clock.advanceBy(1100);
+    const output = ctx.io.written.join('');
+    expect(completed).toBe(true);
+    expect(output).toContain('\x1b[?25h');
   });
 
   it('fires onComplete after cursor is restored on natural completion', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      let cursorRestoredBeforeCallback = false;
-      const t = createTimer({
-        duration: 1000, interval: 100, ctx,
-        onComplete: () => {
-          // At the time onComplete fires, cursor should already be restored
-          const output = ctx.io.written.join('');
-          cursorRestoredBeforeCallback = output.endsWith('\x1b[?25h');
-        },
-      });
-      t.start();
-      vi.advanceTimersByTime(1100);
-      expect(cursorRestoredBeforeCallback).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    let cursorRestoredBeforeCallback = false;
+    const t = createTimer({
+      duration: 1000, interval: 100, ctx,
+      onComplete: () => {
+        // At the time onComplete fires, cursor should already be restored
+        const output = ctx.io.written.join('');
+        cursorRestoredBeforeCallback = output.endsWith('\x1b[?25h');
+      },
+    });
+    t.start();
+    clock.advanceBy(1100);
+    expect(cursorRestoredBeforeCallback).toBe(true);
   });
 
   it('fires onComplete in non-interactive mode for zero-duration timer', () => {
@@ -159,27 +147,19 @@ describe('createTimer', () => {
   });
 
   it('displays countdown value that decreases over time', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      const t = createTimer({ duration: 60_000, interval: 1000, ctx });
-      t.start();
-      vi.advanceTimersByTime(30_000);
-      const output = ctx.io.written.join('');
-      // Should contain a value showing ~30s remaining
-      expect(output).toContain('00:30');
-      t.stop();
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    const t = createTimer({ duration: 60_000, interval: 1000, ctx });
+    t.start();
+    clock.advanceBy(30_000);
+    const output = ctx.io.written.join('');
+    // Should contain a value showing ~30s remaining
+    expect(output).toContain('00:30');
+    t.stop();
   });
 });
 
 describe('createStopwatch', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('emits a single line in non-interactive mode', () => {
     const ctx = createTestContext({ mode: 'pipe' });
     const sw = createStopwatch({ ctx });
@@ -204,114 +184,90 @@ describe('createStopwatch', () => {
   });
 
   it('calling start() twice does not leak interval handles', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      const sw = createStopwatch({ interval: 100, ctx });
-      sw.start();
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    const sw = createStopwatch({ interval: 100, ctx });
+    sw.start();
 
-      // Start again — should cancel the first interval
-      sw.start();
-      vi.advanceTimersByTime(500);
-      sw.stop();
+    // Start again — should cancel the first interval
+    sw.start();
+    clock.advanceBy(500);
+    sw.stop();
 
-      // Count tick writes (those containing CLEAR_LINE_RETURN = \r\x1b[K)
-      const tickWrites = ctx.io.written.filter((s: string) => s.includes('\r\x1b[K'));
-      // 2 initial renders (one per start) + 5 ticks (500ms / 100ms) = 7
-      // With a leak we'd see ~12+ from both intervals running
-      expect(tickWrites.length).toBeGreaterThanOrEqual(5);
-      expect(tickWrites.length).toBeLessThanOrEqual(8);
-    } finally {
-      vi.useRealTimers();
-    }
+    // Count tick writes (those containing CLEAR_LINE_RETURN = \r\x1b[K)
+    const tickWrites = ctx.io.written.filter((s: string) => s.includes('\r\x1b[K'));
+    // 2 initial renders (one per start) + 5 ticks (500ms / 100ms) = 7
+    // With a leak we'd see ~12+ from both intervals running
+    expect(tickWrites.length).toBeGreaterThanOrEqual(5);
+    expect(tickWrites.length).toBeLessThanOrEqual(8);
   });
 
   it('elapsed() returns a live value while running', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      const sw = createStopwatch({ interval: 1000, ctx });
-      sw.start();
-      vi.advanceTimersByTime(500);
-      // Between ticks, elapsed() should still reflect real time
-      expect(sw.elapsed()).toBeGreaterThanOrEqual(500);
-      sw.stop();
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    const sw = createStopwatch({ interval: 1000, ctx });
+    sw.start();
+    clock.advanceBy(500);
+    // Between ticks, elapsed() should still reflect real time
+    expect(sw.elapsed()).toBeGreaterThanOrEqual(500);
+    sw.stop();
   });
 
   it('pause and resume preserve elapsed', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      const sw = createStopwatch({ interval: 100, ctx });
-      sw.start();
-      vi.advanceTimersByTime(300);
-      sw.pause();
-      const atPause = sw.elapsed();
-      expect(atPause).toBeGreaterThanOrEqual(300);
-      // Time passes while paused — elapsed should NOT advance
-      vi.advanceTimersByTime(500);
-      expect(sw.elapsed()).toBe(atPause);
-      // Resume and verify elapsed advances again
-      sw.resume();
-      vi.advanceTimersByTime(200);
-      expect(sw.elapsed()).toBeGreaterThanOrEqual(atPause + 200);
-      sw.stop();
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    const sw = createStopwatch({ interval: 100, ctx });
+    sw.start();
+    clock.advanceBy(300);
+    sw.pause();
+    const atPause = sw.elapsed();
+    expect(atPause).toBeGreaterThanOrEqual(300);
+    // Time passes while paused — elapsed should NOT advance
+    clock.advanceBy(500);
+    expect(sw.elapsed()).toBe(atPause);
+    // Resume and verify elapsed advances again
+    sw.resume();
+    clock.advanceBy(200);
+    expect(sw.elapsed()).toBeGreaterThanOrEqual(atPause + 200);
+    sw.stop();
   });
 
   it('start() while paused resets paused state', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      const sw = createStopwatch({ interval: 100, ctx });
-      sw.start();
-      vi.advanceTimersByTime(200);
-      sw.pause();
-      // Restart while paused — should not remain frozen
-      sw.start();
-      vi.advanceTimersByTime(300);
-      expect(sw.elapsed()).toBeGreaterThanOrEqual(300);
-      sw.stop();
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    const sw = createStopwatch({ interval: 100, ctx });
+    sw.start();
+    clock.advanceBy(200);
+    sw.pause();
+    // Restart while paused — should not remain frozen
+    sw.start();
+    clock.advanceBy(300);
+    expect(sw.elapsed()).toBeGreaterThanOrEqual(300);
+    sw.stop();
   });
 
   it('stop() snapshots accurate elapsed value', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      const sw = createStopwatch({ interval: 1000, ctx });
-      sw.start();
-      vi.advanceTimersByTime(550);
-      sw.stop();
-      // elapsed() after stop should reflect time at stop, not last tick
-      expect(sw.elapsed()).toBeGreaterThanOrEqual(550);
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    const sw = createStopwatch({ interval: 1000, ctx });
+    sw.start();
+    clock.advanceBy(550);
+    sw.stop();
+    // elapsed() after stop should reflect time at stop, not last tick
+    expect(sw.elapsed()).toBeGreaterThanOrEqual(550);
   });
 
   it('stop() after pause() preserves paused elapsed value', () => {
-    vi.useFakeTimers();
-    try {
-      const ctx = createTestContext({ mode: 'interactive' });
-      const sw = createStopwatch({ interval: 100, ctx });
-      sw.start();
-      vi.advanceTimersByTime(400);
-      sw.pause();
-      const atPause = sw.elapsed();
-      expect(atPause).toBeGreaterThanOrEqual(400);
-      // Stop while paused — elapsed should reflect time at pause
-      sw.stop();
-      expect(sw.elapsed()).toBe(atPause);
-    } finally {
-      vi.useRealTimers();
-    }
+    const clock = mockClock();
+    const ctx = createTestContext({ mode: 'interactive', clock });
+    const sw = createStopwatch({ interval: 100, ctx });
+    sw.start();
+    clock.advanceBy(400);
+    sw.pause();
+    const atPause = sw.elapsed();
+    expect(atPause).toBeGreaterThanOrEqual(400);
+    // Stop while paused — elapsed should reflect time at pause
+    sw.stop();
+    expect(sw.elapsed()).toBe(atPause);
   });
 });

--- a/packages/bijou/src/core/runtime-viewport.test.ts
+++ b/packages/bijou/src/core/runtime-viewport.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { RuntimePort } from '../ports/runtime.js';
+import {
+  installRuntimeViewportOverlay,
+  readRuntimeViewport,
+  sanitizeRuntimeDimension,
+  updateRuntimeViewport,
+} from './runtime-viewport.js';
+
+function createRuntime(columns: number, rows: number): RuntimePort {
+  return {
+    env(key: string): string | undefined {
+      return key === 'TEST_KEY' ? 'ok' : undefined;
+    },
+    stdoutIsTTY: true,
+    stdinIsTTY: false,
+    columns,
+    rows,
+    refreshRate: 144,
+  };
+}
+
+describe('runtime viewport helpers', () => {
+  it('sanitizes runtime dimensions to non-negative integers', () => {
+    expect(sanitizeRuntimeDimension(12.9)).toBe(12);
+    expect(sanitizeRuntimeDimension(-5)).toBe(0);
+    expect(sanitizeRuntimeDimension(Number.NaN)).toBe(0);
+  });
+
+  it('installs a mutable viewport overlay without mutating the base runtime object', () => {
+    const baseRuntime = createRuntime(120.8, -2);
+    const host = { runtime: baseRuntime };
+
+    const runtime = installRuntimeViewportOverlay(host);
+
+    expect(host.runtime).toBe(runtime);
+    expect(readRuntimeViewport(runtime)).toEqual({ columns: 120, rows: 0 });
+    expect(runtime.env('TEST_KEY')).toBe('ok');
+    expect(runtime.stdoutIsTTY).toBe(true);
+    expect(runtime.stdinIsTTY).toBe(false);
+    expect(runtime.refreshRate).toBe(144);
+
+    const next = updateRuntimeViewport(runtime, 90.7, 22.1);
+    expect(next).toEqual({ columns: 90, rows: 22 });
+    expect(readRuntimeViewport(runtime)).toEqual({ columns: 90, rows: 22 });
+    expect(baseRuntime.columns).toBe(120.8);
+    expect(baseRuntime.rows).toBe(-2);
+  });
+});

--- a/packages/bijou/src/core/runtime-viewport.ts
+++ b/packages/bijou/src/core/runtime-viewport.ts
@@ -1,0 +1,88 @@
+import type { RuntimePort } from '../ports/runtime.js';
+
+/** Sanitized terminal viewport dimensions. */
+export interface RuntimeViewport {
+  readonly columns: number;
+  readonly rows: number;
+}
+
+/**
+ * Clamp a terminal dimension to a non-negative integer.
+ *
+ * Runtime adapters may surface fractional, negative, or non-finite values
+ * transiently during resize flows. The TUI runtime only operates on whole,
+ * non-negative cell counts.
+ */
+export function sanitizeRuntimeDimension(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+/** Read the current runtime viewport using Bijou's shared dimension rules. */
+export function readRuntimeViewport(runtime: RuntimePort): RuntimeViewport {
+  return {
+    columns: sanitizeRuntimeDimension(runtime.columns),
+    rows: sanitizeRuntimeDimension(runtime.rows),
+  };
+}
+
+/**
+ * Install a mutable viewport overlay on top of an existing runtime port.
+ *
+ * This gives runtimes backed by immutable globals (for example Node's
+ * `process.stdout.columns`) a stable, writable source of truth for scripted
+ * resizes and worker-proxy synchronization.
+ */
+export function installRuntimeViewportOverlay<T extends { runtime: RuntimePort }>(host: T): RuntimePort {
+  const baseRuntime = host.runtime;
+  const viewport = readRuntimeViewport(baseRuntime);
+  const state = {
+    columns: viewport.columns,
+    rows: viewport.rows,
+  };
+  const runtime: RuntimePort = {
+    env(key: string): string | undefined {
+      return baseRuntime.env(key);
+    },
+    get stdoutIsTTY(): boolean {
+      return baseRuntime.stdoutIsTTY;
+    },
+    get stdinIsTTY(): boolean {
+      return baseRuntime.stdinIsTTY;
+    },
+    get columns(): number {
+      return state.columns;
+    },
+    set columns(value: number) {
+      state.columns = sanitizeRuntimeDimension(value);
+    },
+    get rows(): number {
+      return state.rows;
+    },
+    set rows(value: number) {
+      state.rows = sanitizeRuntimeDimension(value);
+    },
+    get refreshRate(): number {
+      return baseRuntime.refreshRate;
+    },
+  };
+
+  host.runtime = runtime;
+  return runtime;
+}
+
+/**
+ * Update a mutable runtime overlay with sanitized viewport dimensions.
+ *
+ * Use this after {@link installRuntimeViewportOverlay} when resize events or
+ * worker messages need to advance the current runtime viewport source of truth.
+ */
+export function updateRuntimeViewport(
+  runtime: RuntimePort,
+  columns: number,
+  rows: number,
+): RuntimeViewport {
+  runtime.columns = columns;
+  runtime.rows = rows;
+  return readRuntimeViewport(runtime);
+}

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -40,6 +40,13 @@ export {
 // Context resolution helpers
 export { resolveCtx, resolveSafeCtx } from './core/resolve-ctx.js';
 export { systemClock, resolveClock, sleep, defer } from './core/clock.js';
+export {
+  type RuntimeViewport,
+  sanitizeRuntimeDimension,
+  readRuntimeViewport,
+  installRuntimeViewportOverlay,
+  updateRuntimeViewport,
+} from './core/runtime-viewport.js';
 
 // Mode rendering strategy
 export {


### PR DESCRIPTION
## Summary
- extract a shared runtime viewport overlay helper for main and worker runtimes
- unify viewport sanitization and mutable resize bookkeeping across those paths
- add focused regression coverage for the shared helper and runtime integrations

## Verification
- npm run build
- npm run typecheck:test
- npx vitest run --config vitest.config.ts packages/bijou/src/core/runtime-viewport.test.ts
- npx vitest run --config vitest.config.ts packages/bijou-tui/src/runtime.test.ts
- npx vitest run --config vitest.config.ts packages/bijou-node/src/worker/worker.proxy.test.ts
- npm test
