### PR TITLE
feat(blocks): add first-party definitions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   metadata, data contracts, command intents, story declarations, schema-bound
   wrappers, and package visibility. This does not implement rendered AppShell,
   provider subscriptions, active runtime traversal, command dispatch, DOGFOOD
-  captures, or the full standard block catalog.
+  captures, or the full standard block catalog. First-party block schema
+  adapters reject accessor-backed and non-plain boundary inputs without invoking
+  getters, so schema validation stays a data-shape boundary check.
 - **Schema-bound block contract for `bijou`** — `@flyingrobots/bijou` now
   exports adapter-first schema-bound block primitives:
   `BlockSchemaAdapter`, `defineBlockSchemaAdapter()`, `defineSchemaBlock()`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,15 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **First-party standard block definitions for `bijou`** —
+  `@flyingrobots/bijou` now exports `appShellBlock`, `readerSurfaceBlock`,
+  `inspectorPanelBlock`, `standardBlocks`, `standardBlockStories`,
+  `standardBlockPackageManifest`, and schema-bound Reader/Inspector helpers for
+  the DX-031C definition slice. These are real `defineBlock()` outputs with
+  metadata, data contracts, command intents, story declarations, schema-bound
+  wrappers, and package visibility. This does not implement rendered AppShell,
+  provider subscriptions, active runtime traversal, command dispatch, DOGFOOD
+  captures, or the full standard block catalog.
 - **Schema-bound block contract for `bijou`** — `@flyingrobots/bijou` now
   exports adapter-first schema-bound block primitives:
   `BlockSchemaAdapter`, `defineBlockSchemaAdapter()`, `defineSchemaBlock()`,

--- a/docs/design-system/blocks.md
+++ b/docs/design-system/blocks.md
@@ -62,6 +62,11 @@ Bijou now exposes a metadata-first block authoring contract from
   authors publish or index them.
 - `defineBlock()` can attach DX-034 view data contracts and command intents for
   discovery without provider handles or command callbacks.
+- `appShellBlock`, `readerSurfaceBlock`, `inspectorPanelBlock`,
+  `standardBlocks`, `standardBlockStories`, and
+  `standardBlockPackageManifest` expose the first first-party block definitions:
+  AppShell, ReaderSurface, and InspectorPanel. They are definition and contract
+  artifacts, not rendered block product.
 - `defineAppShellComposition()` groups runtime-backed blocks into logical
   navigation, content, inspector, status, and overlay slots without rendering.
 - `defineBlockSchemaAdapter()`, `defineSchemaBlock()`, and

--- a/docs/design-system/blocks.md
+++ b/docs/design-system/blocks.md
@@ -64,9 +64,9 @@ Bijou now exposes a metadata-first block authoring contract from
   discovery without provider handles or command callbacks.
 - `appShellBlock`, `readerSurfaceBlock`, `inspectorPanelBlock`,
   `standardBlocks`, `standardBlockStories`, and
-  `standardBlockPackageManifest` expose the first first-party block definitions:
+  `standardBlockPackageManifest` expose the first-party block definitions:
   AppShell, ReaderSurface, and InspectorPanel. They are definition and contract
-  artifacts, not rendered block product.
+  artifacts, not rendered block products.
 - `defineAppShellComposition()` groups runtime-backed blocks into logical
   navigation, content, inspector, status, and overlay slots without rendering.
 - `defineBlockSchemaAdapter()`, `defineSchemaBlock()`, and

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -3153,9 +3153,10 @@ blocks.
 8. Done: add adapter-first `defineSchemaBlock()` support without making Zod,
    provider lifecycle, AppShell rendering, or DOGFOOD proof part of the core
    schema-bound block contract.
-9. Next: add an optional Zod schema adapter package or helper.
-10. Next: add block stories for `AppShell`, `ReaderSurface`, and
-   `InspectorPanel`.
+9. Done: add first-party block definitions and story declarations for
+   `AppShell`, `ReaderSurface`, and `InspectorPanel` without making them
+   rendered block product.
+10. Next: add an optional Zod schema adapter package or helper.
 11. Next: capture interactive, static, pipe, and accessible outputs for the
    first implementation set.
 12. Next: prove the first three blocks in DOGFOOD before broadening the
@@ -3315,11 +3316,29 @@ What is now true:
   class instances, built-ins, and backchannel handles cannot silently normalize
   into empty input.
 
+DX-031C First-Party Block Definitions adds the first first-party standard block
+definition slice.
+
+What is now true:
+
+- `@flyingrobots/bijou` exports `appShellBlock`, `readerSurfaceBlock`,
+  `inspectorPanelBlock`, `standardBlocks`, `standardBlockStories`, and
+  `standardBlockPackageManifest`.
+- The first-party `AppShell`, `ReaderSurface`, and `InspectorPanel` blocks are
+  real `defineBlock()` outputs with valid metadata.
+- `ReaderSurface` and `InspectorPanel` declare DX-034 data contracts and command
+  intents.
+- Reader and Inspector schema-bound wrappers validate boundary data before
+  producing render input.
+- AppShell uses semantic slots: `navigation`, `content`, `inspector`, `status`,
+  and `overlays`.
+- Definition and composition introspection do not render blocks, subscribe,
+  dispatch, resolve providers, or walk the active runtime tree.
+
 Still out of scope after this slice:
 
 - Zod adapters and schema-to-block compilers.
-- Rendered first-party `AppShell`, `ReaderSurface`, and `InspectorPanel`
-  blocks.
+- Rendered first-party `AppShell`, `ReaderSurface`, and `InspectorPanel` blocks.
 - DOGFOOD block galleries and multi-mode story captures for rendered blocks.
 - Modal stacks, notifications, auth blocks, workspace docking, and complex
   domain-specific block packages.

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -3155,7 +3155,7 @@ blocks.
    schema-bound block contract.
 9. Done: add first-party block definitions and story declarations for
    `AppShell`, `ReaderSurface`, and `InspectorPanel` without making them
-   rendered block product.
+   rendered block products.
 10. Next: add an optional Zod schema adapter package or helper.
 11. Next: capture interactive, static, pipe, and accessible outputs for the
    first implementation set.
@@ -3316,7 +3316,7 @@ What is now true:
   class instances, built-ins, and backchannel handles cannot silently normalize
   into empty input.
 
-DX-031C First-Party Block Definitions adds the first first-party standard block
+DX-031C First-Party Block Definitions adds the first-party standard block
 definition slice.
 
 What is now true:

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -223,7 +223,7 @@ global runtime behavior.
 
 ## First-Party Standard Blocks
 
-Bijou exports the first first-party standard block definitions:
+Bijou exports the first-party standard block definitions:
 
 ```typescript
 import {

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -221,6 +221,38 @@ Schema-bound blocks validate shape at the block boundary. They do not fetch,
 subscribe, dispatch commands, resolve providers, render AppShell, or register
 global runtime behavior.
 
+## First-Party Standard Blocks
+
+Bijou exports the first first-party standard block definitions:
+
+```typescript
+import {
+  appShellBlock,
+  inspectorPanelBlock,
+  readerSurfaceBlock,
+  standardBlockPackageManifest,
+  standardBlockStories,
+  standardBlocks,
+} from '@flyingrobots/bijou';
+
+standardBlocks.map(block => block.metadata.blockName);
+standardBlockStories.map(story => story.id);
+standardBlockPackageManifest.blocks;
+
+readerSurfaceBlock.data?.names();
+readerSurfaceBlock.commands?.map(command => command.id);
+inspectorPanelBlock.data?.names();
+appShellBlock.metadata.slots.map(slot => slot.id);
+```
+
+These definitions are contract artifacts. They declare metadata, semantic
+slots, data requirements, command intents, story ids, and package visibility for
+`AppShell`, `ReaderSurface`, and `InspectorPanel`.
+
+They do not implement rendered AppShell, provider subscriptions, active runtime
+traversal, command dispatch, DOGFOOD captures, or the full standard block
+catalog.
+
 ## AppShell Composition
 
 Use `defineAppShellComposition()` to describe logical shell slots before

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -96,7 +96,7 @@ fake duplication rather than a real second API.
   scale, mode, slot, variant, config, component, story, semantic facts, optional
   view data contracts, and command intents.
 - **`standardBlocks` / `appShellBlock` / `readerSurfaceBlock` /
-  `inspectorPanelBlock`**: Import the first first-party standard block
+  `inspectorPanelBlock`**: Import the first-party standard block
   definitions for AppShell, ReaderSurface, and InspectorPanel. These expose
   contracts, stories, data requirements, command intents, and schema-bound
   posture without providing rendered AppShell product yet.

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -95,6 +95,11 @@ fake duplication rather than a real second API.
 - **`defineBlock()`**: Declare a validated reusable block with package, family,
   scale, mode, slot, variant, config, component, story, semantic facts, optional
   view data contracts, and command intents.
+- **`standardBlocks` / `appShellBlock` / `readerSurfaceBlock` /
+  `inspectorPanelBlock`**: Import the first first-party standard block
+  definitions for AppShell, ReaderSurface, and InspectorPanel. These expose
+  contracts, stories, data requirements, command intents, and schema-bound
+  posture without providing rendered AppShell product yet.
 - **`defineBlockPackage()`**: Declare exported blocks, docs, tags, version, and
   Bijou peer compatibility for ordinary NPM block packages.
 - **`defineBlockSchemaAdapter()` / `defineSchemaBlock()`**: Validate unknown

--- a/packages/bijou/src/core/standard-blocks.test.ts
+++ b/packages/bijou/src/core/standard-blocks.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defineAppShellComposition,
+} from './app-shell-composition.js';
+import {
+  defineBlock,
+  validateBlockMetadata,
+  validateBlockPackageManifest,
+  type BlockMetadata,
+} from './block-metadata.js';
+import {
+  bindSchemaBlockInput,
+  isSchemaBoundBlockDefinition,
+} from './schema-block.js';
+import {
+  appShellBlock,
+  inspectorPanelBlock,
+  inspectorPanelSchemaBlock,
+  readerSurfaceBlock,
+  readerSurfaceSchemaBlock,
+  standardBlockPackageManifest,
+  standardBlocks,
+  standardBlockStories,
+} from './standard-blocks.js';
+
+describe('first-party standard block definitions', () => {
+  it('exports valid AppShell, ReaderSurface, and InspectorPanel block definitions', () => {
+    expect(standardBlocks).toEqual([
+      appShellBlock,
+      readerSurfaceBlock,
+      inspectorPanelBlock,
+    ]);
+    expect(Object.isFrozen(standardBlocks)).toBe(true);
+
+    for (const block of standardBlocks) {
+      expect(validateBlockMetadata(block.metadata)).toMatchObject({ passed: true });
+      expect(Object.isFrozen(block)).toBe(true);
+    }
+
+    expect(validateBlockPackageManifest(standardBlockPackageManifest)).toMatchObject({
+      passed: true,
+    });
+    expect(standardBlockPackageManifest.blocks).toEqual([
+      'AppShell',
+      'ReaderSurface',
+      'InspectorPanel',
+    ]);
+  });
+
+  it('keeps AppShell slots semantic and content-first', () => {
+    const slotIds = appShellBlock.metadata.slots.map((slot) => slot.id);
+
+    expect(slotIds).toEqual([
+      'navigation',
+      'content',
+      'inspector',
+      'status',
+      'overlays',
+    ]);
+    expect(appShellBlock.metadata.slots.filter((slot) => slot.required !== false).map((slot) => slot.id)).toEqual([
+      'content',
+    ]);
+    expect(slotIds).not.toContain('left');
+    expect(slotIds).not.toContain('right');
+    expect(slotIds).not.toContain('center');
+    expect(slotIds).not.toContain('bottom');
+  });
+
+  it('declares data contracts and command intents for reader and inspector blocks', () => {
+    expect(readerSurfaceBlock.data?.names()).toEqual(['article', 'outline']);
+    expect(readerSurfaceBlock.data?.requirementIds()).toEqual([
+      'reader.article',
+      'reader.outline',
+    ]);
+    expect(readerSurfaceBlock.commands?.map((command) => command.id)).toEqual([
+      'reader.selectHeading',
+      'reader.openReference',
+    ]);
+
+    expect(inspectorPanelBlock.data?.names()).toEqual(['selection', 'details']);
+    expect(inspectorPanelBlock.data?.requirementIds()).toEqual([
+      'inspector.selection',
+      'inspector.details',
+    ]);
+    expect(inspectorPanelBlock.commands?.map((command) => command.id)).toEqual([
+      'inspector.revealSelection',
+      'inspector.focusSource',
+    ]);
+
+    expect(appShellBlock.commands?.map((command) => command.id)).toEqual([
+      'shell.focusRegion',
+      'shell.toggleInspector',
+      'shell.openOverlay',
+    ]);
+  });
+
+  it('publishes deterministic stories and metadata story ids without rendering', () => {
+    const storiesByBlock = new Map<string, readonly string[]>(
+      ['AppShell', 'ReaderSurface', 'InspectorPanel'].map((blockName) => [
+        blockName,
+        standardBlockStories
+          .filter((story) => story.blockName === blockName)
+          .map((story) => story.state),
+      ]),
+    );
+
+    expect(storiesByBlock.get('AppShell')).toEqual([
+      'ready',
+      'narrow',
+      'overlay',
+    ]);
+    expect(storiesByBlock.get('ReaderSurface')).toEqual([
+      'ready',
+      'loading',
+      'stale',
+      'empty',
+      'error',
+    ]);
+    expect(storiesByBlock.get('InspectorPanel')).toEqual([
+      'ready',
+      'empty',
+      'loading',
+      'stale',
+      'error',
+    ]);
+
+    for (const block of standardBlocks) {
+      const storyIds = standardBlockStories
+        .filter((story) => story.blockName === block.metadata.blockName)
+        .map((story) => story.id);
+      expect(block.metadata.storyIds).toEqual(storyIds);
+    }
+  });
+
+  it('binds reader and inspector schema data without owning rendering or provider lifecycle', () => {
+    expect(isSchemaBoundBlockDefinition(readerSurfaceSchemaBlock)).toBe(true);
+    expect(isSchemaBoundBlockDefinition(inspectorPanelSchemaBlock)).toBe(true);
+
+    const readerBound = bindSchemaBlockInput(readerSurfaceSchemaBlock, {
+      id: 'dx-031',
+      title: 'DX-031',
+      body: 'First-party block definitions.',
+      outline: [{ id: 'intro', label: 'Intro' }],
+    });
+    expect(readerBound).toMatchObject({
+      ok: true,
+      input: {
+        slots: {
+          content: 'First-party block definitions.',
+          outline: ['Intro'],
+        },
+      },
+    });
+
+    const inspectorBound = bindSchemaBlockInput(inspectorPanelSchemaBlock, {
+      selectionId: 'heading:intro',
+      label: 'Intro',
+      details: ['Selected heading'],
+    });
+    expect(inspectorBound).toMatchObject({
+      ok: true,
+      input: {
+        slots: {
+          selection: 'Intro',
+          details: ['Selected heading'],
+        },
+      },
+    });
+
+    expect('provider' in readerSurfaceSchemaBlock).toBe(false);
+    expect('subscribe' in readerSurfaceSchemaBlock).toBe(false);
+    expect('dispatch' in inspectorPanelSchemaBlock).toBe(false);
+  });
+
+  it('lets AppShell composition inspect declarations without executing render', () => {
+    let renderCalls = 0;
+    const spyBlock = defineBlock({
+      metadata: spyMetadata,
+      data: readerSurfaceBlock.data,
+      commands: readerSurfaceBlock.commands,
+      render: () => {
+        renderCalls += 1;
+        return { output: 'should not render during introspection' };
+      },
+    });
+
+    const composition = defineAppShellComposition({
+      slots: {
+        navigation: spyBlock,
+        content: readerSurfaceBlock,
+        inspector: inspectorPanelBlock,
+        status: appShellBlock,
+      },
+    });
+
+    expect(composition.blocks()).toEqual([
+      spyBlock,
+      readerSurfaceBlock,
+      inspectorPanelBlock,
+      appShellBlock,
+    ]);
+    expect(composition.dataContracts()).toContain(readerSurfaceBlock.data);
+    expect(composition.dataContracts()).toContain(inspectorPanelBlock.data);
+    expect(composition.commandIntents().map((intent) => intent.id)).toContain('reader.selectHeading');
+    expect(composition.commandIntents().map((intent) => intent.id)).toContain('inspector.revealSelection');
+    expect(renderCalls).toBe(0);
+  });
+});
+
+const spyMetadata: BlockMetadata = {
+  packageName: '@flyingrobots/bijou',
+  blockName: 'SpyNavigation',
+  family: 'app-structure',
+  scale: 'panel',
+  modes: ['interactive', 'static', 'pipe', 'accessible'],
+  docs: {
+    summary: 'Test-only navigation block for introspection proof.',
+  },
+  slots: [{ id: 'content', required: true }],
+};

--- a/packages/bijou/src/core/standard-blocks.test.ts
+++ b/packages/bijou/src/core/standard-blocks.test.ts
@@ -172,6 +172,57 @@ describe('first-party standard block definitions', () => {
     expect('dispatch' in inspectorPanelSchemaBlock).toBe(false);
   });
 
+  it('rejects schema boundary accessors without invoking them', () => {
+    let getterCalls = 0;
+    const accessorArticle = Object.defineProperties({}, {
+      id: {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          return 'dx-031';
+        },
+      },
+      title: {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          return 'DX-031';
+        },
+      },
+      body: {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          return 'Hidden accessor body';
+        },
+      },
+    });
+    const accessorSelection = Object.defineProperties({}, {
+      selectionId: {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          return 'heading:intro';
+        },
+      },
+      label: {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          return 'Intro';
+        },
+      },
+    });
+
+    expect(bindSchemaBlockInput(readerSurfaceSchemaBlock, accessorArticle)).toMatchObject({
+      ok: false,
+    });
+    expect(bindSchemaBlockInput(inspectorPanelSchemaBlock, accessorSelection)).toMatchObject({
+      ok: false,
+    });
+    expect(getterCalls).toBe(0);
+  });
+
   it('lets AppShell composition inspect declarations without executing render', () => {
     let renderCalls = 0;
     const spyBlock = defineBlock({

--- a/packages/bijou/src/core/standard-blocks.ts
+++ b/packages/bijou/src/core/standard-blocks.ts
@@ -1,0 +1,520 @@
+import {
+  commandIntent,
+  defineDataRequirement,
+  defineViewData,
+  type BindingFact,
+} from './binding.js';
+import {
+  defineBlock,
+  defineBlockPackage,
+  type BlockDefinition,
+  type BlockMetadata,
+  type BlockPackageManifest,
+} from './block-metadata.js';
+import {
+  defineBlockSchemaAdapter,
+  defineSchemaBlock,
+  type BlockSchemaAdapter,
+  type BlockSchemaResult,
+  type SchemaBoundBlockDefinition,
+} from './schema-block.js';
+
+const BIJOU_PACKAGE = '@flyingrobots/bijou';
+const ALL_OUTPUT_MODES = Object.freeze([
+  'interactive',
+  'static',
+  'pipe',
+  'accessible',
+] as const);
+
+export type StandardBlockName = 'AppShell' | 'ReaderSurface' | 'InspectorPanel';
+export type StandardBlockStoryState =
+  | 'ready'
+  | 'narrow'
+  | 'overlay'
+  | 'loading'
+  | 'stale'
+  | 'empty'
+  | 'error';
+
+export interface StandardBlockStory {
+  readonly id: string;
+  readonly blockName: StandardBlockName;
+  readonly label: string;
+  readonly state: StandardBlockStoryState;
+  readonly facts: readonly BindingFact[];
+}
+
+export interface ReaderSurfaceSchemaData {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+  readonly outline?: readonly ReaderSurfaceOutlineItem[];
+}
+
+export interface ReaderSurfaceOutlineItem {
+  readonly id: string;
+  readonly label: string;
+}
+
+export interface InspectorPanelSchemaData {
+  readonly selectionId: string;
+  readonly label: string;
+  readonly details?: readonly string[];
+}
+
+const shellFocusRegion = commandIntent<{ readonly region: string }>('shell.focusRegion', {
+  label: 'Focus region',
+  description: 'Move focus to a named AppShell region.',
+  facts: [{ kind: 'entity', key: 'block.command', value: 'AppShell' }],
+});
+const shellToggleInspector = commandIntent('shell.toggleInspector', {
+  label: 'Toggle inspector',
+  description: 'Request inspector visibility change.',
+  facts: [{ kind: 'entity', key: 'block.command', value: 'AppShell' }],
+});
+const shellOpenOverlay = commandIntent<{ readonly overlayId: string }>('shell.openOverlay', {
+  label: 'Open overlay',
+  description: 'Request a shell overlay by id.',
+  facts: [{ kind: 'entity', key: 'block.command', value: 'AppShell' }],
+});
+
+const readerArticleRequirement = defineDataRequirement({
+  id: 'reader.article',
+  resource: 'reader.article',
+  label: 'Article',
+  description: 'Primary readable article content.',
+  facts: [{ kind: 'entity', key: 'block.data', value: 'ReaderSurface' }],
+});
+const readerOutlineRequirement = defineDataRequirement({
+  id: 'reader.outline',
+  resource: 'reader.outline',
+  label: 'Outline',
+  description: 'Optional article outline for navigation.',
+  optional: true,
+  facts: [{ kind: 'entity', key: 'block.data', value: 'ReaderSurface' }],
+});
+const readerSurfaceData = defineViewData({
+  id: 'reader-surface.data',
+  label: 'ReaderSurface data',
+  description: 'Boundary data required to render a readable content surface.',
+  requirements: [
+    { name: 'article', requirement: readerArticleRequirement },
+    { name: 'outline', requirement: readerOutlineRequirement },
+  ],
+});
+const readerSelectHeading = commandIntent<{ readonly headingId: string }>('reader.selectHeading', {
+  label: 'Select heading',
+  description: 'Select a heading inside the reader outline.',
+  facts: [{ kind: 'entity', key: 'block.command', value: 'ReaderSurface' }],
+});
+const readerOpenReference = commandIntent<{ readonly referenceId: string }>('reader.openReference', {
+  label: 'Open reference',
+  description: 'Open a referenced document or citation from reader content.',
+  facts: [{ kind: 'entity', key: 'block.command', value: 'ReaderSurface' }],
+});
+
+const inspectorSelectionRequirement = defineDataRequirement({
+  id: 'inspector.selection',
+  resource: 'inspector.selection',
+  label: 'Selection',
+  description: 'The active entity selected elsewhere in the app.',
+  facts: [{ kind: 'entity', key: 'block.data', value: 'InspectorPanel' }],
+});
+const inspectorDetailsRequirement = defineDataRequirement({
+  id: 'inspector.details',
+  resource: 'inspector.details',
+  label: 'Selection details',
+  description: 'Optional detail facts for the selected entity.',
+  optional: true,
+  facts: [{ kind: 'entity', key: 'block.data', value: 'InspectorPanel' }],
+});
+const inspectorPanelData = defineViewData({
+  id: 'inspector-panel.data',
+  label: 'InspectorPanel data',
+  description: 'Boundary data required to explain the current selection.',
+  requirements: [
+    { name: 'selection', requirement: inspectorSelectionRequirement },
+    { name: 'details', requirement: inspectorDetailsRequirement },
+  ],
+});
+const inspectorRevealSelection = commandIntent<{ readonly selectionId: string }>('inspector.revealSelection', {
+  label: 'Reveal selection',
+  description: 'Request navigation to the selected source entity.',
+  facts: [{ kind: 'entity', key: 'block.command', value: 'InspectorPanel' }],
+});
+const inspectorFocusSource = commandIntent<{ readonly sourceId: string }>('inspector.focusSource', {
+  label: 'Focus source',
+  description: 'Request focus for the source associated with the active selection.',
+  facts: [{ kind: 'entity', key: 'block.command', value: 'InspectorPanel' }],
+});
+
+export const appShellBlock: BlockDefinition = defineBlock({
+  metadata: appShellMetadata(),
+  commands: [
+    shellFocusRegion,
+    shellToggleInspector,
+    shellOpenOverlay,
+  ],
+  render: () => ({
+    output: 'AppShell definition placeholder',
+    facts: [{ kind: 'entity', key: 'block', value: 'AppShell' }],
+  }),
+});
+
+export const readerSurfaceBlock: BlockDefinition = defineBlock({
+  metadata: readerSurfaceMetadata(),
+  data: readerSurfaceData,
+  commands: [
+    readerSelectHeading,
+    readerOpenReference,
+  ],
+  render: ({ slots }) => ({
+    output: slots?.['content'] ?? 'ReaderSurface definition placeholder',
+    facts: [{ kind: 'entity', key: 'block', value: 'ReaderSurface' }],
+  }),
+});
+
+export const inspectorPanelBlock: BlockDefinition = defineBlock({
+  metadata: inspectorPanelMetadata(),
+  data: inspectorPanelData,
+  commands: [
+    inspectorRevealSelection,
+    inspectorFocusSource,
+  ],
+  render: ({ slots }) => ({
+    output: slots?.['selection'] ?? 'InspectorPanel definition placeholder',
+    facts: [{ kind: 'entity', key: 'block', value: 'InspectorPanel' }],
+  }),
+});
+
+export const readerSurfaceSchemaAdapter: BlockSchemaAdapter<ReaderSurfaceSchemaData> =
+  defineBlockSchemaAdapter({
+    id: 'reader-surface.article',
+    parse(input) {
+      if (!isReaderSurfaceSchemaData(input)) {
+        return schemaError('reader.article.invalid', 'Reader article data is required.');
+      }
+
+      return {
+        ok: true,
+        data: {
+          id: input.id,
+          title: input.title,
+          body: input.body,
+          ...(input.outline === undefined ? {} : { outline: input.outline }),
+        },
+      };
+    },
+    describe: () => ({
+      requiredFields: ['id', 'title', 'body'],
+      optionalFields: ['outline'],
+      facts: [{ kind: 'entity', key: 'block.schema', value: 'ReaderSurface' }],
+    }),
+  });
+
+export const inspectorPanelSchemaAdapter: BlockSchemaAdapter<InspectorPanelSchemaData> =
+  defineBlockSchemaAdapter({
+    id: 'inspector-panel.selection',
+    parse(input) {
+      if (!isInspectorPanelSchemaData(input)) {
+        return schemaError('inspector.selection.invalid', 'Inspector selection data is required.');
+      }
+
+      return {
+        ok: true,
+        data: {
+          selectionId: input.selectionId,
+          label: input.label,
+          ...(input.details === undefined ? {} : { details: input.details }),
+        },
+      };
+    },
+    describe: () => ({
+      requiredFields: ['selectionId', 'label'],
+      optionalFields: ['details'],
+      facts: [{ kind: 'entity', key: 'block.schema', value: 'InspectorPanel' }],
+    }),
+  });
+
+export const readerSurfaceSchemaBlock: SchemaBoundBlockDefinition<ReaderSurfaceSchemaData> =
+  defineSchemaBlock({
+    block: readerSurfaceBlock,
+    schema: readerSurfaceSchemaAdapter,
+    bind: (article) => ({
+      input: {
+        slots: {
+          content: article.body,
+          ...(article.outline === undefined
+            ? {}
+            : { outline: article.outline.map((item) => item.label) }),
+        },
+      },
+      facts: [
+        { kind: 'entity', key: 'article', value: article.id },
+        { kind: 'label', key: 'article.title', value: article.title },
+      ],
+    }),
+  });
+
+export const inspectorPanelSchemaBlock: SchemaBoundBlockDefinition<InspectorPanelSchemaData> =
+  defineSchemaBlock({
+    block: inspectorPanelBlock,
+    schema: inspectorPanelSchemaAdapter,
+    bind: (selection) => ({
+      input: {
+        slots: {
+          selection: selection.label,
+          ...(selection.details === undefined ? {} : { details: selection.details }),
+        },
+      },
+      facts: [
+        { kind: 'entity', key: 'selection', value: selection.selectionId },
+        { kind: 'label', key: 'selection.label', value: selection.label },
+      ],
+    }),
+  });
+
+export const standardBlocks = Object.freeze([
+  appShellBlock,
+  readerSurfaceBlock,
+  inspectorPanelBlock,
+]);
+
+export const standardBlockStories: readonly StandardBlockStory[] = Object.freeze([
+  standardBlockStory('app-shell.ready', 'AppShell', 'Ready shell', 'ready'),
+  standardBlockStory('app-shell.narrow', 'AppShell', 'Narrow shell', 'narrow'),
+  standardBlockStory('app-shell.overlay', 'AppShell', 'Overlay shell', 'overlay'),
+  standardBlockStory('reader-surface.ready', 'ReaderSurface', 'Reader ready', 'ready'),
+  standardBlockStory('reader-surface.loading', 'ReaderSurface', 'Reader loading', 'loading'),
+  standardBlockStory('reader-surface.stale', 'ReaderSurface', 'Reader stale', 'stale'),
+  standardBlockStory('reader-surface.empty', 'ReaderSurface', 'Reader empty', 'empty'),
+  standardBlockStory('reader-surface.error', 'ReaderSurface', 'Reader error', 'error'),
+  standardBlockStory('inspector-panel.ready', 'InspectorPanel', 'Inspector ready', 'ready'),
+  standardBlockStory('inspector-panel.empty', 'InspectorPanel', 'Inspector empty', 'empty'),
+  standardBlockStory('inspector-panel.loading', 'InspectorPanel', 'Inspector loading', 'loading'),
+  standardBlockStory('inspector-panel.stale', 'InspectorPanel', 'Inspector stale', 'stale'),
+  standardBlockStory('inspector-panel.error', 'InspectorPanel', 'Inspector error', 'error'),
+]);
+
+export const standardBlockPackageManifest: BlockPackageManifest = defineBlockPackage({
+  packageName: BIJOU_PACKAGE,
+  version: '5.0.0',
+  bijouPeerRange: '^5.0.0',
+  blocks: standardBlocks.map((block) => block.metadata.blockName),
+  docs: [
+    'docs/design-system/blocks.md',
+    'docs/design/DX-031-standard-bijou-blocks.md',
+  ],
+  tags: ['standard-blocks', 'dx-031', 'first-party'],
+});
+
+function appShellMetadata(): BlockMetadata {
+  return {
+    packageName: BIJOU_PACKAGE,
+    blockName: 'AppShell',
+    family: 'app-structure',
+    scale: 'app',
+    modes: ALL_OUTPUT_MODES,
+    docs: {
+      summary: 'Composes logical app regions for navigation, content, inspection, status, and overlays.',
+      useWhen: ['Building a shell around nested Bijou blocks.'],
+      avoidWhen: ['A single section or panel does not need app-level region structure.'],
+      relatedDocs: ['docs/design/DX-034-declarative-view-data-binding.md'],
+    },
+    sourcePath: 'packages/bijou/src/core/standard-blocks.ts',
+    slots: [
+      { id: 'navigation', required: false, description: 'Navigation or outline blocks.' },
+      { id: 'content', required: true, description: 'Primary content block.' },
+      { id: 'inspector', required: false, description: 'Contextual inspection blocks.' },
+      { id: 'status', required: false, description: 'Status or command feedback blocks.' },
+      { id: 'overlays', required: false, description: 'Overlay block declarations.' },
+    ],
+    variants: [
+      {
+        id: 'wide',
+        label: 'Wide',
+        requiredSlots: ['content'],
+        optionalSlots: ['navigation', 'inspector', 'status', 'overlays'],
+      },
+      {
+        id: 'narrow',
+        label: 'Narrow',
+        requiredSlots: ['content'],
+        optionalSlots: ['navigation', 'inspector', 'status', 'overlays'],
+      },
+    ],
+    composedComponents: ['AppShellComposition', 'ProviderScope', 'BlockDefinition'],
+    semanticFacts: [{ kind: 'entity', key: 'block', value: 'AppShell' }],
+    storyIds: ['app-shell.ready', 'app-shell.narrow', 'app-shell.overlay'],
+    examples: [{ id: 'app-shell.docs', label: 'Docs shell composition' }],
+    tags: ['standard', 'shell', 'composition'],
+  };
+}
+
+function readerSurfaceMetadata(): BlockMetadata {
+  return {
+    packageName: BIJOU_PACKAGE,
+    blockName: 'ReaderSurface',
+    family: 'content-reading',
+    scale: 'section',
+    modes: ALL_OUTPUT_MODES,
+    docs: {
+      summary: 'Composes readable content with optional navigation and outline context.',
+      useWhen: ['Rendering provider-backed prose, docs, articles, or reports.'],
+      avoidWhen: ['The surface is an editable form or command palette.'],
+    },
+    sourcePath: 'packages/bijou/src/core/standard-blocks.ts',
+    slots: [
+      { id: 'content', required: true, description: 'Readable body content.' },
+      { id: 'navigation', required: false, description: 'Sibling navigation content.' },
+      { id: 'outline', required: false, description: 'Current content outline.' },
+    ],
+    variants: [
+      {
+        id: 'article',
+        label: 'Article',
+        requiredSlots: ['content'],
+        optionalSlots: ['navigation', 'outline'],
+      },
+      {
+        id: 'loading',
+        label: 'Loading',
+        requiredSlots: ['content'],
+        optionalSlots: ['navigation', 'outline'],
+        facts: [{ kind: 'state', key: 'binding.status', value: 'loading' }],
+      },
+    ],
+    composedComponents: ['Markdown', 'Breadcrumb', 'Tree'],
+    semanticFacts: [{ kind: 'entity', key: 'block', value: 'ReaderSurface' }],
+    storyIds: [
+      'reader-surface.ready',
+      'reader-surface.loading',
+      'reader-surface.stale',
+      'reader-surface.empty',
+      'reader-surface.error',
+    ],
+    examples: [{ id: 'reader-surface.docs', label: 'Docs article reader' }],
+    tags: ['standard', 'reader', 'content'],
+  };
+}
+
+function inspectorPanelMetadata(): BlockMetadata {
+  return {
+    packageName: BIJOU_PACKAGE,
+    blockName: 'InspectorPanel',
+    family: 'inspection',
+    scale: 'panel',
+    modes: ALL_OUTPUT_MODES,
+    docs: {
+      summary: 'Explains the current selection with optional facts and source actions.',
+      useWhen: ['Showing contextual details for a selected entity.'],
+      avoidWhen: ['The view owns primary content rather than selection explanation.'],
+    },
+    sourcePath: 'packages/bijou/src/core/standard-blocks.ts',
+    slots: [
+      { id: 'selection', required: true, description: 'Selected entity label or summary.' },
+      { id: 'details', required: false, description: 'Facts or properties for the selected entity.' },
+      { id: 'actions', required: false, description: 'Selection-specific command affordances.' },
+    ],
+    variants: [
+      {
+        id: 'selection',
+        label: 'Selection',
+        requiredSlots: ['selection'],
+        optionalSlots: ['details', 'actions'],
+      },
+      {
+        id: 'empty',
+        label: 'Empty',
+        requiredSlots: ['selection'],
+        optionalSlots: ['details', 'actions'],
+        facts: [{ kind: 'state', key: 'binding.status', value: 'empty' }],
+      },
+    ],
+    composedComponents: ['Inspector', 'StatsPanel', 'Log'],
+    semanticFacts: [{ kind: 'entity', key: 'block', value: 'InspectorPanel' }],
+    storyIds: [
+      'inspector-panel.ready',
+      'inspector-panel.empty',
+      'inspector-panel.loading',
+      'inspector-panel.stale',
+      'inspector-panel.error',
+    ],
+    examples: [{ id: 'inspector-panel.selection', label: 'Selection inspector' }],
+    tags: ['standard', 'inspector', 'selection'],
+  };
+}
+
+function standardBlockStory(
+  id: string,
+  blockName: StandardBlockName,
+  label: string,
+  state: StandardBlockStoryState,
+): StandardBlockStory {
+  const facts: readonly BindingFact[] = Object.freeze([
+    Object.freeze({ kind: 'entity', key: 'block', value: blockName }),
+    Object.freeze({ kind: 'state', key: 'story.state', value: state }),
+  ]);
+
+  return Object.freeze({
+    id,
+    blockName,
+    label,
+    state,
+    facts,
+  });
+}
+
+function schemaError<Data = never>(code: string, message: string): BlockSchemaResult<Data> {
+  return {
+    ok: false,
+    issues: [{
+      severity: 'error' as const,
+      code,
+      message,
+    }],
+  };
+}
+
+function isReaderSurfaceSchemaData(input: unknown): input is ReaderSurfaceSchemaData {
+  if (!isRecord(input)) {
+    return false;
+  }
+
+  if (
+    typeof input['id'] !== 'string'
+    || typeof input['title'] !== 'string'
+    || typeof input['body'] !== 'string'
+  ) {
+    return false;
+  }
+
+  const outline = input['outline'];
+  return outline === undefined
+    || (Array.isArray(outline) && outline.every(isReaderSurfaceOutlineItem));
+}
+
+function isReaderSurfaceOutlineItem(input: unknown): input is ReaderSurfaceOutlineItem {
+  return isRecord(input)
+    && typeof input['id'] === 'string'
+    && typeof input['label'] === 'string';
+}
+
+function isInspectorPanelSchemaData(input: unknown): input is InspectorPanelSchemaData {
+  if (!isRecord(input)) {
+    return false;
+  }
+
+  if (typeof input['selectionId'] !== 'string' || typeof input['label'] !== 'string') {
+    return false;
+  }
+
+  const details = input['details'];
+  return details === undefined
+    || (Array.isArray(details) && details.every((detail) => typeof detail === 'string'));
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return input !== null && typeof input === 'object' && !Array.isArray(input);
+}

--- a/packages/bijou/src/core/standard-blocks.ts
+++ b/packages/bijou/src/core/standard-blocks.ts
@@ -478,43 +478,56 @@ function schemaError<Data = never>(code: string, message: string): BlockSchemaRe
 }
 
 function isReaderSurfaceSchemaData(input: unknown): input is ReaderSurfaceSchemaData {
-  if (!isRecord(input)) {
+  if (!isPlainRecord(input)) {
     return false;
   }
 
   if (
-    typeof input['id'] !== 'string'
-    || typeof input['title'] !== 'string'
-    || typeof input['body'] !== 'string'
+    typeof ownDataProperty(input, 'id') !== 'string'
+    || typeof ownDataProperty(input, 'title') !== 'string'
+    || typeof ownDataProperty(input, 'body') !== 'string'
   ) {
     return false;
   }
 
-  const outline = input['outline'];
+  const outline = ownDataProperty(input, 'outline');
   return outline === undefined
     || (Array.isArray(outline) && outline.every(isReaderSurfaceOutlineItem));
 }
 
 function isReaderSurfaceOutlineItem(input: unknown): input is ReaderSurfaceOutlineItem {
-  return isRecord(input)
-    && typeof input['id'] === 'string'
-    && typeof input['label'] === 'string';
+  return isPlainRecord(input)
+    && typeof ownDataProperty(input, 'id') === 'string'
+    && typeof ownDataProperty(input, 'label') === 'string';
 }
 
 function isInspectorPanelSchemaData(input: unknown): input is InspectorPanelSchemaData {
-  if (!isRecord(input)) {
+  if (!isPlainRecord(input)) {
     return false;
   }
 
-  if (typeof input['selectionId'] !== 'string' || typeof input['label'] !== 'string') {
+  if (
+    typeof ownDataProperty(input, 'selectionId') !== 'string'
+    || typeof ownDataProperty(input, 'label') !== 'string'
+  ) {
     return false;
   }
 
-  const details = input['details'];
+  const details = ownDataProperty(input, 'details');
   return details === undefined
     || (Array.isArray(details) && details.every((detail) => typeof detail === 'string'));
 }
 
-function isRecord(input: unknown): input is Record<string, unknown> {
-  return input !== null && typeof input === 'object' && !Array.isArray(input);
+function isPlainRecord(input: unknown): input is Record<string, unknown> {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(input);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function ownDataProperty(input: Record<string, unknown>, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(input, key);
+  return descriptor !== undefined && 'value' in descriptor ? descriptor.value : undefined;
 }

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -239,6 +239,24 @@ export {
   type SchemaBoundBlockDefinitionInput,
 } from './core/schema-block.js';
 export {
+  appShellBlock,
+  inspectorPanelBlock,
+  inspectorPanelSchemaAdapter,
+  inspectorPanelSchemaBlock,
+  readerSurfaceBlock,
+  readerSurfaceSchemaAdapter,
+  readerSurfaceSchemaBlock,
+  standardBlockPackageManifest,
+  standardBlocks,
+  standardBlockStories,
+  type InspectorPanelSchemaData,
+  type ReaderSurfaceOutlineItem,
+  type ReaderSurfaceSchemaData,
+  type StandardBlockName,
+  type StandardBlockStory,
+  type StandardBlockStoryState,
+} from './core/standard-blocks.js';
+export {
   componentMetadataReportText,
   componentMetadataSummary,
   defineComponentMetadata,

--- a/tests/cycles/DX-031/first-party-block-definitions.test.ts
+++ b/tests/cycles/DX-031/first-party-block-definitions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   appShellBlock,
+  defineBlock,
   defineAppShellComposition,
   inspectorPanelBlock,
   readerSurfaceBlock,
@@ -45,26 +46,55 @@ describe('DX-031C first-party block definitions', () => {
   });
 
   it('composes declared blocks without rendering them', () => {
+    const renderCalls: string[] = [];
+    const spyReaderSurfaceBlock = defineBlock({
+      metadata: readerSurfaceBlock.metadata,
+      data: readerSurfaceBlock.data,
+      commands: readerSurfaceBlock.commands,
+      render: (input) => {
+        renderCalls.push('ReaderSurface');
+        return readerSurfaceBlock.render(input);
+      },
+    });
+    const spyInspectorPanelBlock = defineBlock({
+      metadata: inspectorPanelBlock.metadata,
+      data: inspectorPanelBlock.data,
+      commands: inspectorPanelBlock.commands,
+      render: (input) => {
+        renderCalls.push('InspectorPanel');
+        return inspectorPanelBlock.render(input);
+      },
+    });
+    const spyAppShellBlock = defineBlock({
+      metadata: appShellBlock.metadata,
+      data: appShellBlock.data,
+      commands: appShellBlock.commands,
+      render: (input) => {
+        renderCalls.push('AppShell');
+        return appShellBlock.render(input);
+      },
+    });
     const composition = defineAppShellComposition({
       slots: {
-        content: readerSurfaceBlock,
-        inspector: inspectorPanelBlock,
-        status: appShellBlock,
+        content: spyReaderSurfaceBlock,
+        inspector: spyInspectorPanelBlock,
+        status: spyAppShellBlock,
       },
     });
 
     expect(composition.blocks()).toEqual([
-      readerSurfaceBlock,
-      inspectorPanelBlock,
-      appShellBlock,
+      spyReaderSurfaceBlock,
+      spyInspectorPanelBlock,
+      spyAppShellBlock,
     ]);
     expect(composition.dataContracts()).toEqual([
-      readerSurfaceBlock.data,
-      inspectorPanelBlock.data,
+      spyReaderSurfaceBlock.data,
+      spyInspectorPanelBlock.data,
     ]);
     expect(composition.commandIntents().map((intent) => intent.id)).toContain('shell.focusRegion');
     expect(composition.commandIntents().map((intent) => intent.id)).toContain('reader.selectHeading');
     expect(composition.commandIntents().map((intent) => intent.id)).toContain('inspector.revealSelection');
+    expect(renderCalls).toEqual([]);
   });
 
   it('declares deterministic first-party story coverage in code', () => {

--- a/tests/cycles/DX-031/first-party-block-definitions.test.ts
+++ b/tests/cycles/DX-031/first-party-block-definitions.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appShellBlock,
+  defineAppShellComposition,
+  inspectorPanelBlock,
+  readerSurfaceBlock,
+  standardBlockPackageManifest,
+  standardBlocks,
+  standardBlockStories,
+  validateBlockMetadata,
+  validateBlockPackageManifest,
+} from '../../../packages/bijou/src/index.js';
+
+describe('DX-031C first-party block definitions', () => {
+  it('publishes the first standard block set through the public barrel', () => {
+    expect(standardBlocks).toEqual([
+      appShellBlock,
+      readerSurfaceBlock,
+      inspectorPanelBlock,
+    ]);
+    expect(standardBlocks.map((block) => block.metadata.blockName)).toEqual([
+      'AppShell',
+      'ReaderSurface',
+      'InspectorPanel',
+    ]);
+
+    for (const block of standardBlocks) {
+      expect(validateBlockMetadata(block.metadata).passed).toBe(true);
+    }
+    expect(validateBlockPackageManifest(standardBlockPackageManifest).passed).toBe(true);
+  });
+
+  it('keeps AppShell semantic instead of physical', () => {
+    const slotIds = appShellBlock.metadata.slots.map((slot) => slot.id);
+
+    expect(slotIds).toContain('navigation');
+    expect(slotIds).toContain('content');
+    expect(slotIds).toContain('inspector');
+    expect(slotIds).toContain('status');
+    expect(slotIds).toContain('overlays');
+    expect(slotIds).not.toContain('left');
+    expect(slotIds).not.toContain('right');
+    expect(slotIds).not.toContain('center');
+    expect(slotIds).not.toContain('bottom');
+  });
+
+  it('composes declared blocks without rendering them', () => {
+    const composition = defineAppShellComposition({
+      slots: {
+        content: readerSurfaceBlock,
+        inspector: inspectorPanelBlock,
+        status: appShellBlock,
+      },
+    });
+
+    expect(composition.blocks()).toEqual([
+      readerSurfaceBlock,
+      inspectorPanelBlock,
+      appShellBlock,
+    ]);
+    expect(composition.dataContracts()).toEqual([
+      readerSurfaceBlock.data,
+      inspectorPanelBlock.data,
+    ]);
+    expect(composition.commandIntents().map((intent) => intent.id)).toContain('shell.focusRegion');
+    expect(composition.commandIntents().map((intent) => intent.id)).toContain('reader.selectHeading');
+    expect(composition.commandIntents().map((intent) => intent.id)).toContain('inspector.revealSelection');
+  });
+
+  it('declares deterministic first-party story coverage in code', () => {
+    expect(standardBlockStories.map((story) => story.id)).toEqual([
+      'app-shell.ready',
+      'app-shell.narrow',
+      'app-shell.overlay',
+      'reader-surface.ready',
+      'reader-surface.loading',
+      'reader-surface.stale',
+      'reader-surface.empty',
+      'reader-surface.error',
+      'inspector-panel.ready',
+      'inspector-panel.empty',
+      'inspector-panel.loading',
+      'inspector-panel.stale',
+      'inspector-panel.error',
+    ]);
+    expect(standardBlockStories.map((story) => story.blockName)).toEqual([
+      'AppShell',
+      'AppShell',
+      'AppShell',
+      'ReaderSurface',
+      'ReaderSurface',
+      'ReaderSurface',
+      'ReaderSurface',
+      'ReaderSurface',
+      'InspectorPanel',
+      'InspectorPanel',
+      'InspectorPanel',
+      'InspectorPanel',
+      'InspectorPanel',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the DX-031C first-party block definition slice for `@flyingrobots/bijou`.

This exports the first standard block definitions: `AppShell`, `ReaderSurface`, and `InspectorPanel`, plus `standardBlocks`, `standardBlockStories`, `standardBlockPackageManifest`, and schema-bound Reader/Inspector helpers. These are public contract artifacts built from existing block, data, command, schema, and AppShell composition primitives.

## What changed

- Added first-party `defineBlock()` outputs for `AppShell`, `ReaderSurface`, and `InspectorPanel`.
- Declared semantic AppShell slots: `navigation`, `content`, `inspector`, `status`, and `overlays`.
- Attached DX-034 data contracts and command intents to ReaderSurface and InspectorPanel.
- Added Reader/Inspector schema adapters and schema-bound wrappers for boundary validation.
- Added deterministic story declarations and a standard block package manifest.
- Exported the new API from the root `@flyingrobots/bijou` barrel.
- Updated docs and changelog to describe the public API without claiming rendered block availability.

## Non-goals

- no rendered AppShell
- no provider subscriptions
- no active runtime traversal
- no command dispatch implementation
- no DOGFOOD visual proof
- no full standard block catalog

## Validation

- `npm test -- --run packages/bijou/src/core/standard-blocks.test.ts tests/cycles/DX-031/first-party-block-definitions.test.ts`
- `npm run typecheck:test`
- `npm run docs:inventory`
- `git diff --check`
- `npm run lint`
- `npm test`
- pre-push reran `npm run typecheck:test`, full `npm test`, and `npm run verify:interactive-examples`

Full suite: 297 test files passed, 3393 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exported first-party standard block definitions for AppShell, ReaderSurface, and InspectorPanel with metadata, data contracts, command intents, and story declarations.

* **Documentation**
  * Updated documentation to describe standard block definition artifacts and their usage patterns.

* **Tests**
  * Added test coverage validating standard block exports, story declarations, and composition introspection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->