### PR TITLE
feat(blocks): add schema-bound contract

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Schema-bound block contract for `bijou`** — `@flyingrobots/bijou` now
+  exports adapter-first schema-bound block primitives:
+  `BlockSchemaAdapter`, `defineBlockSchemaAdapter()`, `defineSchemaBlock()`,
+  `parseBlockSchema()`, and `bindSchemaBlockInput()`. Blocks can validate
+  unknown boundary data into immutable typed data or deterministic issues before
+  producing immutable block render input and binding facts. This does not add a
+  hard Zod dependency, provider subscriptions, command dispatch, rendered
+  AppShell, DOGFOOD integration, or a broad block catalog.
 - **Runtime binding loop proofs for DX-034** —
   `@flyingrobots/bijou-tui` now exports runtime binding-source collection over
   the existing `RuntimeViewStack`, using `blocksBelow` to decide which declared

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   unknown boundary data into immutable typed data or deterministic issues before
   producing immutable block render input and binding facts. This does not add a
   hard Zod dependency, provider subscriptions, command dispatch, rendered
-  AppShell, DOGFOOD integration, or a broad block catalog.
+  AppShell, DOGFOOD integration, or a broad block catalog. Schema-bound bind
+  outputs now reject unsupported render-input/backchannel keys and malformed
+  untyped scalar/list inputs with deterministic domain errors.
 - **Runtime binding loop proofs for DX-034** —
   `@flyingrobots/bijou-tui` now exports runtime binding-source collection over
   the existing `RuntimeViewStack`, using `blocksBelow` to decide which declared

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   hard Zod dependency, provider subscriptions, command dispatch, rendered
   AppShell, DOGFOOD integration, or a broad block catalog. Schema-bound bind
   outputs now reject unsupported render-input/backchannel keys and malformed
-  untyped scalar/list inputs with deterministic domain errors.
+  untyped scalar/list inputs with deterministic domain errors. Schema adapter
+  callbacks are snapshotted at definition time, and schema-bound bind outputs
+  must be plain objects so class instances and built-ins cannot normalize to
+  empty render input.
 - **Runtime binding loop proofs for DX-034** —
   `@flyingrobots/bijou-tui` now exports runtime binding-source collection over
   the existing `RuntimeViewStack`, using `blocksBelow` to decide which declared

--- a/docs/design-system/blocks.md
+++ b/docs/design-system/blocks.md
@@ -64,15 +64,19 @@ Bijou now exposes a metadata-first block authoring contract from
   discovery without provider handles or command callbacks.
 - `defineAppShellComposition()` groups runtime-backed blocks into logical
   navigation, content, inspector, status, and overlay slots without rendering.
+- `defineBlockSchemaAdapter()`, `defineSchemaBlock()`, and
+  `bindSchemaBlockInput()` validate unknown boundary data before producing block
+  render input and binding facts.
 - `validateBlockMetadata()`, `blockMetadataSummary()`, and report helpers give
   tests, docs, DOGFOOD, MCP payloads, and agents a deterministic way to inspect
   block facts without rendering a terminal surface.
 
-This is the first DX-031 slice: blocks are described before they render, package
-authors avoid hidden global registration, and tooling can discover slots and
-mode support directly. Schema-bound blocks remain a follow-on; the current
-contract deliberately does not make Zod, GraphQL, or database schemas part of
-the core block dependency surface.
+Blocks are described before they render, package authors avoid hidden global
+registration, and tooling can discover slots and mode support directly.
+Schema-bound blocks validate unknown boundary data without making Zod, GraphQL,
+or database schemas part of the core block dependency surface. Provider
+subscriptions, active hierarchy traversal, rendered AppShell, and DOGFOOD block
+proof remain follow-on work.
 
 ## First credible block candidates
 

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -3307,9 +3307,13 @@ What is now true:
   metadata, data contracts, command intents, and ordinary render ownership.
 - Schema adapters validate unknown input into immutable typed data or immutable
   deterministic issues.
+- Schema adapters snapshot their parse/describe callbacks at definition time.
 - Binding schema data produces immutable block render input and optional
   semantic facts without rendering, subscribing, dispatching, resolving
   providers, or owning AppShell behavior.
+- Bind outputs must be plain objects with supported render-input keys, so
+  class instances, built-ins, and backchannel handles cannot silently normalize
+  into empty input.
 
 Still out of scope after this slice:
 

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -279,7 +279,7 @@ classDiagram
 
   BlockPackageManifest "1" *-- "1..*" BlockDefinition : exports
   BlockDefinition "1" *-- "1" BlockMetadata : describes
-  SchemaBoundBlock "1" --|> BlockDefinition : specializes
+  SchemaBoundBlock "1" *-- "1" BlockDefinition : wraps
   SchemaBoundBlock "1" *-- "1" BlockSchemaAdapter : validates
   BlockMetadata "1" *-- "1..*" BlockSlot : required slots
   BlockMetadata "1" o-- "0..*" BlockSlot : optional slots

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -366,19 +366,28 @@ interface BlockExample {
   readonly command?: string;
 }
 
+type DeepReadonly<T> = T extends readonly (infer Item)[]
+  ? readonly DeepReadonly<Item>[]
+  : T extends object
+    ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+    : T;
+
 type BlockSchemaResult<Data> =
-  | { readonly ok: true; readonly data: Data }
+  | { readonly ok: true; readonly data: DeepReadonly<Data> }
   | { readonly ok: false; readonly issues: readonly BlockSchemaIssue[] };
 
 interface BlockSchemaIssue {
-  readonly path: readonly string[];
+  readonly severity: 'info' | 'warning' | 'error';
+  readonly code: string;
   readonly message: string;
+  readonly path?: string;
 }
 
-interface BlockSchemaFacts {
-  readonly requiredFields: readonly string[];
-  readonly optionalFields: readonly string[];
+interface BlockSchemaDescription {
+  readonly requiredFields?: readonly string[];
+  readonly optionalFields?: readonly string[];
   readonly redactedFields?: readonly string[];
+  readonly facts?: readonly ModeLoweringFact[];
 }
 
 interface BlockDefinition<Config = unknown> {
@@ -391,13 +400,18 @@ interface BlockDefinition<Config = unknown> {
 interface BlockSchemaAdapter<Data> {
   readonly id: string;
   readonly parse: (input: unknown) => BlockSchemaResult<Data>;
-  readonly describe?: () => BlockSchemaFacts;
+  readonly describe?: () => BlockSchemaDescription;
 }
 
-interface SchemaBoundBlockDefinition<Data, Config = unknown>
-  extends BlockDefinition<Config> {
+interface SchemaBoundBlockDefinition<Data, Config = unknown> {
+  readonly block: BlockDefinition<Config>;
   readonly schema: BlockSchemaAdapter<Data>;
-  readonly bind: (data: Data) => BlockRenderInput<Config>;
+  readonly bind: (
+    data: DeepReadonly<Data>,
+  ) => BlockRenderInput<Config> | {
+    readonly input: BlockRenderInput<Config>;
+    readonly facts?: readonly ModeLoweringFact[];
+  };
 }
 
 interface BlockPackageManifest {
@@ -423,10 +437,18 @@ declare function defineSchemaBlock<Data, Config>(
   definition: SchemaBoundBlockDefinition<Data, Config>,
 ): SchemaBoundBlockDefinition<Data, Config>;
 
-declare function renderSchemaBlock<Data, Config>(
+declare function bindSchemaBlockInput<Data, Config>(
   block: SchemaBoundBlockDefinition<Data, Config>,
   input: unknown,
-): BlockRenderResult;
+): {
+  readonly ok: true;
+  readonly input: BlockRenderInput<Config>;
+  readonly facts: readonly ModeLoweringFact[];
+} | {
+  readonly ok: false;
+  readonly issues: readonly BlockSchemaIssue[];
+  readonly facts: readonly ModeLoweringFact[];
+};
 
 declare function defineBlockPackage(
   manifest: BlockPackageManifest,
@@ -434,9 +456,14 @@ declare function defineBlockPackage(
 ```
 
 DX-031A lands this as a public metadata-first API in `@flyingrobots/bijou`.
-The schema-bound functions remain follow-on API work. The important boundary is
-that a block is described before it renders, and its slots and semantic facts
-are visible to tests, docs, DOGFOOD, and agents.
+
+DX-031B Schema-Bound Blocks lands the schema adapter layer as a public boundary
+contract in `@flyingrobots/bijou`. Schema-bound blocks validate boundary data
+before producing block render input or binding facts. They do not fetch,
+subscribe, dispatch, compose runtime views, or render AppShell. The important
+boundary is that a block and its schema are described before rendering, and their
+slots, semantic facts, and validation facts are visible to tests, docs, DOGFOOD,
+and agents.
 
 ## Public Block API And Distribution
 
@@ -540,35 +567,43 @@ snapshots without owning business state.
 
 ## Schema-Bound Blocks
 
-The happy path for app builders should be extremely direct:
+The schema-bound boundary for app builders should be direct:
 
 1. define or import a schema
 2. bind that schema to a block
 3. pass a schema-compliant object
-4. get a working UI with validation, defaults, slots, and semantic facts
+4. receive immutable block render input and validation facts
 
 In app code, the target ergonomics should feel like:
 
 ```ts
-const productDetailsBlock = defineSchemaBlock({
+const productDetailsBaseBlock = defineBlock({
   metadata: productDetailsMetadata,
-  schema: zodBlockSchema(productDetailsSchema),
-  bind: product => ({
-    slots: {
-      title: product.name,
-      summary: product.summary,
-      specs: product.specs,
-      reviews: product.reviews,
-      primaryAction: { id: 'add-to-cart', label: 'Add to cart' },
-    },
-    config: {
-      variant: 'purchase-detail',
-    },
-  }),
   render: productDetails,
 });
 
-renderSchemaBlock(productDetailsBlock, {
+const productDetailsBlock = defineSchemaBlock({
+  block: productDetailsBaseBlock,
+  schema: zodBlockSchema(productDetailsSchema),
+  bind: product => ({
+    input: {
+      slots: {
+        title: product.name,
+        summary: product.summary,
+        specs: product.specs,
+        reviews: product.reviews,
+        primaryAction: { id: 'add-to-cart', label: 'Add to cart' },
+      },
+      config: {
+        variant: 'purchase-detail',
+      },
+    },
+    facts: [{ kind: 'entity', key: 'product', value: product.id }],
+  }),
+});
+
+bindSchemaBlockInput(productDetailsBlock, {
+  id: 'bijou-pro',
   name: 'Bijou Pro',
   summary: 'Runtime truth for terminal apps.',
   specs: [{ label: 'Mode', value: 'interactive' }],
@@ -576,14 +611,15 @@ renderSchemaBlock(productDetailsBlock, {
 });
 ```
 
-That is the real DX target: give the block a valid object and it should render
-the expected surface without the app author manually wiring every row, action,
-validation message, and lower-mode fact.
+That is the real DX target for this layer: give the schema-bound block an
+unknown object and it should validate the boundary before producing immutable
+render input, validation issues, and lower-mode facts. Rendering remains the
+ordinary block renderer's job.
 
-Zod should be the first-class authoring adapter because it is familiar in the
-TypeScript ecosystem and Bijou already uses it in MCP tooling. The core block
-contract should still be schema-adapter shaped so the runtime does not require
-Zod as a hard dependency forever.
+Zod can become the first optional authoring adapter because it is familiar in
+the TypeScript ecosystem and Bijou already uses it in MCP tooling. The core
+block contract is schema-adapter shaped so the runtime does not require Zod as a
+hard dependency.
 
 Recommended split:
 
@@ -622,6 +658,8 @@ Rules:
 
 - schema validation happens before rendering
 - invalid data produces explicit validation facts, not partial mystery UI
+- schema-bound blocks validate boundary data and do not fetch, subscribe,
+  dispatch, compose runtime views, or render AppShell
 - schema-bound blocks still render through ordinary Bijou layout envelopes
 - schemas may describe data shape, but blocks still own presentation choices
 - secret fields must be redacted before metadata, diagnostics, or captures
@@ -3112,16 +3150,19 @@ blocks.
 7. Done: prove active runtime binding collection, provider snapshot
    invalidation into new immutable frames, and command intent routing before
    rendered AppShell work begins.
-8. Next: add `defineSchemaBlock()` and a Zod schema adapter.
-9. Next: add block stories for `AppShell`, `ReaderSurface`, and
+8. Done: add adapter-first `defineSchemaBlock()` support without making Zod,
+   provider lifecycle, AppShell rendering, or DOGFOOD proof part of the core
+   schema-bound block contract.
+9. Next: add an optional Zod schema adapter package or helper.
+10. Next: add block stories for `AppShell`, `ReaderSurface`, and
    `InspectorPanel`.
-10. Next: capture interactive, static, pipe, and accessible outputs for the
+11. Next: capture interactive, static, pipe, and accessible outputs for the
    first implementation set.
-11. Next: prove the first three blocks in DOGFOOD before broadening the
+12. Next: prove the first three blocks in DOGFOOD before broadening the
    catalog.
-12. Next: add catalog-only variant/config metadata for later blocks without
+13. Next: add catalog-only variant/config metadata for later blocks without
    implementing those blocks yet.
-13. Continue to defer modal stacks, notifications, auth forms, animated
+14. Continue to defer modal stacks, notifications, auth forms, animated
    carousels, complex controls, and workspace-like behavior until the first
    rendered block set is proven.
 
@@ -3134,9 +3175,10 @@ blocks.
   compatibility.
 - Public API tests proving importing a block package does not mutate global
   runtime state.
-- Public API tests proving a schema-bound block validates data before render.
-- Public API tests proving a Zod-backed adapter can bind valid data into block
-  slots, config, and semantic facts.
+- Public API tests proving a schema-bound block validates data before bind or
+  render output is consumed.
+- Public API tests proving an adapter can bind valid data into block slots,
+  config, and semantic facts without a hard Zod dependency.
 - Public API tests proving invalid schema data becomes validation facts instead
   of partial rendered UI.
 - Tooling tests proving block metadata can be indexed without rendering a
@@ -3177,8 +3219,8 @@ blocks.
 - Importing a block package does not register runtime behavior globally.
 - Blocks can bind schema-compliant data objects to slots, config, validation,
   semantic facts, and render input.
-- Zod is supported as a first-class schema authoring adapter without making
-  every block depend on Zod directly.
+- The core schema-bound block API is adapter-first and does not require Zod as a
+  hard dependency.
 - GraphQL, database, or local-storage schema compilers can generate draft block
   metadata, schema adapters, stories, and semantic facts.
 - Tooling can discover block slots, variants, modes, semantic facts, and story
@@ -3254,9 +3296,24 @@ What is now true:
 - The design-system blocks entrypoint now points to the current public
   contract instead of only naming future candidates.
 
-Still out of scope for this slice:
+DX-031B Schema-Bound Blocks adds the boundary validation slice.
 
-- `defineSchemaBlock()`, Zod adapters, and schema-to-block compilers.
+What is now true:
+
+- `@flyingrobots/bijou` exports `BlockSchemaAdapter`,
+  `defineBlockSchemaAdapter()`, `defineSchemaBlock()`,
+  `parseBlockSchema()`, and `bindSchemaBlockInput()`.
+- Schema-bound blocks wrap an existing `BlockDefinition`, preserving block
+  metadata, data contracts, command intents, and ordinary render ownership.
+- Schema adapters validate unknown input into immutable typed data or immutable
+  deterministic issues.
+- Binding schema data produces immutable block render input and optional
+  semantic facts without rendering, subscribing, dispatching, resolving
+  providers, or owning AppShell behavior.
+
+Still out of scope after this slice:
+
+- Zod adapters and schema-to-block compilers.
 - Rendered first-party `AppShell`, `ReaderSurface`, and `InspectorPanel`
   blocks.
 - DOGFOOD block galleries and multi-mode story captures for rendered blocks.

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -118,9 +118,12 @@ that tools can inspect before rendering:
 ```typescript
 import {
   commandIntent,
+  bindSchemaBlockInput,
   defineBlock,
   defineBlockPackage,
+  defineBlockSchemaAdapter,
   defineDataRequirement,
+  defineSchemaBlock,
   defineViewData,
 } from '@flyingrobots/bijou';
 
@@ -164,8 +167,59 @@ export const docsBlocks = defineBlockPackage({
 Blocks are explicit imports, not runtime plugins. `BlockMetadata` and
 `BlockPackageManifest` are intended for docs, DOGFOOD, MCP payloads, and package
 compatibility checks. `data` and `commands` are inspectable contracts, not
-runtime provider handles or command callbacks. Schema-bound blocks are still a
-follow-on layer.
+runtime provider handles or command callbacks.
+
+Use schema-bound blocks when unknown boundary data needs validation before it
+becomes render input:
+
+```typescript
+const articleSchema = defineBlockSchemaAdapter<{ id: string; title: string }>({
+  id: 'docs.article',
+  parse(input) {
+    if (
+      input === null
+      || typeof input !== 'object'
+      || typeof (input as { id?: unknown }).id !== 'string'
+      || typeof (input as { title?: unknown }).title !== 'string'
+    ) {
+      return {
+        ok: false,
+        issues: [{
+          severity: 'error',
+          code: 'article.invalid',
+          message: 'Article data is required.',
+        }],
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        id: (input as { id: string }).id,
+        title: (input as { title: string }).title,
+      },
+    };
+  },
+});
+
+const articleReaderBlock = defineSchemaBlock({
+  block: readerSurfaceBlock,
+  schema: articleSchema,
+  bind: article => ({
+    input: { slots: { content: article.title } },
+    facts: [{ kind: 'entity', key: 'article', value: article.id }],
+  }),
+});
+
+const bound = bindSchemaBlockInput(articleReaderBlock, {
+  id: 'intro',
+  title: 'Introduction',
+});
+```
+
+Schema-bound blocks validate shape at the block boundary. They do not fetch,
+subscribe, dispatch commands, resolve providers, render AppShell, or register
+global runtime behavior.
 
 ## AppShell Composition
 

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -97,6 +97,9 @@ fake duplication rather than a real second API.
   view data contracts, and command intents.
 - **`defineBlockPackage()`**: Declare exported blocks, docs, tags, version, and
   Bijou peer compatibility for ordinary NPM block packages.
+- **`defineBlockSchemaAdapter()` / `defineSchemaBlock()`**: Validate unknown
+  boundary data before producing immutable block render input and binding facts,
+  without fetching, subscribing, dispatching, or rendering AppShell.
 - **`blockMetadataSummary()`**: Render compact block metadata for docs, MCP
   payloads, and agent-facing reports.
 - **`defineAppShellComposition()`**: Compose runtime-backed blocks into logical

--- a/packages/bijou/src/core/schema-block.test.ts
+++ b/packages/bijou/src/core/schema-block.test.ts
@@ -104,6 +104,32 @@ describe('schema-bound block contract', () => {
     expect(schemaBlock.schema).toBe(articleSchema);
   });
 
+  it('snapshots adapter callbacks when the schema adapter is defined', () => {
+    const schemaInput = {
+      id: 'docs.article',
+      parse: (): { readonly ok: true; readonly data: Article } => ({
+        ok: true,
+        data: { id: 'original', title: 'Original' },
+      }),
+      describe: () => ({ requiredFields: ['id'] }),
+    };
+    const articleSchema = defineBlockSchemaAdapter<Article>(schemaInput);
+
+    schemaInput.parse = () => ({
+      ok: true,
+      data: { id: 'mutated', title: 'Mutated' },
+    });
+    schemaInput.describe = () => ({ requiredFields: ['mutated'] });
+
+    expect(parseBlockSchema(articleSchema, {})).toEqual({
+      ok: true,
+      data: { id: 'original', title: 'Original' },
+    });
+    expect(articleSchema.describe?.()).toMatchObject({
+      requiredFields: ['id'],
+    });
+  });
+
   it('validates unknown boundary data into immutable typed data or immutable issues', () => {
     const articleSchema = defineArticleSchema();
     const valid = parseBlockSchema(articleSchema, {
@@ -231,6 +257,41 @@ describe('schema-bound block contract', () => {
       id: 'dx-031',
       title: 'DX-031',
     })).toThrow('schema block bind: unsupported bind output key dispatch');
+  });
+
+  it('rejects non-plain bind outputs instead of normalizing them to empty input', () => {
+    const block = defineBlock({
+      metadata: readerSurfaceMetadata,
+      render: () => ({ output: 'reader' }),
+    });
+    const dateOutput = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: () => new Date(0) as never,
+    });
+    const wrappedDateInput = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: () => ({ input: new Date(0) }) as never,
+    });
+    const arrayOutput = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: () => [] as never,
+    });
+
+    expect(() => bindSchemaBlockInput(dateOutput, {
+      id: 'dx-031',
+      title: 'DX-031',
+    })).toThrow('schema block bind: bind output must be a plain object');
+    expect(() => bindSchemaBlockInput(wrappedDateInput, {
+      id: 'dx-031',
+      title: 'DX-031',
+    })).toThrow('schema block bind: input must be a plain object');
+    expect(() => bindSchemaBlockInput(arrayOutput, {
+      id: 'dx-031',
+      title: 'DX-031',
+    })).toThrow('schema block bind: bind output must be a plain object');
   });
 
   it('preserves data and command contracts without taking ownership of provider lifecycle', () => {

--- a/packages/bijou/src/core/schema-block.test.ts
+++ b/packages/bijou/src/core/schema-block.test.ts
@@ -195,6 +195,44 @@ describe('schema-bound block contract', () => {
     }
   });
 
+  it('rejects unsupported bind output keys instead of dropping them silently', () => {
+    const block = defineBlock({
+      metadata: readerSurfaceMetadata,
+      render: () => ({ output: 'reader' }),
+    });
+    const topLevelTypo = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: () => ({ slotz: { content: 'typo' } }) as never,
+    });
+    const wrappedTypo = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: () => ({ input: { slotz: { content: 'typo' } } }) as never,
+    });
+    const backchannel = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: () => ({
+        input: { slots: { content: 'safe' } },
+        dispatch: () => undefined,
+      }) as never,
+    });
+
+    expect(() => bindSchemaBlockInput(topLevelTypo, {
+      id: 'dx-031',
+      title: 'DX-031',
+    })).toThrow('schema block bind: unsupported bind output key slotz');
+    expect(() => bindSchemaBlockInput(wrappedTypo, {
+      id: 'dx-031',
+      title: 'DX-031',
+    })).toThrow('schema block bind: unsupported input key slotz');
+    expect(() => bindSchemaBlockInput(backchannel, {
+      id: 'dx-031',
+      title: 'DX-031',
+    })).toThrow('schema block bind: unsupported bind output key dispatch');
+  });
+
   it('preserves data and command contracts without taking ownership of provider lifecycle', () => {
     const article = defineDataRequirement({
       id: 'article',
@@ -263,5 +301,53 @@ describe('schema-bound block contract', () => {
       id: 'docs.invalid',
       parse: () => ({ ok: false, issues: [] }),
     }), {})).toThrow(Error);
+  });
+
+  it('reports deterministic errors for malformed untyped schema inputs', () => {
+    expect(() => defineBlockSchemaAdapter({
+      id: 42,
+      parse: () => ({ ok: true, data: {} }),
+    } as never)).toThrow('block schema adapter: id must be a string');
+
+    expect(() => parseBlockSchema(defineBlockSchemaAdapter({
+      id: 'docs.invalid',
+      parse: () => ({ ok: false, issues: { code: 'bad' } }) as never,
+    }), {})).toThrow('block schema result: issues must be an array');
+
+    const badDescription = defineBlockSchemaAdapter({
+      id: 'docs.description',
+      parse: () => ({ ok: true, data: {} }),
+      describe: () => ({ requiredFields: 'id' }) as never,
+    });
+    expect(() => badDescription.describe?.()).toThrow(
+      'block schema description: requiredFields must be an array',
+    );
+
+    const badSchemaFacts = defineBlockSchemaAdapter({
+      id: 'docs.facts',
+      parse: () => ({ ok: true, data: {} }),
+      describe: () => ({ facts: 'entity:article' }) as never,
+    });
+    expect(() => badSchemaFacts.describe?.()).toThrow(
+      'block schema description: facts must be an array',
+    );
+
+    const block = defineBlock({
+      metadata: readerSurfaceMetadata,
+      render: () => ({ output: 'reader' }),
+    });
+    const badBindFacts = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: () => ({
+        input: { slots: { content: 'DX-031' } },
+        facts: 'entity:article',
+      }) as never,
+    });
+
+    expect(() => bindSchemaBlockInput(badBindFacts, {
+      id: 'dx-031',
+      title: 'DX-031',
+    })).toThrow('schema block bind: facts must be an array');
   });
 });

--- a/packages/bijou/src/core/schema-block.test.ts
+++ b/packages/bijou/src/core/schema-block.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commandIntent,
+  defineDataRequirement,
+  defineViewData,
+} from './binding.js';
+import {
+  defineBlock,
+  type BlockMetadata,
+} from './block-metadata.js';
+import {
+  bindSchemaBlockInput,
+  defineBlockSchemaAdapter,
+  defineSchemaBlock,
+  isBlockSchemaAdapter,
+  isSchemaBoundBlockDefinition,
+  parseBlockSchema,
+  type BlockSchemaIssue,
+} from './schema-block.js';
+
+interface Article {
+  readonly id: string;
+  readonly title: string;
+  readonly tags?: readonly string[];
+}
+
+const readerSurfaceMetadata: BlockMetadata = {
+  packageName: '@flyingrobots/bijou',
+  blockName: 'ReaderSurface',
+  family: 'content-reading',
+  scale: 'section',
+  modes: ['interactive', 'static', 'pipe', 'accessible'],
+  docs: {
+    summary: 'Composes readable article content with optional navigation and outline slots.',
+  },
+  slots: [
+    { id: 'content', required: true },
+    { id: 'navigation', required: false },
+    { id: 'outline', required: false },
+  ],
+};
+
+function defineArticleSchema() {
+  return defineBlockSchemaAdapter<Article>({
+    id: ' docs.article ',
+    parse(input) {
+      if (!isArticleInput(input)) {
+        return {
+          ok: false,
+          issues: [{
+            severity: 'error',
+            code: 'article.invalid',
+            message: 'Article data is required.',
+            path: 'article',
+          }],
+        };
+      }
+
+      return {
+        ok: true,
+        data: {
+          id: input.id,
+          title: input.title,
+          ...(input.tags === undefined ? {} : { tags: input.tags }),
+        },
+      };
+    },
+    describe: () => ({
+      requiredFields: ['id', 'title'],
+      optionalFields: ['tags'],
+      redactedFields: ['secret'],
+    }),
+  });
+}
+
+function isArticleInput(input: unknown): input is Article {
+  if (input === null || typeof input !== 'object') {
+    return false;
+  }
+
+  const article = input as Partial<Article>;
+  return typeof article.id === 'string' && typeof article.title === 'string';
+}
+
+describe('schema-bound block contract', () => {
+  it('creates branded schema adapters and schema-bound blocks around block definitions', () => {
+    const articleSchema = defineArticleSchema();
+    const block = defineBlock({
+      metadata: readerSurfaceMetadata,
+      render: ({ config }) => ({ output: config }),
+    });
+    const schemaBlock = defineSchemaBlock({
+      block,
+      schema: articleSchema,
+      bind: (article) => ({ config: { heading: article.title } }),
+    });
+
+    expect(articleSchema.id).toBe('docs.article');
+    expect(isBlockSchemaAdapter(articleSchema)).toBe(true);
+    expect(isSchemaBoundBlockDefinition(schemaBlock)).toBe(true);
+    expect(Object.isFrozen(articleSchema)).toBe(true);
+    expect(Object.isFrozen(schemaBlock)).toBe(true);
+    expect(schemaBlock.block.metadata).toBe(block.metadata);
+    expect(schemaBlock.schema).toBe(articleSchema);
+  });
+
+  it('validates unknown boundary data into immutable typed data or immutable issues', () => {
+    const articleSchema = defineArticleSchema();
+    const valid = parseBlockSchema(articleSchema, {
+      id: 'dx-034',
+      title: 'DX-034',
+      tags: ['binding'],
+    });
+    const invalid = parseBlockSchema(articleSchema, undefined);
+
+    expect(valid.ok).toBe(true);
+    if (valid.ok) {
+      expect(valid.data).toEqual({
+        id: 'dx-034',
+        title: 'DX-034',
+        tags: ['binding'],
+      });
+      expect(Object.isFrozen(valid)).toBe(true);
+      expect(Object.isFrozen(valid.data)).toBe(true);
+      expect(Object.isFrozen(valid.data.tags)).toBe(true);
+      expect(() => {
+        (valid.data as { title: string }).title = 'mutated';
+      }).toThrow(TypeError);
+    }
+
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect(invalid.issues).toEqual([{
+        severity: 'error',
+        code: 'article.invalid',
+        message: 'Article data is required.',
+        path: 'article',
+      }]);
+      expect(Object.isFrozen(invalid)).toBe(true);
+      expect(Object.isFrozen(invalid.issues)).toBe(true);
+      expect(Object.isFrozen(invalid.issues[0])).toBe(true);
+      expect(() => {
+        (invalid.issues as BlockSchemaIssue[]).push({
+          severity: 'error',
+          code: 'article.extra',
+          message: 'extra',
+        });
+      }).toThrow(TypeError);
+    }
+  });
+
+  it('validates schema data before bind output is consumed and never renders for validation', () => {
+    let bindCalls = 0;
+    let renderCalls = 0;
+    const articleSchema = defineArticleSchema();
+    const block = defineBlock<{ heading: string }, string>({
+      metadata: readerSurfaceMetadata,
+      render: ({ config }) => {
+        renderCalls += 1;
+        return { output: config?.heading ?? '' };
+      },
+    });
+    const schemaBlock = defineSchemaBlock({
+      block,
+      schema: articleSchema,
+      bind: (article) => {
+        bindCalls += 1;
+        return {
+          input: { config: { heading: article.title } },
+          facts: [{ kind: 'entity', key: 'article', value: article.id }],
+        };
+      },
+    });
+
+    const invalid = bindSchemaBlockInput(schemaBlock, undefined);
+    expect(invalid.ok).toBe(false);
+    expect(bindCalls).toBe(0);
+    expect(renderCalls).toBe(0);
+
+    const valid = bindSchemaBlockInput(schemaBlock, {
+      id: 'dx-031',
+      title: 'DX-031',
+    });
+    expect(valid).toMatchObject({
+      ok: true,
+      input: { config: { heading: 'DX-031' } },
+      facts: [{ kind: 'entity', key: 'article', value: 'dx-031' }],
+    });
+    expect(bindCalls).toBe(1);
+    expect(renderCalls).toBe(0);
+    if (valid.ok) {
+      expect(Object.isFrozen(valid.input)).toBe(true);
+      expect(Object.isFrozen(valid.input.config)).toBe(true);
+      expect(Object.isFrozen(valid.facts)).toBe(true);
+    }
+  });
+
+  it('preserves data and command contracts without taking ownership of provider lifecycle', () => {
+    const article = defineDataRequirement({
+      id: 'article',
+      resource: 'docs.article',
+    });
+    const data = defineViewData({
+      id: 'reader.data',
+      requirements: [{ name: 'article', requirement: article }],
+    });
+    const openArticle = commandIntent<{ articleId: string }>('reader.openArticle');
+    const block = defineBlock({
+      metadata: readerSurfaceMetadata,
+      data,
+      commands: [openArticle],
+      render: () => ({ output: 'reader' }),
+    });
+    const schemaBlock = defineSchemaBlock({
+      block,
+      schema: defineArticleSchema(),
+      bind: (schemaArticle) => ({ slots: { content: schemaArticle.title } }),
+    });
+
+    expect(schemaBlock.block.data).toBe(data);
+    expect(schemaBlock.block.commands).toEqual([openArticle]);
+    expect(schemaBlock.block.data?.requirement('article')).toBe(article);
+    expect(schemaBlock.block.commands?.[0]).toBe(openArticle);
+    expect('provider' in schemaBlock).toBe(false);
+    expect('subscribe' in schemaBlock).toBe(false);
+    expect('refresh' in schemaBlock).toBe(false);
+    expect('dispatch' in schemaBlock).toBe(false);
+  });
+
+  it('rejects loose schema-shaped objects and unsupported schema ids/results', () => {
+    const block = defineBlock({
+      metadata: readerSurfaceMetadata,
+      render: () => ({ output: 'reader' }),
+    });
+
+    expect(() => defineBlockSchemaAdapter(null as never)).toThrow(Error);
+    expect(() => defineSchemaBlock(null as never)).toThrow(Error);
+
+    expect(() => defineBlockSchemaAdapter({
+      id: '   ',
+      parse: () => ({ ok: true, data: {} }),
+    })).toThrow(Error);
+
+    expect(() => defineSchemaBlock({
+      block,
+      schema: {
+        id: 'docs.article',
+        parse: () => ({ ok: true, data: {} }),
+      } as never,
+      bind: () => ({}),
+    })).toThrow(Error);
+
+    expect(() => defineSchemaBlock({
+      block: {
+        metadata: readerSurfaceMetadata,
+        render: () => ({ output: 'reader' }),
+      } as never,
+      schema: defineArticleSchema(),
+      bind: () => ({}),
+    })).toThrow(Error);
+
+    expect(() => parseBlockSchema(defineBlockSchemaAdapter({
+      id: 'docs.invalid',
+      parse: () => ({ ok: false, issues: [] }),
+    }), {})).toThrow(Error);
+  });
+});

--- a/packages/bijou/src/core/schema-block.ts
+++ b/packages/bijou/src/core/schema-block.ts
@@ -224,7 +224,12 @@ interface SchemaBoundBlockBrandCarrier {
 interface RequiredTextOptions {
   readonly scope: string;
   readonly field: string;
-  readonly value: string;
+  readonly value: unknown;
+}
+
+interface TextFieldOptions {
+  readonly scope: string;
+  readonly field: string;
 }
 
 interface NormalizedBindOutput<Config> {
@@ -269,7 +274,7 @@ function normalizeSchemaDescription(
     requiredFields: freezeStringList(description.requiredFields, 'requiredFields'),
     optionalFields: freezeStringList(description.optionalFields, 'optionalFields'),
     redactedFields: freezeStringList(description.redactedFields, 'redactedFields'),
-    facts: freezeFacts(description.facts),
+    facts: freezeFacts(description.facts, 'block schema description'),
   });
 }
 
@@ -281,6 +286,10 @@ function normalizeBindOutput<Config>(
   }
 
   if (Object.prototype.hasOwnProperty.call(output, 'input')) {
+    assertOnlyKeys(output, ['input', 'facts'], {
+      scope: 'schema block bind',
+      label: 'bind output',
+    });
     const wrappedOutput = output as {
       readonly input?: BlockRenderInput<Config>;
       readonly facts?: readonly BindingFact[];
@@ -288,13 +297,21 @@ function normalizeBindOutput<Config>(
     if (!isObjectLike(wrappedOutput.input)) {
       throw new Error('schema block bind: input must be an object');
     }
+    assertOnlyKeys(wrappedOutput.input, ['config', 'slots', 'mode'], {
+      scope: 'schema block bind',
+      label: 'input',
+    });
 
     return {
       input: freezeRenderInput(wrappedOutput.input),
-      facts: freezeFacts(wrappedOutput.facts),
+      facts: freezeFacts(wrappedOutput.facts, 'schema block bind'),
     };
   }
 
+  assertOnlyKeys(output, ['config', 'slots', 'mode'], {
+    scope: 'schema block bind',
+    label: 'bind output',
+  });
   return {
     input: freezeRenderInput(output as BlockRenderInput<Config>),
     facts: EMPTY_BINDING_FACTS,
@@ -321,7 +338,13 @@ function freezeRenderInput<Config>(
 function freezeSchemaIssues(
   issues: readonly BlockSchemaIssue[] | undefined,
 ): readonly BlockSchemaIssue[] {
-  if (issues === undefined || issues.length === 0) {
+  if (issues === undefined) {
+    throw new Error('block schema result: failed result requires at least one issue');
+  }
+  if (!Array.isArray(issues)) {
+    throw new Error('block schema result: issues must be an array');
+  }
+  if (issues.length === 0) {
     throw new Error('block schema result: failed result requires at least one issue');
   }
 
@@ -348,12 +371,24 @@ function normalizeIssue(issue: BlockSchemaIssue, index: number): BlockSchemaIssu
       field: `issues[${index}].message`,
       value: issue.message,
     }),
-    path: optionalTrimmedText(issue.path),
+    path: optionalTrimmedText(issue.path, {
+      scope: 'block schema issue',
+      field: `issues[${index}].path`,
+    }),
   };
 }
 
-function freezeFacts(facts: readonly BindingFact[] | undefined): readonly BindingFact[] {
-  if (facts === undefined || facts.length === 0) {
+function freezeFacts(
+  facts: readonly BindingFact[] | undefined,
+  scope = 'block schema facts',
+): readonly BindingFact[] {
+  if (facts === undefined) {
+    return EMPTY_BINDING_FACTS;
+  }
+  if (!Array.isArray(facts)) {
+    throw new Error(`${scope}: facts must be an array`);
+  }
+  if (facts.length === 0) {
     return EMPTY_BINDING_FACTS;
   }
 
@@ -366,6 +401,9 @@ function freezeStringList(
 ): readonly string[] | undefined {
   if (values === undefined) {
     return undefined;
+  }
+  if (!Array.isArray(values)) {
+    throw new Error(`block schema description: ${field} must be an array`);
   }
 
   return Object.freeze(values.map((value, index) => normalizeRequiredText({
@@ -393,6 +431,10 @@ function normalizeOutputMode(value: OutputMode | undefined): OutputMode | undefi
 }
 
 function normalizeRequiredText(options: RequiredTextOptions): string {
+  if (typeof options.value !== 'string') {
+    throw new Error(`${options.scope}: ${options.field} must be a string`);
+  }
+
   const normalized = options.value.trim();
   if (normalized === '') {
     throw new Error(`${options.scope}: ${options.field} is required`);
@@ -401,9 +443,15 @@ function normalizeRequiredText(options: RequiredTextOptions): string {
   return normalized;
 }
 
-function optionalTrimmedText(value: string | undefined): string | undefined {
+function optionalTrimmedText(
+  value: unknown,
+  options: TextFieldOptions,
+): string | undefined {
   if (value === undefined) {
     return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`${options.scope}: ${options.field} must be a string`);
   }
 
   const normalized = value.trim();
@@ -412,6 +460,27 @@ function optionalTrimmedText(value: string | undefined): string | undefined {
 
 function isObjectLike(value: unknown): value is object {
   return value !== null && typeof value === 'object';
+}
+
+interface AllowedKeyOptions {
+  readonly scope: string;
+  readonly label: string;
+}
+
+function assertOnlyKeys(
+  value: object,
+  allowedKeys: readonly string[],
+  options: AllowedKeyOptions,
+): void {
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== 'string' || !allowedKeys.includes(key)) {
+      throw new Error(`${options.scope}: unsupported ${options.label} key ${keyText(key)}`);
+    }
+  }
+}
+
+function keyText(key: string | symbol): string {
+  return typeof key === 'string' ? key : key.toString();
 }
 
 function freezeInertData<T>(

--- a/packages/bijou/src/core/schema-block.ts
+++ b/packages/bijou/src/core/schema-block.ts
@@ -1,0 +1,529 @@
+import type { OutputMode } from './detect/tty.js';
+import {
+  isBlockDefinition,
+  type BlockDefinition,
+  type BlockRenderInput,
+} from './block-metadata.js';
+import type {
+  BindingFact,
+  BindingIssueSeverity,
+  DeepReadonly,
+} from './binding.js';
+
+const BLOCK_SCHEMA_ADAPTER_BRAND: unique symbol = Symbol('BlockSchemaAdapter');
+const SCHEMA_BOUND_BLOCK_BRAND: unique symbol = Symbol('SchemaBoundBlockDefinition');
+
+const BINDING_ISSUE_SEVERITIES: readonly BindingIssueSeverity[] = [
+  'info',
+  'warning',
+  'error',
+];
+const EMPTY_BINDING_FACTS = Object.freeze([]) as readonly BindingFact[];
+
+export interface BlockSchemaIssue {
+  readonly severity: BindingIssueSeverity;
+  readonly code: string;
+  readonly message: string;
+  readonly path?: string;
+}
+
+export type BlockSchemaResult<Data> =
+  | {
+    readonly ok: true;
+    readonly data: DeepReadonly<Data>;
+  }
+  | {
+    readonly ok: false;
+    readonly issues: readonly BlockSchemaIssue[];
+  };
+
+export interface BlockSchemaDescription {
+  readonly requiredFields?: readonly string[];
+  readonly optionalFields?: readonly string[];
+  readonly redactedFields?: readonly string[];
+  readonly facts?: readonly BindingFact[];
+}
+
+export interface BlockSchemaAdapterInput<Data> {
+  readonly id: string;
+  readonly parse: (input: unknown) => BlockSchemaResult<Data>;
+  readonly describe?: () => BlockSchemaDescription;
+}
+
+export interface BlockSchemaAdapter<Data = unknown> {
+  readonly [BLOCK_SCHEMA_ADAPTER_BRAND]: true;
+  readonly id: string;
+  readonly parse: (input: unknown) => BlockSchemaResult<Data>;
+  readonly describe?: () => BlockSchemaDescription;
+}
+
+export type SchemaBlockBindOutput<Config = unknown> =
+  | BlockRenderInput<Config>
+  | {
+    readonly input: BlockRenderInput<Config>;
+    readonly facts?: readonly BindingFact[];
+  };
+
+export interface SchemaBoundBlockDefinitionInput<
+  Data = unknown,
+  Config = unknown,
+  Output = unknown,
+> {
+  readonly block: BlockDefinition<Config, Output>;
+  readonly schema: BlockSchemaAdapter<Data>;
+  readonly bind: (data: DeepReadonly<Data>) => SchemaBlockBindOutput<Config>;
+}
+
+export interface SchemaBoundBlockDefinition<
+  Data = unknown,
+  Config = unknown,
+  Output = unknown,
+> extends SchemaBoundBlockDefinitionInput<Data, Config, Output> {
+  readonly [SCHEMA_BOUND_BLOCK_BRAND]: true;
+}
+
+export type SchemaBlockBindResult<Config = unknown> =
+  | {
+    readonly ok: true;
+    readonly input: DeepReadonly<BlockRenderInput<Config>>;
+    readonly facts: readonly BindingFact[];
+  }
+  | {
+    readonly ok: false;
+    readonly issues: readonly BlockSchemaIssue[];
+    readonly facts: readonly BindingFact[];
+  };
+
+export function defineBlockSchemaAdapter<Data>(
+  input: BlockSchemaAdapterInput<Data>,
+): BlockSchemaAdapter<Data> {
+  if (!isObjectLike(input)) {
+    throw new Error('block schema adapter: input must be an object');
+  }
+
+  const id = normalizeRequiredText({
+    scope: 'block schema adapter',
+    field: 'id',
+    value: input.id,
+  });
+  if (typeof input.parse !== 'function') {
+    throw new Error('block schema adapter: parse must be a function');
+  }
+
+  const adapter = {
+    id,
+    parse: (value: unknown) => normalizeSchemaResult(input.parse(value)),
+    ...(input.describe === undefined
+      ? {}
+      : { describe: () => normalizeSchemaDescription(input.describe?.() ?? {}) }),
+  } as BlockSchemaAdapter<Data>;
+
+  Object.defineProperty(adapter, BLOCK_SCHEMA_ADAPTER_BRAND, { value: true });
+  return Object.freeze(adapter);
+}
+
+export function isBlockSchemaAdapter(value: unknown): value is BlockSchemaAdapter {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, BLOCK_SCHEMA_ADAPTER_BRAND)
+      && (value as BlockSchemaAdapterBrandCarrier)[BLOCK_SCHEMA_ADAPTER_BRAND] === true,
+  );
+}
+
+export function parseBlockSchema<Data>(
+  schema: BlockSchemaAdapter<Data>,
+  input: unknown,
+): BlockSchemaResult<Data> {
+  if (!isBlockSchemaAdapter(schema)) {
+    throw new Error('block schema parse: schema must be created by defineBlockSchemaAdapter()');
+  }
+
+  return schema.parse(input);
+}
+
+export function defineSchemaBlock<
+  Data = unknown,
+  Config = unknown,
+  Output = unknown,
+>(
+  input: SchemaBoundBlockDefinitionInput<Data, Config, Output>,
+): SchemaBoundBlockDefinition<Data, Config, Output> {
+  if (!isObjectLike(input)) {
+    throw new Error('schema block: input must be an object');
+  }
+
+  if (!isBlockDefinition(input.block)) {
+    throw new Error('schema block: block must be created by defineBlock()');
+  }
+  if (!isBlockSchemaAdapter(input.schema)) {
+    throw new Error('schema block: schema must be created by defineBlockSchemaAdapter()');
+  }
+  if (typeof input.bind !== 'function') {
+    throw new Error('schema block: bind must be a function');
+  }
+
+  const block = {
+    block: input.block,
+    schema: input.schema,
+    bind: input.bind,
+  } as SchemaBoundBlockDefinition<Data, Config, Output>;
+
+  Object.defineProperty(block, SCHEMA_BOUND_BLOCK_BRAND, { value: true });
+  return Object.freeze(block);
+}
+
+export function isSchemaBoundBlockDefinition(
+  value: unknown,
+): value is SchemaBoundBlockDefinition {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && Object.prototype.hasOwnProperty.call(value, SCHEMA_BOUND_BLOCK_BRAND)
+      && (value as SchemaBoundBlockBrandCarrier)[SCHEMA_BOUND_BLOCK_BRAND] === true,
+  );
+}
+
+export function bindSchemaBlockInput<
+  Data = unknown,
+  Config = unknown,
+  Output = unknown,
+>(
+  block: SchemaBoundBlockDefinition<Data, Config, Output>,
+  input: unknown,
+): SchemaBlockBindResult<Config> {
+  if (!isSchemaBoundBlockDefinition(block)) {
+    throw new Error('schema block bind: block must be created by defineSchemaBlock()');
+  }
+
+  const parsed = parseBlockSchema(block.schema, input);
+  if (!parsed.ok) {
+    return Object.freeze({
+      ok: false,
+      issues: parsed.issues,
+      facts: EMPTY_BINDING_FACTS,
+    });
+  }
+
+  const output = normalizeBindOutput(block.bind(parsed.data));
+  return Object.freeze({
+    ok: true,
+    input: output.input,
+    facts: output.facts,
+  }) as SchemaBlockBindResult<Config>;
+}
+
+interface BlockSchemaAdapterBrandCarrier {
+  readonly [BLOCK_SCHEMA_ADAPTER_BRAND]?: true;
+}
+
+interface SchemaBoundBlockBrandCarrier {
+  readonly [SCHEMA_BOUND_BLOCK_BRAND]?: true;
+}
+
+interface RequiredTextOptions {
+  readonly scope: string;
+  readonly field: string;
+  readonly value: string;
+}
+
+interface NormalizedBindOutput<Config> {
+  readonly input: DeepReadonly<BlockRenderInput<Config>>;
+  readonly facts: readonly BindingFact[];
+}
+
+function normalizeSchemaResult<Data>(result: BlockSchemaResult<Data>): BlockSchemaResult<Data> {
+  if (!isObjectLike(result)) {
+    throw new Error('block schema result: result must be an object');
+  }
+
+  if (result.ok === true) {
+    if (!Object.prototype.hasOwnProperty.call(result, 'data')) {
+      throw new Error('block schema result: data is required for ok result');
+    }
+
+    return Object.freeze({
+      ok: true,
+      data: freezeInertData(result.data, 'data') as DeepReadonly<Data>,
+    }) as BlockSchemaResult<Data>;
+  }
+
+  if (result.ok === false) {
+    return Object.freeze({
+      ok: false,
+      issues: freezeSchemaIssues(result.issues),
+    });
+  }
+
+  throw new Error('block schema result: ok must be true or false');
+}
+
+function normalizeSchemaDescription(
+  description: BlockSchemaDescription,
+): BlockSchemaDescription {
+  if (!isObjectLike(description)) {
+    throw new Error('block schema description: description must be an object');
+  }
+
+  return deepFreeze({
+    requiredFields: freezeStringList(description.requiredFields, 'requiredFields'),
+    optionalFields: freezeStringList(description.optionalFields, 'optionalFields'),
+    redactedFields: freezeStringList(description.redactedFields, 'redactedFields'),
+    facts: freezeFacts(description.facts),
+  });
+}
+
+function normalizeBindOutput<Config>(
+  output: SchemaBlockBindOutput<Config>,
+): NormalizedBindOutput<Config> {
+  if (!isObjectLike(output)) {
+    throw new Error('schema block bind: bind output must be an object');
+  }
+
+  if (Object.prototype.hasOwnProperty.call(output, 'input')) {
+    const wrappedOutput = output as {
+      readonly input?: BlockRenderInput<Config>;
+      readonly facts?: readonly BindingFact[];
+    };
+    if (!isObjectLike(wrappedOutput.input)) {
+      throw new Error('schema block bind: input must be an object');
+    }
+
+    return {
+      input: freezeRenderInput(wrappedOutput.input),
+      facts: freezeFacts(wrappedOutput.facts),
+    };
+  }
+
+  return {
+    input: freezeRenderInput(output as BlockRenderInput<Config>),
+    facts: EMPTY_BINDING_FACTS,
+  };
+}
+
+function freezeRenderInput<Config>(
+  input: BlockRenderInput<Config>,
+): DeepReadonly<BlockRenderInput<Config>> {
+  const normalizedMode = normalizeOutputMode(input.mode);
+  const normalizedInput = {
+    ...(input.config === undefined
+      ? {}
+      : { config: freezeInertData(input.config, 'input.config') }),
+    ...(input.slots === undefined
+      ? {}
+      : { slots: freezeInertData(input.slots, 'input.slots') }),
+    ...(normalizedMode === undefined ? {} : { mode: normalizedMode }),
+  };
+
+  return Object.freeze(normalizedInput) as DeepReadonly<BlockRenderInput<Config>>;
+}
+
+function freezeSchemaIssues(
+  issues: readonly BlockSchemaIssue[] | undefined,
+): readonly BlockSchemaIssue[] {
+  if (issues === undefined || issues.length === 0) {
+    throw new Error('block schema result: failed result requires at least one issue');
+  }
+
+  return deepFreeze(issues.map((issue, index) => normalizeIssue(issue, index)));
+}
+
+function normalizeIssue(issue: BlockSchemaIssue, index: number): BlockSchemaIssue {
+  if (!isObjectLike(issue)) {
+    throw new Error(`block schema issue: issue at index ${index} must be an object`);
+  }
+  if (!BINDING_ISSUE_SEVERITIES.includes(issue.severity)) {
+    throw new Error(`block schema issue: unsupported severity ${String(issue.severity)} at index ${index}`);
+  }
+
+  return {
+    severity: issue.severity,
+    code: normalizeRequiredText({
+      scope: 'block schema issue',
+      field: `issues[${index}].code`,
+      value: issue.code,
+    }),
+    message: normalizeRequiredText({
+      scope: 'block schema issue',
+      field: `issues[${index}].message`,
+      value: issue.message,
+    }),
+    path: optionalTrimmedText(issue.path),
+  };
+}
+
+function freezeFacts(facts: readonly BindingFact[] | undefined): readonly BindingFact[] {
+  if (facts === undefined || facts.length === 0) {
+    return EMPTY_BINDING_FACTS;
+  }
+
+  return deepFreeze([...facts]);
+}
+
+function freezeStringList(
+  values: readonly string[] | undefined,
+  field: string,
+): readonly string[] | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+
+  return Object.freeze(values.map((value, index) => normalizeRequiredText({
+    scope: 'block schema description',
+    field: `${field}[${index}]`,
+    value,
+  })));
+}
+
+function normalizeOutputMode(value: OutputMode | undefined): OutputMode | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (
+    value === 'interactive'
+    || value === 'static'
+    || value === 'pipe'
+    || value === 'accessible'
+  ) {
+    return value;
+  }
+
+  throw new Error(`schema block bind: unsupported mode ${String(value)}`);
+}
+
+function normalizeRequiredText(options: RequiredTextOptions): string {
+  const normalized = options.value.trim();
+  if (normalized === '') {
+    throw new Error(`${options.scope}: ${options.field} is required`);
+  }
+
+  return normalized;
+}
+
+function optionalTrimmedText(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized === '' ? undefined : normalized;
+}
+
+function isObjectLike(value: unknown): value is object {
+  return value !== null && typeof value === 'object';
+}
+
+function freezeInertData<T>(
+  value: T,
+  path: string,
+): DeepReadonly<T> {
+  return deepFreeze(cloneInertData(value, path));
+}
+
+function cloneInertData<T>(
+  value: T,
+  path: string,
+  seen: WeakSet<object> = new WeakSet<object>(),
+): T {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'bigint' || typeof value === 'symbol' || typeof value === 'function') {
+    throw new Error(`block schema data: unsupported ${typeof value} at ${path}`);
+  }
+
+  if (value === undefined) {
+    throw new Error(`block schema data: unsupported undefined at ${path}`);
+  }
+
+  if (typeof value !== 'object') {
+    throw new Error(`block schema data: unsupported ${typeof value} at ${path}`);
+  }
+
+  const objectValue = value as object;
+  if (seen.has(objectValue)) {
+    throw new Error(`block schema data: circular reference at ${path}`);
+  }
+  seen.add(objectValue);
+
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item, index) => cloneInertData(item, `${path}[${index}]`, seen)) as T;
+    }
+
+    if (!isPlainObject(value)) {
+      throw new Error(`block schema data: unsupported ${objectKind(value)} at ${path}`);
+    }
+
+    const clone = Object.create(Object.getPrototypeOf(value)) as InertDataObject;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (typeof key === 'symbol') {
+        throw new Error(`block schema data: unsupported symbol property at ${path}`);
+      }
+
+      const propertyPath = `${path}.${key}`;
+      const descriptor = descriptors[key];
+      if (descriptor === undefined) {
+        continue;
+      }
+      if (!descriptor.enumerable) {
+        throw new Error(`block schema data: unsupported non-enumerable property at ${propertyPath}`);
+      }
+      if ('get' in descriptor || 'set' in descriptor) {
+        throw new Error(`block schema data: unsupported accessor at ${propertyPath}`);
+      }
+
+      clone[key] = cloneInertData(descriptor.value, propertyPath, seen);
+    }
+
+    return clone as T;
+  } finally {
+    seen.delete(objectValue);
+  }
+}
+
+interface InertDataObject {
+  [key: string]: unknown;
+}
+
+function isPlainObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function objectKind(value: object): string {
+  return Object.prototype.toString.call(value).slice(8, -1);
+}
+
+function deepFreeze<T>(
+  value: T,
+  seen: WeakSet<object> = new WeakSet<object>(),
+): DeepReadonly<T> {
+  if (value === null || typeof value !== 'object') {
+    return value as DeepReadonly<T>;
+  }
+
+  const objectValue = value as object;
+  if (seen.has(objectValue)) {
+    return value as DeepReadonly<T>;
+  }
+
+  seen.add(objectValue);
+
+  for (const key of Reflect.ownKeys(objectValue)) {
+    const descriptor = Object.getOwnPropertyDescriptor(objectValue, key);
+    if (descriptor !== undefined && 'value' in descriptor) {
+      deepFreeze(descriptor.value, seen);
+    }
+  }
+
+  return Object.freeze(value) as DeepReadonly<T>;
+}

--- a/packages/bijou/src/core/schema-block.ts
+++ b/packages/bijou/src/core/schema-block.ts
@@ -109,13 +109,15 @@ export function defineBlockSchemaAdapter<Data>(
   if (typeof input.parse !== 'function') {
     throw new Error('block schema adapter: parse must be a function');
   }
+  const parse = input.parse;
+  const describe = input.describe;
 
   const adapter = {
     id,
-    parse: (value: unknown) => normalizeSchemaResult(input.parse(value)),
-    ...(input.describe === undefined
+    parse: (value: unknown) => normalizeSchemaResult(parse(value)),
+    ...(describe === undefined
       ? {}
-      : { describe: () => normalizeSchemaDescription(input.describe?.() ?? {}) }),
+      : { describe: () => normalizeSchemaDescription(describe() ?? {}) }),
   } as BlockSchemaAdapter<Data>;
 
   Object.defineProperty(adapter, BLOCK_SCHEMA_ADAPTER_BRAND, { value: true });
@@ -284,6 +286,9 @@ function normalizeBindOutput<Config>(
   if (!isObjectLike(output)) {
     throw new Error('schema block bind: bind output must be an object');
   }
+  if (!isPlainObject(output)) {
+    throw new Error('schema block bind: bind output must be a plain object');
+  }
 
   if (Object.prototype.hasOwnProperty.call(output, 'input')) {
     assertOnlyKeys(output, ['input', 'facts'], {
@@ -296,6 +301,9 @@ function normalizeBindOutput<Config>(
     };
     if (!isObjectLike(wrappedOutput.input)) {
       throw new Error('schema block bind: input must be an object');
+    }
+    if (!isPlainObject(wrappedOutput.input)) {
+      throw new Error('schema block bind: input must be a plain object');
     }
     assertOnlyKeys(wrappedOutput.input, ['config', 'slots', 'mode'], {
       scope: 'schema block bind',

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -222,6 +222,23 @@ export {
   type BlockVariantMetadata,
 } from './core/block-metadata.js';
 export {
+  bindSchemaBlockInput,
+  defineBlockSchemaAdapter,
+  defineSchemaBlock,
+  isBlockSchemaAdapter,
+  isSchemaBoundBlockDefinition,
+  parseBlockSchema,
+  type BlockSchemaAdapter,
+  type BlockSchemaAdapterInput,
+  type BlockSchemaDescription,
+  type BlockSchemaIssue,
+  type BlockSchemaResult,
+  type SchemaBlockBindOutput,
+  type SchemaBlockBindResult,
+  type SchemaBoundBlockDefinition,
+  type SchemaBoundBlockDefinitionInput,
+} from './core/schema-block.js';
+export {
   componentMetadataReportText,
   componentMetadataSummary,
   defineComponentMetadata,

--- a/tests/cycles/DX-031/block-contract.test.ts
+++ b/tests/cycles/DX-031/block-contract.test.ts
@@ -70,7 +70,8 @@ describe('DX-031 block contract cycle', () => {
     expect(blocks).toContain('BlockMetadata');
     expect(blocks).toContain('BlockPackageManifest');
     expect(blocks).toContain('defineBlock()');
-    expect(blocks).toContain('Schema-bound blocks remain a follow-on');
+    expect(blocks).toContain('defineSchemaBlock()');
+    expect(blocks).toContain('Schema-bound blocks validate unknown boundary data');
   });
 
   it('exports public block helpers from the bijou root barrel', () => {
@@ -85,6 +86,9 @@ describe('DX-031 block contract cycle', () => {
     expect(rootBarrel).toContain('blockMetadataSummary');
     expect(rootBarrel).toContain('ViewDataContract');
     expect(rootBarrel).toContain('CommandIntent');
+    expect(rootBarrel).toContain('defineBlockSchemaAdapter');
+    expect(rootBarrel).toContain('defineSchemaBlock');
+    expect(rootBarrel).toContain('bindSchemaBlockInput');
   });
 
   it('lets authors define a block and package manifest without global registration', () => {

--- a/tests/cycles/DX-031/schema-bound-block-contract.test.ts
+++ b/tests/cycles/DX-031/schema-bound-block-contract.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bindSchemaBlockInput,
+  defineBlock,
+  defineBlockSchemaAdapter,
+  defineSchemaBlock,
+  type BlockMetadata,
+} from '../../../packages/bijou/src/index.js';
+import { readRepoFile } from '../repo.js';
+
+interface Article {
+  readonly id: string;
+  readonly title: string;
+}
+
+const readerSurfaceMetadata: BlockMetadata = {
+  packageName: '@flyingrobots/bijou',
+  blockName: 'ReaderSurface',
+  family: 'content-reading',
+  scale: 'section',
+  modes: ['interactive', 'static', 'pipe', 'accessible'],
+  docs: {
+    summary: 'Readable content with optional navigation and outline slots.',
+  },
+  slots: [
+    { id: 'content', required: true },
+    { id: 'navigation', required: false },
+    { id: 'outline', required: false },
+  ],
+};
+
+describe('DX-031B schema-bound block contract', () => {
+  it('binds validated schema data into block render input without rendering or provider lifecycle', () => {
+    let renderCalls = 0;
+    const articleSchema = defineBlockSchemaAdapter<Article>({
+      id: 'docs.article',
+      parse(input) {
+        if (!isArticle(input)) {
+          return {
+            ok: false,
+            issues: [{
+              severity: 'error',
+              code: 'article.invalid',
+              message: 'Article data is required.',
+            }],
+          };
+        }
+
+        return {
+          ok: true,
+          data: { id: input.id, title: input.title },
+        };
+      },
+    });
+    const block = defineBlock({
+      metadata: readerSurfaceMetadata,
+      render: () => {
+        renderCalls += 1;
+        return { output: 'reader' };
+      },
+    });
+    const schemaBlock = defineSchemaBlock({
+      block,
+      schema: articleSchema,
+      bind: (article) => ({
+        slots: { content: article.title },
+      }),
+    });
+
+    const bound = bindSchemaBlockInput(schemaBlock, {
+      id: 'dx-031',
+      title: 'DX-031',
+    });
+
+    expect(bound).toMatchObject({
+      ok: true,
+      input: { slots: { content: 'DX-031' } },
+    });
+    expect(schemaBlock.block.metadata.blockName).toBe('ReaderSurface');
+    expect(renderCalls).toBe(0);
+    expect('provider' in schemaBlock).toBe(false);
+    expect('subscribe' in schemaBlock).toBe(false);
+    expect('dispatch' in schemaBlock).toBe(false);
+  });
+
+  it('documents schema-bound blocks as boundary validation, not rendered AppShell or provider runtime', () => {
+    const dx031 = readRepoFile('docs/design/DX-031-standard-bijou-blocks.md');
+    const blocks = readRepoFile('docs/design-system/blocks.md');
+
+    expect(dx031).toContain('DX-031B Schema-Bound Blocks');
+    expect(dx031).toContain('Schema-bound blocks validate boundary data');
+    expect(dx031).toContain('They do not fetch,');
+    expect(dx031).toContain('subscribe, dispatch, compose runtime views, or render AppShell');
+    expect(blocks).toContain('Schema-bound blocks validate unknown boundary data');
+  });
+});
+
+function isArticle(input: unknown): input is Article {
+  if (input === null || typeof input !== 'object') {
+    return false;
+  }
+
+  const article = input as Partial<Article>;
+  return typeof article.id === 'string' && typeof article.title === 'string';
+}

--- a/tests/cycles/DX-031/schema-bound-block-contract.test.ts
+++ b/tests/cycles/DX-031/schema-bound-block-contract.test.ts
@@ -89,6 +89,8 @@ describe('DX-031B schema-bound block contract', () => {
 
     expect(dx031).toContain('DX-031B Schema-Bound Blocks');
     expect(dx031).toContain('Schema-bound blocks validate boundary data');
+    expect(dx031).toContain('SchemaBoundBlock "1" *-- "1" BlockDefinition : wraps');
+    expect(dx031).not.toContain('SchemaBoundBlock "1" --|> BlockDefinition : specializes');
     expect(dx031).toContain('They do not fetch,');
     expect(dx031).toContain('subscribe, dispatch, compose runtime views, or render AppShell');
     expect(blocks).toContain('Schema-bound blocks validate unknown boundary data');


### PR DESCRIPTION
## Summary

Adds the DX-031B schema-bound block contract in `@flyingrobots/bijou`.

This introduces adapter-first schema-bound primitives so block packages can validate unknown boundary data before producing immutable block render input and binding facts. Schema-bound blocks wrap an existing `BlockDefinition`, preserving metadata, data contracts, command intents, and ordinary render ownership.

## What changed

- Added `packages/bijou/src/core/schema-block.ts` with runtime-branded schema adapters and schema-bound block definitions.
- Added public helpers: `defineBlockSchemaAdapter()`, `parseBlockSchema()`, `defineSchemaBlock()`, `bindSchemaBlockInput()`, and runtime checkers.
- Added behavior coverage for immutable schema results, invalid issue reporting, bind-before-render boundaries, data/command contract preservation, and loose-shape rejection.
- Added DX-031 cycle proof for the schema-bound contract.
- Updated DX-031 docs, design-system block docs, package README/GUIDE, root barrel exports, and changelog.

## Non-goals

- no hard Zod dependency
- no provider subscriptions
- no provider refresh
- no command dispatch
- no rendered AppShell
- no DOGFOOD integration
- no broad block catalog
- no schema-to-block compiler

## Validation

- `npm test -- --run packages/bijou/src/core/schema-block.test.ts tests/cycles/DX-031/schema-bound-block-contract.test.ts tests/cycles/DX-031/block-contract.test.ts`
- `npm run typecheck:test`
- `npm run docs:inventory`
- `git diff --check`
- `npm run lint`
- `npm test`
- pre-commit: `npm run lint`, lockfile consistency
- pre-push: `npm run typecheck:test`, `npm test`, `npm run verify:interactive-examples`

Full suite: 295 test files passed, 3379 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema-bound block APIs now enable validation of unknown boundary data and produce immutable block render input with binding facts. Validation operates independently without triggering data fetches, subscriptions, dispatches, or rendering operations.

* **Documentation**
  * Updated API documentation, authoring guides, design specifications, and changelog to introduce schema-bound block functionality and usage patterns.

* **Tests**
  * Added comprehensive test coverage for schema-bound block contracts and validation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->