### PR TITLE
feat(dogfood): add live Blocks section

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 - **Blocks section in DOGFOOD** — DOGFOOD now has a first-class Blocks section
   beside Components, with pages for what blocks are, how to author them,
-  pre-made first-party blocks, a declaration-backed preview of standard block
-  variants/stories, and how block declarations lower across modes. The preview
-  and lowering pages are generated from the public `standardBlocks`,
+  pre-made first-party blocks, a live accordion preview of standard block pages,
+  and how block declarations lower across modes. The preview renders one inline
+  page per standard block with a live example surface, live lowering preview,
+  and live documentation generated from the public `standardBlocks`,
   `standardBlockStories`, and package-manifest exports rather than copied
   tables.
 - **First-party standard block definitions for `bijou`** —

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Blocks section in DOGFOOD** — DOGFOOD now has a first-class Blocks section
+  beside Components, with pages for what blocks are, how to author them,
+  pre-made first-party blocks, a declaration-backed preview of standard block
+  variants/stories, and how block declarations lower across modes. The preview
+  and lowering pages are generated from the public `standardBlocks`,
+  `standardBlockStories`, and package-manifest exports rather than copied
+  tables.
 - **First-party standard block definitions for `bijou`** —
   `@flyingrobots/bijou` now exports `appShellBlock`, `readerSurfaceBlock`,
   `inspectorPanelBlock`, `standardBlocks`, `standardBlockStories`,

--- a/docs/DOGFOOD.md
+++ b/docs/DOGFOOD.md
@@ -33,8 +33,7 @@ operators need when learning or validating Bijou.
 - **Shell Integrity**: Testing the framed shell, tabs, and pane focus in a production-grade surface.
 - **Component Explorer**: A live, interactive field guide to every component family.
 - **Blocks Section**: A first-class Blocks lane covering block purpose,
-  authoring, first-party blocks, declaration-backed previews, and lowering
-  posture.
+  authoring, first-party blocks, live accordion previews, and lowering posture.
 - **Storybook Workstation**: A standalone interactive story browser plus deterministic story index and matrix capture path over the same DOGFOOD story catalog.
 - **Graceful Lowering**: Verifying that documentation renders correctly across `rich`, `static`, `pipe`, and `accessible` modes.
 - **Responsive Product Layout**: Proving that resize is not enough by selecting `wide`, `standard`, `narrow`, and `tiny` docs layouts that keep constrained terminals useful.

--- a/docs/DOGFOOD.md
+++ b/docs/DOGFOOD.md
@@ -32,6 +32,9 @@ operators need when learning or validating Bijou.
 ### Today's Proof Points
 - **Shell Integrity**: Testing the framed shell, tabs, and pane focus in a production-grade surface.
 - **Component Explorer**: A live, interactive field guide to every component family.
+- **Blocks Section**: A first-class Blocks lane covering block purpose,
+  authoring, first-party blocks, declaration-backed previews, and lowering
+  posture.
 - **Storybook Workstation**: A standalone interactive story browser plus deterministic story index and matrix capture path over the same DOGFOOD story catalog.
 - **Graceful Lowering**: Verifying that documentation renders correctly across `rich`, `static`, `pipe`, and `accessible` modes.
 - **Responsive Product Layout**: Proving that resize is not enough by selecting `wide`, `standard`, `narrow`, and `tiny` docs layouts that keep constrained terminals useful.

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import {
+  accordion,
   boxSurface,
   blockMetadataSummary,
   blockPackageManifestSummary,
@@ -17,6 +18,7 @@ import {
   tv,
   wrapToWidth,
   type BijouContext,
+  type BlockDefinition,
   type PreferenceListTheme,
   type Surface,
   type StandardBlockStory,
@@ -961,6 +963,231 @@ function standardBlockLoweringMarkdown(): string {
 
 function formatDocsList(values: readonly string[]): string {
   return values.length === 0 ? '-' : values.join(', ');
+}
+
+function renderBlocksPreviewPane(
+  width: number,
+  ctx: BijouContext,
+  theme: LandingThemeTokens,
+): Surface {
+  const paneWidth = resolvePaneInnerWidth(width);
+  const bodyWidth = Math.max(28, paneWidth - 6);
+  const sections = standardBlocks.map((block) => ({
+    title: `Page: ${block.metadata.blockName}`,
+    expanded: true,
+    content: standardBlockLivePreviewText(block, bodyWidth, ctx),
+  }));
+  const body = accordion(sections, {
+    indicatorToken: docsThemeBorderToken(theme),
+    titleToken: docsThemeAccentToken(theme),
+    ctx,
+  });
+
+  return insetPaneSurface(column([
+    themedSeparatorSurface('blocks • live preview', paneWidth, ctx, theme),
+    spacer(1, 1),
+    contentSurface(body),
+  ]), width);
+}
+
+function standardBlockLivePreviewText(
+  block: BlockDefinition,
+  width: number,
+  ctx: BijouContext,
+): string {
+  return [
+    'Live example',
+    indentBlock(surfacePlainText(standardBlockExampleSurface(block, width, ctx))),
+    '',
+    'Live lowering preview',
+    indentBlock(standardBlockLoweringPreviewText(block)),
+    '',
+    'Live documentation',
+    indentBlock(standardBlockDocumentationText(block)),
+  ].join('\n');
+}
+
+function standardBlockExampleSurface(
+  block: BlockDefinition,
+  width: number,
+  ctx: BijouContext,
+): Surface {
+  const cardWidth = Math.max(30, Math.min(78, width));
+
+  switch (block.metadata.blockName) {
+    case 'AppShell':
+      return boxSurface(column([
+        line('navigation  Guides / Components / Blocks'),
+        line('content     ReaderSurface: DOGFOOD Blocks'),
+        line('inspector   InspectorPanel: selected block facts'),
+        line('status      provider snapshots idle; commands ready'),
+        line('overlays    none'),
+      ]), {
+        title: 'AppShell live example',
+        width: cardWidth,
+        borderToken: ctx.border('primary'),
+        padding: { left: 1, right: 1 },
+        ctx,
+      });
+    case 'ReaderSurface':
+      return boxSurface(contentSurface(markdown([
+        '# DOGFOOD Blocks',
+        '',
+        'ReaderSurface presents validated content with optional navigation and outline context.',
+        '',
+        '- metadata declares slots and variants',
+        '- data contracts describe boundary needs',
+        '- commands express user intent',
+      ].join('\n'), {
+        width: Math.max(24, cardWidth - 6),
+        ctx,
+      })), {
+        title: 'ReaderSurface live example',
+        width: cardWidth,
+        borderToken: ctx.border('primary'),
+        padding: { left: 1, right: 1 },
+        ctx,
+      });
+    case 'InspectorPanel':
+      return boxSurface(contentSurface(inspector({
+        title: 'InspectorPanel live example',
+        currentValue: 'ReaderSurface',
+        sections: [
+          {
+            title: 'Selection',
+            content: 'standard block definition',
+          },
+          {
+            title: 'Facts',
+            content: 'data: reader.article; command: reader.selectHeading',
+            tone: 'muted',
+          },
+        ],
+        width: Math.max(24, cardWidth - 4),
+        borderToken: ctx.border('muted'),
+        ctx,
+      })), {
+        title: 'InspectorPanel shell',
+        width: cardWidth,
+        borderToken: ctx.border('primary'),
+        padding: { left: 1, right: 1 },
+        ctx,
+      });
+    default:
+      return boxSurface(paragraphSurface(block.metadata.docs.summary, Math.max(24, cardWidth - 6)), {
+        title: `${block.metadata.blockName} live example`,
+        width: cardWidth,
+        borderToken: ctx.border('primary'),
+        padding: { left: 1, right: 1 },
+        ctx,
+      });
+  }
+}
+
+function standardBlockLoweringPreviewText(block: BlockDefinition): string {
+  const slots = standardBlockExampleSlots(block.metadata.blockName);
+  return block.metadata.modes
+    .map((mode) => {
+      const result = block.render({ mode, slots });
+      const output = blockRenderOutputText(result.output);
+      const facts = formatDocsList((result.facts ?? []).map((fact) => `${fact.kind}:${fact.key}=${fact.value}`));
+      return `${mode}: ${output} | facts: ${facts}`;
+    })
+    .join('\n');
+}
+
+function standardBlockExampleSlots(blockName: string): Readonly<Record<string, unknown>> {
+  switch (blockName) {
+    case 'AppShell':
+      return {
+        navigation: 'Guides / Components / Blocks',
+        content: 'ReaderSurface block page',
+        inspector: 'selected block facts',
+        status: 'ready',
+        overlays: [],
+      };
+    case 'ReaderSurface':
+      return {
+        content: 'ReaderSurface live content from DOGFOOD Blocks.',
+        navigation: 'Blocks navigation',
+        outline: ['What are Blocks', 'How Blocks Lower'],
+      };
+    case 'InspectorPanel':
+      return {
+        selection: 'ReaderSurface',
+        details: ['schema-bound', 'provider-ready', 'command-aware'],
+        actions: ['Reveal selection', 'Focus source'],
+      };
+    default:
+      return {};
+  }
+}
+
+function standardBlockDocumentationText(block: BlockDefinition): string {
+  const metadata = block.metadata;
+  const stories = standardBlockStories.filter((story) => story.blockName === metadata.blockName);
+  const slots = metadata.slots.map((slot) => `${slot.id}${slot.required === true ? ' required' : ' optional'}`);
+  const variants = (metadata.variants ?? []).map((variant) => `${variant.id} (${variant.label})`);
+  const dataNames = block.data?.names() ?? [];
+  const commands = block.commands?.map((command) => command.id) ?? [];
+
+  return [
+    metadata.docs.summary,
+    `Contract: ${blockMetadataSummary(metadata)}`,
+    `Slots: ${formatDocsList(slots)}`,
+    `Variants: ${formatDocsList(variants)}`,
+    `Data requirements: ${formatDocsList(dataNames)}`,
+    `Command intents: ${formatDocsList(commands)}`,
+    `Stories: ${formatDocsList(stories.map((story) => `${story.id} (${story.state})`))}`,
+    `Source: ${metadata.sourcePath ?? '-'}`,
+  ].join('\n');
+}
+
+function blockRenderOutputText(output: unknown): string {
+  if (typeof output === 'string') {
+    return compactInlineText(output);
+  }
+  if (isSurfaceLike(output)) {
+    return compactInlineText(surfacePlainText(output));
+  }
+  try {
+    return compactInlineText(JSON.stringify(output));
+  } catch {
+    return String(output);
+  }
+}
+
+function isSurfaceLike(value: unknown): value is Surface {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && typeof (value as Surface).width === 'number'
+      && typeof (value as Surface).height === 'number'
+      && typeof (value as Surface).get === 'function',
+  );
+}
+
+function surfacePlainText(surface: Surface): string {
+  const lines: string[] = [];
+  for (let y = 0; y < surface.height; y++) {
+    let text = '';
+    for (let x = 0; x < surface.width; x++) {
+      text += surface.get(x, y).char || ' ';
+    }
+    lines.push(text.trimEnd());
+  }
+  return lines.join('\n').trimEnd();
+}
+
+function compactInlineText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim() || '-';
+}
+
+function indentBlock(value: string): string {
+  return value
+    .split('\n')
+    .map((lineText) => `  ${lineText}`)
+    .join('\n');
 }
 
 function guideDocsForPage(pageId: DocsPageId): readonly GuideDoc[] {
@@ -2760,6 +2987,10 @@ function renderGuideReaderPane(
         ctx,
       }),
     ]), width);
+  }
+
+  if (pageId === BLOCKS_PAGE_ID && doc.id === 'blocks-preview') {
+    return renderBlocksPreviewPane(width, ctx, theme);
   }
 
   return insetPaneSurface(column([

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import {
   boxSurface,
+  blockMetadataSummary,
+  blockPackageManifestSummary,
   cloneContextWithTheme,
   createSurface,
   CYAN_MAGENTA,
@@ -8,12 +10,16 @@ import {
   lerp3,
   markdown,
   progressBar,
-  type PreferenceListTheme,
   separatorSurface,
+  standardBlockPackageManifest,
+  standardBlocks,
+  standardBlockStories,
   tv,
   wrapToWidth,
   type BijouContext,
+  type PreferenceListTheme,
   type Surface,
+  type StandardBlockStory,
   type Theme,
   type TokenValue,
 } from '@flyingrobots/bijou';
@@ -104,6 +110,11 @@ const GUIDES_START_HERE_TEXT = readMarkdownDoc('./content/guides-start-here.md')
 const GUIDES_NAVIGATE_DOGFOOD_TEXT = readMarkdownDoc('./content/guides-navigate-dogfood.md');
 const GUIDES_DOCUMENTATION_MAP_TEXT = readMarkdownDoc('../../docs/README.md');
 const GUIDES_SECONDARY_EXAMPLES_TEXT = readMarkdownDoc('../../docs/EXAMPLES.md');
+const BLOCKS_WHAT_ARE_BLOCKS_TEXT = readMarkdownDoc('../../docs/design-system/blocks.md');
+const BLOCKS_MAKE_YOUR_OWN_TEXT = readMarkdownDoc('./content/blocks-make-your-own.md');
+const BLOCKS_PRE_MADE_TEXT = standardBlockInventoryMarkdown();
+const BLOCKS_PREVIEW_TEXT = standardBlockPreviewMarkdown();
+const BLOCKS_LOWERING_TEXT = standardBlockLoweringMarkdown();
 const PACKAGES_OVERVIEW_TEXT = readMarkdownDoc('./content/packages-overview.md');
 const PACKAGE_BIJOU_TEXT = readMarkdownDocExcerpt('../../packages/bijou/README.md', ['## Install']);
 const PACKAGE_BIJOU_NODE_TEXT = readMarkdownDocExcerpt('../../packages/bijou-node/README.md', ['## Install']);
@@ -130,6 +141,7 @@ const LANDING_CONTROLS_TEXT = 'Esc/q quit • ↑/↓ quality • ←/→ theme 
 const VERSION_TEXT = `v${BIJOU_VERSION}`;
 const GUIDES_PAGE_ID = 'guides';
 const COMPONENTS_PAGE_ID = 'components';
+const BLOCKS_PAGE_ID = 'blocks';
 const PACKAGES_PAGE_ID = 'packages';
 const PHILOSOPHY_PAGE_ID = 'philosophy';
 const RELEASE_PAGE_ID = 'release';
@@ -181,6 +193,7 @@ export const DOGFOOD_I18N_CATALOG: I18nCatalog = {
     dogfoodMessage('docs.footer.guideMeta', '{paneSwitch} • section overview'),
     dogfoodMessage('docs.page.guides', 'Guides'),
     dogfoodMessage('docs.page.components', 'Components'),
+    dogfoodMessage('docs.page.blocks', 'Blocks'),
     dogfoodMessage('docs.page.packages', 'Packages'),
     dogfoodMessage('docs.page.philosophy', 'Philosophy'),
     dogfoodMessage('docs.page.release', 'Release'),
@@ -234,6 +247,7 @@ interface StoryFamily {
 type DocsPageId =
   | typeof GUIDES_PAGE_ID
   | typeof COMPONENTS_PAGE_ID
+  | typeof BLOCKS_PAGE_ID
   | typeof PACKAGES_PAGE_ID
   | typeof PHILOSOPHY_PAGE_ID
   | typeof RELEASE_PAGE_ID;
@@ -358,6 +372,7 @@ const DOGFOOD_DOCS_COVERAGE = resolveDogfoodDocsCoverage(COMPONENT_STORIES);
 const DOCS_SITE_PAGES: readonly DocsPageSpec[] = Object.freeze([
   { id: GUIDES_PAGE_ID, title: 'Guides' },
   { id: COMPONENTS_PAGE_ID, title: 'Components' },
+  { id: BLOCKS_PAGE_ID, title: 'Blocks' },
   { id: PACKAGES_PAGE_ID, title: 'Packages' },
   { id: PHILOSOPHY_PAGE_ID, title: 'Philosophy' },
   { id: RELEASE_PAGE_ID, title: 'Release' },
@@ -390,6 +405,41 @@ const GUIDE_DOCS: readonly GuideDoc[] = Object.freeze([
     title: 'Secondary Example Map',
     summary: 'Why examples are now secondary/internal and what reference value they still keep.',
     body: GUIDES_SECONDARY_EXAMPLES_TEXT,
+  },
+  {
+    id: 'blocks-what-are-blocks',
+    pageId: BLOCKS_PAGE_ID,
+    title: 'What are Blocks',
+    summary: 'The design-system posture for larger, opinionated Bijou assemblies.',
+    body: BLOCKS_WHAT_ARE_BLOCKS_TEXT,
+  },
+  {
+    id: 'blocks-make-your-own',
+    pageId: BLOCKS_PAGE_ID,
+    title: 'How to Make Your Own Blocks',
+    summary: 'The block authoring contract: metadata first, schema adapters at boundaries, and commands as intent.',
+    body: BLOCKS_MAKE_YOUR_OWN_TEXT,
+  },
+  {
+    id: 'blocks-pre-made',
+    pageId: BLOCKS_PAGE_ID,
+    title: 'Pre-made Blocks',
+    summary: 'The first-party standard blocks exported by @flyingrobots/bijou.',
+    body: BLOCKS_PRE_MADE_TEXT,
+  },
+  {
+    id: 'blocks-preview',
+    pageId: BLOCKS_PAGE_ID,
+    title: 'Block Preview',
+    summary: 'A code-backed preview index for standard blocks, variants, and declared stories.',
+    body: BLOCKS_PREVIEW_TEXT,
+  },
+  {
+    id: 'blocks-lowering',
+    pageId: BLOCKS_PAGE_ID,
+    title: 'How Blocks Lower',
+    summary: 'How standard block declarations carry mode and semantic facts before rendered block output lands.',
+    body: BLOCKS_LOWERING_TEXT,
   },
   {
     id: 'packages-overview',
@@ -795,6 +845,124 @@ function readMarkdownDocExcerpt(path: string, stopAtHeadings: readonly string[])
   return (stopIndex === -1 ? lines : lines.slice(0, stopIndex)).join('\n').trim();
 }
 
+function standardBlockInventoryMarkdown(): string {
+  const blockSections = standardBlocks
+    .map((block) => {
+      const metadata = block.metadata;
+      const requiredSlots = metadata.slots
+        .filter((slot) => slot.required === true)
+        .map((slot) => slot.id);
+      const optionalSlots = metadata.slots
+        .filter((slot) => slot.required !== true)
+        .map((slot) => slot.id);
+      const dataNames = block.data?.names() ?? [];
+      const commandIds = block.commands?.map((command) => command.id) ?? [];
+
+      return [
+        `## ${metadata.blockName}`,
+        '',
+        metadata.docs.summary,
+        '',
+        `- Contract: ${blockMetadataSummary(metadata)}`,
+        `- Family: ${metadata.family}`,
+        `- Scale: ${metadata.scale}`,
+        `- Modes: ${metadata.modes.join(', ')}`,
+        `- Required slots: ${formatDocsList(requiredSlots)}`,
+        `- Optional slots: ${formatDocsList(optionalSlots)}`,
+        `- Data requirements: ${formatDocsList(dataNames)}`,
+        `- Command intents: ${formatDocsList(commandIds)}`,
+        `- Source: ${metadata.sourcePath ?? 'not published'}`,
+      ].join('\n');
+    })
+    .join('\n\n');
+
+  return [
+    '# Pre-made Blocks',
+    '',
+    `Package: ${blockPackageManifestSummary(standardBlockPackageManifest)}`,
+    '',
+    blockSections,
+  ].join('\n');
+}
+
+function standardBlockPreviewMarkdown(): string {
+  const storiesByBlock = new Map<string, StandardBlockStory[]>();
+  for (const story of standardBlockStories) {
+    const existing = storiesByBlock.get(story.blockName) ?? [];
+    storiesByBlock.set(story.blockName, [...existing, story]);
+  }
+
+  const storyMatrix = standardBlockStories
+    .map((story) => `- ${story.id} - ${story.label} - ${story.blockName} - ${story.state}`)
+    .join('\n');
+  const blockSections = standardBlocks
+    .map((block) => {
+      const metadata = block.metadata;
+      const variants = metadata.variants ?? [];
+      const stories = storiesByBlock.get(metadata.blockName) ?? [];
+
+      return [
+        `## ${metadata.blockName}`,
+        '',
+        `Variants: ${formatDocsList(variants.map((variant) => `${variant.id} (${variant.label})`))}`,
+        '',
+        'Stories:',
+        stories.map((story) => `- ${story.id} - ${story.label} - ${story.state}`).join('\n'),
+      ].join('\n');
+    })
+    .join('\n\n');
+
+  return [
+    '# Block Preview',
+    '',
+    'The current standard block preview is declaration-backed. It indexes metadata, variants, and stories without rendering AppShell or resolving provider lifecycles.',
+    '',
+    '## Story Matrix',
+    '',
+    storyMatrix,
+    '',
+    blockSections,
+  ].join('\n');
+}
+
+function standardBlockLoweringMarkdown(): string {
+  const declaredModes = Array.from(
+    new Set(standardBlocks.flatMap((block) => block.metadata.modes)),
+  ).sort();
+  const blockRows = standardBlocks
+    .map((block) => {
+      const metadata = block.metadata;
+      const semanticFacts = (metadata.semanticFacts ?? [])
+        .map((fact) => `${fact.kind}:${fact.key}=${fact.value}`);
+      const variantFacts = (metadata.variants ?? [])
+        .flatMap((variant) => variant.facts ?? [])
+        .map((fact) => `${fact.kind}:${fact.key}=${fact.value}`);
+
+      return [
+        `## ${metadata.blockName}`,
+        '',
+        `- Modes: ${metadata.modes.join(', ')}`,
+        `- Semantic facts: ${formatDocsList(semanticFacts)}`,
+        `- Variant facts: ${formatDocsList(variantFacts)}`,
+      ].join('\n');
+    })
+    .join('\n\n');
+
+  return [
+    '# How Blocks Lower',
+    '',
+    'Blocks lower by preserving declared modes, semantic facts, story states, data requirements, and command intents as inspectable contract data before rendered output exists.',
+    '',
+    `Declared modes: ${declaredModes.join(', ')}`,
+    '',
+    blockRows,
+  ].join('\n');
+}
+
+function formatDocsList(values: readonly string[]): string {
+  return values.length === 0 ? '-' : values.join(', ');
+}
+
 function guideDocsForPage(pageId: DocsPageId): readonly GuideDoc[] {
   return GUIDE_DOCS.filter((doc) => doc.pageId === pageId);
 }
@@ -813,6 +981,8 @@ function pageTitle(pageId: DocsPageId, i18n?: I18nRuntime): string {
       return dogfoodText(i18n, 'docs.page.guides', 'Guides');
     case COMPONENTS_PAGE_ID:
       return dogfoodText(i18n, 'docs.page.components', 'Components');
+    case BLOCKS_PAGE_ID:
+      return dogfoodText(i18n, 'docs.page.blocks', 'Blocks');
     case PACKAGES_PAGE_ID:
       return dogfoodText(i18n, 'docs.page.packages', 'Packages');
     case PHILOSOPHY_PAGE_ID:
@@ -2617,6 +2787,8 @@ function renderGuideInfoPane(
     switch (pageId) {
       case GUIDES_PAGE_ID:
         return 'This is the reader-first orientation path for DOGFOOD, including the repo documentation map.';
+      case BLOCKS_PAGE_ID:
+        return 'This section publishes the block authoring, inventory, preview, and lowering path directly inside DOGFOOD.';
       case PACKAGES_PAGE_ID:
         return 'This section now publishes explainer pages for the shipped workspace packages inside DOGFOOD.';
       case PHILOSOPHY_PAGE_ID:

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -22,7 +22,7 @@ import {
   type StandardBlockStory,
   type Theme,
   type TokenValue,
-} from '@flyingrobots/bijou';
+} from '../../packages/bijou/src/index.js';
 import {
   FRAME_I18N_CATALOG,
   browsableListSurface,

--- a/examples/docs/content/blocks-make-your-own.md
+++ b/examples/docs/content/blocks-make-your-own.md
@@ -1,0 +1,75 @@
+# How to Make Your Own Blocks
+
+Blocks are authored as public contracts first. A block should be discoverable
+before it renders, and a package should be able to publish block metadata
+without relying on import-time registration.
+
+## Authoring Loop
+
+1. Define the block metadata.
+2. Declare slots, variants, modes, examples, and semantic facts.
+3. Add data contracts only when the block needs provider-backed inputs.
+4. Declare command intents for user actions.
+5. Add a schema adapter when unknown boundary data needs validation.
+6. Export the block and include it in a package manifest.
+
+## Minimal Shape
+
+```ts
+import {
+  commandIntent,
+  defineBlock,
+  defineBlockPackage,
+  defineDataRequirement,
+  defineViewData,
+} from '@flyingrobots/bijou';
+
+const article = defineDataRequirement({
+  id: 'docs.article',
+  resource: 'docs.article',
+});
+
+const readerData = defineViewData({
+  id: 'reader.data',
+  requirements: [{ name: 'article', requirement: article }],
+});
+
+export const readerBlock = defineBlock({
+  metadata: {
+    packageName: '@example/blocks',
+    blockName: 'Reader',
+    family: 'reading',
+    scale: 'section',
+    modes: ['interactive', 'static', 'pipe', 'accessible'],
+    docs: {
+      summary: 'Renders validated article content.',
+    },
+    slots: [{ id: 'content', required: true }],
+  },
+  data: readerData,
+  commands: [
+    commandIntent('reader.selectHeading', {
+      label: 'Select heading',
+    }),
+  ],
+  render: ({ slots }) => ({
+    output: String(slots?.content ?? ''),
+  }),
+});
+
+export const manifest = defineBlockPackage({
+  packageName: '@example/blocks',
+  version: '1.0.0',
+  bijouPeerRange: '^5.0.0',
+  blocks: ['Reader'],
+});
+```
+
+## Boundaries
+
+Schema-bound blocks validate shape at the boundary. Provider-bound data flow is
+separate: providers publish immutable snapshots, frames deliver render-time
+data, and commands express user intent back to business logic.
+
+Do not put provider handles, subscription handles, refresh methods, dispatch
+callbacks, or hidden mutable stores in a block render input.

--- a/scripts/docs-preview.test.ts
+++ b/scripts/docs-preview.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -108,6 +109,17 @@ describe('docs preview app', () => {
     expect(source).toContain("../../packages/bijou-node/src/index.js");
     expect(source).toContain("../../packages/bijou-tui/src/index.js");
     expect(source).toMatch(/await run\(createDocsApp\(ctx\), \{ ctx, mouse: true \}\);/);
+  });
+
+  it('imports the DOGFOOD app through the same tsx path used by npm run dogfood', () => {
+    execFileSync(
+      process.execPath,
+      ['--import', 'tsx', '-e', "await import('./examples/docs/app.ts')"],
+      {
+        cwd: resolve(import.meta.dirname, '..'),
+        stdio: 'pipe',
+      },
+    );
   });
 
   it('builds the framed explorer shell from the provided ctx without relying on a default singleton', async () => {

--- a/tests/cycles/DF-023/publish-repo-package-and-release-guides-in-dogfood.test.ts
+++ b/tests/cycles/DF-023/publish-repo-package-and-release-guides-in-dogfood.test.ts
@@ -51,8 +51,8 @@ describe('DF-023 publish repo, package, and release guides in DOGFOOD', () => {
 
   it('publishes package explainer pages in the Packages section', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
-    const app = createDocsApp(ctx, { initialRoute: 'docs' });
-    const opened = await runScript(app, [{ key: ']' }, { key: ']' }], { ctx });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'packages' });
+    const opened = await runScript(app, [], { ctx });
     const packagesText = frameText(opened.frames.at(-1)!);
 
     expect(opened.model.docsModel.activePageId).toBe('packages');
@@ -64,8 +64,6 @@ describe('DF-023 publish repo, package, and release guides in DOGFOOD', () => {
     expect(packagesText).not.toContain('left lane');
 
     const packageDoc = await runScript(app, [
-      { key: ']' },
-      { key: ']' },
       { msg: { type: 'docs', msg: { type: 'select-guide', guideId: 'package-bijou' } } },
     ], { ctx });
     const packageText = frameText(packageDoc.frames.at(-1)!);
@@ -77,8 +75,8 @@ describe('DF-023 publish repo, package, and release guides in DOGFOOD', () => {
   it('publishes the current release story and migration guide in Release', async () => {
     const versionSlug = BIJOU_VERSION.replaceAll('.', '-');
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
-    const app = createDocsApp(ctx, { initialRoute: 'docs' });
-    const opened = await runScript(app, [{ key: ']' }, { key: ']' }, { key: ']' }, { key: ']' }], { ctx });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'release' });
+    const opened = await runScript(app, [], { ctx });
     const releaseText = frameText(opened.frames.at(-1)!);
 
     expect(opened.model.docsModel.activePageId).toBe('release');
@@ -86,19 +84,11 @@ describe('DF-023 publish repo, package, and release guides in DOGFOOD', () => {
     expect(releaseText).toContain(`Migration Guide v${BIJOU_VERSION}`);
 
     const whatsNew = await runScript(app, [
-      { key: ']' },
-      { key: ']' },
-      { key: ']' },
-      { key: ']' },
       { msg: { type: 'docs', msg: { type: 'select-guide', guideId: `release-whats-new-${versionSlug}` } } },
     ], { ctx });
     expect(frameText(whatsNew.frames.at(-1)!)).toContain(`New in Bijou ${BIJOU_VERSION}`);
 
     const migration = await runScript(app, [
-      { key: ']' },
-      { key: ']' },
-      { key: ']' },
-      { key: ']' },
       { msg: { type: 'docs', msg: { type: 'select-guide', guideId: `release-migration-${versionSlug}` } } },
     ], { ctx });
     expect(frameText(migration.frames.at(-1)!)).toContain(`Migrating to Bijou ${BIJOU_VERSION}`);

--- a/tests/cycles/DF-024/publish-philosophy-architecture-and-doctrine-guides-in-dogfood.test.ts
+++ b/tests/cycles/DF-024/publish-philosophy-architecture-and-doctrine-guides-in-dogfood.test.ts
@@ -31,8 +31,8 @@ describe('DF-024 publish philosophy, architecture, and doctrine guides in DOGFOO
 
   it('publishes doctrine and architecture pages in the Philosophy section', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
-    const app = createDocsApp(ctx, { initialRoute: 'docs' });
-    const opened = await runScript(app, [{ key: ']' }, { key: ']' }, { key: ']' }], { ctx });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'philosophy' });
+    const opened = await runScript(app, [], { ctx });
     const overviewText = frameText(opened.frames.at(-1)!);
 
     expect(opened.model.docsModel.activePageId).toBe('philosophy');
@@ -43,9 +43,6 @@ describe('DF-024 publish philosophy, architecture, and doctrine guides in DOGFOO
     expect(overviewText).toContain('Design System Overview');
 
     const systemStyle = await runScript(app, [
-      { key: ']' },
-      { key: ']' },
-      { key: ']' },
       { msg: { type: 'docs', msg: { type: 'select-guide', guideId: 'philosophy-system-style-javascript' } } },
     ], { ctx });
     const systemStyleText = frameText(systemStyle.frames.at(-1)!);
@@ -53,9 +50,6 @@ describe('DF-024 publish philosophy, architecture, and doctrine guides in DOGFOO
     expect(systemStyleText).toContain('TypeScript is a useful dialect');
 
     const architecture = await runScript(app, [
-      { key: ']' },
-      { key: ']' },
-      { key: ']' },
       { msg: { type: 'docs', msg: { type: 'select-guide', guideId: 'philosophy-architecture' } } },
     ], { ctx });
     const architectureText = frameText(architecture.frames.at(-1)!);

--- a/tests/cycles/DX-031/dogfood-blocks-section.test.ts
+++ b/tests/cycles/DX-031/dogfood-blocks-section.test.ts
@@ -49,8 +49,8 @@ describe('DX-031D DOGFOOD Blocks section', () => {
     expect(blocksModel.selectedGuideId).toBe('blocks-what-are-blocks');
   });
 
-  it('renders a code-backed preview of standard blocks and their story variants', async () => {
-    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 180, rows: 54 } });
+  it('renders an accordion-backed live preview for standard blocks and their story variants', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 220, rows: 160 } });
     const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
 
     const result = await runScript(app, [{
@@ -62,12 +62,19 @@ describe('DX-031D DOGFOOD Blocks section', () => {
     const text = frameText(result.frames.at(-1)!);
 
     expect(docsPageModel(result.model as any, 'blocks').selectedGuideId).toBe('blocks-preview');
+    expect(text).toContain('blocks • live preview');
+    expect(text).toContain('Live example');
+    expect(text).toContain('Live lowering preview');
+    expect(text).toContain('Live documentation');
+    expect(text).toContain('AppShell live example');
+    expect(text).toContain('ReaderSurface live example');
+    expect(text).toContain('InspectorPanel live example');
     for (const block of standardBlocks) {
+      expect(text).toContain(`Page: ${block.metadata.blockName}`);
       expect(text).toContain(block.metadata.blockName);
     }
-    for (const story of standardBlockStories.slice(0, 8)) {
+    for (const story of standardBlockStories) {
       expect(text).toContain(story.id);
-      expect(text).toContain(story.label);
     }
   });
 

--- a/tests/cycles/DX-031/dogfood-blocks-section.test.ts
+++ b/tests/cycles/DX-031/dogfood-blocks-section.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { standardBlocks, standardBlockStories } from '@flyingrobots/bijou';
+import { _resetDefaultContextForTesting, createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { runScript } from '@flyingrobots/bijou-tui';
+import { createDocsApp } from '../../../examples/docs/app.js';
+
+const KEY_ENTER = '\r';
+const KEY_NEXT_TAB = ']';
+
+function docsPageModel(model: any, pageId: string) {
+  return model.docsModel.pageModels[pageId];
+}
+
+function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
+  let text = '';
+  for (let y = 0; y < frame.height; y++) {
+    for (let x = 0; x < frame.width; x++) {
+      text += frame.get(x, y).char || ' ';
+    }
+    text += '\n';
+  }
+  return text;
+}
+
+describe('DX-031D DOGFOOD Blocks section', () => {
+  afterEach(() => _resetDefaultContextForTesting());
+
+  it('publishes Blocks as a top-level DOGFOOD section with the requested pages', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 160, rows: 44 } });
+    const app = createDocsApp(ctx);
+
+    const result = await runScript(app, [
+      { key: KEY_ENTER },
+      { key: KEY_NEXT_TAB },
+      { key: KEY_NEXT_TAB },
+    ], { ctx });
+    const model = result.model as any;
+    const blocksModel = docsPageModel(model, 'blocks');
+    const guideLabels = blocksModel.guideState.items.map((item: { label: string }) => item.label);
+
+    expect(model.docsModel.activePageId).toBe('blocks');
+    expect(guideLabels).toEqual([
+      'What are Blocks',
+      'How to Make Your Own Blocks',
+      'Pre-made Blocks',
+      'Block Preview',
+      'How Blocks Lower',
+    ]);
+    expect(blocksModel.selectedGuideId).toBe('blocks-what-are-blocks');
+  });
+
+  it('renders a code-backed preview of standard blocks and their story variants', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 180, rows: 54 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
+
+    const result = await runScript(app, [{
+      msg: {
+        type: 'docs',
+        msg: { type: 'select-guide', guideId: 'blocks-preview' },
+      },
+    }], { ctx });
+    const text = frameText(result.frames.at(-1)!);
+
+    expect(docsPageModel(result.model as any, 'blocks').selectedGuideId).toBe('blocks-preview');
+    for (const block of standardBlocks) {
+      expect(text).toContain(block.metadata.blockName);
+    }
+    for (const story of standardBlockStories.slice(0, 8)) {
+      expect(text).toContain(story.id);
+      expect(text).toContain(story.label);
+    }
+  });
+
+  it('renders block lowering posture from the standard block mode declarations', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 180, rows: 54 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
+
+    const result = await runScript(app, [{
+      msg: {
+        type: 'docs',
+        msg: { type: 'select-guide', guideId: 'blocks-lowering' },
+      },
+    }], { ctx });
+    const text = frameText(result.frames.at(-1)!);
+    const declaredModes = Array.from(
+      new Set(standardBlocks.flatMap((block) => block.metadata.modes)),
+    ).sort();
+
+    expect(docsPageModel(result.model as any, 'blocks').selectedGuideId).toBe('blocks-lowering');
+    for (const mode of declaredModes) {
+      expect(text).toContain(mode);
+    }
+    for (const block of standardBlocks) {
+      expect(text).toContain(block.metadata.blockName);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a first-class DOGFOOD Blocks section next to Components with pages for What are Blocks, How to Make Your Own Blocks, Pre-made Blocks, Block Preview, and How Blocks Lower.
- Makes Block Preview a rendered accordion surface: one expanded page per standard block, each with a live example surface, live lowering preview generated from block render declarations, and live documentation generated from block metadata/data/commands/stories.
- Imports DOGFOOD core symbols from live local Bijou source so `npm run dogfood` does not depend on stale package dist, and adds a subprocess import regression for the actual tsx path.
- Updates older DOGFOOD section tests to target page ids instead of tab-count assumptions.

## Non-goals
- no rendered production AppShell contract
- no provider subscriptions
- no active runtime traversal
- no command dispatch
- no new block catalog beyond AppShell, ReaderSurface, and InspectorPanel

## Validation
- `npm test -- --run tests/cycles/DX-031/dogfood-blocks-section.test.ts scripts/docs-preview.test.ts`
- `npm run typecheck:test`
- `npm run lint`
- `npm run docs:inventory`
- `npm run smoke:dogfood:docs`
- `npm test`
- `npm run verify:interactive-examples`
- pre-push reran `npm run typecheck:test`, `npm test`, and `npm run verify:interactive-examples`