### PR TITLE
feat(dogfood): add responsive layout variants

### DIFF
--- a/docs/DOGFOOD.md
+++ b/docs/DOGFOOD.md
@@ -29,6 +29,7 @@ operators need when learning or validating Bijou.
 - **Component Explorer**: A live, interactive field guide to every component family.
 - **Storybook Workstation**: A deterministic story index and matrix capture path over the same DOGFOOD story catalog.
 - **Graceful Lowering**: Verifying that documentation renders correctly across `rich`, `static`, `pipe`, and `accessible` modes.
+- **Responsive Product Layout**: Proving that resize is not enough by selecting `wide`, `standard`, `narrow`, and `tiny` docs layouts that keep constrained terminals useful.
 - **Motion and Shader Surfaces**: Exercising canvas, glyph-fit raytracing, transitions, springs, and timelines from the docs app itself.
 - **Design Language**: Defining and enforcing the project's visual and interactive standards.
 

--- a/docs/design/DF-067-prove-responsive-dogfood-layout-variants.md
+++ b/docs/design/DF-067-prove-responsive-dogfood-layout-variants.md
@@ -1,0 +1,120 @@
+---
+title: DF-067 Prove Responsive DOGFOOD Layout Variants
+legend: DF
+lane: design
+priority: high
+keywords:
+  - dogfood
+  - responsive
+  - layout
+  - variants
+  - resize
+---
+
+# DF-067 Prove Responsive DOGFOOD Layout Variants
+
+## Framing
+
+DOGFOOD already responds mechanically to terminal resize events: the runtime
+updates viewport dimensions, the framed shell recomputes body geometry, and the
+current grid primitives solve new integer rectangles.
+
+That is not enough.
+
+The current docs shell keeps fixed sidebars and asks the middle track to absorb
+whatever space remains. That is valid geometry, but below useful widths it
+turns the app into a technically present three-column surface whose content is
+no longer the primary thing.
+
+This cycle keeps the work DOGFOOD-scoped. It does not wait for the full RE-035
+layout envelope runtime. It proves the editorial layer first: resize handling
+is mechanical, responsive layout is editorial.
+
+## Sponsored Users
+
+- Readers opening DOGFOOD in small terminals.
+- Maintainers validating layout doctrine against a real product surface.
+- Agents checking whether DOGFOOD remains useful at constrained sizes instead
+  of merely nonblank.
+
+## Hills
+
+1. At wide sizes, a reader sees navigation, content, and metadata/variant
+   context together.
+2. At standard sizes, a reader keeps navigation and content while secondary
+   metadata folds away.
+3. At narrow sizes, content becomes primary while navigation remains reachable.
+4. At tiny sizes, DOGFOOD becomes a single useful pane instead of a crushed
+   multi-column layout.
+
+## Playback Questions
+
+- Does DOGFOOD classify terminal size into explicit layout variants?
+- Does `140x40` keep the wide three-region docs/product shape?
+- Does `100x30` fold metadata while preserving navigation and content?
+- Does `72x20` keep content primary and navigation reachable?
+- Does `50x14` render a single useful pane with no fake sidebars?
+- Do the guide pages and component explorer both obey the same variant policy?
+- Does resize update the variant and viewport state without requiring a
+  restart?
+
+## Requirements
+
+- Add a pure `resolveDocsLayoutVariant(columns, rows)` helper returning:
+  `wide`, `standard`, `narrow`, or `tiny`.
+- Store the current layout variant in DOGFOOD page models so framed page layout
+  functions can select a layout tree without depending on render-time hacks.
+- Keep current wide layouts intact.
+- Fold guide metadata and component variants out of `standard` and `narrow`
+  layouts.
+- Use a smaller navigation track in `narrow`.
+- Use one content pane in `tiny`.
+- Keep resize synchronization responsible for the page model's variant and
+  viewport heights.
+
+## Acceptance Criteria
+
+- `tests/cycles/DF-067/responsive-dogfood-layout-variants.test.ts` proves the
+  cycle doc carries the modern playback sections.
+- The test proves the variant resolver thresholds.
+- The test renders guide pages at `140x40`, `100x30`, `72x20`, and `50x14`.
+- The test renders the component explorer at `140x40`, `72x20`, and `50x14`.
+- The test proves a live resize from wide to tiny updates the model and output.
+
+## Implementation Outline
+
+1. Add the DOGFOOD layout variant type and resolver.
+2. Add `layoutVariant` to `DocsExplorerModel`.
+3. Update DOGFOOD sync to recompute the variant from `FrameModel.columns` and
+   `FrameModel.rows`.
+4. Split guide and component page layout construction by variant.
+5. Update DOGFOOD docs/legend notes with the responsive posture.
+
+## Drift Check
+
+This is not a replacement for RE-035.
+
+DF-067 deliberately uses the current framed shell, grid, pane, and viewport
+primitives. The goal is to create product pressure and executable evidence for
+later runtime-engine responsive doctrine without expanding the runtime API
+prematurely.
+
+## Playback
+
+- RED: DOGFOOD redrew on resize but kept fixed sidebars even when the terminal
+  could no longer support them.
+- GREEN: DOGFOOD selects explicit layout variants and preserves useful content
+  at wide, standard, narrow, and tiny sizes.
+- Guide pages now render nav/content/meta at `wide`, nav/content at
+  `standard` and `narrow`, and content-only at `tiny`.
+- The component explorer now renders family/story/variants at `wide`,
+  family/story at `standard` and `narrow`, and story content only at `tiny`.
+- Resize synchronization updates each page model's variant, visible pane focus,
+  pane scroll map, and list viewport height.
+
+## Retrospective
+
+This closes the immediate product gap without expanding the runtime layout API.
+The current grid/frame primitives are enough to prove the editorial rule:
+constrained layouts should choose a useful surface, not preserve a wider shape
+until it becomes unreadable.

--- a/docs/legends/DF-dogfood-field-guide.md
+++ b/docs/legends/DF-dogfood-field-guide.md
@@ -76,6 +76,7 @@ before DOGFOOD counts as a real terminal docs product, and can see that
 - latest DOGFOOD docs-surface closure:
   - [DF-025 — Make DOGFOOD The Only Human-Facing Docs Surface](../design/DF-025-make-dogfood-the-only-human-facing-docs-surface.md)
 - latest supporting closure:
+  - [DF-067 — Prove Responsive DOGFOOD Layout Variants](../design/DF-067-prove-responsive-dogfood-layout-variants.md)
   - [DF-027 — Storybook-Style Tool for Bijou](../design/DF-027-storybook-style-tool-for-bijou.md)
   - [DF-062 — Audit Notification System Family Across Real Surfaces](../design/DF-062-audit-notification-system-family-across-real-surfaces.md)
   - [DF-061 — Audit Overlay Primitives Family Across Real Surfaces](../design/DF-061-audit-overlay-primitives-family-across-real-surfaces.md)

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -34,6 +34,7 @@ focus it and use the wheel to scroll long docs or help content.
 - the docs pane and preview pane both derive from the same story record once you enter the `Components` section
 - profile switching is part of the experience, not an afterthought
 - a framed shell can present both top-level docs sections and a rich component browser without pretending those are the same thing
+- the docs shell now chooses explicit `wide`, `standard`, `narrow`, and `tiny` layout variants so terminal resize remains a product decision instead of only geometry recomputation
 - DOGFOOD can now publish repo orientation, package docs, and release docs inside the same shell
 
 ## Included story families
@@ -73,6 +74,7 @@ focus it and use the wheel to scroll long docs or help content.
 - `npm run dogfood:storybook` exposes the story catalog as a deterministic text-first workstation for agents, CI, and future MCP or block tooling.
 - DOGFOOD now also uses the standard shell-owned settings drawer, so `F2`, the command palette, or shell-level frame bindings can toggle visible preferences like footer control hints and landing quality without the docs app shipping its own overlay plumbing.
 - Landing quality is adjustable directly from the landing screen too, so users can see the effect before they ever leave the title treatment.
+- The docs shell uses explicit responsive layout variants: wide keeps navigation, content, and metadata/variant context visible; standard and narrow fold secondary panes; tiny renders one useful content pane instead of a crushed multi-column surface.
 - Settings rows now carry real secondary descriptions, toggles render with checkbox-style `☐` / `☑` affordances, and choice rows use a distinct cycling marker so the drawer reads like a product settings surface instead of a plain text list.
 - Focus now owns input in the explorer: the family lane handles browse/expand keys only while it is active, the variants lane can own arrow-key variant changes, and pane clicks or `Tab` move that ownership through the standard frame shell instead of letting inactive lanes keep responding.
 - The footer is now the truthful control surface for the explorer: shell cues stay visible, active-pane hints only appear when they can actually do something, and stale in-pane legends no longer linger under shell overlays or focus changes.

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -45,6 +45,7 @@ import {
   type Cmd,
   type FramePageMsg,
   type FrameModel,
+  type FrameLayoutNode,
   type FramedApp,
   type FramedAppMsg,
   type FrameShellTheme,
@@ -133,6 +134,8 @@ const PACKAGES_PAGE_ID = 'packages';
 const PHILOSOPHY_PAGE_ID = 'philosophy';
 const RELEASE_PAGE_ID = 'release';
 const DOCS_SIDEBAR_WIDTH = 32;
+const DOCS_STANDARD_NAV_WIDTH = 28;
+const DOCS_NARROW_NAV_WIDTH = 26;
 const DOCS_SHELL_HINT = '? Help • / Search • F2 Settings • q Quit';
 const DOCS_PANE_SWITCH_HINT = 'Tab next pane';
 const DOGFOOD_I18N_NAMESPACE = 'bijou.dogfood';
@@ -141,6 +144,17 @@ const DOCS_LAYOUT_VERTICAL_MARGIN_ROWS = 2;
 const DOCS_FAMILY_SEPARATOR_ROWS = 1;
 
 export { FRAME_I18N_CATALOG };
+
+export type DocsLayoutVariant = 'wide' | 'standard' | 'narrow' | 'tiny';
+
+export function resolveDocsLayoutVariant(columns: number, rows: number): DocsLayoutVariant {
+  const width = Math.max(0, Math.floor(columns));
+  const height = Math.max(0, Math.floor(rows));
+  if (width >= 120 && height >= 24) return 'wide';
+  if (width >= 88 && height >= 20) return 'standard';
+  if (width >= 64 && height >= 16) return 'narrow';
+  return 'tiny';
+}
 
 export const DOGFOOD_I18N_CATALOG: I18nCatalog = {
   namespace: DOGFOOD_I18N_NAMESPACE,
@@ -247,6 +261,7 @@ interface RowDescriptor {
 }
 
 interface DocsExplorerModel {
+  readonly layoutVariant: DocsLayoutVariant;
   readonly familyState: ReturnType<typeof createBrowsableListState<string>>;
   readonly expandedFamilies: Readonly<Record<string, boolean>>;
   readonly selectedStoryId?: string;
@@ -826,6 +841,7 @@ function createInitialExplorerModel(ctx: BijouContext, pageId: DocsPageId): Docs
   const expandedFamilies = Object.fromEntries(STORY_FAMILIES.map((family) => [family.id, false]));
   const guideItems = guideItemsForPage(pageId);
   return {
+    layoutVariant: resolveDocsLayoutVariant(ctx.runtime.columns, ctx.runtime.rows),
     familyState: createBrowsableListState({
       items: buildFamilyItems(expandedFamilies),
       height: 14,
@@ -2206,6 +2222,43 @@ function resolveFamilyPaneBodyHeight(frameRows: number): number {
   );
 }
 
+function docsNavWidthForVariant(variant: DocsLayoutVariant): number {
+  switch (variant) {
+    case 'wide':
+      return DOCS_SIDEBAR_WIDTH;
+    case 'standard':
+      return DOCS_STANDARD_NAV_WIDTH;
+    case 'narrow':
+      return DOCS_NARROW_NAV_WIDTH;
+    case 'tiny':
+      return 0;
+  }
+}
+
+function visiblePaneIdsForLayout(pageId: DocsPageId, variant: DocsLayoutVariant): readonly string[] {
+  if (pageId === COMPONENTS_PAGE_ID) {
+    switch (variant) {
+      case 'wide':
+        return ['family-nav', 'story-content', 'story-variants'];
+      case 'standard':
+      case 'narrow':
+        return ['family-nav', 'story-content'];
+      case 'tiny':
+        return ['story-content'];
+    }
+  }
+
+  switch (variant) {
+    case 'wide':
+      return ['guide-nav', 'guide-content', 'guide-meta'];
+    case 'standard':
+    case 'narrow':
+      return ['guide-nav', 'guide-content'];
+    case 'tiny':
+      return ['guide-content'];
+  }
+}
+
 function insetPaneSurface(content: Surface, width: number): Surface {
   const safeWidth = Math.max(1, width);
   const inset = resolvePaneInset(safeWidth);
@@ -2749,6 +2802,161 @@ function resolveGuidePaneMouse(
   return index == null ? undefined : { type: 'activate-guide-index', index };
 }
 
+function createComponentsPageLayout(
+  model: DocsExplorerModel,
+  theme: LandingThemeTokens,
+  getCtx: () => BijouContext,
+  i18n: I18nRuntime,
+): FrameLayoutNode {
+  const family: FrameLayoutNode = {
+    kind: 'pane',
+    paneId: 'family-nav',
+    unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
+    render: (width, height) => renderFamiliesPane(model, width, height, getCtx(), theme),
+  };
+  const main: FrameLayoutNode = {
+    kind: 'pane',
+    paneId: 'story-content',
+    unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
+    render: (width) => renderStoryPane(model, width, getCtx(), theme, i18n),
+  };
+  const variants: FrameLayoutNode = {
+    kind: 'pane',
+    paneId: 'story-variants',
+    unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
+    render: (width, height) => renderVariantsPane(model, width, height, getCtx(), theme),
+  };
+
+  switch (model.layoutVariant) {
+    case 'tiny':
+      return main;
+    case 'narrow': {
+      const navWidth = docsNavWidthForVariant(model.layoutVariant);
+      return {
+        kind: 'grid',
+        gridId: 'docs-shell',
+        columns: [1, navWidth, 1, '1fr'],
+        rows: [1, '1fr', 1],
+        areas: [
+          '. . . .',
+          '. family . main',
+          '. . . .',
+        ],
+        gap: 0,
+        cells: { family, main },
+      };
+    }
+    case 'standard': {
+      const navWidth = docsNavWidthForVariant(model.layoutVariant);
+      return {
+        kind: 'grid',
+        gridId: 'docs-shell',
+        columns: [1, navWidth, 1, '1fr', 1],
+        rows: [1, '1fr', 1],
+        areas: [
+          '. . . . .',
+          '. family . main .',
+          '. . . . .',
+        ],
+        gap: 0,
+        cells: { family, main },
+      };
+    }
+    case 'wide':
+      return {
+        kind: 'grid',
+        gridId: 'docs-shell',
+        columns: [1, DOCS_SIDEBAR_WIDTH, 1, '1fr', 1, DOCS_SIDEBAR_WIDTH, 1],
+        rows: [1, '1fr', 1],
+        areas: [
+          '. . . . . . .',
+          '. family . main . variants .',
+          '. . . . . . .',
+        ],
+        gap: 0,
+        cells: { family, main, variants },
+      };
+  }
+}
+
+function createGuidePageLayout(
+  pageId: DocsPageId,
+  model: DocsExplorerModel,
+  theme: LandingThemeTokens,
+  getCtx: () => BijouContext,
+  i18n: I18nRuntime,
+): FrameLayoutNode {
+  const nav: FrameLayoutNode = {
+    kind: 'pane',
+    paneId: 'guide-nav',
+    unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
+    render: (width, height) => renderGuideNavPane(pageId, model, width, height, getCtx(), theme, i18n),
+  };
+  const main: FrameLayoutNode = {
+    kind: 'pane',
+    paneId: 'guide-content',
+    unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
+    render: (width) => renderGuideReaderPane(pageId, model, width, getCtx(), theme),
+  };
+  const meta: FrameLayoutNode = {
+    kind: 'pane',
+    paneId: 'guide-meta',
+    unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
+    render: (width) => renderGuideInfoPane(pageId, model, width, getCtx(), theme, i18n),
+  };
+
+  switch (model.layoutVariant) {
+    case 'tiny':
+      return main;
+    case 'narrow': {
+      const navWidth = docsNavWidthForVariant(model.layoutVariant);
+      return {
+        kind: 'grid',
+        gridId: `docs-${pageId}`,
+        columns: [1, navWidth, 1, '1fr'],
+        rows: [1, '1fr', 1],
+        areas: [
+          '. . . .',
+          '. nav . main',
+          '. . . .',
+        ],
+        gap: 0,
+        cells: { nav, main },
+      };
+    }
+    case 'standard': {
+      const navWidth = docsNavWidthForVariant(model.layoutVariant);
+      return {
+        kind: 'grid',
+        gridId: `docs-${pageId}`,
+        columns: [1, navWidth, 1, '1fr', 1],
+        rows: [1, '1fr', 1],
+        areas: [
+          '. . . . .',
+          '. nav . main .',
+          '. . . . .',
+        ],
+        gap: 0,
+        cells: { nav, main },
+      };
+    }
+    case 'wide':
+      return {
+        kind: 'grid',
+        gridId: `docs-${pageId}`,
+        columns: [1, DOCS_SIDEBAR_WIDTH, 1, '1fr', 1, DOCS_SIDEBAR_WIDTH, 1],
+        rows: [1, '1fr', 1],
+        areas: [
+          '. . . . . . .',
+          '. nav . main . meta .',
+          '. . . . . . .',
+        ],
+        gap: 0,
+        cells: { nav, main, meta },
+      };
+  }
+}
+
 function createDocsExplorerApp(
   getCtx: () => BijouContext,
   onShellThemeChange: (ctx: BijouContext) => void,
@@ -2846,38 +3054,7 @@ function createDocsExplorerApp(
           },
           layout(model) {
             const theme = resolveLandingTheme(model.landingThemeIndex);
-            return {
-              kind: 'grid',
-              gridId: 'docs-shell',
-              columns: [1, DOCS_SIDEBAR_WIDTH, 1, '1fr', 1, DOCS_SIDEBAR_WIDTH, 1],
-              rows: [1, '1fr', 1],
-              areas: [
-                '. . . . . . .',
-                '. family . main . variants .',
-                '. . . . . . .',
-              ],
-              gap: 0,
-              cells: {
-                family: {
-                  kind: 'pane',
-                  paneId: 'family-nav',
-                  unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
-                  render: (width, height) => renderFamiliesPane(model, width, height, getCtx(), theme),
-                },
-                main: {
-                  kind: 'pane',
-                  paneId: 'story-content',
-                  unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
-                  render: (width) => renderStoryPane(model, width, getCtx(), theme, i18n),
-                },
-                variants: {
-                  kind: 'pane',
-                  paneId: 'story-variants',
-                  unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
-                  render: (width, height) => renderVariantsPane(model, width, height, getCtx(), theme),
-                },
-              },
-            };
+            return createComponentsPageLayout(model, theme, getCtx, i18n);
           },
         };
       }
@@ -2939,38 +3116,7 @@ function createDocsExplorerApp(
         },
         layout(model) {
           const theme = resolveLandingTheme(model.landingThemeIndex);
-          return {
-            kind: 'grid',
-            gridId: `docs-${spec.id}`,
-            columns: [1, DOCS_SIDEBAR_WIDTH, 1, '1fr', 1, DOCS_SIDEBAR_WIDTH, 1],
-            rows: [1, '1fr', 1],
-            areas: [
-              '. . . . . . .',
-              '. nav . main . meta .',
-              '. . . . . . .',
-            ],
-            gap: 0,
-            cells: {
-              nav: {
-                kind: 'pane',
-                paneId: 'guide-nav',
-                unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
-                render: (width, height) => renderGuideNavPane(spec.id, model, width, height, getCtx(), theme, i18n),
-              },
-              main: {
-                kind: 'pane',
-                paneId: 'guide-content',
-                unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
-                render: (width) => renderGuideReaderPane(spec.id, model, width, getCtx(), theme),
-              },
-              meta: {
-                kind: 'pane',
-                paneId: 'guide-meta',
-                unfocusedGutterToken: docsThemeUnfocusedGutterToken(theme),
-                render: (width) => renderGuideInfoPane(spec.id, model, width, getCtx(), theme, i18n),
-              },
-            },
-          };
+          return createGuidePageLayout(spec.id, model, theme, getCtx, i18n);
         },
       };
     }),
@@ -3039,11 +3185,17 @@ function syncDocsExplorerViewportLayout(
   docsModel: FrameModel<DocsExplorerModel>,
 ): FrameModel<DocsExplorerModel> {
   const nextHeight = resolveFamilyPaneBodyHeight(docsModel.rows);
+  const nextLayoutVariant = resolveDocsLayoutVariant(docsModel.columns, docsModel.rows);
   let changed = false;
   const nextPageModels: Record<string, DocsExplorerModel> = {};
+  const nextFocusedPaneByPage: Record<string, string | undefined> = {};
+  const nextScrollByPage: Record<string, Readonly<Record<string, { readonly x: number; readonly y: number }>>> = {};
 
   for (const [pageId, pageModel] of Object.entries(docsModel.pageModels)) {
-    let nextPageModel = pageModel;
+    const docsPageId = pageId as DocsPageId;
+    let nextPageModel: DocsExplorerModel = pageModel.layoutVariant === nextLayoutVariant
+      ? pageModel
+      : { ...pageModel, layoutVariant: nextLayoutVariant };
     if (pageId === COMPONENTS_PAGE_ID) {
       if (pageModel.familyState.height !== nextHeight) {
         nextPageModel = {
@@ -3076,8 +3228,24 @@ function syncDocsExplorerViewportLayout(
       };
     }
 
+    const visiblePaneIds = visiblePaneIdsForLayout(docsPageId, nextLayoutVariant);
+    const previousFocusedPane = docsModel.focusedPaneByPage[pageId];
+    const nextFocusedPane = previousFocusedPane != null && visiblePaneIds.includes(previousFocusedPane)
+      ? previousFocusedPane
+      : visiblePaneIds[0];
+    const previousScroll = docsModel.scrollByPage[pageId] ?? {};
+    const nextScroll = Object.fromEntries(visiblePaneIds.map((paneId) => [
+      paneId,
+      previousScroll[paneId] ?? { x: 0, y: 0 },
+    ]));
+
     nextPageModels[pageId] = nextPageModel;
+    nextFocusedPaneByPage[pageId] = nextFocusedPane;
+    nextScrollByPage[pageId] = nextScroll;
     if (nextPageModel !== pageModel) {
+      changed = true;
+    }
+    if (nextFocusedPane !== previousFocusedPane) {
       changed = true;
     }
   }
@@ -3086,6 +3254,14 @@ function syncDocsExplorerViewportLayout(
     ? {
         ...docsModel,
         pageModels: nextPageModels,
+        focusedPaneByPage: {
+          ...docsModel.focusedPaneByPage,
+          ...nextFocusedPaneByPage,
+        },
+        scrollByPage: {
+          ...docsModel.scrollByPage,
+          ...nextScrollByPage,
+        },
       }
     : docsModel;
 }

--- a/tests/cycles/DF-067/responsive-dogfood-layout-variants.test.ts
+++ b/tests/cycles/DF-067/responsive-dogfood-layout-variants.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { stripAnsi, surfaceToString } from '@flyingrobots/bijou';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { createDocsApp, resolveDocsLayoutVariant } from '../../../examples/docs/app.js';
+import { normalizeViewOutput } from '../../../packages/bijou-tui/src/view-output.js';
+import { readRepoFile } from '../repo.js';
+
+const ENTER = { type: 'key', key: 'enter', ctrl: false, alt: false, shift: false } as const;
+const NEXT_TAB = { type: 'key', key: ']', ctrl: false, alt: false, shift: false } as const;
+
+function renderEnteredDocs(columns: number, rows: number, openComponents = false) {
+  const ctx = createTestContext({ mode: 'interactive', runtime: { columns, rows } });
+  const app = createDocsApp(ctx);
+  let [model] = app.init();
+  [model] = app.update(ENTER, model);
+  if (openComponents) {
+    [model] = app.update(NEXT_TAB, model);
+  }
+  const surface = normalizeViewOutput(app.view(model), { width: columns, height: rows }).surface;
+  return {
+    app,
+    ctx,
+    model,
+    surface,
+    text: stripAnsi(surfaceToString(surface, ctx.style)),
+  };
+}
+
+function activePageModel(model: unknown): any {
+  const root = model as any;
+  return root.docsModel.pageModels[root.docsModel.activePageId];
+}
+
+describe('DF-067 responsive DOGFOOD layout variants', () => {
+  it('keeps the active cycle doc tied to the playback contract', () => {
+    const cycle = readRepoFile('docs/design/DF-067-prove-responsive-dogfood-layout-variants.md');
+
+    expect(cycle).toContain('## Sponsored Users');
+    expect(cycle).toContain('## Hills');
+    expect(cycle).toContain('## Playback Questions');
+    expect(cycle).toContain('## Requirements');
+    expect(cycle).toContain('## Acceptance Criteria');
+    expect(cycle).toContain('## Drift Check');
+    expect(cycle).toContain('## Playback');
+    expect(cycle).toContain('## Retrospective');
+  });
+
+  it('classifies docs layout variants from terminal size', () => {
+    expect(resolveDocsLayoutVariant(140, 40)).toBe('wide');
+    expect(resolveDocsLayoutVariant(100, 30)).toBe('standard');
+    expect(resolveDocsLayoutVariant(72, 20)).toBe('narrow');
+    expect(resolveDocsLayoutVariant(50, 14)).toBe('tiny');
+  });
+
+  it('keeps guide pages useful across wide, standard, narrow, and tiny layouts', () => {
+    const wide = renderEnteredDocs(140, 40);
+    expect(activePageModel(wide.model).layoutVariant).toBe('wide');
+    expect(wide.text).toContain('docs • Start Here');
+    expect(wide.text).toContain('section • guides');
+    expect(wide.text).toContain('Current selection');
+
+    const standard = renderEnteredDocs(100, 30);
+    expect(activePageModel(standard.model).layoutVariant).toBe('standard');
+    expect(standard.text).toContain('guides');
+    expect(standard.text).toContain('docs • Start Here');
+    expect(standard.text).toContain('Bijou is');
+    expect(standard.text).not.toContain('Current selection');
+
+    const narrow = renderEnteredDocs(72, 20);
+    expect(activePageModel(narrow.model).layoutVariant).toBe('narrow');
+    expect(narrow.text).toContain('Navigate DOGFOOD');
+    expect(narrow.text).toContain('Start Here');
+    expect(narrow.text).toContain('Bijou is');
+    expect(narrow.text).not.toContain('Current selection');
+
+    const tiny = renderEnteredDocs(50, 14);
+    expect(activePageModel(tiny.model).layoutVariant).toBe('tiny');
+    expect(tiny.text).toContain('Start Here');
+    expect(tiny.text).toContain('Bijou is');
+    expect(tiny.text).not.toContain('Navigate DOGFOOD');
+    expect(tiny.text).not.toContain('Documentation Map');
+    expect(tiny.text).not.toContain('Current selection');
+  });
+
+  it('keeps the component explorer from becoming a crushed three-column surface', () => {
+    const wide = renderEnteredDocs(140, 40, true);
+    expect(activePageModel(wide.model).layoutVariant).toBe('wide');
+    expect(wide.text).toContain('component families');
+    expect(wide.text).toContain('What is Bijou?');
+    expect(wide.text).toContain('variants');
+
+    const narrow = renderEnteredDocs(72, 20, true);
+    expect(activePageModel(narrow.model).layoutVariant).toBe('narrow');
+    expect(narrow.text).toContain('component families');
+    expect(narrow.text).toContain('What is Bijou?');
+    expect(narrow.text).not.toContain('variants');
+
+    const tiny = renderEnteredDocs(50, 14, true);
+    expect(activePageModel(tiny.model).layoutVariant).toBe('tiny');
+    expect(tiny.text).toContain('What is Bijou?');
+    expect(tiny.text).not.toContain('component families');
+    expect(tiny.text).not.toContain('variants');
+  });
+
+  it('updates the layout variant and useful pane shape during live resize', () => {
+    const { app, ctx, model: initialModel } = renderEnteredDocs(140, 40);
+    let model = initialModel;
+
+    expect(activePageModel(model).layoutVariant).toBe('wide');
+
+    [model] = app.update({ type: 'resize', columns: 50, rows: 14 }, model);
+    const surface = normalizeViewOutput(app.view(model), { width: 50, height: 14 }).surface;
+    const text = stripAnsi(surfaceToString(surface, ctx.style));
+
+    expect(surface.width).toBe(50);
+    expect(surface.height).toBe(14);
+    expect(activePageModel(model).layoutVariant).toBe('tiny');
+    expect(text).toContain('Start Here');
+    expect(text).toContain('Bijou is');
+    expect(text).not.toContain('Navigate DOGFOOD');
+    expect(text).not.toContain('Current selection');
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit DOGFOOD layout variants: `wide`, `standard`, `narrow`, and `tiny`
- keep wide three-region layouts intact while folding metadata/variant panes at constrained sizes
- make tiny terminals render one useful content pane instead of a crushed multi-column docs shell
- sync layout variant, visible pane focus, scroll maps, and list viewport height on resize
- document DF-067 in DOGFOOD notes, the DF legend, and the cycle design doc

## Validation
- `npx vitest run --config vitest.config.ts tests/cycles/DF-067/responsive-dogfood-layout-variants.test.ts`
- `npx vitest run --config vitest.config.ts scripts/docs-preview.test.ts`
- `npm run typecheck:test`
- `npm run lint`
- `npm run docs:inventory`
- `npm run smoke:dogfood`
- `npm test`
- `npm run verify:interactive-examples`
- `npx tsx scripts/smoke-all-examples.ts --skip-build --mode=static-tty`
- `git diff --check`
- pre-push hook: `npm run typecheck:test`, `npm test`, `npm run verify:interactive-examples`