### PR TITLE
chore: patch dependency security alerts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 📝 Documentation
 
+- **XLSX dependency guidance clarification** — the `@flyingrobots/bijou-i18n-tools-xlsx` README now time-bounds the security note for the stale npm `xlsx` package and points maintainers at the official SheetJS Node installation guidance for the supported CDN tarball workflow.
 - **Shell quit-policy spec** — added a dedicated shell quit-policy spec that pins down request-quit semantics across framed apps and DOGFOOD landing, including the text-entry exception for printable keys like `q` inside search surfaces.
 - **Low-allocation renderer design pass** — added a dedicated strategy note for moving the runtime toward reusable framebuffers and a low-garbage hot render loop, explicitly separating short-term buffer reuse and direct-cell diffing from the longer-term question of a dedicated internal mutable framebuffer.
 - **FTUI onboarding primitives added to the roadmap** — the post-v4 backlog now explicitly tracks first-time-user-experience components for guided tutorials, spotlight popovers, input-teaching modal flows, and stepper-style onboarding UX that can run inside framed Bijou apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,15 +1003,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1020,19 +1011,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/chai": {
@@ -1055,27 +1033,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/create-bijou-tui-app": {
@@ -1192,15 +1149,6 @@
         }
       }
     },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1296,9 +1244,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1424,18 +1372,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/stackback": {
@@ -1707,38 +1643,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "version": "0.20.3",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
       "bin": {
         "xlsx": "bin/xlsx.njs"
       },
@@ -1811,7 +1720,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@flyingrobots/bijou-i18n-tools": "4.0.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1847,6 +1756,9 @@
       "name": "@flyingrobots/bijou-tui",
       "version": "4.0.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@flyingrobots/bijou-i18n": "4.0.0"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     "lint": "npm run lint --workspaces",
     "version": "bash scripts/version.sh"
   },
+  "overrides": {
+    "picomatch": "^4.0.4",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsx": "^4.21.0",

--- a/packages/bijou-i18n-tools-xlsx/README.md
+++ b/packages/bijou-i18n-tools-xlsx/README.md
@@ -12,4 +12,4 @@ XLSX workbook adapters for Bijou localization exchange workflows.
 This package intentionally keeps spreadsheet-provider logic out of the pure `@flyingrobots/bijou-i18n-tools` package.
 
 Dependency note:
-`xlsx` is installed from the official SheetJS CDN tarball rather than the stale npm registry release. The npm package line is no longer maintained and carries unresolved security advisories; this package pins the maintained upstream tarball instead.
+As of 2026-04-02, `xlsx` is installed from the official SheetJS CDN tarball rather than the npm registry release, which is stale and carries known security advisories. See https://docs.sheetjs.com/docs/getting-started/installation/nodejs/ for the current upstream installation guidance.

--- a/packages/bijou-i18n-tools-xlsx/README.md
+++ b/packages/bijou-i18n-tools-xlsx/README.md
@@ -10,3 +10,6 @@ XLSX workbook adapters for Bijou localization exchange workflows.
 - deterministic workbook sheet ordering
 
 This package intentionally keeps spreadsheet-provider logic out of the pure `@flyingrobots/bijou-i18n-tools` package.
+
+Dependency note:
+`xlsx` is installed from the official SheetJS CDN tarball rather than the stale npm registry release. The npm package line is no longer maintained and carries unresolved security advisories; this package pins the maintained upstream tarball instead.

--- a/packages/bijou-i18n-tools-xlsx/package.json
+++ b/packages/bijou-i18n-tools-xlsx/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@flyingrobots/bijou-i18n-tools": "4.0.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-i18n-tools-xlsx/src/readme.test.ts
+++ b/packages/bijou-i18n-tools-xlsx/src/readme.test.ts
@@ -5,10 +5,16 @@ import { describe, expect, it } from 'vitest';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const README = readFileSync(resolve(ROOT, 'README.md'), 'utf8');
+const SECURITY_NOTE_PATTERN = /Dependency note:\r?\nAs of \d{4}-\d{2}-\d{2}, `xlsx` is installed from the official SheetJS CDN tarball/;
 
 describe('README dependency note', () => {
   it('anchors the xlsx security note with a date and official install guidance', () => {
-    expect(README).toMatch(/Dependency note:\nAs of \d{4}-\d{2}-\d{2}, `xlsx` is installed from the official SheetJS CDN tarball/);
+    expect(README).toMatch(SECURITY_NOTE_PATTERN);
     expect(README).toContain('https://docs.sheetjs.com/docs/getting-started/installation/nodejs/');
+  });
+
+  it('accepts CRLF checkouts when validating the dependency note', () => {
+    const crlfReadme = README.replace(/\n/g, '\r\n');
+    expect(crlfReadme).toMatch(SECURITY_NOTE_PATTERN);
   });
 });

--- a/packages/bijou-i18n-tools-xlsx/src/readme.test.ts
+++ b/packages/bijou-i18n-tools-xlsx/src/readme.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const README = readFileSync(resolve(ROOT, 'README.md'), 'utf8');
+
+describe('README dependency note', () => {
+  it('anchors the xlsx security note with a date and official install guidance', () => {
+    expect(README).toMatch(/Dependency note:\nAs of \d{4}-\d{2}-\d{2}, `xlsx` is installed from the official SheetJS CDN tarball/);
+    expect(README).toContain('https://docs.sheetjs.com/docs/getting-started/installation/nodejs/');
+  });
+});


### PR DESCRIPTION
## Summary
- pin `picomatch` to `4.0.4` via workspace overrides
- replace the stale npm `xlsx` release with the maintained official SheetJS `0.20.3` tarball
- document why the XLSX package is sourced from the SheetJS CDN

## Validation
- `npm audit --json`
- `./node_modules/.bin/vitest run --config vitest.config.ts packages/bijou-i18n-tools-xlsx/src/xlsx.test.ts tests/cycles/LX-006/bijou-i18n-xlsx.test.ts`
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.tests.json`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned specific dependency resolutions to ensure known-good versions (including picomatch and the XLSX package sourced from the official SheetJS CDN tarball).

* **Documentation**
  * Added dependency sourcing guidance and changelog note clarifying the XLSX installation source and timeline.

* **Tests**
  * Added a test that verifies the README includes the new dependency note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->