### PR TITLE
feat(blocks): render standard block proofs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Rendered standard block proof for `bijou`** —
+  `AppShell`, `ReaderSurface`, and `InspectorPanel` now render deterministic
+  first-party block output across interactive, static, pipe, and accessible
+  modes with stable lowering facts. This replaces definition placeholders with
+  live semantic region/content/selection output while still avoiding provider
+  subscriptions, active runtime traversal, command dispatch, cache policy,
+  rendered production AppShell behavior, or catalog expansion.
 - **Blocks section in DOGFOOD** — DOGFOOD now has a first-class Blocks section
   beside Components, with pages for what blocks are, how to author them,
   pre-made first-party blocks, a live accordion preview of standard block pages,

--- a/docs/design-system/blocks.md
+++ b/docs/design-system/blocks.md
@@ -65,8 +65,10 @@ Bijou now exposes a metadata-first block authoring contract from
 - `appShellBlock`, `readerSurfaceBlock`, `inspectorPanelBlock`,
   `standardBlocks`, `standardBlockStories`, and
   `standardBlockPackageManifest` expose the first-party block definitions:
-  AppShell, ReaderSurface, and InspectorPanel. They are definition and contract
-  artifacts, not rendered block products.
+  AppShell, ReaderSurface, and InspectorPanel. Their render functions now
+  produce deterministic first-proof output across interactive, static, pipe,
+  and accessible modes while keeping provider lifecycle and production AppShell
+  behavior out of the block definition layer.
 - `defineAppShellComposition()` groups runtime-backed blocks into logical
   navigation, content, inspector, status, and overlay slots without rendering.
 - `defineBlockSchemaAdapter()`, `defineSchemaBlock()`, and
@@ -81,7 +83,7 @@ registration, and tooling can discover slots and mode support directly.
 Schema-bound blocks validate unknown boundary data without making Zod, GraphQL,
 or database schemas part of the core block dependency surface. Provider
 subscriptions, active hierarchy traversal, rendered AppShell, and DOGFOOD block
-proof remain follow-on work.
+multi-mode captures remain follow-on work.
 
 ## First credible block candidates
 

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -3156,14 +3156,17 @@ blocks.
 9. Done: add first-party block definitions and story declarations for
    `AppShell`, `ReaderSurface`, and `InspectorPanel` without making them
    rendered block products.
-10. Next: add an optional Zod schema adapter package or helper.
-11. Next: capture interactive, static, pipe, and accessible outputs for the
+10. Done: replace the first-party definition placeholders with deterministic
+   rendered proof output and stable lowering facts for `AppShell`,
+   `ReaderSurface`, and `InspectorPanel`.
+11. Next: add an optional Zod schema adapter package or helper.
+12. Next: capture interactive, static, pipe, and accessible outputs for the
    first implementation set.
-12. Next: prove the first three blocks in DOGFOOD before broadening the
+13. Next: prove the first three blocks in DOGFOOD before broadening the
    catalog.
-13. Next: add catalog-only variant/config metadata for later blocks without
+14. Next: add catalog-only variant/config metadata for later blocks without
    implementing those blocks yet.
-14. Continue to defer modal stacks, notifications, auth forms, animated
+15. Continue to defer modal stacks, notifications, auth forms, animated
    carousels, complex controls, and workspace-like behavior until the first
    rendered block set is proven.
 
@@ -3338,14 +3341,38 @@ What is now true:
 Still out of scope after this slice:
 
 - Zod adapters and schema-to-block compilers.
-- Rendered first-party `AppShell`, `ReaderSurface`, and `InspectorPanel` blocks.
 - DOGFOOD block galleries and multi-mode story captures for rendered blocks.
 - Modal stacks, notifications, auth blocks, workspace docking, and complex
   domain-specific block packages.
+
+DX-031E Rendered Standard Block Proof replaces the first-party placeholders
+with deterministic render output.
+
+What is now true:
+
+- `AppShell`, `ReaderSurface`, and `InspectorPanel` render concrete string
+  output for interactive, static, pipe, and accessible modes.
+- `AppShell` renders semantic region output for `navigation`, `content`,
+  `inspector`, `status`, and `overlays`.
+- `ReaderSurface` renders content, navigation, and outline output.
+- `InspectorPanel` renders selection, details, and actions output.
+- Render facts stay stable across modes so lowering checks do not need to parse
+  rendered text.
+- Render results do not expose provider handles, subscription handles, refresh
+  methods, active-tree traversal, or command dispatch callbacks.
+
+Still out of scope after this slice:
+
+- Provider subscriptions and cache policy.
+- Active runtime traversal.
+- Command dispatch integration.
+- Production AppShell behavior.
+- DOGFOOD multi-mode captures for rendered blocks.
+- Catalog expansion beyond `AppShell`, `ReaderSurface`, and `InspectorPanel`.
 
 ## Retrospective
 
 DX-031 is now partially landed rather than not started. The first slice gives
 the ecosystem a stable block contract to index, review, and publish against,
-but "full block availability" still requires schema binding, a rendered
-first-party block set, DOGFOOD proof, story captures, and catalog expansion.
+but "full block availability" still requires DOGFOOD multi-mode proof, story
+captures, and catalog expansion.

--- a/packages/bijou/GUIDE.md
+++ b/packages/bijou/GUIDE.md
@@ -245,13 +245,13 @@ inspectorPanelBlock.data?.names();
 appShellBlock.metadata.slots.map(slot => slot.id);
 ```
 
-These definitions are contract artifacts. They declare metadata, semantic
-slots, data requirements, command intents, story ids, and package visibility for
-`AppShell`, `ReaderSurface`, and `InspectorPanel`.
+These definitions declare metadata, semantic slots, data requirements, command
+intents, story ids, package visibility, and deterministic first-proof render
+output for `AppShell`, `ReaderSurface`, and `InspectorPanel`.
 
-They do not implement rendered AppShell, provider subscriptions, active runtime
-traversal, command dispatch, DOGFOOD captures, or the full standard block
-catalog.
+They do not implement provider subscriptions, active runtime traversal, command
+dispatch, production AppShell behavior, DOGFOOD multi-mode captures, or the
+full standard block catalog.
 
 ## AppShell Composition
 

--- a/packages/bijou/README.md
+++ b/packages/bijou/README.md
@@ -99,7 +99,8 @@ fake duplication rather than a real second API.
   `inspectorPanelBlock`**: Import the first-party standard block
   definitions for AppShell, ReaderSurface, and InspectorPanel. These expose
   contracts, stories, data requirements, command intents, and schema-bound
-  posture without providing rendered AppShell product yet.
+  posture, with deterministic first-proof render output across all output
+  modes. Production AppShell behavior remains a later runtime slice.
 - **`defineBlockPackage()`**: Declare exported blocks, docs, tags, version, and
   Bijou peer compatibility for ordinary NPM block packages.
 - **`defineBlockSchemaAdapter()` / `defineSchemaBlock()`**: Validate unknown

--- a/packages/bijou/src/core/standard-blocks.test.ts
+++ b/packages/bijou/src/core/standard-blocks.test.ts
@@ -12,6 +12,7 @@ import {
   bindSchemaBlockInput,
   isSchemaBoundBlockDefinition,
 } from './schema-block.js';
+import { lintModeLowering } from './mode-lowering.js';
 import {
   appShellBlock,
   inspectorPanelBlock,
@@ -255,6 +256,101 @@ describe('first-party standard block definitions', () => {
     expect(composition.commandIntents().map((intent) => intent.id)).toContain('reader.selectHeading');
     expect(composition.commandIntents().map((intent) => intent.id)).toContain('inspector.revealSelection');
     expect(renderCalls).toBe(0);
+  });
+
+  it('renders AppShell semantic regions without placeholder output', () => {
+    const rendered = appShellBlock.render({
+      mode: 'pipe',
+      slots: {
+        navigation: 'Docs nav',
+        content: 'Blocks guide',
+        inspector: 'Current block: ReaderSurface',
+        status: 'Ready',
+        overlays: ['Command palette', 'Help drawer'],
+      },
+    });
+
+    expect(rendered.output).toContain('AppShell');
+    expect(rendered.output).toContain('navigation: Docs nav');
+    expect(rendered.output).toContain('content: Blocks guide');
+    expect(rendered.output).toContain('inspector: Current block: ReaderSurface');
+    expect(rendered.output).toContain('status: Ready');
+    expect(rendered.output).toContain('overlays: Command palette; Help drawer');
+    expect(rendered.output).not.toContain('definition placeholder');
+    expect(rendered.facts).toEqual(expect.arrayContaining([
+      { kind: 'entity', key: 'block', value: 'AppShell' },
+      { kind: 'state', key: 'block.rendered', value: true },
+      { kind: 'entity', key: 'region.content', value: 'present' },
+    ]));
+  });
+
+  it('renders ReaderSurface content, navigation, and outline deterministically', () => {
+    const outline = Object.freeze(['Why Blocks', 'Lowering']);
+    const rendered = readerSurfaceBlock.render({
+      mode: 'accessible',
+      slots: {
+        content: '# Blocks\nBlocks are reusable Bijou view contracts.',
+        navigation: 'Components > Blocks',
+        outline,
+      },
+    });
+
+    expect(rendered.output).toContain('ReaderSurface');
+    expect(rendered.output).toContain('Navigation: Components > Blocks');
+    expect(rendered.output).toContain('Content:');
+    expect(rendered.output).toContain('# Blocks');
+    expect(rendered.output).toContain('Outline: Why Blocks; Lowering');
+    expect(rendered.output).not.toContain('definition placeholder');
+    expect(outline).toEqual(['Why Blocks', 'Lowering']);
+    expect(rendered.facts).toEqual(expect.arrayContaining([
+      { kind: 'entity', key: 'block', value: 'ReaderSurface' },
+      { kind: 'state', key: 'block.rendered', value: true },
+      { kind: 'entity', key: 'slot.content', value: 'present' },
+      { kind: 'entity', key: 'slot.outline', value: 'present' },
+    ]));
+  });
+
+  it('renders InspectorPanel selection and details deterministically', () => {
+    const details = Object.freeze(['type: block', 'state: ready']);
+    const rendered = inspectorPanelBlock.render({
+      mode: 'pipe',
+      slots: {
+        selection: 'ReaderSurface',
+        details,
+        actions: ['reveal source', 'focus docs'],
+      },
+    });
+
+    expect(rendered.output).toContain('InspectorPanel');
+    expect(rendered.output).toContain('selection: ReaderSurface');
+    expect(rendered.output).toContain('details: type: block; state: ready');
+    expect(rendered.output).toContain('actions: reveal source; focus docs');
+    expect(rendered.output).not.toContain('definition placeholder');
+    expect(details).toEqual(['type: block', 'state: ready']);
+    expect(rendered.facts).toEqual(expect.arrayContaining([
+      { kind: 'entity', key: 'block', value: 'InspectorPanel' },
+      { kind: 'state', key: 'block.rendered', value: true },
+      { kind: 'entity', key: 'slot.selection', value: 'present' },
+      { kind: 'entity', key: 'slot.details', value: 'present' },
+    ]));
+  });
+
+  it('preserves rendered block facts across output modes', () => {
+    const modes = ['interactive', 'static', 'pipe', 'accessible'] as const;
+    const report = lintModeLowering({
+      modes: modes.map((mode) => ({
+        mode,
+        facts: readerSurfaceBlock.render({
+          mode,
+          slots: {
+            content: 'Rendered body',
+            outline: ['Intro'],
+          },
+        }).facts ?? [],
+      })),
+    });
+
+    expect(report).toMatchObject({ passed: true });
   });
 });
 

--- a/packages/bijou/src/core/standard-blocks.test.ts
+++ b/packages/bijou/src/core/standard-blocks.test.ts
@@ -284,6 +284,45 @@ describe('first-party standard block definitions', () => {
     ]));
   });
 
+  it('omits absent optional sections while preserving required section fallback output', () => {
+    const shell = appShellBlock.render({
+      mode: 'pipe',
+      slots: { content: 'Blocks guide' },
+    });
+    expect(shell.output).toContain('content: Blocks guide');
+    expect(shell.output).not.toContain('navigation:');
+    expect(shell.output).not.toContain('inspector:');
+    expect(shell.output).not.toContain('status:');
+    expect(shell.output).not.toContain('overlays:');
+    expect(shell.facts).toContainEqual({ kind: 'entity', key: 'region.content', value: 'present' });
+    expect(shell.facts).not.toContainEqual({ kind: 'entity', key: 'region.navigation', value: 'present' });
+
+    const reader = readerSurfaceBlock.render({
+      mode: 'pipe',
+      slots: { content: 'Only the article body' },
+    });
+    expect(reader.output).toContain('content: Only the article body');
+    expect(reader.output).not.toContain('navigation:');
+    expect(reader.output).not.toContain('outline:');
+    expect(reader.facts).toContainEqual({ kind: 'entity', key: 'slot.content', value: 'present' });
+    expect(reader.facts).not.toContainEqual({ kind: 'entity', key: 'slot.outline', value: 'present' });
+
+    const inspector = inspectorPanelBlock.render({
+      mode: 'pipe',
+      slots: { selection: 'ReaderSurface' },
+    });
+    expect(inspector.output).toContain('selection: ReaderSurface');
+    expect(inspector.output).not.toContain('details:');
+    expect(inspector.output).not.toContain('actions:');
+    expect(inspector.facts).toContainEqual({ kind: 'entity', key: 'slot.selection', value: 'present' });
+    expect(inspector.facts).not.toContainEqual({ kind: 'entity', key: 'slot.details', value: 'present' });
+
+    const missingRequired = readerSurfaceBlock.render({ mode: 'pipe', slots: {} });
+    expect(missingRequired.output).toContain('content: (missing required content)');
+    expect(missingRequired.output).not.toContain('navigation:');
+    expect(missingRequired.output).not.toContain('outline:');
+  });
+
   it('renders ReaderSurface content, navigation, and outline deterministically', () => {
     const outline = Object.freeze(['Why Blocks', 'Lowering']);
     const rendered = readerSurfaceBlock.render({

--- a/packages/bijou/src/core/standard-blocks.ts
+++ b/packages/bijou/src/core/standard-blocks.ts
@@ -469,7 +469,7 @@ function renderAppShellBlock(input: BlockRenderInput): BlockRenderResult<string>
     renderSection('inspector', 'Inspector', ownSlotValue(input.slots, 'inspector'), false),
     renderSection('status', 'Status', ownSlotValue(input.slots, 'status'), false),
     renderSection('overlays', 'Overlays', ownSlotValue(input.slots, 'overlays'), false),
-  ].filter((section) => section.required || section.content !== undefined);
+  ].filter((section) => section.required || section.present);
 
   return renderedBlockResult({
     output: mode === 'accessible'
@@ -487,7 +487,7 @@ function renderReaderSurfaceBlock(input: BlockRenderInput): BlockRenderResult<st
     renderSection('navigation', 'Navigation', ownSlotValue(input.slots, 'navigation'), false),
     renderSection('content', 'Content', ownSlotValue(input.slots, 'content'), true),
     renderSection('outline', 'Outline', ownSlotValue(input.slots, 'outline'), false),
-  ].filter((section) => section.required || section.content !== undefined);
+  ].filter((section) => section.required || section.present);
 
   return renderedBlockResult({
     output: mode === 'accessible'
@@ -505,7 +505,7 @@ function renderInspectorPanelBlock(input: BlockRenderInput): BlockRenderResult<s
     renderSection('selection', 'Selection', ownSlotValue(input.slots, 'selection'), true),
     renderSection('details', 'Details', ownSlotValue(input.slots, 'details'), false),
     renderSection('actions', 'Actions', ownSlotValue(input.slots, 'actions'), false),
-  ].filter((section) => section.required || section.content !== undefined);
+  ].filter((section) => section.required || section.present);
 
   return renderedBlockResult({
     output: mode === 'accessible'
@@ -549,7 +549,7 @@ function renderSection(
   return Object.freeze({
     id,
     label,
-    content: content ?? `(missing required ${id})`,
+    content: content ?? (required ? `(missing required ${id})` : ''),
     required,
     present,
   });

--- a/packages/bijou/src/core/standard-blocks.ts
+++ b/packages/bijou/src/core/standard-blocks.ts
@@ -7,10 +7,14 @@ import {
 import {
   defineBlock,
   defineBlockPackage,
+  isBlockDefinition,
   type BlockDefinition,
   type BlockMetadata,
   type BlockPackageManifest,
+  type BlockRenderInput,
+  type BlockRenderResult,
 } from './block-metadata.js';
+import type { OutputMode } from './detect/tty.js';
 import {
   defineBlockSchemaAdapter,
   defineSchemaBlock,
@@ -156,10 +160,7 @@ export const appShellBlock: BlockDefinition = defineBlock({
     shellToggleInspector,
     shellOpenOverlay,
   ],
-  render: () => ({
-    output: 'AppShell definition placeholder',
-    facts: [{ kind: 'entity', key: 'block', value: 'AppShell' }],
-  }),
+  render: renderAppShellBlock,
 });
 
 export const readerSurfaceBlock: BlockDefinition = defineBlock({
@@ -169,10 +170,7 @@ export const readerSurfaceBlock: BlockDefinition = defineBlock({
     readerSelectHeading,
     readerOpenReference,
   ],
-  render: ({ slots }) => ({
-    output: slots?.['content'] ?? 'ReaderSurface definition placeholder',
-    facts: [{ kind: 'entity', key: 'block', value: 'ReaderSurface' }],
-  }),
+  render: renderReaderSurfaceBlock,
 });
 
 export const inspectorPanelBlock: BlockDefinition = defineBlock({
@@ -182,10 +180,7 @@ export const inspectorPanelBlock: BlockDefinition = defineBlock({
     inspectorRevealSelection,
     inspectorFocusSource,
   ],
-  render: ({ slots }) => ({
-    output: slots?.['selection'] ?? 'InspectorPanel definition placeholder',
-    facts: [{ kind: 'entity', key: 'block', value: 'InspectorPanel' }],
-  }),
+  render: renderInspectorPanelBlock,
 });
 
 export const readerSurfaceSchemaAdapter: BlockSchemaAdapter<ReaderSurfaceSchemaData> =
@@ -464,6 +459,217 @@ function standardBlockStory(
     state,
     facts,
   });
+}
+
+function renderAppShellBlock(input: BlockRenderInput): BlockRenderResult<string> {
+  const mode = normalizeOutputMode(input.mode);
+  const sections: readonly RenderSection[] = [
+    renderSection('navigation', 'Navigation', ownSlotValue(input.slots, 'navigation'), false),
+    renderSection('content', 'Content', ownSlotValue(input.slots, 'content'), true),
+    renderSection('inspector', 'Inspector', ownSlotValue(input.slots, 'inspector'), false),
+    renderSection('status', 'Status', ownSlotValue(input.slots, 'status'), false),
+    renderSection('overlays', 'Overlays', ownSlotValue(input.slots, 'overlays'), false),
+  ].filter((section) => section.required || section.content !== undefined);
+
+  return renderedBlockResult({
+    output: mode === 'accessible'
+      ? renderAccessibleSections('AppShell', sections)
+      : mode === 'pipe'
+        ? renderPipeSections('AppShell', sections)
+        : renderVisualSections('AppShell', sections),
+    facts: renderFacts('AppShell', sections, 'region'),
+  });
+}
+
+function renderReaderSurfaceBlock(input: BlockRenderInput): BlockRenderResult<string> {
+  const mode = normalizeOutputMode(input.mode);
+  const sections: readonly RenderSection[] = [
+    renderSection('navigation', 'Navigation', ownSlotValue(input.slots, 'navigation'), false),
+    renderSection('content', 'Content', ownSlotValue(input.slots, 'content'), true),
+    renderSection('outline', 'Outline', ownSlotValue(input.slots, 'outline'), false),
+  ].filter((section) => section.required || section.content !== undefined);
+
+  return renderedBlockResult({
+    output: mode === 'accessible'
+      ? renderAccessibleSections('ReaderSurface', sections)
+      : mode === 'pipe'
+        ? renderPipeSections('ReaderSurface', sections)
+        : renderVisualSections('ReaderSurface', sections),
+    facts: renderFacts('ReaderSurface', sections, 'slot'),
+  });
+}
+
+function renderInspectorPanelBlock(input: BlockRenderInput): BlockRenderResult<string> {
+  const mode = normalizeOutputMode(input.mode);
+  const sections: readonly RenderSection[] = [
+    renderSection('selection', 'Selection', ownSlotValue(input.slots, 'selection'), true),
+    renderSection('details', 'Details', ownSlotValue(input.slots, 'details'), false),
+    renderSection('actions', 'Actions', ownSlotValue(input.slots, 'actions'), false),
+  ].filter((section) => section.required || section.content !== undefined);
+
+  return renderedBlockResult({
+    output: mode === 'accessible'
+      ? renderAccessibleSections('InspectorPanel', sections)
+      : mode === 'pipe'
+        ? renderPipeSections('InspectorPanel', sections)
+        : renderVisualSections('InspectorPanel', sections),
+    facts: renderFacts('InspectorPanel', sections, 'slot'),
+  });
+}
+
+interface RenderSection {
+  readonly id: string;
+  readonly label: string;
+  readonly content: string;
+  readonly required: boolean;
+  readonly present: boolean;
+}
+
+interface RenderedBlockOptions {
+  readonly output: string;
+  readonly facts: readonly BindingFact[];
+}
+
+function renderedBlockResult(options: RenderedBlockOptions): BlockRenderResult<string> {
+  const facts = Object.freeze(options.facts.map((fact) => Object.freeze({ ...fact })));
+  return Object.freeze({
+    output: options.output,
+    facts,
+  });
+}
+
+function renderSection(
+  id: string,
+  label: string,
+  value: unknown,
+  required: boolean,
+): RenderSection {
+  const content = slotValueText(value);
+  const present = content !== undefined;
+  return Object.freeze({
+    id,
+    label,
+    content: content ?? `(missing required ${id})`,
+    required,
+    present,
+  });
+}
+
+function renderPipeSections(blockName: StandardBlockName, sections: readonly RenderSection[]): string {
+  return [
+    blockName,
+    ...sections.map((section) => formatSectionLine(section.id, section.content)),
+  ].join('\n');
+}
+
+function renderAccessibleSections(blockName: StandardBlockName, sections: readonly RenderSection[]): string {
+  return [
+    blockName,
+    ...sections.map((section) => formatSectionLine(section.label, section.content)),
+  ].join('\n');
+}
+
+function renderVisualSections(blockName: StandardBlockName, sections: readonly RenderSection[]): string {
+  return [
+    blockName,
+    ...sections.flatMap((section) => [
+      `--- ${section.label} ---`,
+      indentBlock(section.content),
+    ]),
+  ].join('\n');
+}
+
+function formatSectionLine(label: string, content: string): string {
+  if (content.includes('\n')) {
+    return `${label}:\n${indentBlock(content)}`;
+  }
+
+  return `${label}: ${content}`;
+}
+
+function indentBlock(content: string): string {
+  return content
+    .split('\n')
+    .map((line) => `  ${line}`)
+    .join('\n');
+}
+
+function renderFacts(
+  blockName: StandardBlockName,
+  sections: readonly RenderSection[],
+  sectionFactPrefix: 'region' | 'slot',
+): readonly BindingFact[] {
+  const facts: BindingFact[] = [
+    { kind: 'entity', key: 'block', value: blockName },
+    { kind: 'state', key: 'block.rendered', value: true },
+  ];
+
+  for (const section of sections) {
+    if (section.present) {
+      facts.push({ kind: 'entity', key: `${sectionFactPrefix}.${section.id}`, value: 'present' });
+    }
+  }
+
+  return facts;
+}
+
+function normalizeOutputMode(mode: OutputMode | undefined): OutputMode {
+  return ALL_OUTPUT_MODES.includes(mode as OutputMode) ? mode as OutputMode : 'interactive';
+}
+
+function ownSlotValue(slots: Readonly<Record<string, unknown>> | undefined, key: string): unknown {
+  if (!isPlainRecord(slots)) {
+    return undefined;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(slots, key);
+  return descriptor !== undefined && 'value' in descriptor ? descriptor.value : undefined;
+}
+
+function slotValueText(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => slotValueText(item))
+      .filter((item): item is string => item !== undefined && item.trim() !== '');
+    return parts.length === 0 ? undefined : parts.join('; ');
+  }
+
+  if (isBlockDefinition(value)) {
+    return value.metadata.blockName;
+  }
+
+  switch (typeof value) {
+    case 'string':
+      return value;
+    case 'number':
+    case 'boolean':
+      return String(value);
+    case 'object':
+      return recordSlotText(value);
+    default:
+      return undefined;
+  }
+}
+
+function recordSlotText(value: object): string | undefined {
+  if (!isPlainRecord(value)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(Object.getOwnPropertyDescriptors(value))
+    .flatMap(([key, descriptor]) => {
+      if (!('value' in descriptor)) {
+        return [];
+      }
+
+      const text = slotValueText(descriptor.value);
+      return text === undefined ? [] : [`${key}: ${text}`];
+    });
+  return entries.length === 0 ? undefined : entries.join('; ');
 }
 
 function schemaError<Data = never>(code: string, message: string): BlockSchemaResult<Data> {

--- a/scripts/docs-preview.test.ts
+++ b/scripts/docs-preview.test.ts
@@ -114,7 +114,7 @@ describe('docs preview app', () => {
   it('imports the DOGFOOD app through the same tsx path used by npm run dogfood', () => {
     execFileSync(
       process.execPath,
-      ['--import', 'tsx', '-e', "await import('./examples/docs/app.ts')"],
+      ['--import', 'tsx', '--input-type=module', '-e', "await import('./examples/docs/app.ts')"],
       {
         cwd: resolve(import.meta.dirname, '..'),
         stdio: 'pipe',

--- a/tests/cycles/DX-031/rendered-standard-block-proof.test.ts
+++ b/tests/cycles/DX-031/rendered-standard-block-proof.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appShellBlock,
+  inspectorPanelBlock,
+  lintModeLowering,
+  readerSurfaceBlock,
+  standardBlocks,
+} from '../../../packages/bijou/src/index.js';
+
+describe('DX-031E rendered standard block proof', () => {
+  it('renders the shipped standard blocks as live outputs instead of placeholders', () => {
+    const rendered = [
+      appShellBlock.render({
+        mode: 'pipe',
+        slots: {
+          navigation: 'Docs nav',
+          content: 'Blocks guide',
+          inspector: 'ReaderSurface details',
+          status: 'Ready',
+        },
+      }).output,
+      readerSurfaceBlock.render({
+        mode: 'pipe',
+        slots: {
+          content: 'Readable block documentation.',
+          outline: ['Intro', 'Lowering'],
+        },
+      }).output,
+      inspectorPanelBlock.render({
+        mode: 'pipe',
+        slots: {
+          selection: 'ReaderSurface',
+          details: ['schema-aware', 'command-aware'],
+        },
+      }).output,
+    ].join('\n\n');
+
+    expect(rendered).toContain('AppShell');
+    expect(rendered).toContain('ReaderSurface');
+    expect(rendered).toContain('InspectorPanel');
+    expect(rendered).toContain('navigation: Docs nav');
+    expect(rendered).toContain('content: Blocks guide');
+    expect(rendered).toContain('content: Readable block documentation.');
+    expect(rendered).toContain('selection: ReaderSurface');
+    expect(rendered).not.toContain('definition placeholder');
+  });
+
+  it('keeps rendered block lowering facts stable across modes', () => {
+    const modes = ['interactive', 'static', 'pipe', 'accessible'] as const;
+
+    for (const block of standardBlocks) {
+      const report = lintModeLowering({
+        modes: modes.map((mode) => ({
+          mode,
+          facts: block.render({
+            mode,
+            slots: renderSlotsFor(block.metadata.blockName),
+          }).facts ?? [],
+        })),
+      });
+
+      expect(report).toMatchObject({ passed: true });
+    }
+  });
+
+  it('does not expose provider, subscription, refresh, render-tree traversal, or dispatch handles', () => {
+    for (const block of standardBlocks) {
+      const rendered = block.render({
+        mode: 'pipe',
+        slots: renderSlotsFor(block.metadata.blockName),
+      });
+
+      expect('provider' in rendered).toBe(false);
+      expect('subscribe' in rendered).toBe(false);
+      expect('unsubscribe' in rendered).toBe(false);
+      expect('refresh' in rendered).toBe(false);
+      expect('dispatch' in rendered).toBe(false);
+      expect('traverse' in rendered).toBe(false);
+    }
+  });
+});
+
+function renderSlotsFor(blockName: string): Readonly<Record<string, unknown>> {
+  switch (blockName) {
+    case 'AppShell':
+      return {
+        navigation: 'Docs nav',
+        content: 'Blocks guide',
+        inspector: 'Current selection',
+        status: 'Ready',
+        overlays: ['Help'],
+      };
+    case 'ReaderSurface':
+      return {
+        content: 'Readable block documentation.',
+        navigation: 'Docs nav',
+        outline: ['Intro', 'Lowering'],
+      };
+    case 'InspectorPanel':
+      return {
+        selection: 'ReaderSurface',
+        details: ['schema-aware', 'command-aware'],
+        actions: ['reveal source'],
+      };
+    default:
+      throw new Error(`unknown standard block ${blockName}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces placeholder render output for the current first-party standard blocks: AppShell, ReaderSurface, and InspectorPanel.
- Adds deterministic render output for interactive, static, pipe, and accessible modes, with stable lowering facts that can be linted without parsing rendered text.
- Keeps the slice deliberately contract-bound: no provider subscriptions, no active runtime traversal, no command dispatch, no cache policy, no production AppShell behavior, and no catalog expansion.
- Adds behavior-focused tests for rendered output, lowering facts, immutable caller inputs, and absence of provider/subscription/dispatch handles.

## Validation
- `npm test -- --run packages/bijou/src/core/standard-blocks.test.ts tests/cycles/DX-031/rendered-standard-block-proof.test.ts`
- `npm run typecheck:test`
- `git diff --check`
- `npm run lint`
- `npm run docs:inventory`
- `npm run smoke:dogfood:docs`
- `npm test`
- `npm run verify:interactive-examples`
- pre-push reran `npm run typecheck:test`, `npm test`, and `npm run verify:interactive-examples`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standard blocks (AppShell, ReaderSurface, InspectorPanel) now render deterministic, live semantic output instead of placeholder text across interactive, static, pipe, and accessible modes.

* **Documentation**
  * Updated guides and design docs to describe standard block rendering behavior, scope, and next implementation steps.

* **Tests**
  * Added tests ensuring deterministic multi-mode rendering and that rendered results expose semantic facts without leaking internal runtime handles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->