### PR TITLE
feat(binding): add lifecycle primitives

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Binding lifecycle primitives for `bijou`** — `@flyingrobots/bijou` now
+  exports lifecycle owners, immutable lifecycle records, deterministic
+  `active`/`suspended`/`disposed` transitions, invalidation records, and
+  lifecycle facts for the DX-034E transition-algebra slice. These are pure
+  contract/value-object primitives: provider subscriptions, active hierarchy
+  traversal, command dispatch, rendered AppShell, schema binding, cache
+  retention, and DOGFOOD integration remain follow-on work.
 - **Binding frame primitives for `bijou`** — `@flyingrobots/bijou` now exports
   `DataRequirement`, `BindingSnapshot`, `BindingFrame`, `BindingStatus`,
   `BindingIssue`, `BindingFact`, `DataProvider`, `ProviderScope`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,11 +12,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   exports lifecycle owners, immutable lifecycle records, deterministic
   `active`/`suspended`/`disposed` transitions, invalidation records, and
   lifecycle facts for the DX-034E transition-algebra slice. These are pure
-  contract/value-object primitives: runtime brand checks require own constructor
-  markers, rehydrated transition histories must remain contiguous, and provider
-  subscriptions, active hierarchy traversal, command dispatch, rendered
-  AppShell, schema binding, cache retention, and DOGFOOD integration remain
-  follow-on work.
+  contract/value-object primitives: provider subscriptions, active hierarchy
+  traversal, command dispatch, rendered AppShell, schema binding, cache
+  retention, and DOGFOOD integration remain follow-on work. Runtime brand checks
+  require own constructor markers, and rehydrated transition histories must
+  remain contiguous.
 - **Binding frame primitives for `bijou`** — `@flyingrobots/bijou` now exports
   `DataRequirement`, `BindingSnapshot`, `BindingFrame`, `BindingStatus`,
   `BindingIssue`, `BindingFact`, `DataProvider`, `ProviderScope`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,9 +12,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   exports lifecycle owners, immutable lifecycle records, deterministic
   `active`/`suspended`/`disposed` transitions, invalidation records, and
   lifecycle facts for the DX-034E transition-algebra slice. These are pure
-  contract/value-object primitives: provider subscriptions, active hierarchy
-  traversal, command dispatch, rendered AppShell, schema binding, cache
-  retention, and DOGFOOD integration remain follow-on work.
+  contract/value-object primitives: runtime brand checks require own constructor
+  markers, rehydrated transition histories must remain contiguous, and provider
+  subscriptions, active hierarchy traversal, command dispatch, rendered
+  AppShell, schema binding, cache retention, and DOGFOOD integration remain
+  follow-on work.
 - **Binding frame primitives for `bijou`** — `@flyingrobots/bijou` now exports
   `DataRequirement`, `BindingSnapshot`, `BindingFrame`, `BindingStatus`,
   `BindingIssue`, `BindingFact`, `DataProvider`, `ProviderScope`,

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -577,6 +577,58 @@ DX-034D answers:
 - What lifecycle facts are inspectable?
 - What lower-mode facts survive static, pipe, and accessible output?
 
+### DX-034E Binding Lifecycle Primitives
+
+DX-034E implements lifecycle as transition algebra, not as a runtime manager.
+
+The primitives answer what state a binding is in, who owns it, what transition
+produced the next record, what invalidation happened, and what lifecycle facts
+tooling can inspect.
+
+They do not subscribe, refresh, dispatch, traverse the active view tree, render
+AppShell, retain caches, or bind schemas.
+
+The public vocabulary stays deliberately small:
+
+- `BindingLifecycleOwner`: the active-view, block, AppShell, or runtime owner
+  responsible for one binding lifetime.
+- `BindingLifecycleRecord`: an immutable record for one owner and one
+  requirement.
+- `BindingLifecycleState`: `active`, `suspended`, and `disposed`.
+- `BindingLifecycleTransition`: the immutable record of an activation,
+  suspension, disposal, or invalidation transition.
+- `BindingInvalidation`: an immutable fact that a provider update, scope
+  change, manual runtime action, owner suspension, or owner disposal means a
+  later runtime layer should assemble a new frame.
+
+Allowed transitions are:
+
+```text
+active -> suspended
+active -> disposed
+suspended -> active
+suspended -> disposed
+active -> active by invalidation only
+suspended -> suspended by invalidation only
+```
+
+Disposed bindings cannot be activated, suspended, or invalidated. A disposed
+binding means ownership was released; later activation requires a new lifecycle
+record and a new ownership event.
+
+Provider updates create invalidation records. They do not mutate existing
+frames, fetch data, call providers, or dispatch Commands:
+
+```text
+provider publishes snapshot
+  -> runtime creates BindingInvalidation
+  -> runtime later assembles next BindingFrame
+```
+
+Lifecycle records are immutable facts, not managers. They expose no provider
+handles, subscription handles, refresh methods, command dispatch callbacks,
+mutable stores, or render hooks.
+
 ### 5. User Input Emits Commands
 
 Views communicate user intent through Commands:
@@ -787,12 +839,14 @@ flow.
    explicit provider scopes, and nested block data/command introspection.
 10. Done: formalize the active binding lifecycle before runtime subscriptions
    or rendered AppShell begin.
-11. Next: add active-view binding collection over the existing view-stack model.
-12. Next: add invalidation flow from provider snapshot updates to view re-render.
-13. Next: add Command intent dispatch proof.
-14. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
+11. Done: add binding lifecycle primitives as immutable transition-algebra
+   value objects.
+12. Next: add active-view binding collection over the existing view-stack model.
+13. Next: add invalidation flow from provider snapshot updates to view re-render.
+14. Next: add Command intent dispatch proof.
+15. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
    and status blocks.
-15. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
+16. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
     error binding states.
 
 ## Tests To Write First
@@ -806,6 +860,8 @@ flow.
 - Cycle tests proving the active hierarchy owns active binding lifetime,
   provider subscriptions belong to runtime lifecycle, and binding frames remain
   immutable render inputs.
+- Behavioral tests proving lifecycle records are immutable transition-algebra
+  facts with active, suspended, disposed, and invalidated states.
 - Runtime tests proving provider scopes resolve nearest-provider wins without
   hidden globals.
 - Runtime tests proving active views create bindings and inactive views dispose
@@ -872,3 +928,8 @@ DX-034D formalized active binding lifecycle ownership before runtime code. The
 important restraint is that active hierarchy, provider subscriptions,
 invalidation, and command dispatch are runtime responsibilities; views still
 receive immutable frames and emit intent only.
+
+DX-034E landed binding lifecycle primitives as transition algebra. The restraint
+is that lifecycle records are immutable facts, not managers: they do not
+subscribe, refresh, dispatch, traverse the active hierarchy, render AppShell,
+retain caches, or bind schemas.

--- a/packages/bijou/src/core/binding-lifecycle.test.ts
+++ b/packages/bijou/src/core/binding-lifecycle.test.ts
@@ -199,6 +199,15 @@ describe('binding lifecycle primitives', () => {
       state: 'active',
       transitions: [{ from: 'disposed', to: 'active', reason: 'activate' }],
     })).toThrow('binding transition: disposed bindings cannot transition to active');
+    expect(() => bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      state: 'disposed',
+      transitions: [
+        { from: 'active', to: 'suspended', reason: 'suspend' },
+        { from: 'active', to: 'disposed', reason: 'dispose' },
+      ],
+    })).toThrow('binding lifecycle: transition chain is discontinuous at index 1');
 
     const record = activeRecord();
     const inheritedRecord = Object.create(record);

--- a/packages/bijou/src/core/binding-lifecycle.test.ts
+++ b/packages/bijou/src/core/binding-lifecycle.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import { commandIntent } from './binding.js';
+import {
+  activateBinding,
+  bindingLifecycleRecord,
+  defineBindingLifecycleOwner,
+  disposeBinding,
+  invalidateBinding,
+  isBindingLifecycleOwner,
+  isBindingLifecycleRecord,
+  suspendBinding,
+  type BindingInvalidation,
+  type BindingLifecycleState,
+} from './binding-lifecycle.js';
+
+describe('binding lifecycle primitives', () => {
+  it('creates active immutable lifecycle records for owned requirements', () => {
+    const owner = defineBindingLifecycleOwner({
+      id: ' reader.view ',
+      kind: ' view ',
+      label: ' Reader View ',
+    });
+    const record = bindingLifecycleRecord({
+      owner,
+      requirementId: ' article ',
+      providerId: ' docs.articleProvider ',
+      facts: [{ kind: 'entity', key: 'binding', value: 'article' }],
+    });
+
+    expect(isBindingLifecycleOwner(owner)).toBe(true);
+    expect(isBindingLifecycleRecord(record)).toBe(true);
+    expect(owner.id).toBe('reader.view');
+    expect(owner.kind).toBe('view');
+    expect(owner.label).toBe('Reader View');
+    expect(record.owner).toBe(owner);
+    expect(record.requirementId).toBe('article');
+    expect(record.providerId).toBe('docs.articleProvider');
+    expect(record.state).toBe('active');
+    expect(record.version).toBe(1);
+    expect(record.invalidations).toEqual([]);
+    expect(record.transitions).toEqual([]);
+    expect(record.facts).toEqual([{ kind: 'entity', key: 'binding', value: 'article' }]);
+    expect(Object.isFrozen(owner)).toBe(true);
+    expect(Object.isFrozen(record)).toBe(true);
+    expect(Object.isFrozen(record.invalidations)).toBe(true);
+    expect(Object.isFrozen(record.transitions)).toBe(true);
+    expect(Object.isFrozen(record.facts)).toBe(true);
+    expect(Object.isFrozen(record.facts[0])).toBe(true);
+  });
+
+  it('suspends active bindings by returning a new frozen record', () => {
+    const active = activeRecord();
+    const suspended = suspendBinding(active);
+
+    expect(active.state).toBe('active');
+    expect(active.version).toBe(1);
+    expect(active.transitions).toEqual([]);
+    expect(suspended.state).toBe('suspended');
+    expect(suspended.version).toBe(2);
+    expect(suspended.transitions).toEqual([
+      { from: 'active', to: 'suspended', reason: 'suspend' },
+    ]);
+    expect(Object.isFrozen(suspended)).toBe(true);
+    expect(Object.isFrozen(suspended.transitions)).toBe(true);
+    expect(Object.isFrozen(suspended.transitions[0])).toBe(true);
+  });
+
+  it('reactivates suspended bindings by returning a new frozen record', () => {
+    const active = activeRecord();
+    const suspended = suspendBinding(active);
+    const reactivated = activateBinding(suspended);
+
+    expect(suspended.state).toBe('suspended');
+    expect(suspended.version).toBe(2);
+    expect(reactivated.state).toBe('active');
+    expect(reactivated.version).toBe(3);
+    expect(reactivated.transitions).toEqual([
+      { from: 'active', to: 'suspended', reason: 'suspend' },
+      { from: 'suspended', to: 'active', reason: 'activate' },
+    ]);
+  });
+
+  it('disposes bindings and rejects later activation, suspension, or invalidation', () => {
+    const active = activeRecord();
+    const disposed = disposeBinding(active);
+
+    expect(active.state).toBe('active');
+    expect(disposed.state).toBe('disposed');
+    expect(disposed.version).toBe(2);
+    expect(disposed.transitions).toEqual([
+      { from: 'active', to: 'disposed', reason: 'dispose' },
+    ]);
+    expect(() => activateBinding(disposed)).toThrow(
+      'binding lifecycle: disposed binding article cannot activate',
+    );
+    expect(() => suspendBinding(disposed)).toThrow(
+      'binding lifecycle: disposed binding article cannot suspend',
+    );
+    expect(() => invalidateBinding(disposed, { reason: 'provider-update' })).toThrow(
+      'binding lifecycle: disposed binding article cannot invalidate',
+    );
+  });
+
+  it('records provider invalidation as a new frozen lifecycle value', () => {
+    const active = activeRecord();
+    const invalidated = invalidateBinding(active, {
+      reason: 'provider-update',
+      snapshotVersion: 2,
+    });
+
+    expect(active.invalidations).toEqual([]);
+    expect(active.transitions).toEqual([]);
+    expect(invalidated.state).toBe('active');
+    expect(invalidated.version).toBe(2);
+    expect(invalidated.invalidations).toEqual([
+      {
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+        reason: 'provider-update',
+        snapshotVersion: 2,
+      },
+    ]);
+    expect(invalidated.transitions).toEqual([
+      { from: 'active', to: 'active', reason: 'invalidate' },
+    ]);
+    expect(Object.isFrozen(invalidated.invalidations)).toBe(true);
+    expect(Object.isFrozen(invalidated.invalidations[0])).toBe(true);
+    expect(() => {
+      (invalidated.invalidations as BindingInvalidation[]).push({
+        requirementId: 'article',
+        reason: 'manual',
+      });
+    }).toThrow(TypeError);
+  });
+
+  it('rejects empty ids, invalid states, and loose lifecycle-shaped objects', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+
+    expect(() => defineBindingLifecycleOwner({ id: '', kind: 'view' })).toThrow(
+      'binding lifecycle owner: id is required',
+    );
+    expect(() => defineBindingLifecycleOwner({
+      id: 'reader.view',
+      kind: 'page' as never,
+    })).toThrow('binding lifecycle owner: unsupported kind page');
+    expect(() => bindingLifecycleRecord({
+      owner: { id: 'reader.view', kind: 'view' } as never,
+      requirementId: 'article',
+    })).toThrow(
+      'binding lifecycle: owner was not created by defineBindingLifecycleOwner()',
+    );
+    expect(() => bindingLifecycleRecord({ owner, requirementId: '   ' })).toThrow(
+      'binding lifecycle: requirementId is required',
+    );
+    expect(() => bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      providerId: '   ',
+    })).toThrow('binding lifecycle: providerId is required');
+    expect(() => bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      state: 'loading' as BindingLifecycleState,
+    })).toThrow('binding lifecycle: unsupported state loading');
+    expect(() => bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      version: 0,
+    })).toThrow('binding lifecycle: version must be a positive integer');
+    expect(() => invalidateBinding(activeRecord(), {
+      reason: 'refresh' as never,
+    })).toThrow('binding invalidation: unsupported reason refresh');
+    expect(() => bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      invalidations: [{ requirementId: 'comments', reason: 'manual' }],
+    })).toThrow(
+      'binding lifecycle: invalidation requirement comments does not match record requirement article',
+    );
+    expect(() => bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      state: 'active',
+      transitions: [{ from: 'active', to: 'disposed', reason: 'dispose' }],
+    })).toThrow(
+      'binding lifecycle: final transition state disposed does not match record state active',
+    );
+    expect(() => bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      state: 'active',
+      transitions: [{ from: 'disposed', to: 'active', reason: 'activate' }],
+    })).toThrow('binding transition: disposed bindings cannot transition to active');
+  });
+
+  it('exposes no provider handles, subscription handles, refresh methods, or dispatch callbacks', () => {
+    const record = invalidateBinding(activeRecord(), {
+      reason: 'provider-update',
+      snapshotVersion: 2,
+    });
+    const invalidation = record.invalidations[0];
+
+    expect('provider' in record).toBe(false);
+    expect('subscription' in record).toBe(false);
+    expect('refresh' in record).toBe(false);
+    expect('subscribe' in record).toBe(false);
+    expect('unsubscribe' in record).toBe(false);
+    expect('dispatch' in record).toBe(false);
+    expect('command' in record).toBe(false);
+    expect('handle' in record).toBe(false);
+    expect('callback' in record).toBe(false);
+    expect('provider' in invalidation).toBe(false);
+    expect('refresh' in invalidation).toBe(false);
+    expect('subscribe' in invalidation).toBe(false);
+    expect('dispatch' in invalidation).toBe(false);
+  });
+
+  it('keeps command intents as metadata and out of lifecycle execution', () => {
+    const intent = commandIntent<{ headingId: string }>('reader.selectHeading');
+    const record = activeRecord();
+
+    expect(intent.id).toBe('reader.selectHeading');
+    expect('execute' in intent).toBe(false);
+    expect('dispatch' in intent).toBe(false);
+    expect('commands' in record).toBe(false);
+    expect('execute' in record).toBe(false);
+    expect('dispatch' in record).toBe(false);
+  });
+});
+
+function activeRecord() {
+  return bindingLifecycleRecord({
+    owner: defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' }),
+    requirementId: 'article',
+    providerId: 'docs.articleProvider',
+  });
+}

--- a/packages/bijou/src/core/binding-lifecycle.test.ts
+++ b/packages/bijou/src/core/binding-lifecycle.test.ts
@@ -135,6 +135,7 @@ describe('binding lifecycle primitives', () => {
 
   it('rejects empty ids, invalid states, and loose lifecycle-shaped objects', () => {
     const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const inheritedOwner = Object.create(owner);
 
     expect(() => defineBindingLifecycleOwner({ id: '', kind: 'view' })).toThrow(
       'binding lifecycle owner: id is required',
@@ -145,6 +146,13 @@ describe('binding lifecycle primitives', () => {
     })).toThrow('binding lifecycle owner: unsupported kind page');
     expect(() => bindingLifecycleRecord({
       owner: { id: 'reader.view', kind: 'view' } as never,
+      requirementId: 'article',
+    })).toThrow(
+      'binding lifecycle: owner was not created by defineBindingLifecycleOwner()',
+    );
+    expect(isBindingLifecycleOwner(inheritedOwner)).toBe(false);
+    expect(() => bindingLifecycleRecord({
+      owner: inheritedOwner,
       requirementId: 'article',
     })).toThrow(
       'binding lifecycle: owner was not created by defineBindingLifecycleOwner()',
@@ -191,6 +199,13 @@ describe('binding lifecycle primitives', () => {
       state: 'active',
       transitions: [{ from: 'disposed', to: 'active', reason: 'activate' }],
     })).toThrow('binding transition: disposed bindings cannot transition to active');
+
+    const record = activeRecord();
+    const inheritedRecord = Object.create(record);
+    expect(isBindingLifecycleRecord(inheritedRecord)).toBe(false);
+    expect(() => suspendBinding(inheritedRecord)).toThrow(
+      'binding lifecycle: record was not created by bindingLifecycleRecord()',
+    );
   });
 
   it('exposes no provider handles, subscription handles, refresh methods, or dispatch callbacks', () => {

--- a/packages/bijou/src/core/binding-lifecycle.ts
+++ b/packages/bijou/src/core/binding-lifecycle.ts
@@ -375,6 +375,19 @@ function freezeTransitions(
   }
 
   const frozenTransitions = transitions.map(freezeTransition);
+  for (let index = 1; index < frozenTransitions.length; index += 1) {
+    const previous = frozenTransitions[index - 1];
+    const current = frozenTransitions[index];
+    if (previous === undefined || current === undefined) {
+      throw new Error(`binding lifecycle: missing transition at index ${index}`);
+    }
+    if (previous.to !== current.from) {
+      throw new Error(
+        `binding lifecycle: transition chain is discontinuous at index ${index}`,
+      );
+    }
+  }
+
   const finalTransition = frozenTransitions.at(-1);
   if (finalTransition !== undefined && finalTransition.to !== expectedState) {
     throw new Error(

--- a/packages/bijou/src/core/binding-lifecycle.ts
+++ b/packages/bijou/src/core/binding-lifecycle.ts
@@ -137,6 +137,7 @@ export function isBindingLifecycleOwner(value: unknown): value is BindingLifecyc
   return Boolean(
     value
       && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, BINDING_LIFECYCLE_OWNER_BRAND)
       && (value as BindingLifecycleOwnerBrandCarrier)[BINDING_LIFECYCLE_OWNER_BRAND] === true,
   );
 }
@@ -192,6 +193,7 @@ export function isBindingLifecycleRecord(value: unknown): value is BindingLifecy
   return Boolean(
     value
       && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, BINDING_LIFECYCLE_RECORD_BRAND)
       && (value as BindingLifecycleRecordBrandCarrier)[BINDING_LIFECYCLE_RECORD_BRAND] === true,
   );
 }

--- a/packages/bijou/src/core/binding-lifecycle.ts
+++ b/packages/bijou/src/core/binding-lifecycle.ts
@@ -1,0 +1,538 @@
+import type {
+  BindingFact,
+  ProviderId,
+  RequirementId,
+} from './binding.js';
+
+const BINDING_LIFECYCLE_OWNER_BRAND: unique symbol = Symbol('BindingLifecycleOwner');
+const BINDING_LIFECYCLE_RECORD_BRAND: unique symbol = Symbol('BindingLifecycleRecord');
+
+export type BindingLifecycleState = 'active' | 'suspended' | 'disposed';
+
+export type BindingLifecycleOwnerKind = 'view' | 'block' | 'app-shell' | 'runtime';
+
+export type BindingInvalidationReason =
+  | 'provider-update'
+  | 'owner-suspended'
+  | 'owner-disposed'
+  | 'scope-changed'
+  | 'manual';
+
+export type BindingLifecycleTransitionReason =
+  | 'activate'
+  | 'suspend'
+  | 'dispose'
+  | 'invalidate';
+
+export interface BindingLifecycleOwnerInput {
+  readonly id: string;
+  readonly kind: string;
+  readonly label?: string;
+}
+
+export interface BindingLifecycleOwner {
+  readonly [BINDING_LIFECYCLE_OWNER_BRAND]: true;
+  readonly id: string;
+  readonly kind: BindingLifecycleOwnerKind;
+  readonly label?: string;
+}
+
+export interface BindingInvalidationInput {
+  readonly reason: BindingInvalidationReason;
+  readonly providerId?: string;
+  readonly snapshotVersion?: number;
+}
+
+export interface BindingInvalidation {
+  readonly requirementId: RequirementId;
+  readonly providerId?: ProviderId;
+  readonly reason: BindingInvalidationReason;
+  readonly snapshotVersion?: number;
+}
+
+export interface BindingLifecycleTransition {
+  readonly from: BindingLifecycleState;
+  readonly to: BindingLifecycleState;
+  readonly reason: BindingLifecycleTransitionReason;
+}
+
+export interface BindingLifecycleRecordInput {
+  readonly owner: BindingLifecycleOwner;
+  readonly requirementId: string;
+  readonly providerId?: string;
+  readonly state?: BindingLifecycleState;
+  readonly version?: number;
+  readonly invalidations?: readonly BindingInvalidation[];
+  readonly transitions?: readonly BindingLifecycleTransition[];
+  readonly facts?: readonly BindingFact[];
+}
+
+export interface BindingLifecycleRecord {
+  readonly [BINDING_LIFECYCLE_RECORD_BRAND]: true;
+  readonly owner: BindingLifecycleOwner;
+  readonly requirementId: RequirementId;
+  readonly providerId?: ProviderId;
+  readonly state: BindingLifecycleState;
+  readonly version: number;
+  readonly invalidations: readonly BindingInvalidation[];
+  readonly transitions: readonly BindingLifecycleTransition[];
+  readonly facts: readonly BindingFact[];
+}
+
+const BINDING_LIFECYCLE_STATES: readonly BindingLifecycleState[] = [
+  'active',
+  'suspended',
+  'disposed',
+];
+const BINDING_LIFECYCLE_OWNER_KINDS: readonly BindingLifecycleOwnerKind[] = [
+  'view',
+  'block',
+  'app-shell',
+  'runtime',
+];
+const BINDING_INVALIDATION_REASONS: readonly BindingInvalidationReason[] = [
+  'provider-update',
+  'owner-suspended',
+  'owner-disposed',
+  'scope-changed',
+  'manual',
+];
+const BINDING_TRANSITION_REASONS: readonly BindingLifecycleTransitionReason[] = [
+  'activate',
+  'suspend',
+  'dispose',
+  'invalidate',
+];
+const EMPTY_BINDING_INVALIDATIONS = Object.freeze([]) as readonly BindingInvalidation[];
+const EMPTY_BINDING_TRANSITIONS = Object.freeze([]) as readonly BindingLifecycleTransition[];
+const EMPTY_BINDING_FACTS = Object.freeze([]) as readonly BindingFact[];
+
+export function defineBindingLifecycleOwner(
+  input: BindingLifecycleOwnerInput,
+): BindingLifecycleOwner {
+  const kind = normalizeRequiredText({
+    scope: 'binding lifecycle owner',
+    field: 'kind',
+    value: input.kind,
+  });
+  if (!isBindingLifecycleOwnerKind(kind)) {
+    throw new Error(`binding lifecycle owner: unsupported kind ${kind}`);
+  }
+
+  const owner = {
+    id: normalizeRequiredText({
+      scope: 'binding lifecycle owner',
+      field: 'id',
+      value: input.id,
+    }),
+    kind,
+    label: optionalTrimmedText(input.label),
+  } as BindingLifecycleOwner;
+
+  Object.defineProperty(owner, BINDING_LIFECYCLE_OWNER_BRAND, { value: true });
+  return Object.freeze(owner);
+}
+
+export function isBindingLifecycleOwner(value: unknown): value is BindingLifecycleOwner {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && (value as BindingLifecycleOwnerBrandCarrier)[BINDING_LIFECYCLE_OWNER_BRAND] === true,
+  );
+}
+
+export function bindingLifecycleRecord(
+  input: BindingLifecycleRecordInput,
+): BindingLifecycleRecord {
+  if (!isBindingLifecycleOwner(input.owner)) {
+    throw new Error(
+      'binding lifecycle: owner was not created by defineBindingLifecycleOwner()',
+    );
+  }
+
+  const state = input.state ?? 'active';
+  if (!isBindingLifecycleState(state)) {
+    throw new Error(`binding lifecycle: unsupported state ${String(state)}`);
+  }
+
+  const version = input.version ?? 1;
+  if (!Number.isInteger(version) || version < 1) {
+    throw new Error('binding lifecycle: version must be a positive integer');
+  }
+
+  const requirementId = normalizeRequiredText({
+    scope: 'binding lifecycle',
+    field: 'requirementId',
+    value: input.requirementId,
+  });
+  const providerId = optionalRequiredText({
+    scope: 'binding lifecycle',
+    field: 'providerId',
+    value: input.providerId,
+  });
+  const invalidations = freezeInvalidations(input.invalidations, requirementId);
+  const transitions = freezeTransitions(input.transitions, state);
+
+  const record = {
+    owner: input.owner,
+    requirementId,
+    providerId,
+    state,
+    version,
+    invalidations,
+    transitions,
+    facts: freezeFacts(input.facts),
+  } as BindingLifecycleRecord;
+
+  Object.defineProperty(record, BINDING_LIFECYCLE_RECORD_BRAND, { value: true });
+  return Object.freeze(record);
+}
+
+export function isBindingLifecycleRecord(value: unknown): value is BindingLifecycleRecord {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && (value as BindingLifecycleRecordBrandCarrier)[BINDING_LIFECYCLE_RECORD_BRAND] === true,
+  );
+}
+
+export function activateBinding(record: BindingLifecycleRecord): BindingLifecycleRecord {
+  assertLifecycleRecord(record);
+  assertNotDisposed(record, 'activate');
+  if (record.state === 'active') {
+    throw new Error(`binding lifecycle: binding ${record.requirementId} is already active`);
+  }
+
+  return transitionRecord(record, 'active', 'activate');
+}
+
+export function suspendBinding(record: BindingLifecycleRecord): BindingLifecycleRecord {
+  assertLifecycleRecord(record);
+  assertNotDisposed(record, 'suspend');
+  if (record.state === 'suspended') {
+    throw new Error(`binding lifecycle: binding ${record.requirementId} is already suspended`);
+  }
+
+  return transitionRecord(record, 'suspended', 'suspend');
+}
+
+export function disposeBinding(record: BindingLifecycleRecord): BindingLifecycleRecord {
+  assertLifecycleRecord(record);
+  if (record.state === 'disposed') {
+    throw new Error(`binding lifecycle: binding ${record.requirementId} is already disposed`);
+  }
+
+  return transitionRecord(record, 'disposed', 'dispose');
+}
+
+export function invalidateBinding(
+  record: BindingLifecycleRecord,
+  input: BindingInvalidationInput,
+): BindingLifecycleRecord {
+  assertLifecycleRecord(record);
+  assertNotDisposed(record, 'invalidate');
+
+  if (!isBindingInvalidationReason(input.reason)) {
+    throw new Error(`binding invalidation: unsupported reason ${String(input.reason)}`);
+  }
+  if (
+    input.snapshotVersion !== undefined
+    && (!Number.isInteger(input.snapshotVersion) || input.snapshotVersion < 1)
+  ) {
+    throw new Error('binding invalidation: snapshotVersion must be a positive integer');
+  }
+
+  const providerId = optionalRequiredText({
+    scope: 'binding invalidation',
+    field: 'providerId',
+    value: input.providerId,
+  }) ?? record.providerId;
+  const invalidation = freezeInvalidation({
+    requirementId: record.requirementId,
+    providerId,
+    reason: input.reason,
+    snapshotVersion: input.snapshotVersion,
+  });
+
+  return bindingLifecycleRecord({
+    owner: record.owner,
+    requirementId: record.requirementId,
+    providerId: record.providerId,
+    state: record.state,
+    version: record.version + 1,
+    invalidations: [...record.invalidations, invalidation],
+    transitions: [
+      ...record.transitions,
+      freezeTransition({
+        from: record.state,
+        to: record.state,
+        reason: 'invalidate',
+      }),
+    ],
+    facts: record.facts,
+  });
+}
+
+function transitionRecord(
+  record: BindingLifecycleRecord,
+  to: BindingLifecycleState,
+  reason: BindingLifecycleTransitionReason,
+): BindingLifecycleRecord {
+  return bindingLifecycleRecord({
+    owner: record.owner,
+    requirementId: record.requirementId,
+    providerId: record.providerId,
+    state: to,
+    version: record.version + 1,
+    invalidations: record.invalidations,
+    transitions: [
+      ...record.transitions,
+      freezeTransition({
+        from: record.state,
+        to,
+        reason,
+      }),
+    ],
+    facts: record.facts,
+  });
+}
+
+function assertLifecycleRecord(record: BindingLifecycleRecord): void {
+  if (!isBindingLifecycleRecord(record)) {
+    throw new Error(
+      'binding lifecycle: record was not created by bindingLifecycleRecord()',
+    );
+  }
+}
+
+function assertNotDisposed(record: BindingLifecycleRecord, action: string): void {
+  if (record.state === 'disposed') {
+    throw new Error(
+      `binding lifecycle: disposed binding ${record.requirementId} cannot ${action}`,
+    );
+  }
+}
+
+function freezeInvalidations(
+  invalidations: readonly BindingInvalidation[] | undefined,
+  expectedRequirementId: RequirementId,
+): readonly BindingInvalidation[] {
+  if (invalidations === undefined || invalidations.length === 0) {
+    return EMPTY_BINDING_INVALIDATIONS;
+  }
+
+  return Object.freeze(
+    invalidations.map((invalidation) => {
+      const frozen = freezeInvalidation(invalidation);
+      if (frozen.requirementId !== expectedRequirementId) {
+        throw new Error(
+          `binding lifecycle: invalidation requirement ${frozen.requirementId} `
+          + `does not match record requirement ${expectedRequirementId}`,
+        );
+      }
+
+      return frozen;
+    }),
+  );
+}
+
+function freezeInvalidation(invalidation: BindingInvalidation): BindingInvalidation {
+  const reason = invalidation.reason;
+  if (!isBindingInvalidationReason(reason)) {
+    throw new Error(`binding invalidation: unsupported reason ${String(reason)}`);
+  }
+  if (
+    invalidation.snapshotVersion !== undefined
+    && (!Number.isInteger(invalidation.snapshotVersion) || invalidation.snapshotVersion < 1)
+  ) {
+    throw new Error('binding invalidation: snapshotVersion must be a positive integer');
+  }
+
+  return Object.freeze({
+    requirementId: normalizeRequiredText({
+      scope: 'binding invalidation',
+      field: 'requirementId',
+      value: invalidation.requirementId,
+    }),
+    providerId: optionalRequiredText({
+      scope: 'binding invalidation',
+      field: 'providerId',
+      value: invalidation.providerId,
+    }),
+    reason,
+    snapshotVersion: invalidation.snapshotVersion,
+  });
+}
+
+function freezeTransitions(
+  transitions: readonly BindingLifecycleTransition[] | undefined,
+  expectedState: BindingLifecycleState,
+): readonly BindingLifecycleTransition[] {
+  if (transitions === undefined || transitions.length === 0) {
+    return EMPTY_BINDING_TRANSITIONS;
+  }
+
+  const frozenTransitions = transitions.map(freezeTransition);
+  const finalTransition = frozenTransitions.at(-1);
+  if (finalTransition !== undefined && finalTransition.to !== expectedState) {
+    throw new Error(
+      `binding lifecycle: final transition state ${finalTransition.to} `
+      + `does not match record state ${expectedState}`,
+    );
+  }
+
+  return Object.freeze(frozenTransitions);
+}
+
+function freezeTransition(
+  transition: BindingLifecycleTransition,
+): BindingLifecycleTransition {
+  if (!isBindingLifecycleState(transition.from)) {
+    throw new Error(`binding transition: unsupported from state ${String(transition.from)}`);
+  }
+  if (!isBindingLifecycleState(transition.to)) {
+    throw new Error(`binding transition: unsupported to state ${String(transition.to)}`);
+  }
+  if (!isBindingTransitionReason(transition.reason)) {
+    throw new Error(`binding transition: unsupported reason ${String(transition.reason)}`);
+  }
+  assertAllowedTransition(transition);
+
+  return Object.freeze({
+    from: transition.from,
+    to: transition.to,
+    reason: transition.reason,
+  });
+}
+
+function assertAllowedTransition(transition: BindingLifecycleTransition): void {
+  if (transition.from === 'disposed') {
+    throw new Error(`binding transition: disposed bindings cannot transition to ${transition.to}`);
+  }
+
+  const expectedReason = expectedTransitionReason(transition.from, transition.to);
+  if (expectedReason === undefined) {
+    throw new Error(`binding transition: unsupported ${transition.from} -> ${transition.to}`);
+  }
+  if (transition.reason !== expectedReason) {
+    throw new Error(
+      `binding transition: reason ${transition.reason} does not match `
+      + `${transition.from} -> ${transition.to}`,
+    );
+  }
+}
+
+function expectedTransitionReason(
+  from: BindingLifecycleState,
+  to: BindingLifecycleState,
+): BindingLifecycleTransitionReason | undefined {
+  if (from === 'active' && to === 'suspended') {
+    return 'suspend';
+  }
+  if (from === 'active' && to === 'disposed') {
+    return 'dispose';
+  }
+  if (from === 'suspended' && to === 'active') {
+    return 'activate';
+  }
+  if (from === 'suspended' && to === 'disposed') {
+    return 'dispose';
+  }
+  if ((from === 'active' || from === 'suspended') && from === to) {
+    return 'invalidate';
+  }
+
+  return undefined;
+}
+
+function freezeFacts(facts: readonly BindingFact[] | undefined): readonly BindingFact[] {
+  if (facts === undefined || facts.length === 0) {
+    return EMPTY_BINDING_FACTS;
+  }
+
+  return deepFreeze([...facts]);
+}
+
+interface BindingLifecycleOwnerBrandCarrier {
+  readonly [BINDING_LIFECYCLE_OWNER_BRAND]?: true;
+}
+
+interface BindingLifecycleRecordBrandCarrier {
+  readonly [BINDING_LIFECYCLE_RECORD_BRAND]?: true;
+}
+
+interface RequiredTextOptions {
+  readonly scope: string;
+  readonly field: string;
+  readonly value: string;
+}
+
+function normalizeRequiredText(options: RequiredTextOptions): string {
+  const normalized = options.value.trim();
+  if (normalized === '') {
+    throw new Error(`${options.scope}: ${options.field} is required`);
+  }
+
+  return normalized;
+}
+
+function optionalRequiredText(
+  options: Omit<RequiredTextOptions, 'value'> & { readonly value?: string },
+): string | undefined {
+  if (options.value === undefined) {
+    return undefined;
+  }
+
+  return normalizeRequiredText({
+    scope: options.scope,
+    field: options.field,
+    value: options.value,
+  });
+}
+
+function optionalTrimmedText(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized === '' ? undefined : normalized;
+}
+
+function isBindingLifecycleState(value: string): value is BindingLifecycleState {
+  return BINDING_LIFECYCLE_STATES.includes(value as BindingLifecycleState);
+}
+
+function isBindingLifecycleOwnerKind(value: string): value is BindingLifecycleOwnerKind {
+  return BINDING_LIFECYCLE_OWNER_KINDS.includes(value as BindingLifecycleOwnerKind);
+}
+
+function isBindingInvalidationReason(value: string): value is BindingInvalidationReason {
+  return BINDING_INVALIDATION_REASONS.includes(value as BindingInvalidationReason);
+}
+
+function isBindingTransitionReason(value: string): value is BindingLifecycleTransitionReason {
+  return BINDING_TRANSITION_REASONS.includes(value as BindingLifecycleTransitionReason);
+}
+
+function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet<object>()): T {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const objectValue = value as object;
+  if (seen.has(objectValue)) {
+    return value;
+  }
+
+  seen.add(objectValue);
+
+  for (const key of Reflect.ownKeys(objectValue)) {
+    const descriptor = Object.getOwnPropertyDescriptor(objectValue, key);
+    if (descriptor !== undefined && 'value' in descriptor) {
+      deepFreeze(descriptor.value, seen);
+    }
+  }
+
+  return Object.freeze(value);
+}

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -144,6 +144,27 @@ export {
   type ViewDataRequirementEntry,
 } from './core/binding.js';
 export {
+  activateBinding,
+  bindingLifecycleRecord,
+  defineBindingLifecycleOwner,
+  disposeBinding,
+  invalidateBinding,
+  isBindingLifecycleOwner,
+  isBindingLifecycleRecord,
+  suspendBinding,
+  type BindingInvalidation,
+  type BindingInvalidationInput,
+  type BindingInvalidationReason,
+  type BindingLifecycleOwner,
+  type BindingLifecycleOwnerInput,
+  type BindingLifecycleOwnerKind,
+  type BindingLifecycleRecord,
+  type BindingLifecycleRecordInput,
+  type BindingLifecycleState,
+  type BindingLifecycleTransition,
+  type BindingLifecycleTransitionReason,
+} from './core/binding-lifecycle.js';
+export {
   AppShellComposition,
   defineAppShellComposition,
   isAppShellComposition,

--- a/tests/cycles/DX-034/binding-lifecycle-primitives.test.ts
+++ b/tests/cycles/DX-034/binding-lifecycle-primitives.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activateBinding,
+  bindingLifecycleRecord,
+  commandIntent,
+  defineBindingLifecycleOwner,
+  disposeBinding,
+  invalidateBinding,
+  isBindingLifecycleRecord,
+  suspendBinding,
+} from '../../../packages/bijou/src/index.js';
+import { readRepoFile } from '../repo.js';
+
+const cycle = () => readRepoFile('docs/design/DX-034-declarative-view-data-binding.md');
+
+describe('DX-034E binding lifecycle primitives', () => {
+  it('models active, suspended, disposed, and invalidated lifecycle facts through the public API', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const active = bindingLifecycleRecord({
+      owner,
+      requirementId: 'article',
+      providerId: 'docs.articleProvider',
+    });
+    const suspended = suspendBinding(active);
+    const reactivated = activateBinding(suspended);
+    const invalidated = invalidateBinding(reactivated, {
+      reason: 'provider-update',
+      snapshotVersion: 2,
+    });
+    const disposed = disposeBinding(invalidated);
+
+    expect(isBindingLifecycleRecord(active)).toBe(true);
+    expect(active.state).toBe('active');
+    expect(suspended.state).toBe('suspended');
+    expect(reactivated.state).toBe('active');
+    expect(invalidated.invalidations).toEqual([
+      {
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+        reason: 'provider-update',
+        snapshotVersion: 2,
+      },
+    ]);
+    expect(disposed.state).toBe('disposed');
+    expect(() => activateBinding(disposed)).toThrow(
+      'binding lifecycle: disposed binding article cannot activate',
+    );
+    expect('provider' in invalidated).toBe(false);
+    expect('subscribe' in invalidated).toBe(false);
+    expect('refresh' in invalidated).toBe(false);
+    expect('dispatch' in invalidated).toBe(false);
+  });
+
+  it('keeps command intent metadata separate from lifecycle transitions', () => {
+    const intent = commandIntent<{ articleId: string }>('docs.openArticle');
+    const lifecycle = bindingLifecycleRecord({
+      owner: defineBindingLifecycleOwner({ id: 'docs.shell', kind: 'app-shell' }),
+      requirementId: 'article',
+    });
+
+    expect(intent.id).toBe('docs.openArticle');
+    expect('execute' in intent).toBe(false);
+    expect('dispatch' in intent).toBe(false);
+    expect('commands' in lifecycle).toBe(false);
+    expect('dispatch' in lifecycle).toBe(false);
+  });
+
+  it('documents DX-034E as transition algebra, not runtime management', () => {
+    const section = compact(bindingLifecyclePrimitivesSection());
+
+    expect(section).toContain('### DX-034E Binding Lifecycle Primitives');
+    expect(section).toContain('DX-034E implements lifecycle as transition algebra');
+    expect(section).toContain('answer what state a binding is in, who owns it');
+    expect(section).toContain('They do not subscribe, refresh, dispatch, traverse the active view tree');
+    expect(section).toContain('`active`, `suspended`, and `disposed`');
+    expect(section).toContain('Provider updates create invalidation records');
+    expect(section).toContain('Lifecycle records are immutable facts, not managers.');
+  });
+
+  it('records the public API slice without claiming runtime lifecycle implementation', () => {
+    const changelog = readRepoFile('docs/CHANGELOG.md');
+
+    expect(changelog).toContain('Binding lifecycle primitives for `bijou`');
+    expect(changelog).toContain('lifecycle owners');
+    expect(changelog).toContain('immutable lifecycle records');
+    expect(changelog).toContain('provider subscriptions');
+    expect(changelog).toContain('remain follow-on work');
+  });
+});
+
+function bindingLifecyclePrimitivesSection(): string {
+  const document = cycle();
+  const start = document.indexOf('### DX-034E Binding Lifecycle Primitives');
+  const end = document.indexOf('### 5. User Input Emits Commands');
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return document.slice(start, end);
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/g, ' ');
+}


### PR DESCRIPTION
## Summary

Adds DX-034E binding lifecycle primitives to `@flyingrobots/bijou`.

This introduces immutable transition-algebra value objects for binding lifecycle ownership:

- `BindingLifecycleOwner`
- `BindingLifecycleRecord`
- `BindingLifecycleState`
- `BindingLifecycleTransition`
- `BindingInvalidation`
- lifecycle constructors/checkers
- active/suspended/disposed transitions
- invalidation records

This is a pure contract/value-object slice. Lifecycle records are immutable facts, not runtime managers.

Provider updates are represented as invalidation facts; assembling the next `BindingFrame` remains a later runtime integration concern.

## Non-goals

- no provider subscriptions
- no active hierarchy traversal
- no command dispatch
- no rendered AppShell
- no schema binding
- no cache retention policy
- no DOGFOOD integration

## Validation

- `npm test -- --run packages/bijou/src/core/binding-lifecycle.test.ts tests/cycles/DX-034/binding-lifecycle-primitives.test.ts`
- `npm test -- --run packages/bijou/src/core/binding.test.ts packages/bijou/src/core/binding-lifecycle.test.ts packages/bijou/src/core/app-shell-composition.test.ts tests/cycles/DX-034/binding-frame-primitives.test.ts tests/cycles/DX-034/provider-scope-contracts.test.ts tests/cycles/DX-034/app-shell-composition-contract.test.ts tests/cycles/DX-034/active-binding-lifecycle.test.ts tests/cycles/DX-034/binding-lifecycle-primitives.test.ts`
- `npm run typecheck:test`
- `npm run docs:inventory`
- `git diff --check`
- `npm run lint`
- `npm test`
- pre-push hook reran `npm run typecheck:test`, `npm test`, and `npm run verify:interactive-examples`

Full suite: 288 test files passed, 3342 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Binding lifecycle primitives: lifecycle owners and immutable value-object records
  * Deterministic state transitions (active, suspended, disposed)
  * Lifecycle invalidation tracking and transition history

* **Documentation**
  * Added binding lifecycle primitives to changelog and design documentation

* **Tests**
  * Added comprehensive binding lifecycle and integration test coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->