### PR TITLE
[codex] Add immutable binding frame primitives

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,11 +12,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   `DataRequirement`, `BindingSnapshot`, `BindingFrame`, `BindingStatus`,
   `BindingIssue`, `BindingFact`, `CommandIntent`, and helper constructors for
   the first DX-034 runtime-truth slice. Snapshots normalize provider and
-  requirement ids, freeze data/issues/facts, carry versioned ready/loading/
-  empty/stale/error status, and bind into immutable frames with `require()`,
-  `get()`, `status()`, `issues()`, and `facts()` accessors. Command intents are
-  inspectable metadata only; provider scopes, subscriptions, active hierarchy
-  traversal, schema adapters, and AppShell rendering remain follow-on work.
+  requirement ids, copy and freeze inert plain snapshot data without freezing
+  caller objects, reject mutable built-ins, executable values, and hidden
+  property channels, carry versioned ready/loading/empty/stale/error status, and
+  bind into immutable frames with `require()`, `get()`, `status()`, `issues()`,
+  and `facts()` accessors. Command intents are inspectable metadata only;
+  provider scopes, subscriptions, active hierarchy traversal, schema adapters,
+  and AppShell rendering remain follow-on work.
 - **Block metadata contract for `bijou`** — `@flyingrobots/bijou` now exports
   `BlockMetadata`, `BlockDefinition`, `BlockPackageManifest`, `defineBlock()`,
   `defineBlockPackage()`, validation/report helpers, and compact summaries so

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,15 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Binding frame primitives for `bijou`** — `@flyingrobots/bijou` now exports
+  `DataRequirement`, `BindingSnapshot`, `BindingFrame`, `BindingStatus`,
+  `BindingIssue`, `BindingFact`, `CommandIntent`, and helper constructors for
+  the first DX-034 runtime-truth slice. Snapshots normalize provider and
+  requirement ids, freeze data/issues/facts, carry versioned ready/loading/
+  empty/stale/error status, and bind into immutable frames with `require()`,
+  `get()`, `status()`, `issues()`, and `facts()` accessors. Command intents are
+  inspectable metadata only; provider scopes, subscriptions, active hierarchy
+  traversal, schema adapters, and AppShell rendering remain follow-on work.
 - **Block metadata contract for `bijou`** — `@flyingrobots/bijou` now exports
   `BlockMetadata`, `BlockDefinition`, `BlockPackageManifest`, `defineBlock()`,
   `defineBlockPackage()`, validation/report helpers, and compact summaries so

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -257,15 +257,22 @@ interface BindingSnapshot<Data> {
   readonly requirementId: string;
   readonly version: number;
   readonly status: 'ready' | 'loading' | 'empty' | 'stale' | 'error';
-  readonly data?: Data;
-  readonly issues?: readonly BindingIssue[];
-  readonly facts?: readonly BindingFact[];
+  readonly data?: DeepReadonly<Data>;
+  readonly issues: readonly BindingIssue[];
+  readonly facts: readonly BindingFact[];
 }
 ```
 
 Provider updates do not mutate mounted views. They produce a new snapshot
 version and trigger a runtime binding invalidation. The next render receives a
 new immutable binding frame.
+
+DX-034A snapshots accept inert plain snapshot data: null, strings, numbers,
+booleans, arrays, and enumerable string-keyed plain objects. They reject mutable
+built-ins and executable values such as `Map`, `Set`, `Date`, typed arrays,
+functions, accessors, symbol-keyed properties, symbols, and bigint. Snapshot
+construction copies accepted data before freezing it, so provider-owned or
+business-owned source objects are not frozen in place.
 
 ### 4. Binding Frames Are Immutable
 

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -277,13 +277,61 @@ The frame should support explicit reads:
 data.require('article');
 data.get('outline');
 data.status('comments');
-data.issueList('reviews');
+data.issues('reviews');
 ```
 
 The frame should not support writes.
 
 Any attempt to mutate data from inside a view should be structurally impossible
 in the public API and rejected at runtime where objects cross a boundary.
+
+### DX-034A Binding Snapshot And Frame Primitives
+
+DX-034A lands the first runtime-truth slice in `@flyingrobots/bijou`.
+
+The public core now includes:
+
+- `DataRequirement`
+- `ProviderId`
+- `RequirementId`
+- `BindingStatus`
+- `BindingSnapshot`
+- `BindingFrame`
+- `BindingIssue`
+- `BindingFact`
+- `CommandIntent`
+- `defineDataRequirement()`
+- `bindingSnapshot()`
+- `bindingFrame()`
+- `commandIntent()`
+
+This slice proves the objects, not the full runtime lifecycle:
+
+```ts
+const article = defineDataRequirement({
+  id: 'article',
+  resource: 'docs.article',
+});
+
+const snapshot = bindingSnapshot({
+  providerId: 'docs.articleProvider',
+  requirementId: article.id,
+  version: 1,
+  status: 'ready',
+  data: { title: 'DX-034' },
+});
+
+const frame = bindingFrame([snapshot]);
+
+frame.require('article');
+frame.get('article');
+frame.status('article');
+frame.issues('article');
+```
+
+The current `BindingFrame` deliberately does not include provider scopes,
+subscriptions, active hierarchy traversal, schema adapters, command dispatch, or
+AppShell rendering. Those remain follow-on runtime layers.
 
 ### 5. User Input Emits Commands
 
@@ -476,34 +524,33 @@ flow.
 
 ## Implementation Outline
 
-1. Define the public architecture vocabulary:
+1. Done: define the public architecture vocabulary:
    - `DataRequirement`
-   - `Provider`
-   - `ProviderScope`
    - `BindingSnapshot`
    - `BindingFrame`
    - `CommandIntent`
-2. Add cycle tests proving the design remains unidirectional, declarative, and
-   immutable.
-3. Add pure runtime prototypes for immutable binding snapshots and binding
-   frames.
-4. Add provider-scope resolution without global registration.
-5. Add active-view binding collection over the existing view-stack model.
-6. Add invalidation flow from provider snapshot updates to view re-render.
-7. Add Command intent declaration and dispatch proof.
-8. Integrate the contract with DX-031 block definitions.
-9. Prove AppShell with nested provider-bound navigation, content, inspector,
+2. Done: add behavioral tests proving the design remains unidirectional,
+   declarative, and immutable at the primitive layer.
+3. Done: add pure runtime primitives for immutable binding snapshots and
+   binding frames.
+4. Next: define provider and provider-scope contracts without global
+   registration.
+5. Next: add provider-scope resolution.
+6. Next: add active-view binding collection over the existing view-stack model.
+7. Next: add invalidation flow from provider snapshot updates to view re-render.
+8. Next: add Command intent dispatch proof.
+9. Next: integrate the contract with DX-031 block definitions.
+10. Next: prove AppShell with nested provider-bound navigation, content, inspector,
    and status blocks.
-10. Add DOGFOOD stories and captures for ready, loading, stale, empty, and
+11. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
     error binding states.
 
 ## Tests To Write First
 
-- Cycle tests proving the design doc names unidirectional, declarative, and
-  immutable as hard requirements.
-- Public contract tests proving views declare data requirements without
-  receiving mutable provider handles.
-- Runtime tests proving binding snapshots are immutable and versioned.
+- Behavioral tests proving public binding frames expose immutable data without
+  provider handles.
+- Behavioral tests proving binding snapshots are immutable and versioned.
+- Behavioral tests proving command intents are metadata, not callbacks.
 - Runtime tests proving provider scopes resolve nearest-provider wins without
   hidden globals.
 - Runtime tests proving active views create bindings and inactive views dispose
@@ -552,4 +599,7 @@ flow.
 
 ## Retrospective
 
-Not started.
+DX-034A landed the primitive contract layer first. The important restraint is
+that `BindingFrame` is not a provider scope, subscription manager, active-view
+resolver, schema adapter, or AppShell slot model. It is only the immutable data
+frame views can read during render.

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -188,6 +188,12 @@ openArticle.id;
 subscriptions, active-view lifecycle, schema adapters, and command dispatch
 remain runtime follow-on layers.
 
+Snapshot data is copied before it is frozen. Use inert plain snapshot data:
+null, strings, numbers, booleans, arrays, and enumerable string-keyed plain
+objects. Mutable built-ins and executable values such as `Map`, `Set`, `Date`,
+typed arrays, functions, accessors, symbol-keyed properties, symbols, and bigint
+are rejected at the binding boundary.
+
 ## Testing
 
 Use `createTestContext` to verify behavior across all modes without mocking:

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -149,6 +149,45 @@ Blocks are explicit imports, not runtime plugins. `BlockMetadata` and
 `BlockPackageManifest` are intended for docs, DOGFOOD, MCP payloads, and package
 compatibility checks; schema-bound blocks are still a follow-on layer.
 
+## Binding Frames
+
+Use binding primitives when a view should render provider-delivered data without
+receiving a provider handle:
+
+```typescript
+import {
+  bindingFrame,
+  bindingSnapshot,
+  commandIntent,
+  defineDataRequirement,
+} from '@flyingrobots/bijou';
+
+const article = defineDataRequirement({
+  id: 'article',
+  resource: 'docs.article',
+});
+
+const frame = bindingFrame([
+  bindingSnapshot({
+    providerId: 'docs.articleProvider',
+    requirementId: article.id,
+    version: 1,
+    status: 'ready',
+    data: { title: 'DX-034' },
+  }),
+]);
+
+const openArticle = commandIntent<{ articleId: string }>('docs.openArticle');
+
+frame.require<{ title: string }>('article');
+frame.status('article');
+openArticle.id;
+```
+
+`BindingFrame` is only the immutable render-time data frame. Provider scopes,
+subscriptions, active-view lifecycle, schema adapters, and command dispatch
+remain runtime follow-on layers.
+
 ## Testing
 
 Use `createTestContext` to verify behavior across all modes without mocking:

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -99,8 +99,8 @@ fake duplication rather than a real second API.
 - **`blockMetadataSummary()`**: Render compact block metadata for docs, MCP
   payloads, and agent-facing reports.
 - **`defineDataRequirement()` / `bindingSnapshot()` / `bindingFrame()`**:
-  Model provider-delivered data as versioned immutable snapshots and read-only
-  render frames.
+  Model provider-delivered plain data as copied, versioned immutable snapshots
+  and read-only render frames.
 - **`commandIntent()`**: Declare user intent outputs as inspectable metadata,
   without business-logic callbacks or provider mutation handles.
 - **`captureStoryMatrix()`**: Capture every profile/variant pair from a story

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -98,6 +98,11 @@ fake duplication rather than a real second API.
   Bijou peer compatibility for ordinary NPM block packages.
 - **`blockMetadataSummary()`**: Render compact block metadata for docs, MCP
   payloads, and agent-facing reports.
+- **`defineDataRequirement()` / `bindingSnapshot()` / `bindingFrame()`**:
+  Model provider-delivered data as versioned immutable snapshots and read-only
+  render frames.
+- **`commandIntent()`**: Declare user intent outputs as inspectable metadata,
+  without business-logic callbacks or provider mutation handles.
 - **`captureStoryMatrix()`**: Capture every profile/variant pair from a story
   renderer.
 - **`storyCaptureMatrixText()`**: Render a deterministic multi-mode story

--- a/packages/bijou/src/core/binding.test.ts
+++ b/packages/bijou/src/core/binding.test.ts
@@ -69,6 +69,110 @@ describe('binding primitives', () => {
     }).toThrow(TypeError);
   });
 
+  it('freezes an immutable snapshot copy without freezing caller-owned data', () => {
+    const article = {
+      title: 'DX-034',
+      tags: ['binding'],
+      meta: { draft: false },
+    };
+    const snapshot = bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 1,
+      status: 'ready',
+      data: article,
+    });
+
+    expect(snapshot.data).toEqual(article);
+    expect(snapshot.data).not.toBe(article);
+    expect(snapshot.data?.tags).not.toBe(article.tags);
+    expect(snapshot.data?.meta).not.toBe(article.meta);
+    expect(Object.isFrozen(snapshot.data)).toBe(true);
+    expect(Object.isFrozen(snapshot.data?.tags)).toBe(true);
+    expect(Object.isFrozen(snapshot.data?.meta)).toBe(true);
+    expect(Object.isFrozen(article)).toBe(false);
+    expect(Object.isFrozen(article.tags)).toBe(false);
+    expect(Object.isFrozen(article.meta)).toBe(false);
+
+    article.title = 'Mutable source';
+    article.tags.push('source-only');
+    article.meta.draft = true;
+
+    expect(snapshot.data).toEqual({
+      title: 'DX-034',
+      tags: ['binding'],
+      meta: { draft: false },
+    });
+  });
+
+  it('rejects mutable built-ins and executable values as snapshot data', () => {
+    const base = {
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 1,
+      status: 'ready' as const,
+    };
+
+    expect(() => bindingSnapshot({
+      ...base,
+      data: new Map([['title', 'DX-034']]),
+    })).toThrow('binding data: unsupported Map at data');
+    expect(() => bindingSnapshot({
+      ...base,
+      data: new Set(['DX-034']),
+    })).toThrow('binding data: unsupported Set at data');
+    expect(() => bindingSnapshot({
+      ...base,
+      data: new Date('2026-05-18T00:00:00.000Z'),
+    })).toThrow('binding data: unsupported Date at data');
+    expect(() => bindingSnapshot({
+      ...base,
+      data: new Uint8Array([1, 2, 3]),
+    })).toThrow('binding data: unsupported Uint8Array at data');
+    expect(() => bindingSnapshot({
+      ...base,
+      data: { load: () => 'provider handle' },
+    })).toThrow('binding data: unsupported function at data.load');
+  });
+
+  it('rejects executable accessors and hidden property channels as snapshot data', () => {
+    const base = {
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 1,
+      status: 'ready' as const,
+    };
+    let getterWasCalled = false;
+    const accessorData = {};
+    Object.defineProperty(accessorData, 'title', {
+      enumerable: true,
+      get() {
+        getterWasCalled = true;
+        return 'DX-034';
+      },
+    });
+    const hiddenData = {};
+    Object.defineProperty(hiddenData, 'title', {
+      enumerable: false,
+      value: 'DX-034',
+    });
+    const secretKey = Symbol('secret');
+
+    expect(() => bindingSnapshot({
+      ...base,
+      data: accessorData,
+    })).toThrow('binding data: unsupported accessor at data.title');
+    expect(getterWasCalled).toBe(false);
+    expect(() => bindingSnapshot({
+      ...base,
+      data: hiddenData,
+    })).toThrow('binding data: unsupported non-enumerable property at data.title');
+    expect(() => bindingSnapshot({
+      ...base,
+      data: { [secretKey]: 'DX-034' },
+    })).toThrow('binding data: unsupported symbol property at data');
+  });
+
   it('rejects invalid snapshot ids, versions, and statuses', () => {
     expect(() => bindingSnapshot({
       providerId: '',

--- a/packages/bijou/src/core/binding.test.ts
+++ b/packages/bijou/src/core/binding.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BindingFrame,
+  bindingFrame,
+  bindingSnapshot,
+  commandIntent,
+  defineDataRequirement,
+  isBindingSnapshot,
+  type BindingIssue,
+  type BindingStatus,
+} from './binding.js';
+
+interface Article {
+  title: string;
+  tags: string[];
+  meta: {
+    draft: boolean;
+  };
+}
+
+describe('binding primitives', () => {
+  it('creates immutable runtime-backed ready snapshots', () => {
+    const article = {
+      title: 'DX-034',
+      tags: ['binding'],
+      meta: { draft: false },
+    };
+    const requirement = defineDataRequirement({
+      id: ' article ',
+      resource: ' docs.article ',
+      facts: [{ kind: 'entity', key: 'resource', value: 'article' }],
+    });
+    const snapshot = bindingSnapshot({
+      providerId: ' docs.articleProvider ',
+      requirementId: requirement.id,
+      version: 1,
+      status: 'ready',
+      data: article,
+      issues: [{ severity: 'warning', code: 'freshness', message: 'fresh data' }],
+      facts: [{ kind: 'state', key: 'freshness', value: 'ready' }],
+    });
+
+    expect(requirement.id).toBe('article');
+    expect(requirement.resource).toBe('docs.article');
+    expect(isBindingSnapshot(snapshot)).toBe(true);
+    expect(snapshot.providerId).toBe('docs.articleProvider');
+    expect(snapshot.requirementId).toBe('article');
+    expect(snapshot.data?.title).toBe('DX-034');
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.data)).toBe(true);
+    expect(Object.isFrozen(snapshot.data?.tags)).toBe(true);
+    expect(Object.isFrozen(snapshot.data?.meta)).toBe(true);
+    expect(Object.isFrozen(snapshot.issues)).toBe(true);
+    expect(Object.isFrozen(snapshot.issues[0])).toBe(true);
+    expect(Object.isFrozen(snapshot.facts)).toBe(true);
+    expect(Object.isFrozen(snapshot.facts[0])).toBe(true);
+    expect(() => {
+      (snapshot.data as { title: string }).title = 'mutated';
+    }).toThrow(TypeError);
+    expect(() => {
+      (snapshot.data?.tags as string[]).push('mutable');
+    }).toThrow(TypeError);
+    expect(() => {
+      (snapshot.issues as BindingIssue[]).push({
+        severity: 'error',
+        code: 'mutation',
+        message: 'mutated',
+      });
+    }).toThrow(TypeError);
+  });
+
+  it('rejects invalid snapshot ids, versions, and statuses', () => {
+    expect(() => bindingSnapshot({
+      providerId: '',
+      requirementId: 'article',
+      version: 1,
+      status: 'ready',
+    })).toThrow('binding snapshot: providerId is required');
+
+    expect(() => bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: '   ',
+      version: 1,
+      status: 'ready',
+    })).toThrow('binding snapshot: requirementId is required');
+
+    expect(() => bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 0,
+      status: 'ready',
+    })).toThrow('binding snapshot: version must be a positive integer');
+
+    expect(() => bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 1,
+      status: 'loaded' as BindingStatus,
+    })).toThrow('binding snapshot: unsupported status loaded');
+  });
+
+  it('creates binding frames with read-only require, get, status, and issues accessors', () => {
+    const article = bindingSnapshot<Article>({
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 1,
+      status: 'ready',
+      data: {
+        title: 'DX-034',
+        tags: ['binding'],
+        meta: { draft: false },
+      },
+    });
+    const comments = bindingSnapshot({
+      providerId: 'docs.commentsProvider',
+      requirementId: 'comments',
+      version: 1,
+      status: 'loading',
+      issues: [{ severity: 'info', code: 'pending', message: 'comments are loading' }],
+    });
+    const frame = bindingFrame([article, comments]);
+
+    expect(frame).toBeInstanceOf(BindingFrame);
+    expect(frame.ids()).toEqual(['article', 'comments']);
+    expect(frame.require<Article>('article').title).toBe('DX-034');
+    expect(frame.get<Article>('article')?.tags).toEqual(['binding']);
+    expect(frame.get('comments')).toBeUndefined();
+    expect(frame.get('missing')).toBeUndefined();
+    expect(frame.status('article')).toBe('ready');
+    expect(frame.status('comments')).toBe('loading');
+    expect(frame.status('missing')).toBeUndefined();
+    expect(frame.issues('comments')).toEqual([
+      { severity: 'info', code: 'pending', message: 'comments are loading' },
+    ]);
+    expect(Object.isFrozen(frame.issues('comments'))).toBe(true);
+    expect(() => frame.require('comments')).toThrow(
+      'binding frame: requirement comments is loading',
+    );
+    expect(() => frame.require('missing')).toThrow(
+      'binding frame: missing requirement missing',
+    );
+    expect(() => {
+      (frame.require<Article>('article') as { title: string }).title = 'mutated';
+    }).toThrow(TypeError);
+  });
+
+  it('reports every known binding status through a frame', () => {
+    const statuses: readonly BindingStatus[] = ['ready', 'loading', 'empty', 'stale', 'error'];
+    const frame = bindingFrame(statuses.map((status, index) => bindingSnapshot({
+      providerId: `provider.${status}`,
+      requirementId: status,
+      version: index + 1,
+      status,
+      data: status === 'ready' ? { status } : undefined,
+    })));
+
+    expect(statuses.map((status) => frame.status(status))).toEqual(statuses);
+  });
+
+  it('rejects duplicate requirements and loose snapshot-shaped objects', () => {
+    const first = bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 1,
+      status: 'ready',
+      data: { title: 'First' },
+    });
+    const second = bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 2,
+      status: 'ready',
+      data: { title: 'Second' },
+    });
+
+    expect(() => bindingFrame([first, second])).toThrow(
+      'binding frame: duplicate requirement id article',
+    );
+    expect(() => bindingFrame([{
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 1,
+      status: 'ready',
+    } as never])).toThrow(
+      'binding frame: snapshot at index 0 was not created by bindingSnapshot()',
+    );
+  });
+
+  it('models provider updates as new frames without mutating the old frame', () => {
+    const firstFrame = bindingFrame([
+      bindingSnapshot({
+        providerId: 'docs.articleProvider',
+        requirementId: 'article',
+        version: 1,
+        status: 'ready',
+        data: { title: 'First' },
+      }),
+    ]);
+    const nextFrame = bindingFrame([
+      bindingSnapshot({
+        providerId: 'docs.articleProvider',
+        requirementId: 'article',
+        version: 2,
+        status: 'ready',
+        data: { title: 'Second' },
+      }),
+    ]);
+
+    expect(firstFrame.require<{ title: string }>('article').title).toBe('First');
+    expect(firstFrame.snapshot('article')?.version).toBe(1);
+    expect(nextFrame.require<{ title: string }>('article').title).toBe('Second');
+    expect(nextFrame.snapshot('article')?.version).toBe(2);
+  });
+
+  it('does not expose provider handles, mutable data bags, or refresh backchannels', () => {
+    const frame = bindingFrame([
+      bindingSnapshot({
+        providerId: 'docs.articleProvider',
+        requirementId: 'article',
+        version: 1,
+        status: 'ready',
+        data: { title: 'DX-034' },
+      }),
+    ]);
+
+    expect(Object.keys(frame)).toEqual([]);
+    expect('provider' in frame).toBe(false);
+    expect('providers' in frame).toBe(false);
+    expect('data' in frame).toBe(false);
+    expect('refresh' in frame).toBe(false);
+    expect('subscribe' in frame).toBe(false);
+  });
+
+  it('defines command intents as inspectable metadata, not business logic callbacks', () => {
+    const intent = commandIntent<{ headingId: string }>(' reader.selectHeading ', {
+      label: 'Select heading',
+      description: 'User selected a heading in the reader surface.',
+      facts: [{ kind: 'entity', key: 'command', value: 'reader.selectHeading' }],
+    });
+
+    expect(intent.id).toBe('reader.selectHeading');
+    expect(intent.label).toBe('Select heading');
+    expect(Object.isFrozen(intent)).toBe(true);
+    expect(Object.isFrozen(intent.facts)).toBe(true);
+    expect('execute' in intent).toBe(false);
+    expect('handler' in intent).toBe(false);
+    expect('dispatch' in intent).toBe(false);
+  });
+});

--- a/packages/bijou/src/core/binding.ts
+++ b/packages/bijou/src/core/binding.ts
@@ -219,7 +219,7 @@ export function bindingSnapshot<Data = unknown>(
     requirementId,
     version: input.version,
     status: input.status,
-    ...(input.data === undefined ? {} : { data: deepFreeze(input.data) }),
+    ...(input.data === undefined ? {} : { data: freezeSnapshotData(input.data) }),
     issues: freezeIssues(input.issues),
     facts: freezeFacts(input.facts),
   } as BindingSnapshot<Data>;
@@ -330,6 +330,88 @@ function freezeFacts(facts: readonly BindingFact[] | undefined): readonly Bindin
   }
 
   return deepFreeze([...facts]);
+}
+
+function freezeSnapshotData<T>(value: T): DeepReadonly<T> {
+  return deepFreeze(cloneSnapshotData(value, 'data'));
+}
+
+function cloneSnapshotData<T>(value: T, path: string, seen: WeakSet<object> = new WeakSet<object>()): T {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'bigint' || typeof value === 'symbol' || typeof value === 'function') {
+    throw new Error(`binding data: unsupported ${typeof value} at ${path}`);
+  }
+
+  if (value === undefined) {
+    throw new Error(`binding data: unsupported undefined at ${path}`);
+  }
+
+  if (typeof value !== 'object') {
+    throw new Error(`binding data: unsupported ${typeof value} at ${path}`);
+  }
+
+  const objectValue = value as object;
+  if (seen.has(objectValue)) {
+    throw new Error(`binding data: circular reference at ${path}`);
+  }
+  seen.add(objectValue);
+
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item, index) => cloneSnapshotData(item, `${path}[${index}]`, seen)) as T;
+    }
+
+    if (!isPlainObject(value)) {
+      throw new Error(`binding data: unsupported ${objectKind(value)} at ${path}`);
+    }
+
+    const clone = Object.create(Object.getPrototypeOf(value)) as SnapshotDataObject;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (typeof key === 'symbol') {
+        throw new Error(`binding data: unsupported symbol property at ${path}`);
+      }
+
+      const propertyPath = `${path}.${key}`;
+      const descriptor = descriptors[key];
+      if (descriptor === undefined) {
+        continue;
+      }
+      if (!descriptor.enumerable) {
+        throw new Error(`binding data: unsupported non-enumerable property at ${propertyPath}`);
+      }
+      if ('get' in descriptor || 'set' in descriptor) {
+        throw new Error(`binding data: unsupported accessor at ${propertyPath}`);
+      }
+
+      clone[key] = cloneSnapshotData(descriptor.value, propertyPath, seen);
+    }
+
+    return clone as T;
+  } finally {
+    seen.delete(objectValue);
+  }
+}
+
+interface SnapshotDataObject {
+  [key: string]: unknown;
+}
+
+function isPlainObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function objectKind(value: object): string {
+  return Object.prototype.toString.call(value).slice(8, -1);
 }
 
 function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet<object>()): DeepReadonly<T> {

--- a/packages/bijou/src/core/binding.ts
+++ b/packages/bijou/src/core/binding.ts
@@ -1,0 +1,355 @@
+import type { ModeLoweringFact } from './mode-lowering.js';
+
+const DATA_REQUIREMENT_BRAND: unique symbol = Symbol('DataRequirement');
+const BINDING_SNAPSHOT_BRAND: unique symbol = Symbol('BindingSnapshot');
+const COMMAND_INTENT_BRAND: unique symbol = Symbol('CommandIntent');
+const COMMAND_INTENT_PAYLOAD: unique symbol = Symbol('CommandIntentPayload');
+
+export type ProviderId = string;
+export type RequirementId = string;
+export type CommandIntentId = string;
+
+export type BindingStatus = 'ready' | 'loading' | 'empty' | 'stale' | 'error';
+
+export type BindingIssueSeverity = 'info' | 'warning' | 'error';
+
+export type BindingFact = ModeLoweringFact;
+
+export type DeepReadonly<T> = T extends readonly (infer Item)[]
+  ? readonly DeepReadonly<Item>[]
+  : T extends object
+    ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+    : T;
+
+export interface BindingIssue {
+  readonly severity: BindingIssueSeverity;
+  readonly code: string;
+  readonly message: string;
+  readonly path?: string;
+}
+
+export interface DataRequirementInput {
+  readonly id: string;
+  readonly resource: string;
+  readonly label?: string;
+  readonly description?: string;
+  readonly optional?: boolean;
+  readonly facts?: readonly BindingFact[];
+}
+
+export interface DataRequirement {
+  readonly [DATA_REQUIREMENT_BRAND]: true;
+  readonly id: RequirementId;
+  readonly resource: string;
+  readonly label?: string;
+  readonly description?: string;
+  readonly optional?: boolean;
+  readonly facts: readonly BindingFact[];
+}
+
+export interface BindingSnapshotInput<Data = unknown> {
+  readonly providerId: string;
+  readonly requirementId: string;
+  readonly version: number;
+  readonly status: BindingStatus;
+  readonly data?: Data;
+  readonly issues?: readonly BindingIssue[];
+  readonly facts?: readonly BindingFact[];
+}
+
+export interface BindingSnapshot<Data = unknown> {
+  readonly [BINDING_SNAPSHOT_BRAND]: true;
+  readonly providerId: ProviderId;
+  readonly requirementId: RequirementId;
+  readonly version: number;
+  readonly status: BindingStatus;
+  readonly data?: DeepReadonly<Data>;
+  readonly issues: readonly BindingIssue[];
+  readonly facts: readonly BindingFact[];
+}
+
+export interface CommandIntentOptions {
+  readonly label?: string;
+  readonly description?: string;
+  readonly facts?: readonly BindingFact[];
+}
+
+export interface CommandIntent<Payload = unknown> {
+  readonly [COMMAND_INTENT_BRAND]: true;
+  readonly [COMMAND_INTENT_PAYLOAD]?: Payload;
+  readonly id: CommandIntentId;
+  readonly label?: string;
+  readonly description?: string;
+  readonly facts: readonly BindingFact[];
+}
+
+const BINDING_STATUSES: readonly BindingStatus[] = [
+  'ready',
+  'loading',
+  'empty',
+  'stale',
+  'error',
+];
+const BINDING_ISSUE_SEVERITIES: readonly BindingIssueSeverity[] = [
+  'info',
+  'warning',
+  'error',
+];
+const EMPTY_BINDING_ISSUES = Object.freeze([]) as readonly BindingIssue[];
+const EMPTY_BINDING_FACTS = Object.freeze([]) as readonly BindingFact[];
+
+export class BindingFrame {
+  readonly #snapshotsByRequirementId: ReadonlyMap<RequirementId, BindingSnapshot>;
+
+  constructor(snapshots: readonly BindingSnapshot[]) {
+    const snapshotsByRequirementId = new Map<RequirementId, BindingSnapshot>();
+
+    snapshots.forEach((snapshot, index) => {
+      if (!isBindingSnapshot(snapshot)) {
+        throw new Error(
+          `binding frame: snapshot at index ${index} was not created by bindingSnapshot()`,
+        );
+      }
+
+      if (snapshotsByRequirementId.has(snapshot.requirementId)) {
+        throw new Error(`binding frame: duplicate requirement id ${snapshot.requirementId}`);
+      }
+
+      snapshotsByRequirementId.set(snapshot.requirementId, snapshot);
+    });
+
+    this.#snapshotsByRequirementId = snapshotsByRequirementId;
+    Object.freeze(this);
+  }
+
+  ids(): readonly RequirementId[] {
+    return Object.freeze([...this.#snapshotsByRequirementId.keys()]);
+  }
+
+  snapshot<Data = unknown>(requirementId: RequirementId): BindingSnapshot<Data> | undefined {
+    const normalizedRequirementId = normalizeRequiredText({
+      scope: 'binding frame',
+      field: 'requirementId',
+      value: requirementId,
+    });
+
+    return this.#snapshotsByRequirementId.get(normalizedRequirementId) as
+      | BindingSnapshot<Data>
+      | undefined;
+  }
+
+  get<Data = unknown>(requirementId: RequirementId): DeepReadonly<Data> | undefined {
+    return this.snapshot<Data>(requirementId)?.data;
+  }
+
+  require<Data = unknown>(requirementId: RequirementId): DeepReadonly<Data> {
+    const snapshot = this.snapshot<Data>(requirementId);
+    if (snapshot === undefined) {
+      throw new Error(`binding frame: missing requirement ${requirementId}`);
+    }
+
+    if (snapshot.status !== 'ready') {
+      throw new Error(`binding frame: requirement ${snapshot.requirementId} is ${snapshot.status}`);
+    }
+
+    if (snapshot.data === undefined) {
+      throw new Error(`binding frame: requirement ${snapshot.requirementId} has no data`);
+    }
+
+    return snapshot.data;
+  }
+
+  status(requirementId: RequirementId): BindingStatus | undefined {
+    return this.snapshot(requirementId)?.status;
+  }
+
+  issues(requirementId: RequirementId): readonly BindingIssue[] {
+    return this.snapshot(requirementId)?.issues ?? EMPTY_BINDING_ISSUES;
+  }
+
+  facts(requirementId: RequirementId): readonly BindingFact[] {
+    return this.snapshot(requirementId)?.facts ?? EMPTY_BINDING_FACTS;
+  }
+}
+
+export function defineDataRequirement(input: DataRequirementInput): DataRequirement {
+  const requirement = {
+    id: normalizeRequiredText({
+      scope: 'data requirement',
+      field: 'id',
+      value: input.id,
+    }),
+    resource: normalizeRequiredText({
+      scope: 'data requirement',
+      field: 'resource',
+      value: input.resource,
+    }),
+    label: optionalTrimmedText(input.label),
+    description: optionalTrimmedText(input.description),
+    optional: input.optional,
+    facts: freezeFacts(input.facts),
+  } as DataRequirement;
+
+  Object.defineProperty(requirement, DATA_REQUIREMENT_BRAND, { value: true });
+  return Object.freeze(requirement);
+}
+
+export function bindingSnapshot<Data = unknown>(
+  input: BindingSnapshotInput<Data>,
+): BindingSnapshot<Data> {
+  const providerId = normalizeRequiredText({
+    scope: 'binding snapshot',
+    field: 'providerId',
+    value: input.providerId,
+  });
+  const requirementId = normalizeRequiredText({
+    scope: 'binding snapshot',
+    field: 'requirementId',
+    value: input.requirementId,
+  });
+  if (!Number.isInteger(input.version) || input.version < 1) {
+    throw new Error('binding snapshot: version must be a positive integer');
+  }
+  if (!isBindingStatus(input.status)) {
+    throw new Error(`binding snapshot: unsupported status ${String(input.status)}`);
+  }
+
+  const snapshot = {
+    providerId,
+    requirementId,
+    version: input.version,
+    status: input.status,
+    ...(input.data === undefined ? {} : { data: deepFreeze(input.data) }),
+    issues: freezeIssues(input.issues),
+    facts: freezeFacts(input.facts),
+  } as BindingSnapshot<Data>;
+
+  Object.defineProperty(snapshot, BINDING_SNAPSHOT_BRAND, { value: true });
+  return Object.freeze(snapshot);
+}
+
+export function bindingFrame(snapshots: readonly BindingSnapshot[]): BindingFrame {
+  return new BindingFrame(snapshots);
+}
+
+export function commandIntent<Payload = unknown>(
+  id: string,
+  options: CommandIntentOptions = {},
+): CommandIntent<Payload> {
+  const intent = {
+    id: normalizeRequiredText({
+      scope: 'command intent',
+      field: 'id',
+      value: id,
+    }),
+    label: optionalTrimmedText(options.label),
+    description: optionalTrimmedText(options.description),
+    facts: freezeFacts(options.facts),
+  } as CommandIntent<Payload>;
+
+  Object.defineProperty(intent, COMMAND_INTENT_BRAND, { value: true });
+  return Object.freeze(intent);
+}
+
+export function isBindingSnapshot(value: unknown): value is BindingSnapshot {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && (value as BindingSnapshotBrandCarrier)[BINDING_SNAPSHOT_BRAND] === true,
+  );
+}
+
+interface BindingSnapshotBrandCarrier {
+  readonly [BINDING_SNAPSHOT_BRAND]?: true;
+}
+
+interface RequiredTextOptions {
+  readonly scope: string;
+  readonly field: string;
+  readonly value: string;
+}
+
+function normalizeRequiredText(options: RequiredTextOptions): string {
+  const normalized = options.value.trim();
+  if (normalized === '') {
+    throw new Error(`${options.scope}: ${options.field} is required`);
+  }
+
+  return normalized;
+}
+
+function optionalTrimmedText(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized === '' ? undefined : normalized;
+}
+
+function isBindingStatus(value: string): value is BindingStatus {
+  return BINDING_STATUSES.includes(value as BindingStatus);
+}
+
+function isBindingIssueSeverity(value: string): value is BindingIssueSeverity {
+  return BINDING_ISSUE_SEVERITIES.includes(value as BindingIssueSeverity);
+}
+
+function freezeIssues(issues: readonly BindingIssue[] | undefined): readonly BindingIssue[] {
+  if (issues === undefined || issues.length === 0) {
+    return EMPTY_BINDING_ISSUES;
+  }
+
+  return deepFreeze(issues.map((issue, index) => normalizeIssue(issue, index)));
+}
+
+function normalizeIssue(issue: BindingIssue, index: number): BindingIssue {
+  if (!isBindingIssueSeverity(issue.severity)) {
+    throw new Error(`binding issue: unsupported severity ${String(issue.severity)} at index ${index}`);
+  }
+
+  return {
+    severity: issue.severity,
+    code: normalizeRequiredText({
+      scope: 'binding issue',
+      field: `issues[${index}].code`,
+      value: issue.code,
+    }),
+    message: normalizeRequiredText({
+      scope: 'binding issue',
+      field: `issues[${index}].message`,
+      value: issue.message,
+    }),
+    path: optionalTrimmedText(issue.path),
+  };
+}
+
+function freezeFacts(facts: readonly BindingFact[] | undefined): readonly BindingFact[] {
+  if (facts === undefined || facts.length === 0) {
+    return EMPTY_BINDING_FACTS;
+  }
+
+  return deepFreeze([...facts]);
+}
+
+function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet<object>()): DeepReadonly<T> {
+  if (value === null || typeof value !== 'object') {
+    return value as DeepReadonly<T>;
+  }
+
+  const objectValue = value as object;
+  if (seen.has(objectValue)) {
+    return value as DeepReadonly<T>;
+  }
+
+  seen.add(objectValue);
+
+  for (const key of Reflect.ownKeys(objectValue)) {
+    const descriptor = Object.getOwnPropertyDescriptor(objectValue, key);
+    if (descriptor !== undefined && 'value' in descriptor) {
+      deepFreeze(descriptor.value, seen);
+    }
+  }
+
+  return Object.freeze(value) as DeepReadonly<T>;
+}

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -97,6 +97,28 @@ export {
   type ModeMap,
 } from './core/mode-render.js';
 export {
+  BindingFrame,
+  bindingFrame,
+  bindingSnapshot,
+  commandIntent,
+  defineDataRequirement,
+  isBindingSnapshot,
+  type BindingFact,
+  type BindingIssue,
+  type BindingIssueSeverity,
+  type BindingSnapshot,
+  type BindingSnapshotInput,
+  type BindingStatus,
+  type CommandIntent,
+  type CommandIntentId,
+  type CommandIntentOptions,
+  type DataRequirement,
+  type DataRequirementInput,
+  type DeepReadonly,
+  type ProviderId,
+  type RequirementId,
+} from './core/binding.js';
+export {
   blockMetadataReportText,
   blockMetadataSummary,
   blockPackageManifestReportText,

--- a/tests/cycles/DX-034/binding-frame-primitives.test.ts
+++ b/tests/cycles/DX-034/binding-frame-primitives.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bindingFrame,
+  bindingSnapshot,
+  commandIntent,
+  defineDataRequirement,
+} from '../../../packages/bijou/src/index.js';
+
+describe('DX-034A binding snapshot and frame primitives', () => {
+  it('lets a view read immutable provider snapshots through the public frame API', () => {
+    const article = defineDataRequirement({
+      id: 'article',
+      resource: 'docs.article',
+    });
+    const snapshot = bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: article.id,
+      version: 1,
+      status: 'ready',
+      data: { title: 'DX-034' },
+    });
+    const frame = bindingFrame([snapshot]);
+    const intent = commandIntent<{ articleId: string }>('docs.openArticle');
+
+    expect(frame.require<{ title: string }>('article')).toEqual({ title: 'DX-034' });
+    expect(frame.status('article')).toBe('ready');
+    expect(Object.isFrozen(frame.require('article'))).toBe(true);
+    expect(intent.id).toBe('docs.openArticle');
+    expect('execute' in intent).toBe(false);
+    expect('provider' in frame).toBe(false);
+  });
+
+  it('models provider updates as replacement frames through the public API', () => {
+    const firstFrame = bindingFrame([
+      bindingSnapshot({
+        providerId: 'docs.articleProvider',
+        requirementId: 'article',
+        version: 1,
+        status: 'ready',
+        data: { title: 'First' },
+      }),
+    ]);
+    const nextFrame = bindingFrame([
+      bindingSnapshot({
+        providerId: 'docs.articleProvider',
+        requirementId: 'article',
+        version: 2,
+        status: 'ready',
+        data: { title: 'Second' },
+      }),
+    ]);
+
+    expect(firstFrame.require<{ title: string }>('article')).toEqual({ title: 'First' });
+    expect(firstFrame.snapshot('article')?.version).toBe(1);
+    expect(nextFrame.require<{ title: string }>('article')).toEqual({ title: 'Second' });
+    expect(nextFrame.snapshot('article')?.version).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

This PR lands DX-034A, the first runtime-truth implementation slice for declarative view data binding.

It adds pure `@flyingrobots/bijou` binding primitives:

- `DataRequirement`
- `BindingSnapshot`
- `BindingFrame`
- `BindingStatus`
- `BindingIssue`
- `BindingFact`
- `CommandIntent`
- `defineDataRequirement()`
- `bindingSnapshot()`
- `bindingFrame()`
- `commandIntent()`
- `isBindingSnapshot()`

## Why

DX-034 established the data loop: business logic/providers publish immutable snapshots, active views render snapshots, views emit Commands as intent, and business logic owns change. This PR proves the small core objects before adding provider scopes, subscriptions, active hierarchy traversal, schema adapters, command dispatch, or AppShell composition.

## Behavior

- Snapshots normalize provider and requirement ids.
- Snapshots require positive integer versions and known `ready` / `loading` / `empty` / `stale` / `error` statuses.
- Snapshot data, issues, and facts are deeply frozen.
- `BindingFrame` rejects duplicate requirement ids and loose snapshot-shaped objects.
- `BindingFrame` exposes read-only `ids()`, `snapshot()`, `require()`, `get()`, `status()`, `issues()`, and `facts()` accessors.
- Frames expose no provider handles, refresh methods, subscription methods, or mutable data bags.
- Command intents are inspectable metadata, not business-logic callbacks.

## Validation

- `npm test -- --run packages/bijou/src/core/binding.test.ts tests/cycles/DX-034/binding-frame-primitives.test.ts`
- `npm test -- --run packages/bijou/src/core/binding.test.ts tests/cycles/DX-034/declarative-view-data-binding.test.ts tests/cycles/DX-034/binding-frame-primitives.test.ts`
- `npm run typecheck:test`
- `npm run docs:inventory`
- `npm run lint`
- `git diff --check`
- full `npm test`: 282 files, 3303 tests passed
- pre-commit reran lint and lockfile consistency
- pre-push reran `npm run typecheck:test`, full `npm test`, and scripted interactive example smoke