### PR TITLE
feat(binding): prove active binding runtime loop

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,19 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Runtime binding loop proofs for DX-034** —
+  `@flyingrobots/bijou-tui` now exports runtime binding-source collection over
+  the existing `RuntimeViewStack`, using `blocksBelow` to decide which declared
+  view data contracts are active without rendering, subscribing, refreshing,
+  dispatching, or resolving provider handles. `@flyingrobots/bijou` now exports
+  `bindingFrameUpdateFromSnapshots()` to turn explicit provider snapshots into a
+  new immutable `BindingFrame` plus lifecycle invalidation facts without
+  mutating prior frames or records. `@flyingrobots/bijou-tui` also exports
+  command intent emissions, explicit intent routes, and dispatch helpers that
+  map declared `CommandIntent` metadata into the existing runtime command
+  buffer while business logic applies commands later. Provider subscriptions,
+  active hierarchy lifecycle management, rendered AppShell, schema binding,
+  cache retention, and DOGFOOD integration remain follow-on work.
 - **Active binding collection primitives for `bijou`** —
   `@flyingrobots/bijou` now exports `ActiveBindingEntry`,
   `ActiveBindingCollection`, `activeBindingEntry()`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,16 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   buffer while business logic applies commands later. Provider subscriptions,
   active hierarchy lifecycle management, rendered AppShell, schema binding,
   cache retention, and DOGFOOD integration remain follow-on work.
+- **Runtime binding loop hardening for DX-034** — Runtime binding sources now
+  normalize, copy, and freeze provider assignment objects instead of retaining
+  caller-owned references. Command intent emissions now copy and deeply freeze
+  inert payload data before routing, rejecting hidden mutation channels before a
+  command reaches the runtime buffer. `bindingFrameUpdateFromSnapshots()` now
+  treats explicit active binding provider assignments as authoritative and
+  reports deterministic `provider.assignment-mismatch` issues instead of
+  accepting snapshots from a different provider resolved by resource alone. The
+  new public binding-loop helpers also reject non-object inputs with
+  deterministic domain errors instead of raw `TypeError`s.
 - **Active binding collection primitives for `bijou`** —
   `@flyingrobots/bijou` now exports `ActiveBindingEntry`,
   `ActiveBindingCollection`, `activeBindingEntry()`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   reports deterministic `provider.assignment-mismatch` issues instead of
   accepting snapshots from a different provider resolved by resource alone. The
   new public binding-loop helpers also reject non-object inputs with
-  deterministic domain errors instead of raw `TypeError`s.
+  deterministic domain errors instead of raw `TypeError`s. Runtime binding layer
+  collection now preserves the existing `blocksBelow` semantics used by input
+  routing, and repeated frame updates with the same provider snapshot version do
+  not duplicate lifecycle invalidations.
 - **Active binding collection primitives for `bijou`** —
   `@flyingrobots/bijou` now exports `ActiveBindingEntry`,
   `ActiveBindingCollection`, `activeBindingEntry()`,

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -3109,16 +3109,19 @@ blocks.
    definitions for discovery.
 6. Done: add a structural AppShell composition contract for logical block slots
    and nested data/command introspection without rendering.
-7. Next: add `defineSchemaBlock()` and a Zod schema adapter.
-8. Next: add block stories for `AppShell`, `ReaderSurface`, and
+7. Done: prove active runtime binding collection, provider snapshot
+   invalidation into new immutable frames, and command intent routing before
+   rendered AppShell work begins.
+8. Next: add `defineSchemaBlock()` and a Zod schema adapter.
+9. Next: add block stories for `AppShell`, `ReaderSurface`, and
    `InspectorPanel`.
-9. Next: capture interactive, static, pipe, and accessible outputs for the
+10. Next: capture interactive, static, pipe, and accessible outputs for the
    first implementation set.
-10. Next: prove the first three blocks in DOGFOOD before broadening the
+11. Next: prove the first three blocks in DOGFOOD before broadening the
    catalog.
-11. Next: add catalog-only variant/config metadata for later blocks without
+12. Next: add catalog-only variant/config metadata for later blocks without
    implementing those blocks yet.
-12. Continue to defer modal stacks, notifications, auth forms, animated
+13. Continue to defer modal stacks, notifications, auth forms, animated
    carousels, complex controls, and workspace-like behavior until the first
    rendered block set is proven.
 

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -706,6 +706,10 @@ Layers expose branded `RuntimeViewBindingSource` values, and
 `collectRuntimeViewBindings()` converts active sources into an
 `ActiveBindingCollection`.
 
+Runtime binding sources normalize, copy, and freeze provider assignment metadata
+at construction so later caller mutation cannot change active binding
+collection results.
+
 DX-034G does not subscribe, refresh, dispatch, render, cache, resolve provider
 handles, bind schemas, or integrate DOGFOOD. It only proves that the active
 view hierarchy can identify active owner/requirement pairs.
@@ -725,6 +729,10 @@ provider manager.
 It resolves the collection's requirements against the scope, assembles the next
 immutable `BindingFrame`, and records provider updates as lifecycle
 invalidations. It never mutates the previous frame or lifecycle records.
+Explicit provider assignments carried by active binding entries are
+authoritative: a scope-resolved provider that conflicts with an explicit
+assignment becomes a deterministic `provider.assignment-mismatch` issue rather
+than data in the frame.
 
 ```text
 provider publishes snapshot
@@ -746,6 +754,8 @@ Views emit branded `RuntimeCommandIntentEmission` values from declared
 `RuntimeCommandIntentRoute` values into the existing `RuntimeCommandBuffer`.
 Business logic still handles the resulting command later through the normal
 command-buffer path.
+Emissions copy and deeply freeze inert payload data before routing so caller
+mutation cannot change the command that eventually reaches business logic.
 
 ```text
 view emits command intent

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -697,8 +697,8 @@ The runtime view stack determines which layers contribute active bindings:
 
 - the top layer is active
 - layers below remain active only while each layer above them has
-  `blocksBelow: true`
-- a layer with `blocksBelow: false` blocks lower layers from active binding
+  `blocksBelow: false`
+- a layer with `blocksBelow: true` blocks lower layers from active binding
   ownership
 
 Runtime binding collection still inspects declarations, not rendered output.
@@ -729,6 +729,9 @@ provider manager.
 It resolves the collection's requirements against the scope, assembles the next
 immutable `BindingFrame`, and records provider updates as lifecycle
 invalidations. It never mutates the previous frame or lifecycle records.
+Snapshots whose provider id and version already appear in a lifecycle record's
+provider-update invalidations do not create duplicate invalidations or lifecycle
+churn.
 Explicit provider assignments carried by active binding entries are
 authoritative: a scope-resolved provider that conflicts with an explicit
 assignment becomes a deterministic `provider.assignment-mismatch` issue rather

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -688,6 +688,75 @@ refresh, dispatch, render, cache, resolve provider scopes, traverse the real TUI
 runtime tree, bind schemas, or integrate DOGFOOD. Provider ids are metadata
 only; provider handles are not exposed.
 
+### DX-034G Active View Binding Collection
+
+DX-034G connects the pure active-binding collection contract to the existing
+runtime view-stack model in `@flyingrobots/bijou-tui`.
+
+The runtime view stack determines which layers contribute active bindings:
+
+- the top layer is active
+- layers below remain active only while each layer above them has
+  `blocksBelow: true`
+- a layer with `blocksBelow: false` blocks lower layers from active binding
+  ownership
+
+Runtime binding collection still inspects declarations, not rendered output.
+Layers expose branded `RuntimeViewBindingSource` values, and
+`collectRuntimeViewBindings()` converts active sources into an
+`ActiveBindingCollection`.
+
+DX-034G does not subscribe, refresh, dispatch, render, cache, resolve provider
+handles, bind schemas, or integrate DOGFOOD. It only proves that the active
+view hierarchy can identify active owner/requirement pairs.
+
+### DX-034H Provider Update Invalidation Flow
+
+DX-034H proves the provider-update half of the loop without implementing a
+provider manager.
+
+`bindingFrameUpdateFromSnapshots()` takes:
+
+- an `ActiveBindingCollection`
+- an explicit `ProviderScope`
+- immutable `BindingSnapshot` values
+- optional current lifecycle records
+
+It resolves the collection's requirements against the scope, assembles the next
+immutable `BindingFrame`, and records provider updates as lifecycle
+invalidations. It never mutates the previous frame or lifecycle records.
+
+```text
+provider publishes snapshot
+  -> binding lifecycle records receive invalidation facts
+  -> runtime assembles next immutable BindingFrame
+  -> views later render the new frame
+```
+
+DX-034H does not fetch data, subscribe, refresh providers, retain caches, walk
+the active hierarchy, render AppShell, or dispatch Commands.
+
+### DX-034I Command Intent Dispatch Proof
+
+DX-034I proves the command half of the loop without putting business logic in
+views.
+
+Views emit branded `RuntimeCommandIntentEmission` values from declared
+`CommandIntent` metadata. Runtime code maps those emissions through explicit
+`RuntimeCommandIntentRoute` values into the existing `RuntimeCommandBuffer`.
+Business logic still handles the resulting command later through the normal
+command-buffer path.
+
+```text
+view emits command intent
+  -> runtime maps intent to a command
+  -> command buffer records the command
+  -> business logic applies the command later
+```
+
+Command intents and emissions expose no provider handles, subscription handles,
+refresh methods, dispatch callbacks, mutable stores, or render hooks.
+
 ### 5. User Input Emits Commands
 
 Views communicate user intent through Commands:
@@ -902,9 +971,10 @@ flow.
    value objects.
 12. Done: add active binding collection primitives for declared owner and
    requirement pairs.
-13. Next: add active-view binding collection over the existing view-stack model.
-14. Next: add invalidation flow from provider snapshot updates to view re-render.
-15. Next: add Command intent dispatch proof.
+13. Done: add active-view binding collection over the existing view-stack model.
+14. Done: add invalidation flow from provider snapshot updates to new immutable
+   binding frames.
+15. Done: add Command intent dispatch proof through the runtime command buffer.
 16. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
    and status blocks.
 17. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
@@ -926,6 +996,8 @@ flow.
 - Behavioral tests proving active binding collections bind declared
   requirements to explicit lifecycle owners without rendering, subscribing, or
   dispatching.
+- Runtime tests proving active view-stack layers determine active bindings
+  without rendering, subscribing, or dispatching.
 - Runtime tests proving provider scopes resolve nearest-provider wins without
   hidden globals.
 - Runtime tests proving active views create bindings and inactive views dispose
@@ -952,6 +1024,8 @@ flow.
 - Active binding collections expose active owner/requirement pairs and lifecycle
   ownership records before runtime provider integration.
 - Provider updates produce new immutable binding frames.
+- Command intent emissions enter the runtime command buffer without embedding
+  business logic callbacks in views.
 - Binding status is visible to tooling and lower modes.
 - Schema-bound blocks compose with provider-bound views but do not replace the
   provider lifecycle.
@@ -1004,3 +1078,17 @@ DX-034F landed active binding collection primitives. The restraint is that
 collections inspect declarations and produce active lifecycle ownership records;
 they do not subscribe, refresh, dispatch, render, cache, resolve provider
 scopes, traverse the real TUI runtime tree, bind schemas, or integrate DOGFOOD.
+
+DX-034G landed active view-stack binding collection in `@flyingrobots/bijou-tui`.
+The restraint is that the runtime stack only decides which declared binding
+sources are active; it still does not render, subscribe, refresh, dispatch,
+resolve provider handles, or retain caches.
+
+DX-034H landed provider-update invalidation and frame assembly as a pure
+contract helper. The restraint is that snapshot updates create new immutable
+frames and lifecycle invalidation facts; no provider manager or subscription
+loop exists yet.
+
+DX-034I landed command intent emission and runtime command-buffer routing. The
+restraint is that command routes map intent records to command values; business
+logic still applies commands later through the existing runtime command buffer.

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -109,6 +109,28 @@ export {
   runtimeComponentAcceptsInput,
   transitionRuntimeState,
 } from './runtime-engine.js';
+export type {
+  DispatchRuntimeCommandIntentInput,
+  DispatchRuntimeCommandIntentResult,
+  RuntimeBindingLayerModel,
+  RuntimeCommandIntentEmission,
+  RuntimeCommandIntentEmissionOptions,
+  RuntimeCommandIntentRoute,
+  RuntimeCommandIntentRouteInput,
+  RuntimeViewBindingSource,
+  RuntimeViewBindingSourceInput,
+} from './runtime-binding.js';
+export {
+  collectRuntimeViewBindings,
+  dispatchRuntimeCommandIntent,
+  isRuntimeCommandIntentEmission,
+  isRuntimeCommandIntentRoute,
+  isRuntimeViewBindingSource,
+  runtimeActiveBindingLayers,
+  runtimeCommandIntentEmission,
+  runtimeCommandIntentRoute,
+  runtimeViewBindingSource,
+} from './runtime-binding.js';
 
 // Key parsing
 export { parseKey, parseMouse } from './keys.js';

--- a/packages/bijou-tui/src/runtime-binding.test.ts
+++ b/packages/bijou-tui/src/runtime-binding.test.ts
@@ -119,6 +119,46 @@ describe('runtime active binding collection', () => {
       'runtime binding collection: source at layer docs-shell index 0 was not created by runtimeViewBindingSource()',
     );
   });
+
+  it('copies provider assignments before freezing a runtime binding source', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'docs.shell', kind: 'app-shell' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const data = defineViewData({
+      requirements: [{ name: 'article', requirement: article }],
+    });
+    const assignment = {
+      requirementId: 'article',
+      providerId: 'docs.articleProvider',
+    };
+    const source = runtimeViewBindingSource({
+      owner,
+      contract: data,
+      providerIds: [assignment],
+    });
+    assignment.providerId = 'docs.mutatedProvider';
+    const stack = createRuntimeViewStack({
+      id: 'docs-shell',
+      kind: 'app-shell',
+      dismissible: false,
+      blocksBelow: false,
+      model: { bindingSources: [source] },
+    });
+
+    expect(Object.isFrozen(source.providerIds)).toBe(true);
+    expect(Object.isFrozen(source.providerIds?.[0])).toBe(true);
+    expect(collectRuntimeViewBindings(stack).get('docs.shell', 'article')?.providerId).toBe(
+      'docs.articleProvider',
+    );
+  });
+
+  it('throws deterministic errors for non-object runtime binding source inputs', () => {
+    expect(() => runtimeViewBindingSource(null as never)).toThrow(
+      'runtime binding source: input must be an object',
+    );
+    expect(() => runtimeViewBindingSource([] as never)).toThrow(
+      'runtime binding source: input must be an object',
+    );
+  });
 });
 
 describe('runtime command intent dispatch proof', () => {
@@ -180,6 +220,48 @@ describe('runtime command intent dispatch proof', () => {
       buffer: createRuntimeCommandBuffer(),
     })).toThrow(
       'runtime command intent dispatch: no route for intent reader.refreshRequested',
+    );
+  });
+
+  it('copies and freezes command intent payloads before routing', () => {
+    type Payload = { readonly heading: { readonly id: string } };
+    type Command = { readonly type: 'reader.selectHeading'; readonly headingId: string };
+    const selectHeading = commandIntent<Payload>('reader.selectHeading');
+    const payload = { heading: { id: 'intro' } };
+    const emission = runtimeCommandIntentEmission(selectHeading, payload);
+    const route = runtimeCommandIntentRoute<Payload, Command>({
+      intent: selectHeading,
+      toCommand: (intentEmission) => ({
+        type: 'reader.selectHeading',
+        headingId: intentEmission.payload.heading.id,
+      }),
+    });
+    payload.heading.id = 'mutated';
+
+    const dispatched = dispatchRuntimeCommandIntent({
+      emission,
+      routes: [route],
+      buffer: createRuntimeCommandBuffer<Command>(),
+    });
+
+    expect(Object.isFrozen(emission.payload)).toBe(true);
+    expect(Object.isFrozen(emission.payload.heading)).toBe(true);
+    expect(dispatched.command.headingId).toBe('intro');
+  });
+
+  it('throws deterministic errors for non-object command routing inputs', () => {
+    const intent = commandIntent('reader.refreshRequested');
+
+    expect(() => runtimeCommandIntentEmission(
+      intent,
+      undefined,
+      null as never,
+    )).toThrow('runtime command intent emission: options must be an object');
+    expect(() => runtimeCommandIntentRoute(null as never)).toThrow(
+      'runtime command intent route: input must be an object',
+    );
+    expect(() => dispatchRuntimeCommandIntent(null as never)).toThrow(
+      'runtime command intent dispatch: input must be an object',
     );
   });
 });

--- a/packages/bijou-tui/src/runtime-binding.test.ts
+++ b/packages/bijou-tui/src/runtime-binding.test.ts
@@ -1,0 +1,185 @@
+import {
+  commandIntent,
+  defineBindingLifecycleOwner,
+  defineDataRequirement,
+  defineViewData,
+} from '@flyingrobots/bijou';
+import { describe, expect, it } from 'vitest';
+import {
+  applyRuntimeCommandBuffer,
+  createRuntimeCommandBuffer,
+  createRuntimeViewStack,
+  pushRuntimeView,
+} from './runtime-engine.js';
+import {
+  collectRuntimeViewBindings,
+  dispatchRuntimeCommandIntent,
+  isRuntimeCommandIntentEmission,
+  isRuntimeViewBindingSource,
+  runtimeActiveBindingLayers,
+  runtimeCommandIntentEmission,
+  runtimeCommandIntentRoute,
+  runtimeViewBindingSource,
+  type RuntimeViewBindingSource,
+} from './runtime-binding.js';
+
+describe('runtime active binding collection', () => {
+  it('collects declared bindings from active runtime view layers only', () => {
+    const shellOwner = defineBindingLifecycleOwner({ id: 'docs.shell', kind: 'app-shell' });
+    const helpOwner = defineBindingLifecycleOwner({ id: 'docs.help', kind: 'view' });
+    const modalOwner = defineBindingLifecycleOwner({ id: 'docs.modal', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const helpTopic = defineDataRequirement({ id: 'helpTopic', resource: 'docs.helpTopic' });
+    const modalChoice = defineDataRequirement({ id: 'modalChoice', resource: 'docs.modalChoice' });
+    const shellData = defineViewData({
+      requirements: [{ name: 'article', requirement: article }],
+    });
+    const helpData = defineViewData({
+      requirements: [{ name: 'helpTopic', requirement: helpTopic }],
+    });
+    const modalData = defineViewData({
+      requirements: [{ name: 'modalChoice', requirement: modalChoice }],
+    });
+    const shellSource = runtimeViewBindingSource({
+      owner: shellOwner,
+      contract: shellData,
+      providerIds: [{ requirementId: 'article', providerId: 'docs.articleProvider' }],
+    });
+    const helpSource = runtimeViewBindingSource({
+      owner: helpOwner,
+      contract: helpData,
+    });
+    const modalSource = runtimeViewBindingSource({
+      owner: modalOwner,
+      contract: modalData,
+    });
+    const passThroughStack = pushRuntimeView(createRuntimeViewStack({
+      id: 'docs-shell',
+      kind: 'app-shell',
+      dismissible: false,
+      blocksBelow: false,
+      model: { bindingSources: [shellSource] },
+    }), {
+      id: 'help',
+      kind: 'overlay',
+      dismissible: true,
+      blocksBelow: true,
+      model: { bindingSources: [helpSource] },
+    });
+    const modalStack = pushRuntimeView(passThroughStack, {
+      id: 'modal',
+      kind: 'modal',
+      dismissible: true,
+      blocksBelow: false,
+      model: { bindingSources: [modalSource] },
+    });
+
+    const passThroughCollection = collectRuntimeViewBindings(passThroughStack);
+    const modalCollection = collectRuntimeViewBindings(modalStack);
+
+    expect(isRuntimeViewBindingSource(shellSource)).toBe(true);
+    expect(runtimeActiveBindingLayers(passThroughStack).map((layer) => layer.id)).toEqual([
+      'docs-shell',
+      'help',
+    ]);
+    expect(passThroughCollection.entries().map((entry) => entry.requirement.id)).toEqual([
+      'article',
+      'helpTopic',
+    ]);
+    expect(passThroughCollection.get('docs.shell', 'article')?.providerId).toBe(
+      'docs.articleProvider',
+    );
+    expect(runtimeActiveBindingLayers(modalStack).map((layer) => layer.id)).toEqual(['modal']);
+    expect(modalCollection.entries().map((entry) => entry.requirement.id)).toEqual([
+      'modalChoice',
+    ]);
+    expect(modalCollection.has('docs.shell', 'article')).toBe(false);
+  });
+
+  it('rejects loose runtime binding source objects before collection', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'docs.shell', kind: 'app-shell' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const data = defineViewData({
+      requirements: [{ name: 'article', requirement: article }],
+    });
+    const stack = createRuntimeViewStack({
+      id: 'docs-shell',
+      kind: 'app-shell',
+      dismissible: false,
+      blocksBelow: false,
+      model: {
+        bindingSources: [{
+          owner,
+          contract: data,
+        } as unknown as RuntimeViewBindingSource],
+      },
+    });
+
+    expect(() => collectRuntimeViewBindings(stack)).toThrow(
+      'runtime binding collection: source at layer docs-shell index 0 was not created by runtimeViewBindingSource()',
+    );
+  });
+});
+
+describe('runtime command intent dispatch proof', () => {
+  it('buffers command intent emissions without executing business logic in the view', () => {
+    type Command = { readonly type: 'reader.selectHeading'; readonly headingId: string };
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const selectHeading = commandIntent<{ readonly headingId: string }>('reader.selectHeading');
+    const emission = runtimeCommandIntentEmission(selectHeading, {
+      headingId: 'intro',
+    }, { owner });
+    const route = runtimeCommandIntentRoute<{ readonly headingId: string }, Command>({
+      intent: selectHeading,
+      toCommand: (intentEmission) => ({
+        type: 'reader.selectHeading',
+        headingId: intentEmission.payload.headingId,
+      }),
+    });
+
+    const dispatched = dispatchRuntimeCommandIntent({
+      emission,
+      routes: [route],
+      buffer: createRuntimeCommandBuffer<Command>(),
+    });
+    const applied = applyRuntimeCommandBuffer(
+      { selectedHeadingId: '' },
+      dispatched.buffer,
+      (state, command) => ({
+        selectedHeadingId: command.headingId,
+      }),
+    );
+
+    expect(isRuntimeCommandIntentEmission(emission)).toBe(true);
+    expect(Object.isFrozen(emission)).toBe(true);
+    expect(emission.intent.id).toBe('reader.selectHeading');
+    expect(dispatched.command).toEqual({
+      type: 'reader.selectHeading',
+      headingId: 'intro',
+    });
+    expect(dispatched.buffer.items).toEqual([{
+      type: 'reader.selectHeading',
+      headingId: 'intro',
+    }]);
+    expect(applied.state.selectedHeadingId).toBe('intro');
+    expect(applied.buffer.items).toEqual([]);
+    expect('provider' in emission).toBe(false);
+    expect('refresh' in emission).toBe(false);
+    expect('subscribe' in emission).toBe(false);
+    expect('dispatch' in emission).toBe(false);
+    expect('handle' in emission).toBe(false);
+  });
+
+  it('rejects command intent emissions without an explicit runtime route', () => {
+    const intent = commandIntent('reader.refreshRequested');
+    const emission = runtimeCommandIntentEmission(intent);
+
+    expect(() => dispatchRuntimeCommandIntent({
+      emission,
+      routes: [],
+      buffer: createRuntimeCommandBuffer(),
+    })).toThrow(
+      'runtime command intent dispatch: no route for intent reader.refreshRequested',
+    );
+  });
+});

--- a/packages/bijou-tui/src/runtime-binding.test.ts
+++ b/packages/bijou-tui/src/runtime-binding.test.ts
@@ -63,14 +63,14 @@ describe('runtime active binding collection', () => {
       id: 'help',
       kind: 'overlay',
       dismissible: true,
-      blocksBelow: true,
+      blocksBelow: false,
       model: { bindingSources: [helpSource] },
     });
     const modalStack = pushRuntimeView(passThroughStack, {
       id: 'modal',
       kind: 'modal',
       dismissible: true,
-      blocksBelow: false,
+      blocksBelow: true,
       model: { bindingSources: [modalSource] },
     });
 

--- a/packages/bijou-tui/src/runtime-binding.ts
+++ b/packages/bijou-tui/src/runtime-binding.ts
@@ -239,7 +239,7 @@ export function runtimeActiveBindingLayers<Model extends RuntimeBindingLayerMode
     }
 
     activeLayers.unshift(layer);
-    if (!layer.blocksBelow) {
+    if (layer.blocksBelow) {
       break;
     }
   }

--- a/packages/bijou-tui/src/runtime-binding.ts
+++ b/packages/bijou-tui/src/runtime-binding.ts
@@ -7,6 +7,7 @@ import {
   type ActiveBindingProviderAssignment,
   type BindingLifecycleOwner,
   type CommandIntent,
+  type DeepReadonly,
   type ViewDataContract,
 } from '@flyingrobots/bijou';
 import {
@@ -46,7 +47,7 @@ export interface RuntimeCommandIntentEmissionOptions {
 export interface RuntimeCommandIntentEmission<Payload = undefined> {
   readonly [RUNTIME_COMMAND_INTENT_EMISSION_BRAND]: true;
   readonly intent: CommandIntent<Payload>;
-  readonly payload: Payload;
+  readonly payload: DeepReadonly<Payload>;
   readonly owner?: BindingLifecycleOwner;
 }
 
@@ -75,6 +76,8 @@ export interface DispatchRuntimeCommandIntentResult<Command> {
 export function runtimeViewBindingSource(
   input: RuntimeViewBindingSourceInput,
 ): RuntimeViewBindingSource {
+  assertObjectRecord(input, 'runtime binding source');
+
   if (!isBindingLifecycleOwner(input.owner)) {
     throw new Error(
       'runtime binding source: owner was not created by defineBindingLifecycleOwner()',
@@ -85,16 +88,11 @@ export function runtimeViewBindingSource(
       'runtime binding source: contract was not created by defineViewData()',
     );
   }
-  if (input.providerIds !== undefined && !Array.isArray(input.providerIds)) {
-    throw new Error('runtime binding source: providerIds must be an array');
-  }
 
   const source = {
     owner: input.owner,
     contract: input.contract,
-    providerIds: input.providerIds === undefined
-      ? undefined
-      : Object.freeze([...input.providerIds]),
+    providerIds: freezeProviderAssignments(input.providerIds),
   } as RuntimeViewBindingSource;
 
   Object.defineProperty(source, RUNTIME_VIEW_BINDING_SOURCE_BRAND, { value: true });
@@ -114,6 +112,8 @@ export function runtimeCommandIntentEmission<Payload>(
   payload?: Payload,
   options: RuntimeCommandIntentEmissionOptions = {},
 ): RuntimeCommandIntentEmission<Payload | undefined> {
+  assertObjectRecord(options, 'runtime command intent emission', 'options');
+
   if (!isCommandIntent(intent)) {
     throw new Error('runtime command intent emission: intent was not created by commandIntent()');
   }
@@ -125,7 +125,7 @@ export function runtimeCommandIntentEmission<Payload>(
 
   const emission = {
     intent,
-    payload,
+    payload: freezeRuntimePayload(payload),
     owner: options.owner,
   } as RuntimeCommandIntentEmission<Payload | undefined>;
 
@@ -147,6 +147,8 @@ export function isRuntimeCommandIntentEmission(
 export function runtimeCommandIntentRoute<Payload, Command>(
   input: RuntimeCommandIntentRouteInput<Payload, Command>,
 ): RuntimeCommandIntentRoute<Payload, Command> {
+  assertObjectRecord(input, 'runtime command intent route');
+
   if (!isCommandIntent(input.intent)) {
     throw new Error('runtime command intent route: intent was not created by commandIntent()');
   }
@@ -175,6 +177,8 @@ export function isRuntimeCommandIntentRoute(value: unknown): value is RuntimeCom
 export function dispatchRuntimeCommandIntent<Payload, Command>(
   input: DispatchRuntimeCommandIntentInput<Payload, Command>,
 ): DispatchRuntimeCommandIntentResult<Command> {
+  assertObjectRecord(input, 'runtime command intent dispatch');
+
   if (!isRuntimeCommandIntentEmission(input.emission)) {
     throw new Error(
       'runtime command intent dispatch: emission was not created by runtimeCommandIntentEmission()',
@@ -299,4 +303,190 @@ function isRuntimeCommandBuffer(value: unknown): value is RuntimeCommandBuffer {
       && typeof value === 'object'
       && Array.isArray((value as RuntimeCommandBuffer).items),
   );
+}
+
+function freezeProviderAssignments(
+  assignments: readonly ActiveBindingProviderAssignment[] | undefined,
+): readonly ActiveBindingProviderAssignment[] | undefined {
+  if (assignments === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(assignments)) {
+    throw new Error('runtime binding source: providerIds must be an array');
+  }
+
+  const seenRequirementIds = new Set<string>();
+  return Object.freeze(assignments.map((assignment, index) => {
+    assertObjectRecord(
+      assignment,
+      'runtime binding source',
+      `provider assignment ${index}`,
+    );
+    const requirementId = normalizeRequiredText({
+      scope: 'runtime binding source',
+      field: `provider assignment ${index} requirementId`,
+      value: assignment['requirementId'],
+    });
+    if (seenRequirementIds.has(requirementId)) {
+      throw new Error(
+        `runtime binding source: duplicate provider assignment ${requirementId}`,
+      );
+    }
+
+    seenRequirementIds.add(requirementId);
+    return Object.freeze({
+      requirementId,
+      providerId: normalizeRequiredText({
+        scope: 'runtime binding source',
+        field: `provider assignment ${index} providerId`,
+        value: assignment['providerId'],
+      }),
+    });
+  }));
+}
+
+function freezeRuntimePayload<Payload>(
+  payload: Payload | undefined,
+): DeepReadonly<Payload | undefined> {
+  if (payload === undefined) {
+    return undefined as DeepReadonly<Payload | undefined>;
+  }
+
+  return deepFreeze(cloneRuntimePayload(payload, 'payload'));
+}
+
+function cloneRuntimePayload<Payload>(
+  value: Payload,
+  path: string,
+  seen: WeakSet<object> = new WeakSet<object>(),
+): Payload {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'bigint' || typeof value === 'symbol' || typeof value === 'function') {
+    throw new Error(`runtime command intent payload: unsupported ${typeof value} at ${path}`);
+  }
+  if (value === undefined) {
+    throw new Error(`runtime command intent payload: unsupported undefined at ${path}`);
+  }
+  if (typeof value !== 'object') {
+    throw new Error(`runtime command intent payload: unsupported ${typeof value} at ${path}`);
+  }
+
+  const objectValue = value as object;
+  if (seen.has(objectValue)) {
+    throw new Error(`runtime command intent payload: circular reference at ${path}`);
+  }
+  seen.add(objectValue);
+
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item, index) => cloneRuntimePayload(
+        item,
+        `${path}[${index}]`,
+        seen,
+      )) as Payload;
+    }
+    if (!isPlainObject(value)) {
+      throw new Error(
+        `runtime command intent payload: unsupported ${objectKind(value)} at ${path}`,
+      );
+    }
+
+    const clone = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (typeof key === 'symbol') {
+        throw new Error(`runtime command intent payload: unsupported symbol property at ${path}`);
+      }
+
+      const descriptor = descriptors[key];
+      const propertyPath = `${path}.${key}`;
+      if (descriptor === undefined) {
+        continue;
+      }
+      if (!descriptor.enumerable) {
+        throw new Error(
+          `runtime command intent payload: unsupported non-enumerable property at ${propertyPath}`,
+        );
+      }
+      if ('get' in descriptor || 'set' in descriptor) {
+        throw new Error(
+          `runtime command intent payload: unsupported accessor at ${propertyPath}`,
+        );
+      }
+
+      clone[key] = cloneRuntimePayload(descriptor.value, propertyPath, seen);
+    }
+
+    return clone as Payload;
+  } finally {
+    seen.delete(objectValue);
+  }
+}
+
+function deepFreeze<Payload>(
+  value: Payload,
+  seen: WeakSet<object> = new WeakSet<object>(),
+): DeepReadonly<Payload> {
+  if (value === null || typeof value !== 'object') {
+    return value as DeepReadonly<Payload>;
+  }
+
+  const objectValue = value as object;
+  if (seen.has(objectValue)) {
+    return value as DeepReadonly<Payload>;
+  }
+
+  seen.add(objectValue);
+  for (const key of Reflect.ownKeys(objectValue)) {
+    const descriptor = Object.getOwnPropertyDescriptor(objectValue, key);
+    if (descriptor !== undefined && 'value' in descriptor) {
+      deepFreeze(descriptor.value, seen);
+    }
+  }
+
+  return Object.freeze(value) as DeepReadonly<Payload>;
+}
+
+function assertObjectRecord(
+  value: unknown,
+  scope: string,
+  label = 'input',
+): asserts value {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${scope}: ${label} must be an object`);
+  }
+}
+
+function normalizeRequiredText(options: {
+  readonly scope: string;
+  readonly field: string;
+  readonly value: unknown;
+}): string {
+  if (typeof options.value !== 'string') {
+    throw new Error(`${options.scope}: ${options.field} must be a string`);
+  }
+
+  const normalized = options.value.trim();
+  if (normalized === '') {
+    throw new Error(`${options.scope}: ${options.field} is required`);
+  }
+
+  return normalized;
+}
+
+function isPlainObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function objectKind(value: object): string {
+  return Object.prototype.toString.call(value).slice(8, -1);
 }

--- a/packages/bijou-tui/src/runtime-binding.ts
+++ b/packages/bijou-tui/src/runtime-binding.ts
@@ -1,0 +1,302 @@
+import {
+  collectActiveBindings,
+  isBindingLifecycleOwner,
+  isCommandIntent,
+  isViewDataContract,
+  type ActiveBindingCollection,
+  type ActiveBindingProviderAssignment,
+  type BindingLifecycleOwner,
+  type CommandIntent,
+  type ViewDataContract,
+} from '@flyingrobots/bijou';
+import {
+  appendRuntimeCommands,
+  type RuntimeCommandBuffer,
+} from './runtime-engine.js';
+import type {
+  RuntimeStackLayer,
+  RuntimeViewStack,
+} from './runtime-engine.js';
+
+const RUNTIME_VIEW_BINDING_SOURCE_BRAND: unique symbol = Symbol('RuntimeViewBindingSource');
+const RUNTIME_COMMAND_INTENT_EMISSION_BRAND: unique symbol = Symbol('RuntimeCommandIntentEmission');
+const RUNTIME_COMMAND_INTENT_ROUTE_BRAND: unique symbol = Symbol('RuntimeCommandIntentRoute');
+
+export interface RuntimeViewBindingSourceInput {
+  readonly owner: BindingLifecycleOwner;
+  readonly contract: ViewDataContract;
+  readonly providerIds?: readonly ActiveBindingProviderAssignment[];
+}
+
+export interface RuntimeViewBindingSource {
+  readonly [RUNTIME_VIEW_BINDING_SOURCE_BRAND]: true;
+  readonly owner: BindingLifecycleOwner;
+  readonly contract: ViewDataContract;
+  readonly providerIds?: readonly ActiveBindingProviderAssignment[];
+}
+
+export interface RuntimeBindingLayerModel {
+  readonly bindingSources?: readonly RuntimeViewBindingSource[];
+}
+
+export interface RuntimeCommandIntentEmissionOptions {
+  readonly owner?: BindingLifecycleOwner;
+}
+
+export interface RuntimeCommandIntentEmission<Payload = undefined> {
+  readonly [RUNTIME_COMMAND_INTENT_EMISSION_BRAND]: true;
+  readonly intent: CommandIntent<Payload>;
+  readonly payload: Payload;
+  readonly owner?: BindingLifecycleOwner;
+}
+
+export interface RuntimeCommandIntentRouteInput<Payload, Command> {
+  readonly intent: CommandIntent<Payload>;
+  readonly toCommand: (emission: RuntimeCommandIntentEmission<Payload>) => Command;
+}
+
+export interface RuntimeCommandIntentRoute<Payload = unknown, Command = unknown> {
+  readonly [RUNTIME_COMMAND_INTENT_ROUTE_BRAND]: true;
+  readonly intent: CommandIntent<Payload>;
+  readonly toCommand: (emission: RuntimeCommandIntentEmission<Payload>) => Command;
+}
+
+export interface DispatchRuntimeCommandIntentInput<Payload, Command> {
+  readonly emission: RuntimeCommandIntentEmission<Payload>;
+  readonly routes: readonly RuntimeCommandIntentRoute<Payload, Command>[];
+  readonly buffer: RuntimeCommandBuffer<Command>;
+}
+
+export interface DispatchRuntimeCommandIntentResult<Command> {
+  readonly command: Command;
+  readonly buffer: RuntimeCommandBuffer<Command>;
+}
+
+export function runtimeViewBindingSource(
+  input: RuntimeViewBindingSourceInput,
+): RuntimeViewBindingSource {
+  if (!isBindingLifecycleOwner(input.owner)) {
+    throw new Error(
+      'runtime binding source: owner was not created by defineBindingLifecycleOwner()',
+    );
+  }
+  if (!isViewDataContract(input.contract)) {
+    throw new Error(
+      'runtime binding source: contract was not created by defineViewData()',
+    );
+  }
+  if (input.providerIds !== undefined && !Array.isArray(input.providerIds)) {
+    throw new Error('runtime binding source: providerIds must be an array');
+  }
+
+  const source = {
+    owner: input.owner,
+    contract: input.contract,
+    providerIds: input.providerIds === undefined
+      ? undefined
+      : Object.freeze([...input.providerIds]),
+  } as RuntimeViewBindingSource;
+
+  Object.defineProperty(source, RUNTIME_VIEW_BINDING_SOURCE_BRAND, { value: true });
+  return Object.freeze(source);
+}
+
+export function runtimeCommandIntentEmission(
+  intent: CommandIntent,
+): RuntimeCommandIntentEmission<undefined>;
+export function runtimeCommandIntentEmission<Payload>(
+  intent: CommandIntent<Payload>,
+  payload: Payload,
+  options?: RuntimeCommandIntentEmissionOptions,
+): RuntimeCommandIntentEmission<Payload>;
+export function runtimeCommandIntentEmission<Payload>(
+  intent: CommandIntent<Payload>,
+  payload?: Payload,
+  options: RuntimeCommandIntentEmissionOptions = {},
+): RuntimeCommandIntentEmission<Payload | undefined> {
+  if (!isCommandIntent(intent)) {
+    throw new Error('runtime command intent emission: intent was not created by commandIntent()');
+  }
+  if (options.owner !== undefined && !isBindingLifecycleOwner(options.owner)) {
+    throw new Error(
+      'runtime command intent emission: owner was not created by defineBindingLifecycleOwner()',
+    );
+  }
+
+  const emission = {
+    intent,
+    payload,
+    owner: options.owner,
+  } as RuntimeCommandIntentEmission<Payload | undefined>;
+
+  Object.defineProperty(emission, RUNTIME_COMMAND_INTENT_EMISSION_BRAND, { value: true });
+  return Object.freeze(emission);
+}
+
+export function isRuntimeCommandIntentEmission(
+  value: unknown,
+): value is RuntimeCommandIntentEmission {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, RUNTIME_COMMAND_INTENT_EMISSION_BRAND)
+      && (value as RuntimeCommandIntentEmissionBrandCarrier)[RUNTIME_COMMAND_INTENT_EMISSION_BRAND] === true,
+  );
+}
+
+export function runtimeCommandIntentRoute<Payload, Command>(
+  input: RuntimeCommandIntentRouteInput<Payload, Command>,
+): RuntimeCommandIntentRoute<Payload, Command> {
+  if (!isCommandIntent(input.intent)) {
+    throw new Error('runtime command intent route: intent was not created by commandIntent()');
+  }
+  if (typeof input.toCommand !== 'function') {
+    throw new Error('runtime command intent route: toCommand must be a function');
+  }
+
+  const route = {
+    intent: input.intent,
+    toCommand: input.toCommand,
+  } as RuntimeCommandIntentRoute<Payload, Command>;
+
+  Object.defineProperty(route, RUNTIME_COMMAND_INTENT_ROUTE_BRAND, { value: true });
+  return Object.freeze(route);
+}
+
+export function isRuntimeCommandIntentRoute(value: unknown): value is RuntimeCommandIntentRoute {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, RUNTIME_COMMAND_INTENT_ROUTE_BRAND)
+      && (value as RuntimeCommandIntentRouteBrandCarrier)[RUNTIME_COMMAND_INTENT_ROUTE_BRAND] === true,
+  );
+}
+
+export function dispatchRuntimeCommandIntent<Payload, Command>(
+  input: DispatchRuntimeCommandIntentInput<Payload, Command>,
+): DispatchRuntimeCommandIntentResult<Command> {
+  if (!isRuntimeCommandIntentEmission(input.emission)) {
+    throw new Error(
+      'runtime command intent dispatch: emission was not created by runtimeCommandIntentEmission()',
+    );
+  }
+  if (!Array.isArray(input.routes)) {
+    throw new Error('runtime command intent dispatch: routes must be an array');
+  }
+  if (!isRuntimeCommandBuffer(input.buffer)) {
+    throw new Error('runtime command intent dispatch: buffer must be a RuntimeCommandBuffer');
+  }
+
+  const route = input.routes.find((candidate, index) => {
+    if (!isRuntimeCommandIntentRoute(candidate)) {
+      throw new Error(
+        `runtime command intent dispatch: route at index ${index} was not created by runtimeCommandIntentRoute()`,
+      );
+    }
+
+    return candidate.intent.id === input.emission.intent.id;
+  });
+  if (route === undefined) {
+    throw new Error(
+      `runtime command intent dispatch: no route for intent ${input.emission.intent.id}`,
+    );
+  }
+
+  const command = route.toCommand(input.emission);
+  return Object.freeze({
+    command,
+    buffer: appendRuntimeCommands(input.buffer, [command]),
+  });
+}
+
+export function isRuntimeViewBindingSource(
+  value: unknown,
+): value is RuntimeViewBindingSource {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, RUNTIME_VIEW_BINDING_SOURCE_BRAND)
+      && (value as RuntimeViewBindingSourceBrandCarrier)[RUNTIME_VIEW_BINDING_SOURCE_BRAND] === true,
+  );
+}
+
+export function runtimeActiveBindingLayers<Model extends RuntimeBindingLayerModel>(
+  stack: RuntimeViewStack<Model>,
+): readonly RuntimeStackLayer<Model>[] {
+  if (!isRuntimeViewStack(stack)) {
+    throw new Error('runtime binding collection: stack must be a RuntimeViewStack');
+  }
+
+  const activeLayers: RuntimeStackLayer<Model>[] = [];
+  for (let index = stack.layers.length - 1; index >= 0; index -= 1) {
+    const layer = stack.layers[index];
+    if (layer === undefined) {
+      continue;
+    }
+
+    activeLayers.unshift(layer);
+    if (!layer.blocksBelow) {
+      break;
+    }
+  }
+
+  return Object.freeze(activeLayers);
+}
+
+export function collectRuntimeViewBindings<Model extends RuntimeBindingLayerModel>(
+  stack: RuntimeViewStack<Model>,
+): ActiveBindingCollection {
+  const contracts = runtimeActiveBindingLayers(stack).flatMap((layer) => {
+    const bindingSources = layer.model?.bindingSources ?? [];
+    if (!Array.isArray(bindingSources)) {
+      throw new Error(
+        `runtime binding collection: bindingSources for layer ${layer.id} must be an array`,
+      );
+    }
+
+    return bindingSources.map((source, index) => {
+      if (!isRuntimeViewBindingSource(source)) {
+        throw new Error(
+          `runtime binding collection: source at layer ${layer.id} index ${index} `
+          + 'was not created by runtimeViewBindingSource()',
+        );
+      }
+
+      return {
+        owner: source.owner,
+        contract: source.contract,
+        providerIds: source.providerIds,
+      };
+    });
+  });
+
+  return collectActiveBindings({ contracts });
+}
+
+interface RuntimeViewBindingSourceBrandCarrier {
+  readonly [RUNTIME_VIEW_BINDING_SOURCE_BRAND]?: true;
+}
+
+interface RuntimeCommandIntentEmissionBrandCarrier {
+  readonly [RUNTIME_COMMAND_INTENT_EMISSION_BRAND]?: true;
+}
+
+interface RuntimeCommandIntentRouteBrandCarrier {
+  readonly [RUNTIME_COMMAND_INTENT_ROUTE_BRAND]?: true;
+}
+
+function isRuntimeViewStack(value: unknown): value is RuntimeViewStack {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Array.isArray((value as RuntimeViewStack).layers),
+  );
+}
+
+function isRuntimeCommandBuffer(value: unknown): value is RuntimeCommandBuffer {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Array.isArray((value as RuntimeCommandBuffer).items),
+  );
+}

--- a/packages/bijou/src/core/binding-frame-update.test.ts
+++ b/packages/bijou/src/core/binding-frame-update.test.ts
@@ -121,4 +121,61 @@ describe('binding frame updates from provider snapshots', () => {
     expect('subscribe' in update).toBe(false);
     expect('dispatch' in update).toBe(false);
   });
+
+  it('treats explicit active binding provider assignments as authoritative', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const collection = activeBindingCollection([
+      activeBindingEntry({
+        owner,
+        requirement: article,
+        providerId: 'docs.expectedProvider',
+      }),
+    ]);
+    const scope = providerScope([
+      provide(defineDataProvider({
+        id: 'docs.actualProvider',
+        resource: 'docs.article',
+      })),
+    ]);
+    const update = bindingFrameUpdateFromSnapshots({
+      collection,
+      scope,
+      snapshots: [
+        bindingSnapshot({
+          providerId: 'docs.actualProvider',
+          requirementId: 'article',
+          version: 1,
+          status: 'ready',
+          data: { title: 'Wrong provider' },
+        }),
+      ],
+    });
+
+    expect(update.frame.get('article')).toBeUndefined();
+    expect(update.records).toEqual([
+      {
+        owner,
+        requirementId: 'article',
+        providerId: 'docs.expectedProvider',
+        state: 'active',
+        version: 1,
+        invalidations: [],
+        transitions: [],
+        facts: [],
+      },
+    ]);
+    expect(update.issues.map((issue) => issue.code)).toEqual([
+      'provider.assignment-mismatch',
+    ]);
+  });
+
+  it('throws deterministic errors for non-object frame update inputs', () => {
+    expect(() => bindingFrameUpdateFromSnapshots(null as never)).toThrow(
+      'binding frame update: input must be an object',
+    );
+    expect(() => bindingFrameUpdateFromSnapshots([] as never)).toThrow(
+      'binding frame update: input must be an object',
+    );
+  });
 });

--- a/packages/bijou/src/core/binding-frame-update.test.ts
+++ b/packages/bijou/src/core/binding-frame-update.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activeBindingCollection,
+  activeBindingEntry,
+} from './active-binding-collection.js';
+import {
+  bindingFrame,
+  bindingSnapshot,
+  defineDataProvider,
+  defineDataRequirement,
+  provide,
+  providerScope,
+} from './binding.js';
+import {
+  defineBindingLifecycleOwner,
+} from './binding-lifecycle.js';
+import {
+  bindingFrameUpdateFromSnapshots,
+} from './binding-frame-update.js';
+
+describe('binding frame updates from provider snapshots', () => {
+  it('creates a new frame and invalidated lifecycle records without mutating the previous frame', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({
+      id: 'article',
+      resource: 'docs.article',
+      facts: [{ kind: 'entity', key: 'resource', value: 'article' }],
+    });
+    const collection = activeBindingCollection([
+      activeBindingEntry({ owner, requirement: article }),
+    ]);
+    const scope = providerScope([
+      provide(defineDataProvider({
+        id: 'docs.articleProvider',
+        resource: 'docs.article',
+      })),
+    ]);
+    const oldFrame = bindingFrame([
+      bindingSnapshot({
+        providerId: 'docs.articleProvider',
+        requirementId: 'article',
+        version: 1,
+        status: 'ready',
+        data: { title: 'Before' },
+      }),
+    ]);
+    const update = bindingFrameUpdateFromSnapshots({
+      collection,
+      scope,
+      snapshots: [
+        bindingSnapshot({
+          providerId: 'docs.articleProvider',
+          requirementId: 'article',
+          version: 2,
+          status: 'ready',
+          data: { title: 'After' },
+        }),
+      ],
+    });
+
+    expect(oldFrame.require<{ title: string }>('article').title).toBe('Before');
+    expect(update.frame.require<{ title: string }>('article').title).toBe('After');
+    expect(update.records).toEqual([
+      {
+        owner,
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+        state: 'active',
+        version: 2,
+        invalidations: [{
+          requirementId: 'article',
+          providerId: 'docs.articleProvider',
+          reason: 'provider-update',
+          snapshotVersion: 2,
+        }],
+        transitions: [{
+          from: 'active',
+          to: 'active',
+          reason: 'invalidate',
+        }],
+        facts: [{ kind: 'entity', key: 'resource', value: 'article' }],
+      },
+    ]);
+    expect(update.issues).toEqual([]);
+    expect(Object.isFrozen(update)).toBe(true);
+    expect(Object.isFrozen(update.records)).toBe(true);
+    expect(Object.isFrozen(update.frame)).toBe(true);
+  });
+
+  it('reports missing or provider-mismatched snapshots without exposing provider handles', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const collection = activeBindingCollection([
+      activeBindingEntry({ owner, requirement: article }),
+    ]);
+    const scope = providerScope([
+      provide(defineDataProvider({
+        id: 'docs.articleProvider',
+        resource: 'docs.article',
+      })),
+    ]);
+    const update = bindingFrameUpdateFromSnapshots({
+      collection,
+      scope,
+      snapshots: [
+        bindingSnapshot({
+          providerId: 'docs.otherProvider',
+          requirementId: 'article',
+          version: 1,
+          status: 'ready',
+          data: { title: 'Wrong source' },
+        }),
+      ],
+    });
+
+    expect(update.frame.get('article')).toBeUndefined();
+    expect(update.records[0]?.version).toBe(1);
+    expect(update.issues.map((issue) => issue.code)).toEqual(['snapshot.provider-mismatch']);
+    expect('provider' in update).toBe(false);
+    expect('refresh' in update).toBe(false);
+    expect('subscribe' in update).toBe(false);
+    expect('dispatch' in update).toBe(false);
+  });
+});

--- a/packages/bijou/src/core/binding-frame-update.test.ts
+++ b/packages/bijou/src/core/binding-frame-update.test.ts
@@ -87,6 +87,49 @@ describe('binding frame updates from provider snapshots', () => {
     expect(Object.isFrozen(update.frame)).toBe(true);
   });
 
+  it('does not re-invalidate lifecycle records for already-applied snapshot versions', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const collection = activeBindingCollection([
+      activeBindingEntry({ owner, requirement: article }),
+    ]);
+    const scope = providerScope([
+      provide(defineDataProvider({
+        id: 'docs.articleProvider',
+        resource: 'docs.article',
+      })),
+    ]);
+    const snapshot = bindingSnapshot({
+      providerId: 'docs.articleProvider',
+      requirementId: 'article',
+      version: 2,
+      status: 'ready',
+      data: { title: 'After' },
+    });
+    const firstUpdate = bindingFrameUpdateFromSnapshots({
+      collection,
+      scope,
+      snapshots: [snapshot],
+    });
+
+    const secondUpdate = bindingFrameUpdateFromSnapshots({
+      collection,
+      scope,
+      snapshots: [snapshot],
+      records: firstUpdate.records,
+    });
+
+    expect(firstUpdate.records[0]?.invalidations).toEqual([{
+      requirementId: 'article',
+      providerId: 'docs.articleProvider',
+      reason: 'provider-update',
+      snapshotVersion: 2,
+    }]);
+    expect(secondUpdate.records[0]).toBe(firstUpdate.records[0]);
+    expect(secondUpdate.records[0]?.invalidations).toHaveLength(1);
+    expect(secondUpdate.records[0]?.version).toBe(firstUpdate.records[0]?.version);
+  });
+
   it('reports missing or provider-mismatched snapshots without exposing provider handles', () => {
     const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
     const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });

--- a/packages/bijou/src/core/binding-frame-update.ts
+++ b/packages/bijou/src/core/binding-frame-update.ts
@@ -1,0 +1,150 @@
+import {
+  isActiveBindingCollection,
+  type ActiveBindingCollection,
+} from './active-binding-collection.js';
+import {
+  bindingFrameFromSnapshots,
+  isBindingSnapshot,
+  isProviderScope,
+  resolveProviderRequirements,
+  type BindingFact,
+  type BindingFrame,
+  type BindingIssue,
+  type BindingSnapshot,
+  type ProviderResolution,
+  type ProviderScope,
+  type RequirementId,
+} from './binding.js';
+import {
+  bindingLifecycleRecord,
+  invalidateBinding,
+  isBindingLifecycleRecord,
+  type BindingLifecycleRecord,
+} from './binding-lifecycle.js';
+
+export interface BindingFrameUpdateFromSnapshotsInput {
+  readonly collection: ActiveBindingCollection;
+  readonly scope: ProviderScope;
+  readonly snapshots: readonly BindingSnapshot[];
+  readonly records?: readonly BindingLifecycleRecord[];
+}
+
+export interface BindingFrameUpdate {
+  readonly frame: BindingFrame;
+  readonly records: readonly BindingLifecycleRecord[];
+  readonly resolutions: readonly ProviderResolution[];
+  readonly issues: readonly BindingIssue[];
+  readonly facts: readonly BindingFact[];
+}
+
+export function bindingFrameUpdateFromSnapshots(
+  input: BindingFrameUpdateFromSnapshotsInput,
+): BindingFrameUpdate {
+  if (!isActiveBindingCollection(input.collection)) {
+    throw new Error(
+      'binding frame update: collection was not created by activeBindingCollection()',
+    );
+  }
+  if (!isProviderScope(input.scope)) {
+    throw new Error('binding frame update: scope was not created by providerScope()');
+  }
+  if (!Array.isArray(input.snapshots)) {
+    throw new Error('binding frame update: snapshots must be an array');
+  }
+
+  input.snapshots.forEach((snapshot, index) => {
+    if (!isBindingSnapshot(snapshot)) {
+      throw new Error(
+        `binding frame update: snapshot at index ${index} was not created by bindingSnapshot()`,
+      );
+    }
+  });
+
+  const resolutions = resolveProviderRequirements(input.collection.requirements(), input.scope);
+  const assembly = bindingFrameFromSnapshots({
+    resolutions,
+    snapshots: input.snapshots,
+  });
+  const records = invalidateUpdatedRecords({
+    records: input.records ?? lifecycleRecordsForResolvedCollection(input.collection, resolutions),
+    resolutions,
+    snapshots: input.snapshots,
+  });
+
+  return Object.freeze({
+    frame: assembly.frame,
+    records,
+    resolutions,
+    issues: assembly.issues,
+    facts: assembly.facts,
+  });
+}
+
+function lifecycleRecordsForResolvedCollection(
+  collection: ActiveBindingCollection,
+  resolutions: readonly ProviderResolution[],
+): readonly BindingLifecycleRecord[] {
+  const resolutionsByRequirementId = new Map<RequirementId, ProviderResolution>();
+  resolutions.forEach((resolution) => {
+    resolutionsByRequirementId.set(resolution.requirementId, resolution);
+  });
+
+  return Object.freeze(
+    collection.entries().map((entry) => {
+      const resolution = resolutionsByRequirementId.get(entry.requirement.id);
+
+      return bindingLifecycleRecord({
+        owner: entry.owner,
+        requirementId: entry.requirement.id,
+        providerId: entry.providerId ?? resolution?.providerId,
+        facts: entry.requirement.facts,
+      });
+    }),
+  );
+}
+
+function invalidateUpdatedRecords(options: {
+  readonly records: readonly BindingLifecycleRecord[];
+  readonly resolutions: readonly ProviderResolution[];
+  readonly snapshots: readonly BindingSnapshot[];
+}): readonly BindingLifecycleRecord[] {
+  if (!Array.isArray(options.records)) {
+    throw new Error('binding frame update: records must be an array');
+  }
+
+  const resolutionsByRequirementId = new Map<RequirementId, ProviderResolution>();
+  options.resolutions.forEach((resolution) => {
+    resolutionsByRequirementId.set(resolution.requirementId, resolution);
+  });
+  const snapshotsByRequirementId = new Map<RequirementId, BindingSnapshot>();
+  options.snapshots.forEach((snapshot) => {
+    snapshotsByRequirementId.set(snapshot.requirementId, snapshot);
+  });
+
+  return Object.freeze(
+    options.records.map((record, index) => {
+      if (!isBindingLifecycleRecord(record)) {
+        throw new Error(
+          `binding frame update: record at index ${index} was not created by bindingLifecycleRecord()`,
+        );
+      }
+
+      const snapshot = snapshotsByRequirementId.get(record.requirementId);
+      const resolution = resolutionsByRequirementId.get(record.requirementId);
+      if (
+        snapshot === undefined
+        || resolution === undefined
+        || resolution.providerId === undefined
+        || snapshot.providerId !== resolution.providerId
+      ) {
+        return record;
+      }
+
+      return invalidateBinding(record, {
+        reason: 'provider-update',
+        providerId: snapshot.providerId,
+        snapshotVersion: snapshot.version,
+      });
+    }),
+  );
+}

--- a/packages/bijou/src/core/binding-frame-update.ts
+++ b/packages/bijou/src/core/binding-frame-update.ts
@@ -158,6 +158,9 @@ function invalidateUpdatedRecords(options: {
       ) {
         return record;
       }
+      if (hasProviderUpdateInvalidation(record, snapshot)) {
+        return record;
+      }
 
       return invalidateBinding(record, {
         reason: 'provider-update',
@@ -166,6 +169,17 @@ function invalidateUpdatedRecords(options: {
       });
     }),
   );
+}
+
+function hasProviderUpdateInvalidation(
+  record: BindingLifecycleRecord,
+  snapshot: BindingSnapshot,
+): boolean {
+  return record.invalidations.some((invalidation) => (
+    invalidation.reason === 'provider-update'
+    && invalidation.providerId === snapshot.providerId
+    && invalidation.snapshotVersion === snapshot.version
+  ));
 }
 
 function providerAssignmentMismatchIssues(

--- a/packages/bijou/src/core/binding-frame-update.ts
+++ b/packages/bijou/src/core/binding-frame-update.ts
@@ -40,6 +40,9 @@ export interface BindingFrameUpdate {
 export function bindingFrameUpdateFromSnapshots(
   input: BindingFrameUpdateFromSnapshotsInput,
 ): BindingFrameUpdate {
+  if (!isObjectRecord(input)) {
+    throw new Error('binding frame update: input must be an object');
+  }
   if (!isActiveBindingCollection(input.collection)) {
     throw new Error(
       'binding frame update: collection was not created by activeBindingCollection()',
@@ -61,21 +64,37 @@ export function bindingFrameUpdateFromSnapshots(
   });
 
   const resolutions = resolveProviderRequirements(input.collection.requirements(), input.scope);
-  const assembly = bindingFrameFromSnapshots({
+  const providerAssignmentMismatches = providerAssignmentMismatchIssues(
+    input.collection,
     resolutions,
-    snapshots: input.snapshots,
+  );
+  const mismatchedRequirementIds = new Set(
+    providerAssignmentMismatches.map((issue) => issue.path),
+  );
+  const effectiveResolutions = resolutions.filter(
+    (resolution) => !mismatchedRequirementIds.has(resolution.requirementId),
+  );
+  const effectiveSnapshots = input.snapshots.filter(
+    (snapshot) => !mismatchedRequirementIds.has(snapshot.requirementId),
+  );
+  const assembly = bindingFrameFromSnapshots({
+    resolutions: effectiveResolutions,
+    snapshots: effectiveSnapshots,
   });
   const records = invalidateUpdatedRecords({
     records: input.records ?? lifecycleRecordsForResolvedCollection(input.collection, resolutions),
-    resolutions,
-    snapshots: input.snapshots,
+    resolutions: effectiveResolutions,
+    snapshots: effectiveSnapshots,
   });
 
   return Object.freeze({
     frame: assembly.frame,
     records,
     resolutions,
-    issues: assembly.issues,
+    issues: freezeIssues([
+      ...providerAssignmentMismatches,
+      ...assembly.issues,
+    ]),
     facts: assembly.facts,
   });
 }
@@ -147,4 +166,48 @@ function invalidateUpdatedRecords(options: {
       });
     }),
   );
+}
+
+function providerAssignmentMismatchIssues(
+  collection: ActiveBindingCollection,
+  resolutions: readonly ProviderResolution[],
+): readonly BindingIssue[] {
+  const providerIdsByRequirementId = new Map<RequirementId, string>();
+  collection.entries().forEach((entry) => {
+    if (entry.providerId !== undefined) {
+      providerIdsByRequirementId.set(entry.requirement.id, entry.providerId);
+    }
+  });
+
+  return freezeIssues(resolutions.flatMap((resolution) => {
+    const expectedProviderId = providerIdsByRequirementId.get(resolution.requirementId);
+    if (
+      expectedProviderId === undefined
+      || resolution.providerId === undefined
+      || resolution.providerId === expectedProviderId
+    ) {
+      return [];
+    }
+
+    return [{
+      severity: 'error',
+      code: 'provider.assignment-mismatch',
+      message:
+        `Resolved provider ${resolution.providerId} for requirement `
+        + `${resolution.requirementId}; expected ${expectedProviderId}`,
+      path: resolution.requirementId,
+    } satisfies BindingIssue];
+  }));
+}
+
+function freezeIssues(issues: readonly BindingIssue[]): readonly BindingIssue[] {
+  if (issues.length === 0) {
+    return Object.freeze([]);
+  }
+
+  return Object.freeze(issues.map((issue) => Object.freeze({ ...issue })));
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -144,6 +144,11 @@ export {
   type ViewDataRequirementEntry,
 } from './core/binding.js';
 export {
+  bindingFrameUpdateFromSnapshots,
+  type BindingFrameUpdate,
+  type BindingFrameUpdateFromSnapshotsInput,
+} from './core/binding-frame-update.js';
+export {
   ActiveBindingCollection,
   activeBindingCollection,
   activeBindingEntry,

--- a/tests/cycles/DX-034/active-binding-runtime-loop.test.ts
+++ b/tests/cycles/DX-034/active-binding-runtime-loop.test.ts
@@ -67,14 +67,14 @@ describe('DX-034G/H/I active binding runtime loop', () => {
       id: 'help-overlay',
       kind: 'overlay',
       dismissible: true,
-      blocksBelow: true,
+      blocksBelow: false,
       model: { bindingSources: [overlaySource] },
     });
     const modalStack = pushRuntimeView(overlayStack, {
       id: 'choice-modal',
       kind: 'modal',
       dismissible: true,
-      blocksBelow: false,
+      blocksBelow: true,
       model: { bindingSources: [modalSource] },
     });
 
@@ -194,6 +194,9 @@ describe('DX-034G/H/I active binding runtime loop', () => {
     expect(cycle).toContain('### DX-034G Active View Binding Collection');
     expect(cycle).toContain('### DX-034H Provider Update Invalidation Flow');
     expect(cycle).toContain('### DX-034I Command Intent Dispatch Proof');
+    expect(cycle).toContain('`blocksBelow: false`');
+    expect(cycle).toContain('`blocksBelow: true` blocks lower layers');
+    expect(cycle).toContain('do not create duplicate invalidations');
     expect(cycle).toContain('DX-034G does not subscribe, refresh, dispatch, render, cache');
     expect(cycle).toContain('DX-034H does not fetch data, subscribe, refresh providers');
     expect(cycle).toContain('Command intents and emissions expose no provider handles');

--- a/tests/cycles/DX-034/active-binding-runtime-loop.test.ts
+++ b/tests/cycles/DX-034/active-binding-runtime-loop.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activeBindingCollection,
+  activeBindingEntry,
+  bindingFrame,
+  bindingFrameUpdateFromSnapshots,
+  bindingSnapshot,
+  commandIntent,
+  defineBindingLifecycleOwner,
+  defineDataProvider,
+  defineDataRequirement,
+  defineViewData,
+  provide,
+  providerScope,
+} from '../../../packages/bijou/src/index.js';
+import {
+  applyRuntimeCommandBuffer,
+  createRuntimeCommandBuffer,
+  createRuntimeViewStack,
+  pushRuntimeView,
+} from '../../../packages/bijou-tui/src/runtime-engine.js';
+import {
+  collectRuntimeViewBindings,
+  dispatchRuntimeCommandIntent,
+  runtimeActiveBindingLayers,
+  runtimeCommandIntentEmission,
+  runtimeCommandIntentRoute,
+  runtimeViewBindingSource,
+} from '../../../packages/bijou-tui/src/runtime-binding.js';
+import { readRepoFile } from '../repo.js';
+
+describe('DX-034G/H/I active binding runtime loop', () => {
+  it('collects active runtime view binding sources without rendering or subscribing', () => {
+    const shellOwner = defineBindingLifecycleOwner({ id: 'docs.shell', kind: 'app-shell' });
+    const overlayOwner = defineBindingLifecycleOwner({ id: 'docs.overlay', kind: 'view' });
+    const modalOwner = defineBindingLifecycleOwner({ id: 'docs.modal', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const overlayHelp = defineDataRequirement({ id: 'overlayHelp', resource: 'docs.help' });
+    const modalChoice = defineDataRequirement({ id: 'modalChoice', resource: 'docs.choice' });
+    const shellSource = runtimeViewBindingSource({
+      owner: shellOwner,
+      contract: defineViewData({
+        requirements: [{ name: 'article', requirement: article }],
+      }),
+      providerIds: [{ requirementId: 'article', providerId: 'docs.articleProvider' }],
+    });
+    const overlaySource = runtimeViewBindingSource({
+      owner: overlayOwner,
+      contract: defineViewData({
+        requirements: [{ name: 'overlayHelp', requirement: overlayHelp }],
+      }),
+    });
+    const modalSource = runtimeViewBindingSource({
+      owner: modalOwner,
+      contract: defineViewData({
+        requirements: [{ name: 'modalChoice', requirement: modalChoice }],
+      }),
+    });
+    const shellStack = createRuntimeViewStack({
+      id: 'docs-shell',
+      kind: 'app-shell',
+      dismissible: false,
+      blocksBelow: false,
+      model: { bindingSources: [shellSource] },
+    });
+    const overlayStack = pushRuntimeView(shellStack, {
+      id: 'help-overlay',
+      kind: 'overlay',
+      dismissible: true,
+      blocksBelow: true,
+      model: { bindingSources: [overlaySource] },
+    });
+    const modalStack = pushRuntimeView(overlayStack, {
+      id: 'choice-modal',
+      kind: 'modal',
+      dismissible: true,
+      blocksBelow: false,
+      model: { bindingSources: [modalSource] },
+    });
+
+    expect(runtimeActiveBindingLayers(overlayStack).map((layer) => layer.id)).toEqual([
+      'docs-shell',
+      'help-overlay',
+    ]);
+    expect(collectRuntimeViewBindings(overlayStack).entries().map((entry) => entry.requirement.id)).toEqual([
+      'article',
+      'overlayHelp',
+    ]);
+    expect(runtimeActiveBindingLayers(modalStack).map((layer) => layer.id)).toEqual([
+      'choice-modal',
+    ]);
+    expect(collectRuntimeViewBindings(modalStack).entries().map((entry) => entry.requirement.id)).toEqual([
+      'modalChoice',
+    ]);
+  });
+
+  it('turns provider snapshots into a new frame and lifecycle invalidation facts', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const article = defineDataRequirement({ id: 'article', resource: 'docs.article' });
+    const collection = activeBindingCollection([
+      activeBindingEntry({ owner, requirement: article }),
+    ]);
+    const scope = providerScope([
+      provide(defineDataProvider({
+        id: 'docs.articleProvider',
+        resource: 'docs.article',
+      })),
+    ]);
+    const oldFrame = bindingFrame([
+      bindingSnapshot({
+        providerId: 'docs.articleProvider',
+        requirementId: 'article',
+        version: 1,
+        status: 'ready',
+        data: { title: 'Before' },
+      }),
+    ]);
+
+    const update = bindingFrameUpdateFromSnapshots({
+      collection,
+      scope,
+      snapshots: [
+        bindingSnapshot({
+          providerId: 'docs.articleProvider',
+          requirementId: 'article',
+          version: 2,
+          status: 'ready',
+          data: { title: 'After' },
+        }),
+      ],
+    });
+
+    expect(oldFrame.require<{ title: string }>('article').title).toBe('Before');
+    expect(update.frame.require<{ title: string }>('article').title).toBe('After');
+    expect(update.records[0]?.invalidations).toEqual([
+      {
+        requirementId: 'article',
+        providerId: 'docs.articleProvider',
+        reason: 'provider-update',
+        snapshotVersion: 2,
+      },
+    ]);
+    expect('provider' in update).toBe(false);
+    expect('refresh' in update).toBe(false);
+    expect('subscribe' in update).toBe(false);
+  });
+
+  it('routes command intent emissions into the runtime command buffer for later business logic', () => {
+    type Command = { readonly type: 'reader.selectHeading'; readonly headingId: string };
+    const owner = defineBindingLifecycleOwner({ id: 'reader.view', kind: 'view' });
+    const selectHeading = commandIntent<{ readonly headingId: string }>('reader.selectHeading');
+    const emission = runtimeCommandIntentEmission(
+      selectHeading,
+      { headingId: 'intro' },
+      { owner },
+    );
+    const route = runtimeCommandIntentRoute<{ readonly headingId: string }, Command>({
+      intent: selectHeading,
+      toCommand: (intentEmission) => ({
+        type: 'reader.selectHeading',
+        headingId: intentEmission.payload.headingId,
+      }),
+    });
+
+    const dispatched = dispatchRuntimeCommandIntent({
+      emission,
+      routes: [route],
+      buffer: createRuntimeCommandBuffer<Command>(),
+    });
+    const applied = applyRuntimeCommandBuffer(
+      { selectedHeadingId: '' },
+      dispatched.buffer,
+      (state, command) => ({
+        selectedHeadingId: command.headingId,
+      }),
+    );
+
+    expect(dispatched.buffer.items).toEqual([{
+      type: 'reader.selectHeading',
+      headingId: 'intro',
+    }]);
+    expect(applied.state.selectedHeadingId).toBe('intro');
+    expect(applied.buffer.items).toEqual([]);
+    expect('provider' in emission).toBe(false);
+    expect('refresh' in emission).toBe(false);
+    expect('subscribe' in emission).toBe(false);
+    expect('dispatch' in emission).toBe(false);
+  });
+
+  it('documents DX-034G through DX-034I without claiming subscriptions or rendering', () => {
+    const cycle = readRepoFile('docs/design/DX-034-declarative-view-data-binding.md');
+    const changelog = readRepoFile('docs/CHANGELOG.md');
+
+    expect(cycle).toContain('### DX-034G Active View Binding Collection');
+    expect(cycle).toContain('### DX-034H Provider Update Invalidation Flow');
+    expect(cycle).toContain('### DX-034I Command Intent Dispatch Proof');
+    expect(cycle).toContain('DX-034G does not subscribe, refresh, dispatch, render, cache');
+    expect(cycle).toContain('DX-034H does not fetch data, subscribe, refresh providers');
+    expect(cycle).toContain('Command intents and emissions expose no provider handles');
+    expect(changelog).toContain('Runtime binding loop proofs for DX-034');
+  });
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -7,7 +7,13 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@flyingrobots/bijou": ["./packages/bijou/src/index.ts"],
+      "@flyingrobots/bijou/adapters/test": ["./packages/bijou/src/adapters/test/index.ts"],
+      "@flyingrobots/bijou/perf": ["./packages/bijou/src/core/render/packed-cell.ts"]
+    }
   },
   "include": ["packages/*/src/**/*.test.ts", "packages/*/src/**/*.d.ts", "scripts/**/*.test.ts", "scripts/**/*.d.ts", "tests/**/*.test.ts", "tests/**/*.d.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@flyingrobots/bijou/adapters/test': fileURLToPath(
+        new URL('./packages/bijou/src/adapters/test/index.ts', import.meta.url),
+      ),
+      '@flyingrobots/bijou/perf': fileURLToPath(
+        new URL('./packages/bijou/src/core/render/packed-cell.ts', import.meta.url),
+      ),
+      '@flyingrobots/bijou': fileURLToPath(
+        new URL('./packages/bijou/src/index.ts', import.meta.url),
+      ),
+    },
+  },
   test: {
     include: ['packages/*/src/**/*.test.ts', 'bench/src/**/*.test.ts', 'scripts/**/*.test.ts', 'tests/**/*.test.ts'],
   },


### PR DESCRIPTION
## Summary

Adds the DX-034G/H/I runtime-loop proof for declarative, immutable view data binding.

This PR connects the existing public binding contracts to the TUI runtime in three deliberately bounded slices:

- DX-034G: `@flyingrobots/bijou-tui` can collect active binding sources from the existing `RuntimeViewStack`, using `blocksBelow` to decide which declared view data contracts are active.
- DX-034H: `@flyingrobots/bijou` can turn explicit provider snapshots into a new immutable `BindingFrame` plus lifecycle invalidation facts through `bindingFrameUpdateFromSnapshots()`.
- DX-034I: `@flyingrobots/bijou-tui` can map declared `CommandIntent` emissions through explicit runtime routes into the existing `RuntimeCommandBuffer`, with business logic applying commands later.

This also updates test resolution so Vitest and `typecheck:test` resolve `@flyingrobots/bijou` workspace source for the main package and existing public subpaths, avoiding stale local `dist` declarations while validating same-branch public APIs.

## Non-goals

- no provider subscriptions
- no provider refresh
- no active hierarchy lifecycle manager
- no provider handle resolution
- no rendered AppShell
- no schema binding
- no cache retention policy
- no DOGFOOD integration
- no command execution inside views

## Validation

- `npm test -- --run packages/bijou-tui/src/runtime-binding.test.ts packages/bijou/src/core/binding-frame-update.test.ts tests/cycles/DX-034/active-binding-runtime-loop.test.ts`
- `npm run build`
- `npm run docs:inventory`
- `git diff --check`
- `npm run typecheck:test`
- `npm run lint`
- `npm test`
- `npm run verify:interactive-examples`
- pre-commit reran `npm run lint` and lockfile consistency
- pre-push reran `npm run typecheck:test`, `npm test`, and `npm run verify:interactive-examples`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime binding collection across stacked views with active layer support
  * Introduced command-intent routing through runtime command buffer
  * Exported new runtime binding APIs for view binding and command management
  * Added binding frame updates from provider snapshots

* **Documentation**
  * Documented DX-034 runtime binding loop proof
  * Updated design documentation with completed implementation milestones

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->