### PR TITLE
feat(binding): collect active binding entries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,15 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Active binding collection primitives for `bijou`** —
+  `@flyingrobots/bijou` now exports `ActiveBindingEntry`,
+  `ActiveBindingCollection`, `activeBindingEntry()`,
+  `activeBindingCollection()`, `collectActiveBindings()`, and runtime checkers
+  for the DX-034F collection slice. Collections bind declared data requirements
+  to explicit lifecycle owners, preserve optional provider id metadata, and can
+  produce active lifecycle records without rendering, subscribing, dispatching,
+  caching, resolving provider handles, traversing the active TUI runtime tree,
+  binding schemas, or integrating DOGFOOD.
 - **Binding lifecycle primitives for `bijou`** — `@flyingrobots/bijou` now
   exports lifecycle owners, immutable lifecycle records, deterministic
   `active`/`suspended`/`disposed` transitions, invalidation records, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,10 +13,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   `ActiveBindingCollection`, `activeBindingEntry()`,
   `activeBindingCollection()`, `collectActiveBindings()`, and runtime checkers
   for the DX-034F collection slice. Collections bind declared data requirements
-  to explicit lifecycle owners, preserve optional provider id metadata, and can
-  produce active lifecycle records without rendering, subscribing, dispatching,
-  caching, resolving provider handles, traversing the active TUI runtime tree,
-  binding schemas, or integrating DOGFOOD.
+  to explicit lifecycle owners, preserve optional provider id metadata, collapse
+  repeated owner/requirement declarations into one logical binding unless
+  provider ids conflict, and can produce active lifecycle records without
+  rendering, subscribing, dispatching, caching, resolving provider handles,
+  traversing the active TUI runtime tree, binding schemas, or integrating
+  DOGFOOD.
 - **Binding lifecycle primitives for `bijou`** — `@flyingrobots/bijou` now
   exports lifecycle owners, immutable lifecycle records, deterministic
   `active`/`suspended`/`disposed` transitions, invalidation records, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,10 +15,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   for the DX-034F collection slice. Collections bind declared data requirements
   to explicit lifecycle owners, preserve optional provider id metadata, collapse
   repeated owner/requirement declarations into one logical binding unless
-  provider ids conflict, and can produce active lifecycle records without
-  rendering, subscribing, dispatching, caching, resolving provider handles,
-  traversing the active TUI runtime tree, binding schemas, or integrating
-  DOGFOOD.
+  provider ids conflict, report malformed contract/provider assignment inputs
+  with deterministic domain errors, and can produce active lifecycle records
+  without rendering, subscribing, dispatching, caching, resolving provider
+  handles, traversing the active TUI runtime tree, binding schemas, or
+  integrating DOGFOOD.
 - **Binding lifecycle primitives for `bijou`** — `@flyingrobots/bijou` now
   exports lifecycle owners, immutable lifecycle records, deterministic
   `active`/`suspended`/`disposed` transitions, invalidation records, and

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -629,6 +629,65 @@ Lifecycle records are immutable facts, not managers. They expose no provider
 handles, subscription handles, refresh methods, command dispatch callbacks,
 mutable stores, or render hooks.
 
+### DX-034F Active Binding Collection
+
+DX-034F collects declared active bindings before provider runtime integration.
+
+The collection answers:
+
+```text
+given declared data requirements and explicit lifecycle owners,
+which owner/requirement pairs are active?
+```
+
+It uses `BindingLifecycleOwner` from DX-034E. It does not introduce another
+ownership vocabulary. An active binding entry binds:
+
+- one explicit `BindingLifecycleOwner`
+- one declared `DataRequirement`
+- optional provider id metadata
+
+Collections can produce active `BindingLifecycleRecord` values from those
+entries so the later runtime layer has stable ownership facts to consume:
+
+```ts
+const collection = activeBindingCollection([
+  activeBindingEntry({
+    owner: defineBindingLifecycleOwner({
+      id: 'docs.shell',
+      kind: 'app-shell',
+    }),
+    requirement: articleRequirement,
+    providerId: 'docs.articleProvider',
+  }),
+]);
+
+collection.entries();
+collection.requirements();
+collection.owners();
+collection.lifecycleRecords();
+```
+
+DX-034F also allows declared `ViewDataContract` values to be collected without
+rendering blocks or views:
+
+```ts
+const collection = collectActiveBindings({
+  contracts: [{
+    owner,
+    contract: readerSurfaceBlock.data,
+    providerIds: [
+      { requirementId: 'article', providerId: 'docs.articleProvider' },
+    ],
+  }],
+});
+```
+
+Collection inspects declarations, not rendered output. It does not subscribe,
+refresh, dispatch, render, cache, resolve provider scopes, traverse the real TUI
+runtime tree, bind schemas, or integrate DOGFOOD. Provider ids are metadata
+only; provider handles are not exposed.
+
 ### 5. User Input Emits Commands
 
 Views communicate user intent through Commands:
@@ -841,12 +900,14 @@ flow.
    or rendered AppShell begin.
 11. Done: add binding lifecycle primitives as immutable transition-algebra
    value objects.
-12. Next: add active-view binding collection over the existing view-stack model.
-13. Next: add invalidation flow from provider snapshot updates to view re-render.
-14. Next: add Command intent dispatch proof.
-15. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
+12. Done: add active binding collection primitives for declared owner and
+   requirement pairs.
+13. Next: add active-view binding collection over the existing view-stack model.
+14. Next: add invalidation flow from provider snapshot updates to view re-render.
+15. Next: add Command intent dispatch proof.
+16. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
    and status blocks.
-16. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
+17. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
     error binding states.
 
 ## Tests To Write First
@@ -862,6 +923,9 @@ flow.
   immutable render inputs.
 - Behavioral tests proving lifecycle records are immutable transition-algebra
   facts with active, suspended, disposed, and invalidated states.
+- Behavioral tests proving active binding collections bind declared
+  requirements to explicit lifecycle owners without rendering, subscribing, or
+  dispatching.
 - Runtime tests proving provider scopes resolve nearest-provider wins without
   hidden globals.
 - Runtime tests proving active views create bindings and inactive views dispose
@@ -885,6 +949,8 @@ flow.
 - Views communicate user intent only through Commands.
 - Providers are explicit, scoped, and free of import-time global registration.
 - Active view hierarchy controls which data bindings are active.
+- Active binding collections expose active owner/requirement pairs and lifecycle
+  ownership records before runtime provider integration.
 - Provider updates produce new immutable binding frames.
 - Binding status is visible to tooling and lower modes.
 - Schema-bound blocks compose with provider-bound views but do not replace the
@@ -933,3 +999,8 @@ DX-034E landed binding lifecycle primitives as transition algebra. The restraint
 is that lifecycle records are immutable facts, not managers: they do not
 subscribe, refresh, dispatch, traverse the active hierarchy, render AppShell,
 retain caches, or bind schemas.
+
+DX-034F landed active binding collection primitives. The restraint is that
+collections inspect declarations and produce active lifecycle ownership records;
+they do not subscribe, refresh, dispatch, render, cache, resolve provider
+scopes, traverse the real TUI runtime tree, bind schemas, or integrate DOGFOOD.

--- a/packages/bijou/src/core/active-binding-collection.test.ts
+++ b/packages/bijou/src/core/active-binding-collection.test.ts
@@ -112,10 +112,62 @@ describe('active binding collection primitives', () => {
     expect(Object.isFrozen(collection.lifecycleRecords()[0])).toBe(true);
   });
 
+  it('treats repeated owner and requirement pairs as one logical active binding', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const outline = defineDataRequirement({ id: 'outline', resource: 'docs.outline' });
+    const collection = activeBindingCollection([
+      activeBindingEntry({ owner, requirement: article }),
+      activeBindingEntry({
+        owner,
+        requirement: article,
+        providerId: 'docs.articleProvider',
+      }),
+      activeBindingEntry({ owner, requirement: outline }),
+    ]);
+
+    expect(collection.entries().map((entry) => ({
+      ownerId: entry.owner.id,
+      requirementId: entry.requirement.id,
+      providerId: entry.providerId,
+    }))).toEqual([
+      {
+        ownerId: 'reader.view',
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+      },
+      {
+        ownerId: 'reader.view',
+        requirementId: 'outline',
+        providerId: undefined,
+      },
+    ]);
+    expect(collection.lifecycleRecords()).toHaveLength(2);
+  });
+
+  it('rejects repeated owner and requirement pairs with conflicting provider ids', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+
+    expect(() => activeBindingCollection([
+      activeBindingEntry({
+        owner,
+        requirement: article,
+        providerId: 'docs.articleProvider',
+      }),
+      activeBindingEntry({
+        owner,
+        requirement: article,
+        providerId: 'docs.otherArticleProvider',
+      }),
+    ])).toThrow(
+      'active binding collection: conflicting providers for owner reader.view requirement article',
+    );
+  });
+
   it('rejects duplicate active entries and loose owner, requirement, or entry objects', () => {
     const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
     const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
-    const entry = activeBindingEntry({ owner, requirement: article });
 
     expect(() => activeBindingEntry({
       owner: { id: 'reader.view', kind: 'view' } as never,
@@ -134,9 +186,6 @@ describe('active binding collection primitives', () => {
       requirement: article,
       providerId: '   ',
     })).toThrow('active binding entry: providerId is required');
-    expect(() => activeBindingCollection([entry, entry])).toThrow(
-      'active binding collection: duplicate owner reader.view requirement article',
-    );
     expect(() => activeBindingCollection([{
       owner,
       requirement: article,

--- a/packages/bijou/src/core/active-binding-collection.test.ts
+++ b/packages/bijou/src/core/active-binding-collection.test.ts
@@ -225,6 +225,13 @@ describe('active binding collection primitives', () => {
       contracts: [{
         owner,
         contract: data,
+        providerIds: { length: 0 } as never,
+      }],
+    })).toThrow('active binding collection: providerIds must be an array');
+    expect(() => collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: data,
         providerIds: [null as never],
       }],
     })).toThrow('active binding collection: provider assignment 0 must be an object');

--- a/packages/bijou/src/core/active-binding-collection.test.ts
+++ b/packages/bijou/src/core/active-binding-collection.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commandIntent,
+  defineDataRequirement,
+  defineViewData,
+} from './binding.js';
+import {
+  defineBindingLifecycleOwner,
+} from './binding-lifecycle.js';
+import { defineBlock, type BlockMetadata } from './block-metadata.js';
+import {
+  ActiveBindingCollection,
+  activeBindingCollection,
+  activeBindingEntry,
+  collectActiveBindings,
+  isActiveBindingCollection,
+  isActiveBindingEntry,
+} from './active-binding-collection.js';
+
+const readerMetadata: BlockMetadata = {
+  packageName: '@flyingrobots/bijou',
+  blockName: 'ReaderSurface',
+  family: 'reader',
+  scale: 'section',
+  modes: ['interactive', 'static', 'pipe', 'accessible'],
+  docs: { summary: 'Reader content surface.' },
+  slots: [{ id: 'content', required: true }],
+};
+
+describe('active binding collection primitives', () => {
+  it('creates frozen active binding collections from explicit owner and requirement entries', () => {
+    const owner = defineBindingLifecycleOwner({
+      id: ' docs.shell ',
+      kind: ' app-shell ',
+      label: ' Docs Shell ',
+    });
+    const article = defineDataRequirement({
+      id: ' article ',
+      resource: ' docs.article ',
+      facts: [{ kind: 'entity', key: 'resource', value: 'article' }],
+    });
+    const entry = activeBindingEntry({
+      owner,
+      requirement: article,
+      providerId: ' docs.articleProvider ',
+    });
+    const collection = activeBindingCollection([entry]);
+
+    expect(isActiveBindingEntry(entry)).toBe(true);
+    expect(isActiveBindingCollection(collection)).toBe(true);
+    expect(collection).toBeInstanceOf(ActiveBindingCollection);
+    expect(entry.owner).toBe(owner);
+    expect(entry.requirement).toBe(article);
+    expect(entry.providerId).toBe('docs.articleProvider');
+    expect(collection.entries()).toEqual([entry]);
+    expect(collection.requirements()).toEqual([article]);
+    expect(collection.owners()).toEqual([owner]);
+    expect(collection.get('docs.shell', 'article')).toBe(entry);
+    expect(collection.has('docs.shell', 'article')).toBe(true);
+    expect(collection.byOwner('docs.shell')).toEqual([entry]);
+    expect(collection.byRequirement('article')).toEqual([entry]);
+    expect(Object.isFrozen(entry)).toBe(true);
+    expect(Object.isFrozen(collection)).toBe(true);
+    expect(Object.isFrozen(collection.entries())).toBe(true);
+  });
+
+  it('produces one active lifecycle record per owner and requirement pair', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({
+      id: 'article',
+      resource: 'docs.article',
+      facts: [{ kind: 'entity', key: 'resource', value: 'article' }],
+    });
+    const outline = defineDataRequirement({
+      id: 'outline',
+      resource: 'docs.outline',
+    });
+    const collection = activeBindingCollection([
+      activeBindingEntry({
+        owner,
+        requirement: article,
+        providerId: 'docs.articleProvider',
+      }),
+      activeBindingEntry({
+        owner,
+        requirement: outline,
+      }),
+    ]);
+
+    expect(collection.lifecycleRecords()).toEqual([
+      {
+        owner,
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+        state: 'active',
+        version: 1,
+        invalidations: [],
+        transitions: [],
+        facts: [{ kind: 'entity', key: 'resource', value: 'article' }],
+      },
+      {
+        owner,
+        requirementId: 'outline',
+        state: 'active',
+        version: 1,
+        invalidations: [],
+        transitions: [],
+        facts: [],
+      },
+    ]);
+    expect(Object.isFrozen(collection.lifecycleRecords())).toBe(true);
+    expect(Object.isFrozen(collection.lifecycleRecords()[0])).toBe(true);
+  });
+
+  it('rejects duplicate active entries and loose owner, requirement, or entry objects', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const entry = activeBindingEntry({ owner, requirement: article });
+
+    expect(() => activeBindingEntry({
+      owner: { id: 'reader.view', kind: 'view' } as never,
+      requirement: article,
+    })).toThrow(
+      'active binding entry: owner was not created by defineBindingLifecycleOwner()',
+    );
+    expect(() => activeBindingEntry({
+      owner,
+      requirement: { id: 'article', resource: 'docs.article' } as never,
+    })).toThrow(
+      'active binding entry: requirement was not created by defineDataRequirement()',
+    );
+    expect(() => activeBindingEntry({
+      owner,
+      requirement: article,
+      providerId: '   ',
+    })).toThrow('active binding entry: providerId is required');
+    expect(() => activeBindingCollection([entry, entry])).toThrow(
+      'active binding collection: duplicate owner reader.view requirement article',
+    );
+    expect(() => activeBindingCollection([{
+      owner,
+      requirement: article,
+    } as never])).toThrow(
+      'active binding collection: entry at index 0 was not created by activeBindingEntry()',
+    );
+  });
+
+  it('does not mutate previous collections when with() creates a new collection', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const outline = defineDataRequirement({ id: 'outline', resource: 'docs.outline' });
+    const collectionA = activeBindingCollection([
+      activeBindingEntry({ owner, requirement: article }),
+    ]);
+    const collectionB = collectionA.with(
+      activeBindingEntry({ owner, requirement: outline }),
+    );
+
+    expect(collectionA.entries()).toHaveLength(1);
+    expect(collectionA.has('reader.view', 'outline')).toBe(false);
+    expect(collectionB.entries()).toHaveLength(2);
+    expect(collectionB.has('reader.view', 'outline')).toBe(true);
+    expect(() => {
+      (collectionA.entries() as unknown[]).push(collectionB.entries()[1]);
+    }).toThrow(TypeError);
+  });
+
+  it('exposes no provider handles, subscription handles, render callbacks, or dispatch callbacks', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const entry = activeBindingEntry({
+      owner,
+      requirement: article,
+      providerId: 'docs.articleProvider',
+    });
+    const collection = activeBindingCollection([entry]);
+
+    expect('provider' in entry).toBe(false);
+    expect('providerHandle' in entry).toBe(false);
+    expect('subscription' in entry).toBe(false);
+    expect('refresh' in entry).toBe(false);
+    expect('subscribe' in entry).toBe(false);
+    expect('unsubscribe' in entry).toBe(false);
+    expect('dispatch' in entry).toBe(false);
+    expect('render' in entry).toBe(false);
+    expect('provider' in collection).toBe(false);
+    expect('subscription' in collection).toBe(false);
+    expect('refresh' in collection).toBe(false);
+    expect('subscribe' in collection).toBe(false);
+    expect('dispatch' in collection).toBe(false);
+    expect('render' in collection).toBe(false);
+  });
+
+  it('collects declared view data contracts without executing block render functions', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const outline = defineDataRequirement({ id: 'outline', resource: 'docs.outline' });
+    const data = defineViewData({
+      requirements: [
+        { name: 'article', requirement: article },
+        { name: 'outline', requirement: outline },
+      ],
+    });
+    let renderCalls = 0;
+    const block = defineBlock({
+      metadata: readerMetadata,
+      data,
+      commands: [commandIntent('reader.selectHeading')],
+      render: () => {
+        renderCalls += 1;
+        return { output: 'rendered' };
+      },
+    });
+
+    const collection = collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: block.data!,
+        providerIds: [
+          { requirementId: 'article', providerId: 'docs.articleProvider' },
+        ],
+      }],
+    });
+
+    expect(renderCalls).toBe(0);
+    expect(collection.entries().map((entry) => entry.requirement.id)).toEqual([
+      'article',
+      'outline',
+    ]);
+    expect(collection.get('reader.view', 'article')?.providerId).toBe(
+      'docs.articleProvider',
+    );
+    expect(collection.get('reader.view', 'outline')?.providerId).toBeUndefined();
+    expect('commands' in collection).toBe(false);
+    expect('dispatch' in collection).toBe(false);
+  });
+});

--- a/packages/bijou/src/core/active-binding-collection.test.ts
+++ b/packages/bijou/src/core/active-binding-collection.test.ts
@@ -194,6 +194,68 @@ describe('active binding collection primitives', () => {
     );
   });
 
+  it('rejects malformed contract inputs and provider assignments with domain errors', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const data = defineViewData({
+      requirements: [{ name: 'article', requirement: article }],
+    });
+    const malformedContract = Object.create(data, {
+      requirementIds: { value: () => ['article'] },
+      requirements: { value: () => [null] },
+    });
+
+    expect(() => collectActiveBindings({
+      entries: {} as never,
+    })).toThrow('active binding collection: entries must be an array');
+    expect(() => collectActiveBindings({
+      contracts: {} as never,
+    })).toThrow('active binding collection: contracts must be an array');
+    expect(() => collectActiveBindings({
+      contracts: [null as never],
+    })).toThrow('active binding collection: contract 0 must be an object');
+    expect(() => collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: data,
+        providerIds: {} as never,
+      }],
+    })).toThrow('active binding collection: providerIds must be an array');
+    expect(() => collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: data,
+        providerIds: [null as never],
+      }],
+    })).toThrow('active binding collection: provider assignment 0 must be an object');
+    expect(() => collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: data,
+        providerIds: [{ requirementId: 42, providerId: 'docs.articleProvider' } as never],
+      }],
+    })).toThrow(
+      'active binding collection: provider assignment 0 requirementId must be a string',
+    );
+    expect(() => collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: data,
+        providerIds: [{ requirementId: 'article', providerId: 42 } as never],
+      }],
+    })).toThrow(
+      'active binding collection: provider assignment 0 providerId must be a string',
+    );
+    expect(() => collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: malformedContract,
+      }],
+    })).toThrow(
+      'active binding collection: contract 0 requirement 0 was not created by defineDataRequirement()',
+    );
+  });
+
   it('does not mutate previous collections when with() creates a new collection', () => {
     const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
     const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });

--- a/packages/bijou/src/core/active-binding-collection.ts
+++ b/packages/bijou/src/core/active-binding-collection.ts
@@ -302,11 +302,14 @@ function activeBindingEntriesFromContract(
 function providerAssignmentsByRequirementId(
   assignments: readonly ActiveBindingProviderAssignment[] | undefined,
 ): ReadonlyMap<RequirementId, ProviderId> {
-  if (assignments === undefined || assignments.length === 0) {
+  if (assignments === undefined) {
     return new Map();
   }
   if (!Array.isArray(assignments)) {
     throw new Error('active binding collection: providerIds must be an array');
+  }
+  if (assignments.length === 0) {
+    return new Map();
   }
 
   const providerIds = new Map<RequirementId, ProviderId>();

--- a/packages/bijou/src/core/active-binding-collection.ts
+++ b/packages/bijou/src/core/active-binding-collection.ts
@@ -58,6 +58,7 @@ export class ActiveBindingCollection {
     Object.defineProperty(this, ACTIVE_BINDING_COLLECTION_BRAND, { value: true });
 
     const entriesByKey = new Map<string, ActiveBindingEntry>();
+    const entryIndexesByKey = new Map<string, number>();
     const normalizedEntries: ActiveBindingEntry[] = [];
 
     entries.forEach((entry, index) => {
@@ -68,14 +69,24 @@ export class ActiveBindingCollection {
       }
 
       const key = activeBindingKey(entry.owner.id, entry.requirement.id);
-      if (entriesByKey.has(key)) {
-        throw new Error(
-          `active binding collection: duplicate owner ${entry.owner.id} `
-          + `requirement ${entry.requirement.id}`,
-        );
+      const existingEntry = entriesByKey.get(key);
+      if (existingEntry !== undefined) {
+        const mergedEntry = mergeDuplicateEntry(existingEntry, entry);
+        const existingIndex = entryIndexesByKey.get(key);
+        if (existingIndex === undefined) {
+          throw new Error(
+            `active binding collection: missing index for owner ${entry.owner.id} `
+            + `requirement ${entry.requirement.id}`,
+          );
+        }
+
+        entriesByKey.set(key, mergedEntry);
+        normalizedEntries[existingIndex] = mergedEntry;
+        return;
       }
 
       entriesByKey.set(key, entry);
+      entryIndexesByKey.set(key, normalizedEntries.length);
       normalizedEntries.push(entry);
     });
 
@@ -301,6 +312,33 @@ function providerAssignmentsByRequirementId(
 
 function activeBindingKey(ownerId: string, requirementId: string): string {
   return `${ownerId}\u0000${requirementId}`;
+}
+
+function mergeDuplicateEntry(
+  existingEntry: ActiveBindingEntry,
+  incomingEntry: ActiveBindingEntry,
+): ActiveBindingEntry {
+  if (
+    existingEntry.providerId !== undefined
+    && incomingEntry.providerId !== undefined
+    && existingEntry.providerId !== incomingEntry.providerId
+  ) {
+    throw new Error(
+      `active binding collection: conflicting providers for owner ${incomingEntry.owner.id} `
+      + `requirement ${incomingEntry.requirement.id}`,
+    );
+  }
+
+  const providerId = existingEntry.providerId ?? incomingEntry.providerId;
+  if (providerId === existingEntry.providerId) {
+    return existingEntry;
+  }
+
+  return activeBindingEntry({
+    owner: existingEntry.owner,
+    requirement: existingEntry.requirement,
+    providerId,
+  });
 }
 
 interface ActiveBindingEntryBrandCarrier {

--- a/packages/bijou/src/core/active-binding-collection.ts
+++ b/packages/bijou/src/core/active-binding-collection.ts
@@ -1,0 +1,341 @@
+import {
+  isDataRequirement,
+  isViewDataContract,
+  type DataRequirement,
+  type ProviderId,
+  type RequirementId,
+  type ViewDataContract,
+} from './binding.js';
+import {
+  bindingLifecycleRecord,
+  isBindingLifecycleOwner,
+  type BindingLifecycleOwner,
+  type BindingLifecycleRecord,
+} from './binding-lifecycle.js';
+
+const ACTIVE_BINDING_ENTRY_BRAND: unique symbol = Symbol('ActiveBindingEntry');
+const ACTIVE_BINDING_COLLECTION_BRAND: unique symbol = Symbol('ActiveBindingCollection');
+
+export interface ActiveBindingEntryInput {
+  readonly owner: BindingLifecycleOwner;
+  readonly requirement: DataRequirement;
+  readonly providerId?: string;
+}
+
+export interface ActiveBindingEntry {
+  readonly [ACTIVE_BINDING_ENTRY_BRAND]: true;
+  readonly owner: BindingLifecycleOwner;
+  readonly requirement: DataRequirement;
+  readonly providerId?: ProviderId;
+}
+
+export interface ActiveBindingProviderAssignment {
+  readonly requirementId: string;
+  readonly providerId: string;
+}
+
+export interface ActiveBindingContractInput {
+  readonly owner: BindingLifecycleOwner;
+  readonly contract: ViewDataContract;
+  readonly providerIds?: readonly ActiveBindingProviderAssignment[];
+}
+
+export interface CollectActiveBindingsInput {
+  readonly entries?: readonly ActiveBindingEntry[];
+  readonly contracts?: readonly ActiveBindingContractInput[];
+}
+
+export class ActiveBindingCollection {
+  readonly [ACTIVE_BINDING_COLLECTION_BRAND]!: true;
+  readonly #entries: readonly ActiveBindingEntry[];
+  readonly #entriesByKey: ReadonlyMap<string, ActiveBindingEntry>;
+
+  constructor(entries: readonly ActiveBindingEntry[]) {
+    if (!Array.isArray(entries)) {
+      throw new Error('active binding collection: entries must be an array');
+    }
+
+    Object.defineProperty(this, ACTIVE_BINDING_COLLECTION_BRAND, { value: true });
+
+    const entriesByKey = new Map<string, ActiveBindingEntry>();
+    const normalizedEntries: ActiveBindingEntry[] = [];
+
+    entries.forEach((entry, index) => {
+      if (!isActiveBindingEntry(entry)) {
+        throw new Error(
+          `active binding collection: entry at index ${index} was not created by activeBindingEntry()`,
+        );
+      }
+
+      const key = activeBindingKey(entry.owner.id, entry.requirement.id);
+      if (entriesByKey.has(key)) {
+        throw new Error(
+          `active binding collection: duplicate owner ${entry.owner.id} `
+          + `requirement ${entry.requirement.id}`,
+        );
+      }
+
+      entriesByKey.set(key, entry);
+      normalizedEntries.push(entry);
+    });
+
+    this.#entries = Object.freeze(normalizedEntries);
+    this.#entriesByKey = entriesByKey;
+    Object.freeze(this);
+  }
+
+  entries(): readonly ActiveBindingEntry[] {
+    return Object.freeze([...this.#entries]);
+  }
+
+  requirements(): readonly DataRequirement[] {
+    const requirementsById = new Map<RequirementId, DataRequirement>();
+    this.#entries.forEach((entry) => {
+      if (!requirementsById.has(entry.requirement.id)) {
+        requirementsById.set(entry.requirement.id, entry.requirement);
+      }
+    });
+
+    return Object.freeze([...requirementsById.values()]);
+  }
+
+  owners(): readonly BindingLifecycleOwner[] {
+    const ownersById = new Map<string, BindingLifecycleOwner>();
+    this.#entries.forEach((entry) => {
+      if (!ownersById.has(entry.owner.id)) {
+        ownersById.set(entry.owner.id, entry.owner);
+      }
+    });
+
+    return Object.freeze([...ownersById.values()]);
+  }
+
+  lifecycleRecords(): readonly BindingLifecycleRecord[] {
+    return Object.freeze(
+      this.#entries.map((entry) => bindingLifecycleRecord({
+        owner: entry.owner,
+        requirementId: entry.requirement.id,
+        providerId: entry.providerId,
+        facts: entry.requirement.facts,
+      })),
+    );
+  }
+
+  get(ownerId: string, requirementId: string): ActiveBindingEntry | undefined {
+    return this.#entriesByKey.get(activeBindingKey(
+      normalizeRequiredText({
+        scope: 'active binding collection',
+        field: 'ownerId',
+        value: ownerId,
+      }),
+      normalizeRequiredText({
+        scope: 'active binding collection',
+        field: 'requirementId',
+        value: requirementId,
+      }),
+    ));
+  }
+
+  has(ownerId: string, requirementId: string): boolean {
+    return this.get(ownerId, requirementId) !== undefined;
+  }
+
+  byOwner(ownerId: string): readonly ActiveBindingEntry[] {
+    const normalizedOwnerId = normalizeRequiredText({
+      scope: 'active binding collection',
+      field: 'ownerId',
+      value: ownerId,
+    });
+
+    return Object.freeze(
+      this.#entries.filter((entry) => entry.owner.id === normalizedOwnerId),
+    );
+  }
+
+  byRequirement(requirementId: string): readonly ActiveBindingEntry[] {
+    const normalizedRequirementId = normalizeRequiredText({
+      scope: 'active binding collection',
+      field: 'requirementId',
+      value: requirementId,
+    });
+
+    return Object.freeze(
+      this.#entries.filter((entry) => entry.requirement.id === normalizedRequirementId),
+    );
+  }
+
+  with(entry: ActiveBindingEntry): ActiveBindingCollection {
+    return new ActiveBindingCollection([...this.#entries, entry]);
+  }
+}
+
+export function activeBindingEntry(input: ActiveBindingEntryInput): ActiveBindingEntry {
+  if (!isBindingLifecycleOwner(input.owner)) {
+    throw new Error(
+      'active binding entry: owner was not created by defineBindingLifecycleOwner()',
+    );
+  }
+  if (!isDataRequirement(input.requirement)) {
+    throw new Error(
+      'active binding entry: requirement was not created by defineDataRequirement()',
+    );
+  }
+
+  const entry = {
+    owner: input.owner,
+    requirement: input.requirement,
+    providerId: optionalRequiredText({
+      scope: 'active binding entry',
+      field: 'providerId',
+      value: input.providerId,
+    }),
+  } as ActiveBindingEntry;
+
+  Object.defineProperty(entry, ACTIVE_BINDING_ENTRY_BRAND, { value: true });
+  return Object.freeze(entry);
+}
+
+export function isActiveBindingEntry(value: unknown): value is ActiveBindingEntry {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, ACTIVE_BINDING_ENTRY_BRAND)
+      && (value as ActiveBindingEntryBrandCarrier)[ACTIVE_BINDING_ENTRY_BRAND] === true,
+  );
+}
+
+export function activeBindingCollection(
+  entries: readonly ActiveBindingEntry[],
+): ActiveBindingCollection {
+  return new ActiveBindingCollection(entries);
+}
+
+export function isActiveBindingCollection(value: unknown): value is ActiveBindingCollection {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, ACTIVE_BINDING_COLLECTION_BRAND)
+      && (value as ActiveBindingCollectionBrandCarrier)[ACTIVE_BINDING_COLLECTION_BRAND] === true,
+  );
+}
+
+export function collectActiveBindings(
+  input: CollectActiveBindingsInput,
+): ActiveBindingCollection {
+  if (input === undefined || input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('active binding collection: input must be an object');
+  }
+
+  const entries = [...(input.entries ?? [])];
+  (input.contracts ?? []).forEach((source, index) => {
+    entries.push(...activeBindingEntriesFromContract(source, index));
+  });
+
+  return new ActiveBindingCollection(entries);
+}
+
+function activeBindingEntriesFromContract(
+  source: ActiveBindingContractInput,
+  index: number,
+): readonly ActiveBindingEntry[] {
+  if (!isBindingLifecycleOwner(source.owner)) {
+    throw new Error(
+      `active binding collection: contract ${index} owner was not created by defineBindingLifecycleOwner()`,
+    );
+  }
+  if (!isViewDataContract(source.contract)) {
+    throw new Error(
+      `active binding collection: contract ${index} was not created by defineViewData()`,
+    );
+  }
+
+  const providerIds = providerAssignmentsByRequirementId(source.providerIds);
+  const requirementIds = new Set(source.contract.requirementIds());
+  providerIds.forEach((_, requirementId) => {
+    if (!requirementIds.has(requirementId)) {
+      throw new Error(
+        `active binding collection: provider assignment ${requirementId} `
+        + `does not match contract ${index}`,
+      );
+    }
+  });
+
+  return Object.freeze(
+    source.contract.requirements().map((requirement) => activeBindingEntry({
+      owner: source.owner,
+      requirement,
+      providerId: providerIds.get(requirement.id),
+    })),
+  );
+}
+
+function providerAssignmentsByRequirementId(
+  assignments: readonly ActiveBindingProviderAssignment[] | undefined,
+): ReadonlyMap<RequirementId, ProviderId> {
+  if (assignments === undefined || assignments.length === 0) {
+    return new Map();
+  }
+
+  const providerIds = new Map<RequirementId, ProviderId>();
+  assignments.forEach((assignment) => {
+    const requirementId = normalizeRequiredText({
+      scope: 'active binding collection',
+      field: 'requirementId',
+      value: assignment.requirementId,
+    });
+    if (providerIds.has(requirementId)) {
+      throw new Error(
+        `active binding collection: duplicate provider assignment ${requirementId}`,
+      );
+    }
+
+    providerIds.set(requirementId, normalizeRequiredText({
+      scope: 'active binding collection',
+      field: 'providerId',
+      value: assignment.providerId,
+    }));
+  });
+
+  return providerIds;
+}
+
+function activeBindingKey(ownerId: string, requirementId: string): string {
+  return `${ownerId}\u0000${requirementId}`;
+}
+
+interface ActiveBindingEntryBrandCarrier {
+  readonly [ACTIVE_BINDING_ENTRY_BRAND]?: true;
+}
+
+interface ActiveBindingCollectionBrandCarrier {
+  readonly [ACTIVE_BINDING_COLLECTION_BRAND]?: true;
+}
+
+interface RequiredTextOptions {
+  readonly scope: string;
+  readonly field: string;
+  readonly value: string;
+}
+
+function normalizeRequiredText(options: RequiredTextOptions): string {
+  const normalized = options.value.trim();
+  if (normalized === '') {
+    throw new Error(`${options.scope}: ${options.field} is required`);
+  }
+
+  return normalized;
+}
+
+function optionalRequiredText(
+  options: Omit<RequiredTextOptions, 'value'> & { readonly value?: string },
+): string | undefined {
+  if (options.value === undefined) {
+    return undefined;
+  }
+
+  return normalizeRequiredText({
+    scope: options.scope,
+    field: options.field,
+    value: options.value,
+  });
+}

--- a/packages/bijou/src/core/active-binding-collection.ts
+++ b/packages/bijou/src/core/active-binding-collection.ts
@@ -236,6 +236,12 @@ export function collectActiveBindings(
   if (input === undefined || input === null || typeof input !== 'object' || Array.isArray(input)) {
     throw new Error('active binding collection: input must be an object');
   }
+  if (input.entries !== undefined && !Array.isArray(input.entries)) {
+    throw new Error('active binding collection: entries must be an array');
+  }
+  if (input.contracts !== undefined && !Array.isArray(input.contracts)) {
+    throw new Error('active binding collection: contracts must be an array');
+  }
 
   const entries = [...(input.entries ?? [])];
   (input.contracts ?? []).forEach((source, index) => {
@@ -249,6 +255,9 @@ function activeBindingEntriesFromContract(
   source: ActiveBindingContractInput,
   index: number,
 ): readonly ActiveBindingEntry[] {
+  if (!isObjectRecord(source)) {
+    throw new Error(`active binding collection: contract ${index} must be an object`);
+  }
   if (!isBindingLifecycleOwner(source.owner)) {
     throw new Error(
       `active binding collection: contract ${index} owner was not created by defineBindingLifecycleOwner()`,
@@ -270,9 +279,19 @@ function activeBindingEntriesFromContract(
       );
     }
   });
+  const requirements = source.contract.requirements().map((requirement, requirementIndex) => {
+    if (!isDataRequirement(requirement)) {
+      throw new Error(
+        `active binding collection: contract ${index} requirement ${requirementIndex} `
+        + 'was not created by defineDataRequirement()',
+      );
+    }
+
+    return requirement;
+  });
 
   return Object.freeze(
-    source.contract.requirements().map((requirement) => activeBindingEntry({
+    requirements.map((requirement) => activeBindingEntry({
       owner: source.owner,
       requirement,
       providerId: providerIds.get(requirement.id),
@@ -286,13 +305,33 @@ function providerAssignmentsByRequirementId(
   if (assignments === undefined || assignments.length === 0) {
     return new Map();
   }
+  if (!Array.isArray(assignments)) {
+    throw new Error('active binding collection: providerIds must be an array');
+  }
 
   const providerIds = new Map<RequirementId, ProviderId>();
-  assignments.forEach((assignment) => {
+  assignments.forEach((assignment, index) => {
+    if (!isObjectRecord(assignment)) {
+      throw new Error(
+        `active binding collection: provider assignment ${index} must be an object`,
+      );
+    }
+    if (typeof assignment['requirementId'] !== 'string') {
+      throw new Error(
+        `active binding collection: provider assignment ${index} `
+        + 'requirementId must be a string',
+      );
+    }
+    if (typeof assignment['providerId'] !== 'string') {
+      throw new Error(
+        `active binding collection: provider assignment ${index} providerId must be a string`,
+      );
+    }
+
     const requirementId = normalizeRequiredText({
       scope: 'active binding collection',
       field: 'requirementId',
-      value: assignment.requirementId,
+      value: assignment['requirementId'],
     });
     if (providerIds.has(requirementId)) {
       throw new Error(
@@ -303,7 +342,7 @@ function providerAssignmentsByRequirementId(
     providerIds.set(requirementId, normalizeRequiredText({
       scope: 'active binding collection',
       field: 'providerId',
-      value: assignment.providerId,
+      value: assignment['providerId'],
     }));
   });
 
@@ -312,6 +351,10 @@ function providerAssignmentsByRequirementId(
 
 function activeBindingKey(ownerId: string, requirementId: string): string {
   return `${ownerId}\u0000${requirementId}`;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
 function mergeDuplicateEntry(

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -144,6 +144,19 @@ export {
   type ViewDataRequirementEntry,
 } from './core/binding.js';
 export {
+  ActiveBindingCollection,
+  activeBindingCollection,
+  activeBindingEntry,
+  collectActiveBindings,
+  isActiveBindingCollection,
+  isActiveBindingEntry,
+  type ActiveBindingContractInput,
+  type ActiveBindingEntry,
+  type ActiveBindingEntryInput,
+  type ActiveBindingProviderAssignment,
+  type CollectActiveBindingsInput,
+} from './core/active-binding-collection.js';
+export {
   activateBinding,
   bindingLifecycleRecord,
   defineBindingLifecycleOwner,

--- a/tests/cycles/DX-034/active-binding-collection.test.ts
+++ b/tests/cycles/DX-034/active-binding-collection.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activeBindingCollection,
+  activeBindingEntry,
+  collectActiveBindings,
+  commandIntent,
+  defineBindingLifecycleOwner,
+  defineDataRequirement,
+  defineViewData,
+  isActiveBindingCollection,
+} from '../../../packages/bijou/src/index.js';
+import { readRepoFile } from '../repo.js';
+
+const cycle = () => readRepoFile('docs/design/DX-034-declarative-view-data-binding.md');
+
+describe('DX-034F active binding collection', () => {
+  it('collects active owner and requirement pairs as immutable public contract objects', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'docs.shell', kind: 'app-shell' });
+    const article = defineDataRequirement({
+      id: 'article',
+      resource: 'docs.article',
+    });
+    const collection = activeBindingCollection([
+      activeBindingEntry({
+        owner,
+        requirement: article,
+        providerId: 'docs.articleProvider',
+      }),
+    ]);
+
+    expect(isActiveBindingCollection(collection)).toBe(true);
+    expect(collection.entries().map((entry) => ({
+      ownerId: entry.owner.id,
+      requirementId: entry.requirement.id,
+      providerId: entry.providerId,
+    }))).toEqual([
+      {
+        ownerId: 'docs.shell',
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+      },
+    ]);
+    expect(collection.lifecycleRecords().map((record) => ({
+      ownerId: record.owner.id,
+      requirementId: record.requirementId,
+      providerId: record.providerId,
+      state: record.state,
+    }))).toEqual([
+      {
+        ownerId: 'docs.shell',
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+        state: 'active',
+      },
+    ]);
+    expect('provider' in collection).toBe(false);
+    expect('subscribe' in collection).toBe(false);
+    expect('refresh' in collection).toBe(false);
+    expect('dispatch' in collection).toBe(false);
+    expect('render' in collection).toBe(false);
+  });
+
+  it('collects declared view data contracts without command execution or runtime provider work', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const data = defineViewData({
+      requirements: [{ name: 'article', requirement: article }],
+    });
+    const intent = commandIntent('reader.selectHeading');
+    const collection = collectActiveBindings({
+      contracts: [{
+        owner,
+        contract: data,
+        providerIds: [{ requirementId: 'article', providerId: 'docs.articleProvider' }],
+      }],
+    });
+
+    expect(intent.id).toBe('reader.selectHeading');
+    expect(collection.get('reader.view', 'article')?.providerId).toBe(
+      'docs.articleProvider',
+    );
+    expect(collection.lifecycleRecords()[0]?.state).toBe('active');
+    expect('execute' in intent).toBe(false);
+    expect('commands' in collection).toBe(false);
+    expect('dispatch' in collection).toBe(false);
+  });
+
+  it('documents DX-034F as collection only, not provider runtime integration', () => {
+    const section = compact(activeBindingCollectionSection());
+
+    expect(section).toContain('### DX-034F Active Binding Collection');
+    expect(section).toContain('DX-034F collects declared active bindings');
+    expect(section).toContain('uses `BindingLifecycleOwner`');
+    expect(section).toContain('It does not subscribe, refresh, dispatch, render, cache');
+    expect(section).toContain('Collection inspects declarations, not rendered output.');
+  });
+
+  it('records the public API slice without claiming rendered AppShell or subscriptions', () => {
+    const changelog = readRepoFile('docs/CHANGELOG.md');
+
+    expect(changelog).toContain('Active binding collection primitives for `bijou`');
+    expect(changelog).toContain('declared data requirements');
+    expect(changelog).toContain('explicit lifecycle owners');
+    expect(changelog).toContain('active lifecycle records');
+    expect(changelog).toContain('without rendering, subscribing, dispatching');
+  });
+});
+
+function activeBindingCollectionSection(): string {
+  const document = cycle();
+  const start = document.indexOf('### DX-034F Active Binding Collection');
+  const end = document.indexOf('### 5. User Input Emits Commands');
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return document.slice(start, end);
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/g, ' ');
+}


### PR DESCRIPTION
## Summary

Adds the DX-034F active binding collection contract slice in `@flyingrobots/bijou`. This introduces runtime-backed active binding entries and immutable collections that bind declared data requirements to existing `BindingLifecycleOwner` values, preserve optional provider id metadata, and produce active lifecycle records for later runtime integration.

This PR deliberately does not add provider subscriptions, provider refresh, active TUI runtime traversal, command dispatch, rendered AppShell, schema binding, cache retention, DOGFOOD integration, or hidden global provider lookup. Collection inspects declarations, not rendered output.

## Public API

- `ActiveBindingEntry`
- `ActiveBindingCollection`
- `ActiveBindingProviderAssignment`
- `ActiveBindingContractInput`
- `CollectActiveBindingsInput`
- `activeBindingEntry()`
- `activeBindingCollection()`
- `collectActiveBindings()`
- `isActiveBindingEntry()`
- `isActiveBindingCollection()`

## Validation

- `npm test -- --run packages/bijou/src/core/active-binding-collection.test.ts tests/cycles/DX-034/active-binding-collection.test.ts`
- `npm run typecheck:test`
- `npm run docs:inventory`
- `git diff --check`
- `npm run lint`
- `npm test`
- Pre-push reran `npm run typecheck:test`, `npm test`, and `npm run verify:interactive-examples`

Full suite: 290 test files passed, 3352 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added active binding collection primitives that record declared owner→requirement pairs as immutable lifecycle records without performing rendering, subscribing, dispatching, or provider runtime work.

* **Documentation**
  * Updated design docs and changelog to describe the new collection behavior, acceptance criteria, and constraints.

* **Tests**
  * Added test suites validating immutability, merging/validation rules, lifecycle record shape, and absence of runtime execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->