### PR TITLE
docs(binding): design active binding lifecycle

### DIFF
--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -471,6 +471,112 @@ such blocks. The composition exposes the nested blocks' declared view data
 contracts and command intents for tooling without adding provider handles or
 render-time mutation paths.
 
+### DX-034D Active Binding Lifecycle
+
+DX-034D formalizes the active binding lifecycle before rendered AppShell or
+runtime provider subscriptions begin.
+
+Core invariant:
+
+```text
+Active hierarchy owns which bindings are active.
+Providers publish snapshots.
+Runtime assembles new frames.
+Views render frames.
+Commands leave views as intent.
+Business logic owns change.
+```
+
+This slice is design-only. It defines lifecycle ownership and vocabulary; it
+does not implement provider subscriptions, active hierarchy traversal, command
+dispatch, rendered AppShell, schema binding, cache retention, or DOGFOOD
+integration.
+
+#### Lifecycle Ownership
+
+The active view hierarchy owns binding lifetime.
+
+A data requirement becomes active when all of these are true:
+
+1. a block or view declares the requirement through an inspectable data contract
+2. that block or view is present in the active hierarchy
+3. the runtime resolves the requirement against an explicit provider scope
+4. the runtime creates binding ownership for that active view node
+
+Views never choose their own binding state. Views do not subscribe, refresh,
+dispose, retain cache, or mutate provider state. The runtime owns lifecycle
+transitions and provider subscription policy.
+
+#### Lifecycle Vocabulary
+
+Use the smallest useful lifecycle vocabulary first:
+
+- `active`: the requirement is owned by the active hierarchy; the runtime may
+  hold a provider subscription; provider snapshots can invalidate the current
+  frame.
+- `suspended`: the requirement is not currently rendering, but runtime/provider
+  policy may retain resumable state or cache. Views do not decide what is
+  retained.
+- `disposed`: the requirement ownership is released. The runtime no longer
+  expects provider updates for that view binding.
+
+Provider cache retention is provider/runtime policy, not view policy. DX-034D
+names lifecycle states but does not implement cache retention.
+
+#### Provider Subscription Ownership
+
+Provider subscriptions are runtime lifecycle. Binding frames are immutable
+render inputs.
+
+Providers may subscribe to channels, messages, queries, files, databases, MCP,
+or in-memory business state internally, but render receives only immutable
+snapshots assembled into a `BindingFrame`. A view never receives provider
+handles, subscription handles, refresh methods, mutable stores, or dispatcher
+callbacks.
+
+#### Provider Update Flow
+
+Provider updates do not mutate rendered views or existing frames.
+
+The lifecycle flow is:
+
+```text
+provider publishes snapshot
+  -> runtime records binding invalidation
+  -> runtime assembles next BindingFrame
+  -> active view renders the next frame
+```
+
+Invalidation belongs to runtime binding ownership, not to rendered cells. Static,
+pipe, and accessible modes must be able to observe lifecycle facts such as
+active, suspended, disposed, loading, stale, empty, error, and invalidated
+without parsing terminal output.
+
+#### Command Flow
+
+Commands leave views as intent records.
+
+Views may emit declared command intents, but they do not dispatch business
+logic, call provider methods, or mutate provider inputs. Runtime command
+integration receives command intent records and hands them to business logic.
+Business logic handles Commands, updates state or provider inputs, and providers
+eventually publish new snapshots.
+
+#### Active Lifecycle Questions
+
+DX-034D answers:
+
+- When does a requirement become active?
+- Who owns the binding while a view is active?
+- What happens when a view leaves the active hierarchy?
+- What is suspended versus disposed?
+- Who owns provider subscriptions?
+- How does a provider update become a new `BindingFrame`?
+- How do Commands leave views?
+- Who dispatches Commands to business logic?
+- What lifecycle facts are inspectable?
+- What lower-mode facts survive static, pipe, and accessible output?
+
 ### 5. User Input Emits Commands
 
 Views communicate user intent through Commands:
@@ -679,12 +785,14 @@ flow.
 8. Done: integrate view data and command contracts with DX-031 block definitions.
 9. Done: add a structural AppShell composition contract for semantic slots,
    explicit provider scopes, and nested block data/command introspection.
-10. Next: add active-view binding collection over the existing view-stack model.
-11. Next: add invalidation flow from provider snapshot updates to view re-render.
-12. Next: add Command intent dispatch proof.
-13. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
+10. Done: formalize the active binding lifecycle before runtime subscriptions
+   or rendered AppShell begin.
+11. Next: add active-view binding collection over the existing view-stack model.
+12. Next: add invalidation flow from provider snapshot updates to view re-render.
+13. Next: add Command intent dispatch proof.
+14. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
    and status blocks.
-14. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
+15. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
     error binding states.
 
 ## Tests To Write First
@@ -695,6 +803,9 @@ flow.
 - Behavioral tests proving command intents are metadata, not callbacks.
 - Behavioral tests proving provider scopes are explicit local registries without
   hidden globals.
+- Cycle tests proving the active hierarchy owns active binding lifetime,
+  provider subscriptions belong to runtime lifecycle, and binding frames remain
+  immutable render inputs.
 - Runtime tests proving provider scopes resolve nearest-provider wins without
   hidden globals.
 - Runtime tests proving active views create bindings and inactive views dispose
@@ -752,3 +863,12 @@ DX-034B then landed explicit provider/scope metadata. The restraint remains the
 same: `ProviderScope` says which providers are locally available, but it still
 does not perform nearest-scope resolution, subscribe to backing sources,
 invalidate views, or dispatch Commands.
+
+DX-034C landed structural AppShell composition. It proves semantic slots and
+nested block introspection, but still does not render AppShell or invent binding
+lifecycle policy.
+
+DX-034D formalized active binding lifecycle ownership before runtime code. The
+important restraint is that active hierarchy, provider subscriptions,
+invalidation, and command dispatch are runtime responsibilities; views still
+receive immutable frames and emit intent only.

--- a/tests/cycles/DX-034/active-binding-lifecycle.test.ts
+++ b/tests/cycles/DX-034/active-binding-lifecycle.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { readRepoFile } from '../repo.js';
+
+const cycle = () => readRepoFile('docs/design/DX-034-declarative-view-data-binding.md');
+
+describe('DX-034D active binding lifecycle', () => {
+  it('defines the active hierarchy as the owner of active binding lifetime', () => {
+    const section = compact(activeLifecycleSection());
+
+    expect(section).toContain('### DX-034D Active Binding Lifecycle');
+    expect(section).toContain('Active hierarchy owns which bindings are active.');
+    expect(section).toContain('Providers publish snapshots.');
+    expect(section).toContain('Runtime assembles new frames.');
+    expect(section).toContain('Views render frames.');
+    expect(section).toContain('Commands leave views as intent.');
+    expect(section).toContain('Business logic owns change.');
+    expect(section).toContain('The active view hierarchy owns binding lifetime.');
+  });
+
+  it('keeps lifecycle states small and runtime-owned', () => {
+    const section = compact(activeLifecycleSection());
+
+    expect(section).toContain('`active`: the requirement is owned by the active hierarchy');
+    expect(section).toContain('`suspended`: the requirement is not currently rendering');
+    expect(section).toContain('`disposed`: the requirement ownership is released');
+    expect(section).toContain('Views never choose their own binding state.');
+    expect(section).toContain('Provider cache retention is provider/runtime policy, not view policy.');
+  });
+
+  it('separates provider subscriptions from immutable render frames', () => {
+    const section = compact(activeLifecycleSection());
+
+    expect(section).toContain('Provider subscriptions are runtime lifecycle.');
+    expect(section).toContain('Binding frames are immutable render inputs.');
+    expect(section).toContain('render receives only immutable snapshots assembled into a `BindingFrame`');
+    expect(section).toContain('A view never receives provider handles');
+    expect(section).toContain('subscription handles');
+    expect(section).toContain('refresh methods');
+    expect(section).toContain('mutable stores');
+    expect(section).toContain('dispatcher callbacks');
+  });
+
+  it('defines provider update invalidation without frame mutation', () => {
+    const section = compact(activeLifecycleSection());
+
+    expect(section).toContain('Provider updates do not mutate rendered views or existing frames.');
+    expect(section).toContain('provider publishes snapshot');
+    expect(section).toContain('runtime records binding invalidation');
+    expect(section).toContain('runtime assembles next BindingFrame');
+    expect(section).toContain('active view renders the next frame');
+    expect(section).toContain('Invalidation belongs to runtime binding ownership, not to rendered cells.');
+  });
+
+  it('keeps Commands as intent and business logic as the owner of change', () => {
+    const section = compact(activeLifecycleSection());
+
+    expect(section).toContain('Commands leave views as intent records.');
+    expect(section).toContain('Views may emit declared command intents');
+    expect(section).toContain('they do not dispatch business logic');
+    expect(section).toContain('Business logic handles Commands, updates state or provider inputs');
+    expect(section).toContain('providers eventually publish new snapshots');
+  });
+
+  it('keeps rendered AppShell and runtime implementation out of this design slice', () => {
+    const section = compact(activeLifecycleSection());
+
+    expect(section).toContain('This slice is design-only.');
+    expect(section).toContain('does not implement provider subscriptions');
+    expect(section).toContain('active hierarchy traversal');
+    expect(section).toContain('command dispatch');
+    expect(section).toContain('rendered AppShell');
+    expect(section).toContain('schema binding');
+    expect(section).toContain('cache retention');
+    expect(section).toContain('DOGFOOD integration');
+  });
+});
+
+function activeLifecycleSection(): string {
+  const document = cycle();
+  const start = document.indexOf('### DX-034D Active Binding Lifecycle');
+  const end = document.indexOf('### 5. User Input Emits Commands');
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return document.slice(start, end);
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/g, ' ');
+}


### PR DESCRIPTION
## Summary

Adds the DX-034D active binding lifecycle design checkpoint.

This formalizes how the active view hierarchy owns binding activation, how providers publish snapshots, how runtime invalidation produces new immutable `BindingFrame`s, and how Commands leave views as user intent handled by business logic.

This is design/test-only. It does not implement provider subscriptions, active hierarchy traversal, command dispatch, rendered AppShell, schema binding, cache retention policy, or DOGFOOD integration.

## Validation

- `npm test -- --run tests/cycles/DX-034/active-binding-lifecycle.test.ts tests/cycles/DX-034/declarative-view-data-binding.test.ts`
- `npm run docs:inventory`
- `npm run typecheck:test`
- `git diff --check`
- `npm run lint`
- `npm test`
- `npm run verify:interactive-examples`
- Pre-push hook reran `npm run typecheck:test`, `npm test`, and `npm run verify:interactive-examples`

Full suite: 286 test files passed, 3330 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added formal specification defining the active binding lifecycle design layer for declarative data binding.

* **Tests**
  * Added comprehensive test suite validating active binding lifecycle design requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->