### PR TITLE
feat: add notification history center

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,12 @@ jobs:
       npm_dist_tag: ${{ steps.meta.outputs.npm_dist_tag }}
       release_sha: ${{ steps.release_sha.outputs.release_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -86,11 +86,11 @@ jobs:
       matrix:
         package: [bijou, bijou-node, bijou-tui, bijou-tui-app, create-bijou-tui-app]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.verify.outputs.release_sha }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -14,11 +14,11 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       notes_tag: ${{ steps.meta.outputs.notes_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -67,9 +67,9 @@ jobs:
       matrix:
         package: [bijou, bijou-node, bijou-tui, bijou-tui-app, create-bijou-tui-app]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -123,7 +123,7 @@ jobs:
           );
           EOF
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-notes-preview
           path: RELEASE_NOTES_PREVIEW.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 🐛 Fixes
 
 - **GitHub Actions runtime compatibility** — CI, publish, and release dry-run workflows now use `actions/checkout@v6` and `actions/setup-node@v6`, clearing the Node 20 action-runtime deprecation warning path before GitHub flips the default to Node 24.
+- **Notification history filtering and modal safety** — actionable archived notifications are now filtered by variant instead of custom action payload presence, the notification history center blocks background notification shortcuts while open, and the demo initializes framed shell dimensions from the injected runtime so the compact-terminal history modal clamps and wraps correctly.
+- **Release dry-run artifact action compatibility** — the release dry-run workflow now uses `actions/upload-artifact@v7`, matching the current Node 24-compatible action runtime.
 
 ## [3.1.0] - 2026-03-18
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **Notification history center** — `@flyingrobots/bijou-tui` now exposes `renderNotificationHistory()` / `countNotificationHistory()`, and the framed notification lab can open a scrollable history modal from the command palette or `Shift+H`, with filter cycling and archived actionable/error review.
+
+### 🐛 Fixes
+
+- **GitHub Actions runtime compatibility** — CI, publish, and release dry-run workflows now use `actions/checkout@v6` and `actions/setup-node@v6`, clearing the Node 20 action-runtime deprecation warning path before GitHub flips the default to Node 24.
+
 ## [3.1.0] - 2026-03-18
 
 ### ✨ Features

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,10 +78,12 @@ See [COMPLETED.md](COMPLETED.md) for the full shipped log. Summary:
 | **Bijou DevTools Inspector** | bijou-tui | Expand the toggleable overlay (`F12`) into a real inspector for focused node ids/classes, layout rects, BCSS matches, token resolution, message flow, and runtime state. |
 | **Syntax-Aware `textarea`** | bijou | Light-weight syntax highlighting for JSON, YAML, and Markdown within the editor. |
 | **Motion API** | bijou-tui | Declarative entry/exit animations (Framer Motion style) for components in the `view` function. |
+| **Notification Center / History View** | bijou-tui | Build on the shipped notification stack with a reusable history/archive view, command-palette entry points, scroll/filter controls, and richer review/reopen flows for archived notices. |
 | **Continuum Bridge** | bijou | Specialized `ContinuumPort` for live-syncing components with WARP graphs and Shiplog events. |
 | **Scaffold Canary in CI** | repo tooling + create-bijou-tui-app | The generated TUI canary and internal core/static canary shipped. Backlog now covers keeping the scenario coverage broad and the install/build path efficient without weakening published-artifact fidelity. |
 | **PR Review Tooling** | repo tooling | `pr:review-status` and `pr:merge-readiness` shipped. Backlog now covers differentiating active bot-review progress from stale historical chatter, shared GitHub adapter helpers, and batch reply/resolve workflows for addressed threads. |
 | **Release Dry-Run Workflow** | repo tooling | `workflow_dispatch` dry-run and shared release validation shipped. Backlog now covers a local shell-block preflight path plus any remaining release-policy helper cleanup. |
+| **GitHub Actions Runtime Compatibility** | repo tooling | Keep workflow action majors current so CI/publish/dry-run paths stay ahead of runner runtime deprecations like the Node 20 to Node 24 action-runtime switch. |
 | **Python Script Artifact Hygiene** | repo tooling | Bytecode suppression and `.gitignore` backstop shipped. Backlog now covers keeping the PTY helper self-contained and low-noise. |
 | **Smoke Harness Unit Coverage** | repo tooling | Add focused tests for `scripts/smoke-all-examples.ts`, especially path/root resolution and launcher selection, so portability regressions fail before CI smoke runs. |
 | **PTY Lifecycle Race Coverage** | repo tooling + scripts | Add regression coverage for resize/exit ordering and other late-step shutdown races so the PTY harness keeps its lifecycle guarantees explicit. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,7 +86,7 @@ Browse 45 components across 4 categories (Display, Data, Forms, TUI Blocks). Eac
 | [`timeline-anim`](./timeline-anim/) | `timeline()`, `animate()`, `sequence()` | Orchestrated GSAP-style animation |
 | [`modal`](./modal/) | `createInputStack()`, `viewport()` | Layered modal input dispatch |
 | [`toast`](./toast/) | `toast()`, `composite()` | Anchored notification overlay variants |
-| [`notifications`](./notifications/) | `renderNotificationStack()`, `pushNotification()`, `tickNotifications()` | Stacked actionable/inline/toast notifications inside `createFramedApp()` |
+| [`notifications`](./notifications/) | `renderNotificationStack()`, `renderNotificationHistory()`, `pushNotification()`, `tickNotifications()` | Stacked actionable/inline/toast notifications inside `createFramedApp()`, plus a command-palette history center for archived notices |
 | [`help`](./help/) | `createKeyMap()`, `helpView()`, `helpShort()` | Keybinding manager with help toggle |
 | [`print-key`](./print-key/) | `parseKey()` | Key event inspector with modifier badges |
 | [`fullscreen`](./fullscreen/) | `enterScreen()`, `exitScreen()` | Alternate screen with centered content |

--- a/examples/notifications/main.ts
+++ b/examples/notifications/main.ts
@@ -2,15 +2,18 @@ import { initDefaultContext } from '@flyingrobots/bijou-node';
 import { box, kbd } from '@flyingrobots/bijou';
 import {
   activateFocusedNotification,
+  countNotificationHistory,
   createFramedApp,
   createKeyMap,
   createNotificationState,
   cycleNotificationFocus,
   dismissFocusedNotification,
   dismissNotification,
+  modal,
   notificationsNeedTick,
   pushNotification,
   relocateNotifications,
+  renderNotificationHistory,
   quit,
   renderNotificationStack,
   run,
@@ -19,6 +22,7 @@ import {
   trimNotificationsToViewport,
   type Cmd,
   type FramePage,
+  type NotificationHistoryFilter,
   type NotificationPlacement,
   type NotificationSpec,
   type NotificationState,
@@ -43,6 +47,15 @@ const PLACEMENTS: readonly NotificationPlacement[] = [
   'CENTER',
 ];
 
+const HISTORY_FILTERS: readonly NotificationHistoryFilter[] = [
+  'ALL',
+  'ACTIONABLE',
+  'ERROR',
+  'WARNING',
+  'SUCCESS',
+  'INFO',
+];
+
 const DURATION_OPTIONS = [
   { label: 'default', value: undefined },
   { label: 'persistent', value: null },
@@ -59,6 +72,13 @@ type Msg =
   | { type: 'cycle-duration' }
   | { type: 'toggle-action' }
   | { type: 'toggle-wrap' }
+  | { type: 'open-history' }
+  | { type: 'close-history' }
+  | { type: 'history-next' }
+  | { type: 'history-prev' }
+  | { type: 'history-page-down' }
+  | { type: 'history-page-up' }
+  | { type: 'cycle-history-filter' }
   | { type: 'focus-next' }
   | { type: 'focus-prev' }
   | { type: 'activate-focused' }
@@ -77,6 +97,9 @@ interface PageModel {
   readonly durationIndex: number;
   readonly actionEnabled: boolean;
   readonly wrapText: boolean;
+  readonly historyOpen: boolean;
+  readonly historyScroll: number;
+  readonly historyFilterIndex: number;
   readonly nextOrdinal: number;
   readonly lastHandledInput: string;
   readonly log: readonly string[];
@@ -92,6 +115,9 @@ function createInitialPageModel(): PageModel {
     durationIndex: 0,
     actionEnabled: true,
     wrapText: true,
+    historyOpen: false,
+    historyScroll: 0,
+    historyFilterIndex: 0,
     nextOrdinal: 1,
     lastHandledInput: 'none',
     log: [
@@ -115,6 +141,18 @@ function currentPlacement(model: PageModel): NotificationPlacement {
 
 function currentDuration(model: PageModel) {
   return DURATION_OPTIONS[model.durationIndex]!;
+}
+
+function currentHistoryFilter(model: PageModel): NotificationHistoryFilter {
+  return HISTORY_FILTERS[model.historyFilterIndex]!;
+}
+
+function maxHistoryScroll(model: PageModel): number {
+  return Math.max(0, countNotificationHistory(model.notifications, currentHistoryFilter(model)) - 1);
+}
+
+function clampHistoryScroll(model: PageModel, nextScroll: number): number {
+  return Math.max(0, Math.min(nextScroll, maxHistoryScroll(model)));
 }
 
 function toneCopy(tone: NotificationTone): { readonly title: string; readonly message: string } {
@@ -173,6 +211,14 @@ function recordInput(model: PageModel, key: string, message: string): PageModel 
     ...model,
     lastHandledInput: key,
   }, `[${key}] ${message}`);
+}
+
+function openHistory(model: PageModel, key: string): PageModel {
+  return recordInput({
+    ...model,
+    historyOpen: true,
+    historyScroll: clampHistoryScroll(model, model.historyScroll),
+  }, key, `Opened notification history (${countNotificationHistory(model.notifications, currentHistoryFilter(model))} items).`);
 }
 
 function applyNotificationState(
@@ -323,6 +369,7 @@ function renderControlsPane(model: PageModel, width: number): string {
   const activePlacement = currentPlacement(model);
   const nextPlacement = PLACEMENTS[(model.placementIndex + 1) % PLACEMENTS.length]!;
   const activeDuration = currentDuration(model);
+  const historyFilter = currentHistoryFilter(model);
   const focused = model.notifications.focusedId == null
     ? 'none'
     : `#${model.notifications.focusedId}`;
@@ -338,6 +385,7 @@ function renderControlsPane(model: PageModel, width: number): string {
     `Wrap    : ${model.wrapText ? 'enabled' : 'disabled'}`,
     `Stack   : ${model.notifications.items.length}`,
     `History : ${model.notifications.history.length}`,
+    `Center  : ${model.historyOpen ? 'open' : 'closed'} (${historyFilter})`,
     `Focus   : ${focused}`,
     `Last key: ${model.lastHandledInput}`,
     '',
@@ -348,6 +396,7 @@ function renderControlsPane(model: PageModel, width: number): string {
     `${kbd('d')} cycle duration`,
     `${kbd('a')} toggle action`,
     `${kbd('w')} toggle wrap`,
+    `${kbd('shift+h')} open history center`,
     `${kbd('j')} / ${kbd('k')} focus action`,
     `${kbd('enter')} run action`,
     `${kbd('x')} dismiss focused/latest`,
@@ -376,6 +425,29 @@ function renderLogPane(model: PageModel, width: number): string {
     width,
     title: 'Activity',
     overflow: model.wrapText ? 'wrap' : 'truncate',
+    ctx,
+  });
+}
+
+function renderHistoryModal(model: PageModel, screenWidth: number, screenHeight: number) {
+  const modalWidth = Math.max(48, Math.min(96, screenWidth - 6));
+  const bodyWidth = Math.max(20, modalWidth - 4);
+  const bodyHeight = Math.max(8, Math.min(screenHeight - 8, 20));
+  const filter = currentHistoryFilter(model);
+
+  return modal({
+    title: `Notification History (${filter})`,
+    body: renderNotificationHistory(model.notifications, {
+      width: bodyWidth,
+      height: bodyHeight,
+      scroll: model.historyScroll,
+      filter,
+      ctx,
+    }),
+    hint: 'Up/Down scroll • PageUp/PageDown jump • f filter • Esc close',
+    width: modalWidth,
+    screenWidth,
+    screenHeight,
     ctx,
   });
 }
@@ -437,12 +509,63 @@ const page: FramePage<PageModel, Msg> = {
           ...model,
           wrapText: !model.wrapText,
         }, 'w', `Wrap ${!model.wrapText ? 'enabled' : 'disabled'}.`), []];
+      case 'open-history':
+        return [openHistory(model, 'shift+h'), []];
+      case 'close-history':
+        if (!model.historyOpen) return [model, []];
+        return [recordInput({
+          ...model,
+          historyOpen: false,
+        }, 'escape', 'Closed notification history.'), []];
+      case 'history-next':
+        if (!model.historyOpen) return [model, []];
+        return [{
+          ...model,
+          historyScroll: clampHistoryScroll(model, model.historyScroll + 1),
+        }, []];
+      case 'history-prev':
+        if (!model.historyOpen) return [model, []];
+        return [{
+          ...model,
+          historyScroll: clampHistoryScroll(model, model.historyScroll - 1),
+        }, []];
+      case 'history-page-down':
+        if (!model.historyOpen) return [model, []];
+        return [{
+          ...model,
+          historyScroll: clampHistoryScroll(model, model.historyScroll + 5),
+        }, []];
+      case 'history-page-up':
+        if (!model.historyOpen) return [model, []];
+        return [{
+          ...model,
+          historyScroll: clampHistoryScroll(model, model.historyScroll - 5),
+        }, []];
+      case 'cycle-history-filter':
+        if (!model.historyOpen) return [model, []];
+        return [recordInput({
+          ...model,
+          historyFilterIndex: (model.historyFilterIndex + 1) % HISTORY_FILTERS.length,
+          historyScroll: 0,
+        }, 'f', `History filter -> ${HISTORY_FILTERS[(model.historyFilterIndex + 1) % HISTORY_FILTERS.length]!}.`), []];
       case 'focus-next':
+        if (model.historyOpen) {
+          return [{
+            ...model,
+            historyScroll: clampHistoryScroll(model, model.historyScroll + 1),
+          }, []];
+        }
         return [recordInput({
           ...model,
           notifications: cycleNotificationFocus(model.notifications, 1),
         }, 'j', 'Focused next actionable notification.'), []];
       case 'focus-prev':
+        if (model.historyOpen) {
+          return [{
+            ...model,
+            historyScroll: clampHistoryScroll(model, model.historyScroll - 1),
+          }, []];
+        }
         return [recordInput({
           ...model,
           notifications: cycleNotificationFocus(model.notifications, -1),
@@ -477,6 +600,12 @@ const page: FramePage<PageModel, Msg> = {
           lastHandledInput: `${msg.key}:${msg.route}`,
         }, `[key ${msg.key}] route=${msg.route}`), []];
       case 'quit-app':
+        if (model.historyOpen) {
+          return [recordInput({
+            ...model,
+            historyOpen: false,
+          }, 'q', 'Closed notification history.'), []];
+        }
         return [model, [quit()]];
       default:
         return [model, []];
@@ -490,11 +619,27 @@ const page: FramePage<PageModel, Msg> = {
     .bind('d', 'Cycle duration', { type: 'cycle-duration' })
     .bind('a', 'Toggle action button', { type: 'toggle-action' })
     .bind('w', 'Toggle text wrap', { type: 'toggle-wrap' })
+    .bind('shift+h', 'Open notification history', { type: 'open-history' })
+    .bind('escape', 'Close history modal', { type: 'close-history' })
+    .bind('up', 'Scroll history up', { type: 'history-prev' })
+    .bind('down', 'Scroll history down', { type: 'history-next' })
+    .bind('pageup', 'History page up', { type: 'history-page-up' })
+    .bind('pagedown', 'History page down', { type: 'history-page-down' })
+    .bind('f', 'Cycle history filter', { type: 'cycle-history-filter' })
     .bind('j', 'Focus next actionable notification', { type: 'focus-next' })
     .bind('k', 'Focus previous actionable notification', { type: 'focus-prev' })
     .bind('enter', 'Run focused notification action', { type: 'activate-focused' })
     .bind('x', 'Dismiss focused/latest notification', { type: 'dismiss-notification' })
-    .bind('q', 'Quit demo', { type: 'quit-app' }),
+    .bind('q', 'Quit demo / Close history', { type: 'quit-app' }),
+  commandItems(model) {
+    return [{
+      id: 'view-history',
+      label: 'View notifications history',
+      description: `${countNotificationHistory(model.notifications, currentHistoryFilter(model))} archived notifications`,
+      category: 'Notifications',
+      action: { type: 'open-history' },
+    }];
+  },
   layout(model) {
     return {
       kind: 'grid',
@@ -541,7 +686,7 @@ const app = createFramedApp<PageModel, Msg>({
         height: Math.max(...paneRects.map((rect) => rect.row + rect.height)) - Math.min(...paneRects.map((rect) => rect.row)),
       };
 
-    return renderNotificationStack(frame.pageModel.notifications, {
+    const overlays = renderNotificationStack(frame.pageModel.notifications, {
       screenWidth: frame.screenRect.width,
       screenHeight: frame.screenRect.height,
       region,
@@ -549,6 +694,12 @@ const app = createFramedApp<PageModel, Msg>({
       gap: 1,
       ctx,
     });
+
+    if (frame.pageModel.historyOpen) {
+      overlays.push(renderHistoryModal(frame.pageModel, frame.screenRect.width, frame.screenRect.height));
+    }
+
+    return overlays;
   },
 });
 

--- a/examples/notifications/main.ts
+++ b/examples/notifications/main.ts
@@ -1,5 +1,6 @@
+import { pathToFileURL } from 'node:url';
 import { initDefaultContext } from '@flyingrobots/bijou-node';
-import { box, kbd } from '@flyingrobots/bijou';
+import { box, kbd, resolveClock } from '@flyingrobots/bijou';
 import {
   activateFocusedNotification,
   countNotificationHistory,
@@ -30,10 +31,9 @@ import {
   type NotificationVariant,
 } from '@flyingrobots/bijou-tui';
 
-const ctx = initDefaultContext();
+export const ctx = initDefaultContext();
 
 const NOTIFICATION_TICK_MS = 40;
-const AUTO_DEMO = ctx.runtime.env.CI === '1' || process.env.CI === '1';
 
 const VARIANTS: readonly NotificationVariant[] = ['ACTIONABLE', 'INLINE', 'TOAST'];
 const TONES: readonly NotificationTone[] = ['INFO', 'SUCCESS', 'WARNING', 'ERROR'];
@@ -87,6 +87,32 @@ type Msg =
   | { type: 'key-observed'; key: string; route: string }
   | { type: 'quit-app' }
   | { type: 'notification-action'; ordinal: number };
+
+const pageKeyMap = createKeyMap<Msg>()
+  .bind('n', 'Spawn notification', { type: 'spawn-notification' })
+  .bind('v', 'Cycle variant', { type: 'cycle-variant' })
+  .bind('t', 'Cycle tone', { type: 'cycle-tone' })
+  .bind('l', 'Cycle placement', { type: 'cycle-placement' })
+  .bind('d', 'Cycle duration', { type: 'cycle-duration' })
+  .bind('a', 'Toggle action button', { type: 'toggle-action' })
+  .bind('w', 'Toggle text wrap', { type: 'toggle-wrap' })
+  .bind('shift+h', 'Open notification history', { type: 'open-history' })
+  .bind('j', 'Focus next actionable notification', { type: 'focus-next' })
+  .bind('k', 'Focus previous actionable notification', { type: 'focus-prev' })
+  .bind('enter', 'Run focused notification action', { type: 'activate-focused' })
+  .bind('x', 'Dismiss focused/latest notification', { type: 'dismiss-notification' })
+  .bind('q', 'Quit demo / Close history', { type: 'quit-app' });
+
+const historyKeyMap = createKeyMap<Msg>()
+  .bind('escape', 'Close history center', { type: 'close-history' })
+  .bind('q', 'Close history center', { type: 'close-history' })
+  .bind('up', 'Scroll history up', { type: 'history-prev' })
+  .bind('down', 'Scroll history down', { type: 'history-next' })
+  .bind('j', 'Scroll history down', { type: 'history-next' })
+  .bind('k', 'Scroll history up', { type: 'history-prev' })
+  .bind('pageup', 'History page up', { type: 'history-page-up' })
+  .bind('pagedown', 'History page down', { type: 'history-page-down' })
+  .bind('f', 'Cycle history filter', { type: 'cycle-history-filter' });
 
 interface PageModel {
   readonly notifications: NotificationState<Msg>;
@@ -221,149 +247,24 @@ function openHistory(model: PageModel, key: string): PageModel {
   }, key, `Opened notification history (${countNotificationHistory(model.notifications, currentHistoryFilter(model))} items).`);
 }
 
-function applyNotificationState(
-  model: PageModel,
-  notifications: NotificationState<Msg>,
-  commands: readonly Cmd<Msg>[] = [],
-  forceTick = false,
-): [PageModel, Cmd<Msg>[]] {
-  const trimmed = trimNotificationsToViewport(notifications, {
-    screenWidth: ctx.runtime.columns,
-    screenHeight: Math.max(0, ctx.runtime.rows - 2),
-    margin: 2,
-    gap: 1,
-    ctx,
-  }, ctx.clock.now());
-  const needsTick = notificationsNeedTick(trimmed);
-  const nextModel: PageModel = {
-    ...model,
-    notifications: trimmed,
-    notificationLoopActive: needsTick,
-  };
-  const shouldScheduleTick = needsTick && (forceTick || !model.notificationLoopActive);
-
-  return [
-    nextModel,
-    shouldScheduleTick
-      ? [...commands, tick(NOTIFICATION_TICK_MS, { type: 'notification-tick' })]
-      : [...commands],
-  ];
-}
-
-function spawnConfiguredNotification(model: PageModel): [PageModel, Cmd<Msg>[]] {
-  const ordinal = model.nextOrdinal;
-  const variant = currentVariant(model);
-  const tone = currentTone(model);
-  const placement = currentPlacement(model);
-  const duration = currentDuration(model);
-  const copy = toneCopy(tone);
-  const spec: NotificationSpec<Msg> = {
-    title: `${copy.title} #${ordinal}`,
-    message: `${copy.message} ${variant} @ ${placement} • ${duration.label}`,
-    variant,
-    tone,
-    placement,
-    durationMs: duration.value,
-    action: variant === 'ACTIONABLE' && model.actionEnabled
-      ? {
-        label: actionLabelForTone(tone),
-        payload: { type: 'notification-action', ordinal },
-      }
-      : undefined,
-    overflow: model.wrapText ? 'wrap' : 'truncate',
-  };
-
-  const notifications = pushNotification(model.notifications, spec, ctx.clock.now());
-  const nextModel = appendLog({
-    ...model,
-    lastHandledInput: 'n',
-    notifications,
-    nextOrdinal: ordinal + 1,
-  }, `[n] Spawned ${variant} #${ordinal} at ${placement} (${formatDurationLabel(duration.value)}).`);
-
-  return applyNotificationState(nextModel, notifications);
-}
-
-function dismissCurrentNotification(model: PageModel): [PageModel, Cmd<Msg>[]] {
-  const nowMs = ctx.clock.now();
-  const latest = model.notifications.items.at(-1);
-  const notifications = model.notifications.focusedId != null
-    ? dismissFocusedNotification(model.notifications, nowMs)
-    : (latest == null ? model.notifications : dismissNotification(model.notifications, latest.id, nowMs));
-
-  if (notifications === model.notifications) return [model, []];
-
-  const nextModel = recordInput({
-    ...model,
-    notifications,
-  }, 'x', 'Dismissed a notification.');
-
-  return applyNotificationState(nextModel, notifications);
-}
-
-function seedDemoNotifications(model: PageModel): PageModel {
-  const entries = [
-    {
-      title: 'Deploy blocked',
-      message: 'Retryable actionable notice in the upper right.',
-      variant: 'ACTIONABLE' as const,
-      tone: 'ERROR' as const,
-      placement: 'UPPER_RIGHT' as const,
-      durationMs: null,
-      actionLabel: 'Retry deploy',
-    },
-    {
-      title: 'Queue pressure rising',
-      message: 'Inline notice centered at the top edge.',
-      variant: 'INLINE' as const,
-      tone: 'WARNING' as const,
-      placement: 'TOP_CENTER' as const,
-      durationMs: 5_000,
-    },
-    {
-      title: 'Release shipped cleanly',
-      message: 'Toast variant stacked near the lower-right anchor.',
-      variant: 'TOAST' as const,
-      tone: 'SUCCESS' as const,
-      placement: 'LOWER_RIGHT' as const,
-      durationMs: 4_000,
-    },
-  ] as const;
-
-  let next = model;
-  let nowMs = ctx.clock.now();
-
-  for (const entry of entries) {
-    const ordinal = next.nextOrdinal;
-    const notifications = pushNotification(next.notifications, {
-      title: `${entry.title} #${ordinal}`,
-      message: entry.message,
-      variant: entry.variant,
-      tone: entry.tone,
-      placement: entry.placement,
-      durationMs: entry.durationMs,
-      action: entry.actionLabel == null
-        ? undefined
-        : {
-          label: entry.actionLabel,
-          payload: { type: 'notification-action', ordinal },
-        },
-      overflow: next.wrapText ? 'wrap' : 'truncate',
-    }, nowMs);
-
-    next = appendLog({
-      ...next,
-      notifications,
-      nextOrdinal: ordinal + 1,
-    }, `Seeded ${entry.variant} #${ordinal} for automated smoke rendering.`);
-
-    nowMs += 60;
+function blocksBehindHistory(msg: Msg): boolean {
+  switch (msg.type) {
+    case 'open-history':
+    case 'close-history':
+    case 'history-next':
+    case 'history-prev':
+    case 'history-page-down':
+    case 'history-page-up':
+    case 'cycle-history-filter':
+    case 'key-observed':
+    case 'quit-app':
+      return false;
+    default:
+      return true;
   }
-
-  return next;
 }
 
-function renderControlsPane(model: PageModel, width: number): string {
+function renderControlsPane(model: PageModel, width: number, notificationCtx = ctx): string {
   const activeVariant = currentVariant(model);
   const activeTone = currentTone(model);
   const activePlacement = currentPlacement(model);
@@ -410,11 +311,11 @@ function renderControlsPane(model: PageModel, width: number): string {
     width,
     title: 'Controls',
     overflow: model.wrapText ? 'wrap' : 'truncate',
-    ctx,
+    ctx: notificationCtx,
   });
 }
 
-function renderLogPane(model: PageModel, width: number): string {
+function renderLogPane(model: PageModel, width: number, notificationCtx = ctx): string {
   const lines = [
     'Recent events',
     '',
@@ -425,48 +326,233 @@ function renderLogPane(model: PageModel, width: number): string {
     width,
     title: 'Activity',
     overflow: model.wrapText ? 'wrap' : 'truncate',
-    ctx,
+    ctx: notificationCtx,
   });
 }
 
-function renderHistoryModal(model: PageModel, screenWidth: number, screenHeight: number) {
-  const modalWidth = Math.max(48, Math.min(96, screenWidth - 6));
-  const bodyWidth = Math.max(20, modalWidth - 4);
-  const bodyHeight = Math.max(8, Math.min(screenHeight - 8, 20));
+function renderHistoryModal(
+  model: PageModel,
+  screenWidth: number,
+  screenHeight: number,
+  notificationCtx = ctx,
+) {
   const filter = currentHistoryFilter(model);
+  const compact = screenWidth < 52;
+  const title = compact ? 'History' : `Notification History (${filter})`;
+  const hint = compact
+    ? 'Up/Down • PgUp/PgDn • f • Esc'
+    : 'Up/Down scroll • PageUp/PageDown jump • f filter • Esc close';
+  const headerRows = 2;
+  const hintRows = 2;
+  const borderRows = 2;
+  const modalWidth = Math.max(12, Math.min(96, Math.max(12, screenWidth - 2)));
+  const bodyWidth = Math.max(1, modalWidth - 4);
+  const bodyHeight = Math.max(
+    1,
+    Math.min(20, screenHeight - borderRows - headerRows - hintRows),
+  );
 
   return modal({
-    title: `Notification History (${filter})`,
+    title,
     body: renderNotificationHistory(model.notifications, {
       width: bodyWidth,
       height: bodyHeight,
       scroll: model.historyScroll,
       filter,
-      ctx,
+      ctx: notificationCtx,
     }),
-    hint: 'Up/Down scroll • PageUp/PageDown jump • f filter • Esc close',
+    hint,
     width: modalWidth,
     screenWidth,
     screenHeight,
-    ctx,
+    ctx: notificationCtx,
   });
 }
 
-const page: FramePage<PageModel, Msg> = {
-  id: 'notifications',
-  title: 'Notifications',
-  init() {
-    const seeded = AUTO_DEMO ? seedDemoNotifications(createInitialPageModel()) : createInitialPageModel();
-    const [model, cmds] = applyNotificationState(seeded, seeded.notifications);
-    return [
-      model,
-      AUTO_DEMO ? [...cmds, tick(1_600, { type: 'quit-app' })] : cmds,
-    ];
-  },
-  update(msg, model) {
-    switch (msg.type) {
+function applyNotificationState(
+  model: PageModel,
+  notifications: NotificationState<Msg>,
+  notificationCtx = ctx,
+  commands: readonly Cmd<Msg>[] = [],
+  forceTick = false,
+): [PageModel, Cmd<Msg>[]] {
+  const clock = resolveClock(notificationCtx);
+  const trimmed = trimNotificationsToViewport(notifications, {
+    screenWidth: notificationCtx.runtime.columns,
+    screenHeight: Math.max(0, notificationCtx.runtime.rows - 2),
+    margin: 2,
+    gap: 1,
+    ctx: notificationCtx,
+  }, clock.now());
+  const needsTick = notificationsNeedTick(trimmed);
+  const nextModel: PageModel = {
+    ...model,
+    notifications: trimmed,
+    notificationLoopActive: needsTick,
+    historyScroll: clampHistoryScroll({
+      ...model,
+      notifications: trimmed,
+    }, model.historyScroll),
+  };
+  const shouldScheduleTick = needsTick && (forceTick || !model.notificationLoopActive);
+
+  return [
+    nextModel,
+    shouldScheduleTick
+      ? [...commands, tick(NOTIFICATION_TICK_MS, { type: 'notification-tick' })]
+      : [...commands],
+  ];
+}
+
+function spawnConfiguredNotification(
+  model: PageModel,
+  notificationCtx = ctx,
+): [PageModel, Cmd<Msg>[]] {
+  const clock = resolveClock(notificationCtx);
+  const ordinal = model.nextOrdinal;
+  const variant = currentVariant(model);
+  const tone = currentTone(model);
+  const placement = currentPlacement(model);
+  const duration = currentDuration(model);
+  const copy = toneCopy(tone);
+  const spec: NotificationSpec<Msg> = {
+    title: `${copy.title} #${ordinal}`,
+    message: `${copy.message} ${variant} @ ${placement} • ${duration.label}`,
+    variant,
+    tone,
+    placement,
+    durationMs: duration.value,
+    action: variant === 'ACTIONABLE' && model.actionEnabled
+      ? {
+        label: actionLabelForTone(tone),
+        payload: { type: 'notification-action', ordinal },
+      }
+      : undefined,
+    overflow: model.wrapText ? 'wrap' : 'truncate',
+  };
+
+  const notifications = pushNotification(model.notifications, spec, clock.now());
+  const nextModel = appendLog({
+    ...model,
+    lastHandledInput: 'n',
+    notifications,
+    nextOrdinal: ordinal + 1,
+  }, `[n] Spawned ${variant} #${ordinal} at ${placement} (${formatDurationLabel(duration.value)}).`);
+
+  return applyNotificationState(nextModel, notifications, notificationCtx);
+}
+
+function dismissCurrentNotification(
+  model: PageModel,
+  notificationCtx = ctx,
+): [PageModel, Cmd<Msg>[]] {
+  const nowMs = resolveClock(notificationCtx).now();
+  const latest = model.notifications.items.at(-1);
+  const notifications = model.notifications.focusedId != null
+    ? dismissFocusedNotification(model.notifications, nowMs)
+    : (latest == null ? model.notifications : dismissNotification(model.notifications, latest.id, nowMs));
+
+  if (notifications === model.notifications) return [model, []];
+
+  const nextModel = recordInput({
+    ...model,
+    notifications,
+  }, 'x', 'Dismissed a notification.');
+
+  return applyNotificationState(nextModel, notifications, notificationCtx);
+}
+
+function seedDemoNotifications(model: PageModel, notificationCtx = ctx): PageModel {
+  const entries = [
+    {
+      title: 'Deploy blocked',
+      message: 'Retryable actionable notice in the upper right.',
+      variant: 'ACTIONABLE' as const,
+      tone: 'ERROR' as const,
+      placement: 'UPPER_RIGHT' as const,
+      durationMs: null,
+      actionLabel: 'Retry deploy',
+    },
+    {
+      title: 'Queue pressure rising',
+      message: 'Inline notice centered at the top edge.',
+      variant: 'INLINE' as const,
+      tone: 'WARNING' as const,
+      placement: 'TOP_CENTER' as const,
+      durationMs: 5_000,
+    },
+    {
+      title: 'Release shipped cleanly',
+      message: 'Toast variant stacked near the lower-right anchor.',
+      variant: 'TOAST' as const,
+      tone: 'SUCCESS' as const,
+      placement: 'LOWER_RIGHT' as const,
+      durationMs: 4_000,
+    },
+  ] as const;
+
+  let next = model;
+  let nowMs = resolveClock(notificationCtx).now();
+
+  for (const entry of entries) {
+    const ordinal = next.nextOrdinal;
+    const notifications = pushNotification(next.notifications, {
+      title: `${entry.title} #${ordinal}`,
+      message: entry.message,
+      variant: entry.variant,
+      tone: entry.tone,
+      placement: entry.placement,
+      durationMs: entry.durationMs,
+      action: !('actionLabel' in entry) || entry.actionLabel == null
+        ? undefined
+        : {
+          label: entry.actionLabel,
+          payload: { type: 'notification-action', ordinal },
+        },
+      overflow: next.wrapText ? 'wrap' : 'truncate',
+    }, nowMs);
+
+    next = appendLog({
+      ...next,
+      notifications,
+      nextOrdinal: ordinal + 1,
+    }, `Seeded ${entry.variant} #${ordinal} for automated smoke rendering.`);
+
+    nowMs += 60;
+  }
+
+  return next;
+}
+
+export function createNotificationDemoApp(
+  notificationCtx = ctx,
+  options: { readonly autoDemo?: boolean } = {},
+) {
+  const autoDemo = options.autoDemo ?? (
+    notificationCtx.runtime.env('CI') === '1' || process.env.CI === '1'
+  );
+
+  const page: FramePage<PageModel, Msg> = {
+    id: 'notifications',
+    title: 'Notifications',
+    init() {
+      const seeded = autoDemo
+        ? seedDemoNotifications(createInitialPageModel(), notificationCtx)
+        : createInitialPageModel();
+      const [model, cmds] = applyNotificationState(seeded, seeded.notifications, notificationCtx);
+      return [
+        model,
+        autoDemo ? [...cmds, tick(1_600, { type: 'quit-app' })] : cmds,
+      ];
+    },
+    update(msg, model) {
+      if (model.historyOpen && blocksBehindHistory(msg)) {
+        return [model, []];
+      }
+
+      switch (msg.type) {
       case 'spawn-notification':
-        return spawnConfiguredNotification(model);
+        return spawnConfiguredNotification(model, notificationCtx);
       case 'cycle-variant':
         return [recordInput({
           ...model,
@@ -484,7 +570,7 @@ const page: FramePage<PageModel, Msg> = {
         const notifications = relocateNotifications(
           model.notifications,
           nextPlacement,
-          ctx.clock.now(),
+          resolveClock(notificationCtx).now(),
         );
         const nextModel = appendLog({
           ...model,
@@ -492,7 +578,7 @@ const page: FramePage<PageModel, Msg> = {
           placementIndex: nextPlacementIndex,
           notifications,
         }, `[l] Placement -> ${nextPlacement}; active notifications relocated.`);
-        return applyNotificationState(nextModel, notifications);
+        return applyNotificationState(nextModel, notifications, notificationCtx);
       }
       case 'cycle-duration':
         return [recordInput({
@@ -571,9 +657,9 @@ const page: FramePage<PageModel, Msg> = {
           notifications: cycleNotificationFocus(model.notifications, -1),
         }, 'k', 'Focused previous actionable notification.'), []];
       case 'dismiss-notification':
-        return dismissCurrentNotification(model);
+        return dismissCurrentNotification(model, notificationCtx);
       case 'activate-focused': {
-        const result = activateFocusedNotification(model.notifications, ctx.clock.now());
+        const result = activateFocusedNotification(model.notifications, resolveClock(notificationCtx).now());
         let nextModel = {
           ...model,
           notifications: result.state,
@@ -583,16 +669,16 @@ const page: FramePage<PageModel, Msg> = {
           nextModel = recordInput(nextModel, 'enter', `Action fired from notification #${result.payload.ordinal}.`);
         }
 
-        return applyNotificationState(nextModel, nextModel.notifications);
+        return applyNotificationState(nextModel, nextModel.notifications, notificationCtx);
       }
       case 'notification-action':
         return [appendLog(model, `Notification #${msg.ordinal} delivered its action payload.`), []];
       case 'notification-tick': {
-        const notifications = tickNotifications(model.notifications, ctx.clock.now());
+        const notifications = tickNotifications(model.notifications, resolveClock(notificationCtx).now());
         return applyNotificationState({
           ...model,
           notifications,
-        }, notifications, [], true);
+        }, notifications, notificationCtx, [], true);
       }
       case 'key-observed':
         return [appendLog({
@@ -610,97 +696,94 @@ const page: FramePage<PageModel, Msg> = {
       default:
         return [model, []];
     }
-  },
-  keyMap: createKeyMap<Msg>()
-    .bind('n', 'Spawn notification', { type: 'spawn-notification' })
-    .bind('v', 'Cycle variant', { type: 'cycle-variant' })
-    .bind('t', 'Cycle tone', { type: 'cycle-tone' })
-    .bind('l', 'Cycle placement', { type: 'cycle-placement' })
-    .bind('d', 'Cycle duration', { type: 'cycle-duration' })
-    .bind('a', 'Toggle action button', { type: 'toggle-action' })
-    .bind('w', 'Toggle text wrap', { type: 'toggle-wrap' })
-    .bind('shift+h', 'Open notification history', { type: 'open-history' })
-    .bind('escape', 'Close history modal', { type: 'close-history' })
-    .bind('up', 'Scroll history up', { type: 'history-prev' })
-    .bind('down', 'Scroll history down', { type: 'history-next' })
-    .bind('pageup', 'History page up', { type: 'history-page-up' })
-    .bind('pagedown', 'History page down', { type: 'history-page-down' })
-    .bind('f', 'Cycle history filter', { type: 'cycle-history-filter' })
-    .bind('j', 'Focus next actionable notification', { type: 'focus-next' })
-    .bind('k', 'Focus previous actionable notification', { type: 'focus-prev' })
-    .bind('enter', 'Run focused notification action', { type: 'activate-focused' })
-    .bind('x', 'Dismiss focused/latest notification', { type: 'dismiss-notification' })
-    .bind('q', 'Quit demo / Close history', { type: 'quit-app' }),
-  commandItems(model) {
-    return [{
-      id: 'view-history',
-      label: 'View notifications history',
-      description: `${countNotificationHistory(model.notifications, currentHistoryFilter(model))} archived notifications`,
-      category: 'Notifications',
-      action: { type: 'open-history' },
-    }];
-  },
-  layout(model) {
-    return {
-      kind: 'grid',
-      gridId: 'notification-lab',
-      columns: [38, '1fr'],
-      rows: ['1fr'],
-      areas: ['controls activity'],
-      gap: 1,
-      cells: {
-        controls: {
-          kind: 'pane',
-          paneId: 'controls',
-          render: (width) => renderControlsPane(model, width),
+    },
+    keyMap: pageKeyMap,
+    commandItems(model) {
+      return [{
+        id: 'view-history',
+        label: 'View notifications history',
+        description: `${countNotificationHistory(model.notifications, currentHistoryFilter(model))} archived notifications`,
+        category: 'Notifications',
+        action: { type: 'open-history' },
+      }];
+    },
+    layout(model) {
+      return {
+        kind: 'grid',
+        gridId: 'notification-lab',
+        columns: [38, '1fr'],
+        rows: ['1fr'],
+        areas: ['controls activity'],
+        gap: 1,
+        cells: {
+          controls: {
+            kind: 'pane',
+            paneId: 'controls',
+            render: (width) => renderControlsPane(model, width, notificationCtx),
+          },
+          activity: {
+            kind: 'pane',
+            paneId: 'activity',
+            render: (width) => renderLogPane(model, width, notificationCtx),
+          },
         },
-        activity: {
-          kind: 'pane',
-          paneId: 'activity',
-          render: (width) => renderLogPane(model, width),
-        },
-      },
-    };
-  },
-};
-
-const app = createFramedApp<PageModel, Msg>({
-  title: 'Bijou Notification Lab',
-  pages: [page],
-  keyPriority: 'page-first',
-  helpLineSource: ({ activePage }) => activePage.helpSource ?? activePage.keyMap,
-  observeKey: (msg, route) => ({
-    type: 'key-observed',
-    key: `${msg.ctrl ? 'ctrl+' : ''}${msg.alt ? 'alt+' : ''}${msg.shift ? 'shift+' : ''}${msg.key}`,
-    route,
-  }),
-  enableCommandPalette: true,
-  overlayFactory(frame) {
-    const paneRects = [...frame.paneRects.values()];
-    const region = paneRects.length === 0
-      ? frame.screenRect
-      : {
-        col: Math.min(...paneRects.map((rect) => rect.col)),
-        row: Math.min(...paneRects.map((rect) => rect.row)),
-        width: Math.max(...paneRects.map((rect) => rect.col + rect.width)) - Math.min(...paneRects.map((rect) => rect.col)),
-        height: Math.max(...paneRects.map((rect) => rect.row + rect.height)) - Math.min(...paneRects.map((rect) => rect.row)),
       };
+    },
+  };
 
-    const overlays = renderNotificationStack(frame.pageModel.notifications, {
-      screenWidth: frame.screenRect.width,
-      screenHeight: frame.screenRect.height,
-      region,
-      margin: 2,
-      gap: 1,
-      ctx,
-    });
+  return createFramedApp<PageModel, Msg>({
+    title: 'Bijou Notification Lab',
+    pages: [page],
+    initialColumns: notificationCtx.runtime.columns,
+    initialRows: notificationCtx.runtime.rows,
+    keyPriority: 'page-first',
+    helpLineSource: ({ model, activePage }) => {
+      const pageModel = model.pageModels[model.activePageId] as PageModel | undefined;
+      if (pageModel?.historyOpen) return historyKeyMap;
+      return activePage.helpSource ?? activePage.keyMap;
+    },
+    observeKey: (msg, route) => ({
+      type: 'key-observed',
+      key: `${msg.ctrl ? 'ctrl+' : ''}${msg.alt ? 'alt+' : ''}${msg.shift ? 'shift+' : ''}${msg.key}`,
+      route,
+    }),
+    enableCommandPalette: true,
+    overlayFactory(frame) {
+      const paneRects = [...frame.paneRects.values()];
+      const region = paneRects.length === 0
+        ? frame.screenRect
+        : {
+          col: Math.min(...paneRects.map((rect) => rect.col)),
+          row: Math.min(...paneRects.map((rect) => rect.row)),
+          width: Math.max(...paneRects.map((rect) => rect.col + rect.width)) - Math.min(...paneRects.map((rect) => rect.col)),
+          height: Math.max(...paneRects.map((rect) => rect.row + rect.height)) - Math.min(...paneRects.map((rect) => rect.row)),
+        };
 
-    if (frame.pageModel.historyOpen) {
-      overlays.push(renderHistoryModal(frame.pageModel, frame.screenRect.width, frame.screenRect.height));
-    }
+      const overlays = [...renderNotificationStack(frame.pageModel.notifications, {
+        screenWidth: frame.screenRect.width,
+        screenHeight: frame.screenRect.height,
+        region,
+        margin: 2,
+        gap: 1,
+        ctx: notificationCtx,
+      })];
 
-    return overlays;
-  },
-});
+      if (frame.pageModel.historyOpen) {
+        overlays.push(renderHistoryModal(
+          frame.pageModel,
+          frame.screenRect.width,
+          frame.screenRect.height,
+          notificationCtx,
+        ));
+      }
 
-run(app);
+      return overlays;
+    },
+  });
+}
+
+export const app = createNotificationDemoApp();
+
+if (process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run(app);
+}

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -752,4 +752,40 @@ describe('createFramedApp', () => {
     expect(rendered).toContain('Command rejected: worker crashed during boot');
     expect(cmds).toHaveLength(1);
   });
+
+  it('treats modal keymaps as exclusive while a page modal is open', async () => {
+    const app = createFramedApp({
+      pages: [{
+        id: 'home',
+        title: 'Home',
+        init: () => [{ count: 0, modalOpen: true }, []],
+        update(msg, model) {
+          if (msg.type === 'inc') return [{ ...model, count: model.count + 1 }, []];
+          if (msg.type === 'noop') return [model, []];
+          return [model, []];
+        },
+        layout: () => ({
+          kind: 'pane',
+          paneId: 'main',
+          render: () => 'modal page',
+        }),
+        keyMap: createKeyMap<Msg>()
+          .bind('x', 'Increment', { type: 'inc' }),
+        modalKeyMap(model) {
+          if (!model.modalOpen) return undefined;
+          return createKeyMap<Msg>()
+            .bind('escape', 'Close modal', { type: 'noop' });
+        },
+      }],
+    });
+
+    const result = await runScript(app, [
+      { key: 'x' },
+      { key: ']' },
+      { key: KEY_ESCAPE },
+    ]);
+
+    expect(result.model.activePageId).toBe('home');
+    expect(result.model.pageModels.home?.count).toBe(0);
+  });
 });

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -102,6 +102,8 @@ export interface FramePage<PageModel, Msg> {
   layout(model: PageModel): FrameLayoutNode;
   /** Optional page keymap. */
   keyMap?: KeyMap<Msg>;
+  /** Optional modal keymap. When present, it captures all keys until dismissed. */
+  modalKeyMap?: (model: PageModel) => KeyMap<Msg> | undefined;
   /** Optional help source override. */
   helpSource?: BindingSource;
   /** Optional page-scoped command items for command palette listing/execution. */
@@ -582,6 +584,16 @@ export function createFramedApp<PageModel, Msg>(
         }
 
         const activePage = pagesById.get(model.activePageId)!;
+        const activePageModel = model.pageModels[model.activePageId]!;
+        const modalKeyMap = activePage.modalKeyMap?.(activePageModel);
+        if (modalKeyMap != null) {
+          const modalAction = modalKeyMap.handle(msg);
+          if (modalAction !== undefined) {
+            return [model, withObservedKey(model, [emitMsgForPage(model.activePageId, modalAction)], msg, 'page')];
+          }
+          return [model, withObservedKey(model, [], msg, 'page')];
+        }
+
         const pageAction = activePage.keyMap?.handle(msg);
         const globalAction = options.globalKeys?.handle(msg);
         const frameAction = frameKeys.handle(msg);

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -353,6 +353,7 @@ export {
 
 // Notification stack overlays
 export {
+  type NotificationHistoryFilter,
   type NotificationVariant,
   type NotificationTone,
   type NotificationPlacement,
@@ -361,7 +362,9 @@ export {
   type NotificationPhase,
   type NotificationRecord,
   type NotificationState,
+  type RenderNotificationHistoryOptions,
   type RenderNotificationStackOptions,
+  countNotificationHistory,
   createNotificationState,
   pushNotification,
   dismissNotification,
@@ -373,6 +376,7 @@ export {
   tickNotifications,
   hasNotifications,
   notificationsNeedTick,
+  renderNotificationHistory,
   renderNotificationStack,
 } from './notification.js';
 

--- a/packages/bijou-tui/src/notification.test.ts
+++ b/packages/bijou-tui/src/notification.test.ts
@@ -163,6 +163,31 @@ describe('notification state', () => {
     expect(stripAnsi(body)).not.toContain('Archived info');
   });
 
+  it('treats actionable history as the variant, not action presence', () => {
+    let state = createNotificationState<Msg>();
+    state = pushNotification(state, {
+      title: 'Dismiss-only actionable',
+      message: 'Archived without a custom action payload.',
+      variant: 'ACTIONABLE',
+      tone: 'WARNING',
+      durationMs: null,
+    }, 0);
+
+    state = tickNotifications(state, 250);
+    state = dismissNotification(state, state.items[0]!.id, 300);
+    state = tickNotifications(state, 900);
+
+    expect(countNotificationHistory(state, 'ACTIONABLE')).toBe(1);
+
+    const body = renderNotificationHistory(state, {
+      width: 28,
+      height: 8,
+      filter: 'ACTIONABLE',
+    });
+
+    expect(stripAnsi(body)).toMatch(/Dismiss-only actio\s*nable/);
+  });
+
   it('supports scrolling through archived notification history', () => {
     let state = createNotificationState<Msg>();
     for (let index = 0; index < 3; index++) {

--- a/packages/bijou-tui/src/notification.test.ts
+++ b/packages/bijou-tui/src/notification.test.ts
@@ -3,12 +3,14 @@ import { createTestContext } from '@flyingrobots/bijou/adapters/test';
 import { stripAnsi } from './viewport.js';
 import {
   activateFocusedNotification,
+  countNotificationHistory,
   createNotificationState,
   cycleNotificationFocus,
   dismissNotification,
   relocateNotifications,
   notificationsNeedTick,
   pushNotification,
+  renderNotificationHistory,
   renderNotificationStack,
   trimNotificationsToViewport,
   tickNotifications,
@@ -120,6 +122,73 @@ describe('notification state', () => {
 
     state = tickNotifications(state, 900);
     expect(state.history.some((item) => item.title === 'Notice 1')).toBe(true);
+  });
+
+  it('counts and renders archived notification history with filters', () => {
+    let state = createNotificationState<Msg>();
+    state = pushNotification(state, {
+      title: 'Archived info',
+      message: 'Informational trail entry.',
+      variant: 'TOAST',
+      tone: 'INFO',
+      durationMs: null,
+    }, 0);
+    state = pushNotification(state, {
+      title: 'Archived action',
+      message: 'Needs follow-up.',
+      variant: 'ACTIONABLE',
+      tone: 'ERROR',
+      durationMs: null,
+      action: { label: 'Retry deploy', payload: { type: 'retry', id: 42 } },
+    }, 10);
+
+    state = tickNotifications(state, 250);
+    state = dismissNotification(state, state.items[0]!.id, 300);
+    state = dismissNotification(state, state.items[1]!.id, 310);
+    state = tickNotifications(state, 900);
+
+    expect(countNotificationHistory(state)).toBe(2);
+    expect(countNotificationHistory(state, 'ACTIONABLE')).toBe(1);
+    expect(countNotificationHistory(state, 'ERROR')).toBe(1);
+
+    const body = renderNotificationHistory(state, {
+      width: 34,
+      height: 8,
+      filter: 'ACTIONABLE',
+    });
+
+    expect(stripAnsi(body)).toContain('History • Actionable • 1-1 of 1');
+    expect(stripAnsi(body)).toContain('Archived action');
+    expect(stripAnsi(body)).toContain('Retry deploy');
+    expect(stripAnsi(body)).not.toContain('Archived info');
+  });
+
+  it('supports scrolling through archived notification history', () => {
+    let state = createNotificationState<Msg>();
+    for (let index = 0; index < 3; index++) {
+      state = pushNotification(state, {
+        title: `Archived ${index + 1}`,
+        message: 'Scrollable history entry.',
+        variant: 'TOAST',
+        durationMs: null,
+      }, index * 10);
+    }
+
+    state = tickNotifications(state, 250);
+    for (const item of state.items) {
+      state = dismissNotification(state, item.id, 300 + item.id);
+    }
+    state = tickNotifications(state, 900);
+
+    const body = renderNotificationHistory(state, {
+      width: 28,
+      height: 7,
+      scroll: 1,
+    });
+
+    expect(stripAnsi(body)).toContain('History • All • 2-2 of 3');
+    expect(stripAnsi(body)).toContain('Archived 2');
+    expect(stripAnsi(body)).not.toContain('Archived 3');
   });
 });
 

--- a/packages/bijou-tui/src/notification.ts
+++ b/packages/bijou-tui/src/notification.ts
@@ -140,7 +140,7 @@ function matchesHistoryFilter<Msg>(
   filter: NotificationHistoryFilter,
 ): boolean {
   if (filter === 'ALL') return true;
-  if (filter === 'ACTIONABLE') return item.action != null;
+  if (filter === 'ACTIONABLE') return item.variant === 'ACTIONABLE';
   return item.tone === filter;
 }
 
@@ -148,7 +148,11 @@ export function countNotificationHistory<Msg>(
   state: NotificationState<Msg>,
   filter: NotificationHistoryFilter = 'ALL',
 ): number {
-  return state.history.filter((item) => matchesHistoryFilter(item, filter)).length;
+  let count = 0;
+  for (const item of state.history) {
+    if (matchesHistoryFilter(item, filter)) count++;
+  }
+  return count;
 }
 
 function filterLabel(filter: NotificationHistoryFilter): string {
@@ -160,7 +164,7 @@ function renderHistoryEntry<Msg>(
   width: number,
   ctx: BijouContext | undefined,
 ): readonly string[] {
-  const safeWidth = Math.max(12, width);
+  const safeWidth = Math.max(1, width);
   const toneLabel = `[${item.tone}]`;
   const title = ctx == null
     ? `${toneLabel} ${item.title}`
@@ -190,8 +194,8 @@ export function renderNotificationHistory<Msg>(
   state: NotificationState<Msg>,
   options: RenderNotificationHistoryOptions,
 ): string {
-  const safeWidth = Math.max(20, options.width);
-  const safeHeight = Math.max(4, options.height);
+  const safeWidth = Math.max(1, options.width);
+  const safeHeight = Math.max(3, options.height);
   const filter = options.filter ?? 'ALL';
   const filtered = state.history.filter((item) => matchesHistoryFilter(item, filter));
   const maxBodyLines = Math.max(1, safeHeight - 2);

--- a/packages/bijou-tui/src/notification.ts
+++ b/packages/bijou-tui/src/notification.ts
@@ -8,6 +8,7 @@ import {
   createSurface,
   segmentGraphemes,
   surfaceToString,
+  wrapToWidth,
 } from '@flyingrobots/bijou';
 import type { Overlay } from './overlay.js';
 import type { LayoutRect } from './layout-rect.js';
@@ -23,6 +24,11 @@ export type NotificationPlacement =
   | 'TOP_CENTER'
   | 'BOTTOM_CENTER'
   | 'CENTER';
+
+export type NotificationHistoryFilter =
+  | 'ALL'
+  | 'ACTIONABLE'
+  | NotificationTone;
 
 export interface NotificationAction<Msg> {
   readonly label: string;
@@ -81,6 +87,14 @@ export interface RenderNotificationStackOptions {
   readonly gap?: number;
 }
 
+export interface RenderNotificationHistoryOptions {
+  readonly width: number;
+  readonly height: number;
+  readonly scroll?: number;
+  readonly filter?: NotificationHistoryFilter;
+  readonly ctx?: BijouContext;
+}
+
 interface CellTextStyle {
   readonly fg?: string;
   readonly bg?: string;
@@ -119,6 +133,112 @@ export function createNotificationState<Msg>(): NotificationState<Msg> {
     history: [],
     nextId: 1,
   };
+}
+
+function matchesHistoryFilter<Msg>(
+  item: NotificationRecord<Msg>,
+  filter: NotificationHistoryFilter,
+): boolean {
+  if (filter === 'ALL') return true;
+  if (filter === 'ACTIONABLE') return item.action != null;
+  return item.tone === filter;
+}
+
+export function countNotificationHistory<Msg>(
+  state: NotificationState<Msg>,
+  filter: NotificationHistoryFilter = 'ALL',
+): number {
+  return state.history.filter((item) => matchesHistoryFilter(item, filter)).length;
+}
+
+function filterLabel(filter: NotificationHistoryFilter): string {
+  return filter === 'ALL' ? 'All' : filter === 'ACTIONABLE' ? 'Actionable' : filter;
+}
+
+function renderHistoryEntry<Msg>(
+  item: NotificationRecord<Msg>,
+  width: number,
+  ctx: BijouContext | undefined,
+): readonly string[] {
+  const safeWidth = Math.max(12, width);
+  const toneLabel = `[${item.tone}]`;
+  const title = ctx == null
+    ? `${toneLabel} ${item.title}`
+    : `${ctx.style.styled(ctx.semantic(toneSemanticKey(item.tone)), toneLabel)} ${ctx.style.bold(item.title)}`;
+  const meta = `${formatTimeLabel(item.createdAtMs)} • ${item.variant} • ${item.placement}`;
+  const metaLine = ctx == null ? meta : ctx.style.styled(ctx.semantic('muted'), meta);
+  const actionLine = item.action == null
+    ? undefined
+    : (ctx == null
+      ? `Action: ${item.action.label}`
+      : ctx.style.styled(ctx.semantic('muted'), `Action: ${item.action.label}`));
+  const messageLine = item.message.length === 0
+    ? undefined
+    : (ctx == null ? item.message : ctx.style.styled(ctx.semantic('muted'), item.message));
+
+  const lines = [
+    ...wrapToWidth(title, safeWidth),
+    ...wrapToWidth(metaLine, safeWidth),
+    ...(messageLine == null ? [] : wrapToWidth(messageLine, safeWidth)),
+    ...(actionLine == null ? [] : wrapToWidth(actionLine, safeWidth)),
+  ];
+
+  return lines.length === 0 ? [''] : lines;
+}
+
+export function renderNotificationHistory<Msg>(
+  state: NotificationState<Msg>,
+  options: RenderNotificationHistoryOptions,
+): string {
+  const safeWidth = Math.max(20, options.width);
+  const safeHeight = Math.max(4, options.height);
+  const filter = options.filter ?? 'ALL';
+  const filtered = state.history.filter((item) => matchesHistoryFilter(item, filter));
+  const maxBodyLines = Math.max(1, safeHeight - 2);
+  const start = Math.max(0, Math.min(options.scroll ?? 0, Math.max(0, filtered.length - 1)));
+
+  if (filtered.length === 0) {
+    const empty = wrapToWidth(
+      options.ctx == null
+        ? `No archived notifications for ${filterLabel(filter)} yet.`
+        : options.ctx.style.styled(
+          options.ctx.semantic('muted'),
+          `No archived notifications for ${filterLabel(filter)} yet.`,
+        ),
+      safeWidth,
+    ).slice(0, maxBodyLines);
+    return [
+      `History • ${filterLabel(filter)} • 0 items`,
+      '',
+      ...empty,
+    ].join('\n');
+  }
+
+  const bodyLines: string[] = [];
+  let renderedCount = 0;
+
+  for (const item of filtered.slice(start)) {
+    const entryLines = renderHistoryEntry(item, safeWidth, options.ctx);
+    const remaining = maxBodyLines - bodyLines.length;
+    if (remaining <= 0) break;
+
+    if (bodyLines.length > 0) {
+      if (remaining <= 1) break;
+      bodyLines.push('');
+    }
+
+    bodyLines.push(...entryLines.slice(0, maxBodyLines - bodyLines.length));
+    renderedCount++;
+
+    if (bodyLines.length >= maxBodyLines) break;
+  }
+
+  const end = Math.min(filtered.length, start + Math.max(1, renderedCount));
+  return [
+    `History • ${filterLabel(filter)} • ${start + 1}-${end} of ${filtered.length}`,
+    '',
+    ...bodyLines,
+  ].join('\n');
 }
 
 function defaultDurationMs(variant: NotificationVariant): number | null {

--- a/scripts/notifications-demo.test.ts
+++ b/scripts/notifications-demo.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { _resetDefaultContextForTesting, createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { setDefaultContext, surfaceToString } from '@flyingrobots/bijou';
+import { runScript } from '@flyingrobots/bijou-tui';
+import { createNotificationDemoApp } from '../examples/notifications/main.js';
+
+describe('notifications demo', () => {
+  const testCtx = createTestContext({
+    noColor: true,
+    runtime: { columns: 80, rows: 24 },
+  });
+
+  beforeAll(() => setDefaultContext(testCtx));
+  afterAll(() => _resetDefaultContextForTesting());
+
+  it('blocks background notification shortcuts while the history center is open', async () => {
+    const app = createNotificationDemoApp(testCtx, { autoDemo: false });
+    const result = await runScript(app, [
+      { key: 'n' },
+      { key: 'H' },
+      { key: 'n' },
+      { key: 'q' },
+    ], { ctx: testCtx });
+
+    const pageModel = result.model.pageModels.notifications!;
+    expect(pageModel.nextOrdinal).toBe(2);
+    expect(pageModel.notifications.items).toHaveLength(1);
+    expect(pageModel.historyOpen).toBe(false);
+  });
+
+  it('clamps the history center to compact terminals', async () => {
+    const compactCtx = createTestContext({
+      noColor: true,
+      runtime: { columns: 40, rows: 12 },
+    });
+    setDefaultContext(compactCtx);
+
+    const app = createNotificationDemoApp(compactCtx, { autoDemo: false });
+    const result = await runScript(app, [{ key: 'H' }], {
+      ctx: compactCtx,
+      pulseFps: false,
+    });
+
+    const rendered = surfaceToString(result.frames.at(-1)!, compactCtx.style);
+    expect(rendered).toContain('History');
+    expect(rendered).toContain('PgUp/PgDn');
+    expect(rendered).toContain('No archived notifications');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable notification history renderer plus a history-center modal in the notifications demo
- expose the history view through the command palette with scroll/filter controls for archived notifications
- upgrade GitHub workflow action majors to the Node 24-compatible runtime and refresh roadmap/changelog notes

## Verification
- npm run build
- npm run typecheck:test
- npx vitest run --config vitest.config.ts packages/bijou-tui/src/notification.test.ts
- npx vitest run --config vitest.config.ts packages/bijou-tui/src/app-frame.test.ts
- npm run workflow:shell:preflight
- CI=1 node --import tsx examples/notifications/main.ts
- npm run smoke:examples:all
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification history modal: browse archived notifications, cycle filters (All/Actionable/by type), scroll navigation, and open via command palette/shortcut.

* **Documentation**
  * Example and changelog updated to document the new notification history APIs and usage.

* **Chores**
  * CI and publish workflows updated to newer GitHub Actions versions.

* **Tests**
  * Added tests for history rendering, filtering, scrolling, and demo interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->