### PR TITLE
feat: add release readiness gate

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Clock-driven test scheduling** — the remaining timer-sensitive runtime, command, component, and I/O adapter tests now use injected `mockClock()` instances instead of Vitest fake timers, and the Node/test I/O adapters accept clock injection so those tests never have to touch wall-clock scheduling.
 - **Worker proxy test seams** — `runInWorker()` and `startWorkerApp()` now accept explicit worker-thread bindings, so the proxy-runtime tests can assert host/worker IPC behavior without module-reset mock churn.
 - **Workflow and smoke harness hardening** — `smoke-all-examples` now exposes testable launcher/path helpers with focused unit coverage, the repo ships a local `workflow:shell:preflight` command for validating workflow shell blocks before CI is first to see them, and the PTY driver has extra shutdown-ordering coverage for late labeled steps after child exit.
+- **Release readiness gate** — the repo now ships `npm run release:readiness`, a single local command that runs the build, test, frame-regression, smoke, workflow-shell, and release-preflight bars in release order instead of relying on tribal knowledge.
 
 ### 🧪 Tests
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest --config vitest.config.ts",
     "typecheck:test": "tsc --noEmit -p tsconfig.tests.json",
     "release:preflight": "tsx scripts/release-metadata.ts --current-version --notes-tag-run-id local",
+    "release:readiness": "tsx scripts/release-readiness.ts",
     "workflow:shell:preflight": "tsx scripts/workflow-shell-preflight.ts",
     "smoke:examples": "tsx scripts/smoke-v3-examples.ts",
     "smoke:examples:all": "tsx scripts/smoke-all-examples.ts",

--- a/scripts/release-readiness.test.ts
+++ b/scripts/release-readiness.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildReleaseReadinessPlan, runReleaseReadiness } from './release-readiness.js';
+
+describe('release-readiness', () => {
+  it('runs the expected release gate commands in order', () => {
+    const plan = buildReleaseReadinessPlan();
+    expect(plan.map((step) => step.label)).toEqual([
+      'build',
+      'typecheck:test',
+      'workflow:shell:preflight',
+      'release:preflight',
+      'test:frames',
+      'smoke:canaries',
+      'smoke:examples:all',
+      'test',
+    ]);
+    expect(plan.find((step) => step.label === 'smoke:canaries')?.args).toEqual([
+      'run',
+      'smoke:canaries',
+      '--',
+      '--skip-build',
+    ]);
+  });
+
+  it('fails fast when a release gate step fails', () => {
+    const executed: string[] = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const code = runReleaseReadiness({
+      cwd: '/tmp/bijou',
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+      runCommand(step, cwd) {
+        executed.push(`${cwd}:${step.label}`);
+        return {
+          status: step.label === 'test:frames' ? 2 : 0,
+        };
+      },
+    });
+
+    expect(code).toBe(2);
+    expect(executed).toEqual([
+      '/tmp/bijou:build',
+      '/tmp/bijou:typecheck:test',
+      '/tmp/bijou:workflow:shell:preflight',
+      '/tmp/bijou:release:preflight',
+      '/tmp/bijou:test:frames',
+    ]);
+    expect(stdout).toContain('==> test:frames\n');
+    expect(stderr).toContain('release-readiness: test:frames exited with status 2\n');
+  });
+
+  it('prints success when every gate passes', () => {
+    const stdout: string[] = [];
+    const code = runReleaseReadiness({
+      stdout: (text) => stdout.push(text),
+      runCommand() {
+        return { status: 0 };
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(stdout.at(-1)).toBe('release-readiness: ok\n');
+  });
+});

--- a/scripts/release-readiness.ts
+++ b/scripts/release-readiness.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env tsx
+
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface ReleaseReadinessStep {
+  readonly label: string;
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+export interface ReleaseReadinessIO {
+  readonly cwd?: string;
+  readonly stdout?: (text: string) => void;
+  readonly stderr?: (text: string) => void;
+  readonly runCommand?: (step: ReleaseReadinessStep, cwd: string) => {
+    readonly status: number | null;
+    readonly error?: Error;
+  };
+}
+
+function npmCommand(): string {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+export function buildReleaseReadinessPlan(): readonly ReleaseReadinessStep[] {
+  const npm = npmCommand();
+  return [
+    { label: 'build', command: npm, args: ['run', 'build'] },
+    { label: 'typecheck:test', command: npm, args: ['run', 'typecheck:test'] },
+    { label: 'workflow:shell:preflight', command: npm, args: ['run', 'workflow:shell:preflight'] },
+    { label: 'release:preflight', command: npm, args: ['run', 'release:preflight'] },
+    { label: 'test:frames', command: npm, args: ['run', 'test:frames'] },
+    { label: 'smoke:canaries', command: npm, args: ['run', 'smoke:canaries', '--', '--skip-build'] },
+    { label: 'smoke:examples:all', command: npm, args: ['run', 'smoke:examples:all'] },
+    { label: 'test', command: npm, args: ['test'] },
+  ];
+}
+
+function defaultRunCommand(step: ReleaseReadinessStep, cwd: string): { readonly status: number | null; readonly error?: Error } {
+  const result = spawnSync(step.command, step.args, {
+    cwd,
+    stdio: 'inherit',
+  });
+  return {
+    status: result.status,
+    error: result.error,
+  };
+}
+
+export function runReleaseReadiness(io: ReleaseReadinessIO = {}): number {
+  const cwd = resolve(io.cwd ?? process.cwd());
+  const stdout = io.stdout ?? ((text: string) => process.stdout.write(text));
+  const stderr = io.stderr ?? ((text: string) => process.stderr.write(text));
+  const runCommand = io.runCommand ?? defaultRunCommand;
+
+  for (const step of buildReleaseReadinessPlan()) {
+    stdout(`==> ${step.label}\n`);
+    const result = runCommand(step, cwd);
+    if (result.error) {
+      stderr(`release-readiness: ${step.label} failed: ${result.error.message}\n`);
+      return 1;
+    }
+    if (result.status !== 0) {
+      stderr(`release-readiness: ${step.label} exited with status ${result.status ?? 'null'}\n`);
+      return result.status ?? 1;
+    }
+  }
+
+  stdout('release-readiness: ok\n');
+  return 0;
+}
+
+function main(): void {
+  process.exitCode = runReleaseReadiness();
+}
+
+if (process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add a single local release-readiness command that runs the build, typecheck, frame, smoke, workflow-shell, and release-preflight bars in release order
- add focused unit coverage for command ordering, fail-fast behavior, and success reporting
- document the new gate in the changelog

## Verification
- npx vitest run --config vitest.config.ts scripts/release-readiness.test.ts
- npm run typecheck:test
- npm run release:readiness
