### PR TITLE
feat(dogfood): add locale preference ratchet

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   preference, and syncs the chosen locale across docs pages. The first LX-011
   ratchet covers the language settings surface and supported language catalog
   entries so new DOGFOOD localization work stays behind the i18n runtime instead
-  of adding another hard-coded English settings seam.
+  of adding another hard-coded English settings seam. Supported explicit locale
+  aliases such as `fr-FR` normalize to their catalog ids, while partial catalog
+  overrides fall back through the language-label helper instead of crashing the
+  Settings drawer.
 - **Rendered standard block proof for `bijou`** —
   `AppShell`, `ReaderSurface`, and `InspectorPanel` now render deterministic
   first-party block output across interactive, static, pipe, and accessible

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **DOGFOOD locale preference and i18n ratchet** — DOGFOOD now resolves its
+  initial language through an explicit locale port with a Node adapter that
+  reads operating-system locale signals, exposes a Settings drawer language
+  preference, and syncs the chosen locale across docs pages. The first LX-011
+  ratchet covers the language settings surface and supported language catalog
+  entries so new DOGFOOD localization work stays behind the i18n runtime instead
+  of adding another hard-coded English settings seam.
 - **Rendered standard block proof for `bijou`** —
   `AppShell`, `ReaderSurface`, and `InspectorPanel` now render deterministic
   first-party block output across interactive, static, pipe, and accessible

--- a/docs/DOGFOOD.md
+++ b/docs/DOGFOOD.md
@@ -10,6 +10,12 @@ Bijou engine.
 npm run dogfood
 ```
 
+DOGFOOD initializes its language through the host locale adapter and then lets
+users change the preferred language from the Settings drawer (`F2`). The docs
+app consumes this through a locale port rather than reading process state from
+view code, so localization remains behind the same hexagonal boundary as the
+rest of the host integration.
+
 For the standalone Storybook-style development and testing workbench:
 ```bash
 npm run storybook
@@ -34,6 +40,8 @@ operators need when learning or validating Bijou.
 - **Component Explorer**: A live, interactive field guide to every component family.
 - **Blocks Section**: A first-class Blocks lane covering block purpose,
   authoring, first-party blocks, live accordion previews, and lowering posture.
+- **Locale Preference**: The Settings drawer can switch DOGFOOD's preferred
+  language after startup, while startup itself uses the host locale adapter.
 - **Storybook Workstation**: A standalone interactive story browser plus deterministic story index and matrix capture path over the same DOGFOOD story catalog.
 - **Graceful Lowering**: Verifying that documentation renders correctly across `rich`, `static`, `pipe`, and `accessible` modes.
 - **Responsive Product Layout**: Proving that resize is not enough by selecting `wide`, `standard`, `narrow`, and `tiny` docs layouts that keep constrained terminals useful.

--- a/docs/method/backlog/asap/LX-012-dogfood-i18n-debt-inventory.md
+++ b/docs/method/backlog/asap/LX-012-dogfood-i18n-debt-inventory.md
@@ -1,0 +1,48 @@
+---
+title: "LX-012 — DOGFOOD i18n Debt Inventory"
+legend: LX
+lane: asap
+---
+
+# LX-012 — DOGFOOD i18n Debt Inventory
+
+LX-011 added the first DOGFOOD locale preference ratchet, but most visible
+DOGFOOD copy can still enter the app as raw English strings in pages, previews,
+and examples.
+
+Problem:
+
+- DOGFOOD now has a localization seam, but no counted inventory of the remaining
+  localizable UI copy.
+- New surfaces can add English strings without making the debt visible.
+- Reviewers cannot distinguish intentionally literal examples from user-facing
+  copy that should move through catalogs.
+
+Desired outcome:
+
+- Add a deterministic DOGFOOD i18n debt inventory grouped by surface area.
+- Count localizable UI strings and ratchet the count downward or hold it steady.
+- Separate true nonlocalizable identifiers, code examples, and fixture literals
+  from visible application copy.
+- Make the report useful in code review without relying on rendered screenshots
+  or fragile stdout snapshots.
+
+Why ASAP:
+
+- The Settings locale selector made localization visible to users.
+- The next DOGFOOD documentation and Blocks work will otherwise keep adding
+  English-only copy.
+- A counted debt ledger lets catalog expansion happen incrementally without
+  pretending the whole app is translated.
+
+Hill:
+
+A maintainer can run one deterministic check and see which DOGFOOD surfaces
+still contain localizable English, what changed, and whether the branch
+increased or reduced the debt.
+
+Non-goals:
+
+- Do not translate all DOGFOOD copy in this cycle.
+- Do not block markdown source documentation that is intentionally prose.
+- Do not infer localization coverage by scraping terminal render output.

--- a/docs/method/backlog/asap/LX-013-dogfood-locale-preference-persistence.md
+++ b/docs/method/backlog/asap/LX-013-dogfood-locale-preference-persistence.md
@@ -1,0 +1,48 @@
+---
+title: "LX-013 — DOGFOOD Locale Preference Persistence"
+legend: LX
+lane: asap
+---
+
+# LX-013 — DOGFOOD Locale Preference Persistence
+
+DOGFOOD can choose a preferred language in Settings, and startup can read the
+host locale through an explicit adapter. That choice is still process-local.
+
+Problem:
+
+- Changing the DOGFOOD language in Settings does not survive a restart.
+- Persistence would be easy to wire ad hoc from the docs app, which would bypass
+  the hexagonal architecture established by LX-011.
+- Tests need a deterministic fake persistence adapter rather than direct reads
+  from user config paths.
+
+Desired outcome:
+
+- Add a preferred-locale persistence port for DOGFOOD.
+- Add a Node adapter that stores the preference outside application state.
+- Keep initial locale selection explicit:
+  1. persisted preference when present
+  2. operating-system locale through the host adapter
+  3. project default locale
+- Add behavior tests for missing, present, invalid, and changed preferences.
+
+Why ASAP:
+
+- Users reasonably expect a Settings language change to persist.
+- The persistence seam should land before more settings are added.
+- Keeping this behind a port prevents locale preference storage from becoming a
+  hidden global or Node-only assumption.
+
+Hill:
+
+A DOGFOOD user can change the language, restart the app, and see the same
+language selected through an explicit persistence adapter with deterministic test
+coverage.
+
+Non-goals:
+
+- Do not add a general settings database.
+- Do not couple DOGFOOD localization to a specific home-directory layout in core
+  contracts.
+- Do not persist translated catalog data.

--- a/docs/method/backlog/asap/LX-014-expand-dogfood-catalog-coverage.md
+++ b/docs/method/backlog/asap/LX-014-expand-dogfood-catalog-coverage.md
@@ -1,0 +1,49 @@
+---
+title: "LX-014 — Expand DOGFOOD Catalog Coverage"
+legend: LX
+lane: asap
+---
+
+# LX-014 — Expand DOGFOOD Catalog Coverage
+
+LX-011 localized the language settings surface first. The next visible DOGFOOD
+surfaces still need catalog coverage before localization becomes more than a
+settings demo.
+
+Problem:
+
+- Top-level navigation, Blocks documentation, and component preview prose still
+  carry English-first assumptions.
+- The language setting can switch locale while many nearby UI surfaces remain
+  unchanged.
+- Without a focused expansion cycle, catalog coverage will grow only when a
+  reviewer happens to notice a hard-coded string.
+
+Desired outcome:
+
+- Move the next DOGFOOD surfaces through the localization catalog:
+  - top-level navigation labels
+  - Blocks section labels and preview chrome
+  - component preview headings and short helper copy
+- Keep examples, code literals, component names, and API identifiers distinct
+  from translatable UI strings.
+- Add behavior tests that prove locale changes alter the intended UI model data,
+  not tests that merely match rendered text dumps.
+
+Why ASAP:
+
+- Blocks are becoming a visible DOGFOOD product surface.
+- Component and Block previews are where users will notice localization quality.
+- Catalog coverage should grow while the Settings selector is still fresh in the
+  architecture.
+
+Hill:
+
+A user can switch DOGFOOD language and see navigation, Blocks preview chrome,
+and component preview labels change through catalog-backed UI data.
+
+Non-goals:
+
+- Do not translate every long-form documentation page.
+- Do not add machine translation.
+- Do not make component API names or code examples localizable.

--- a/docs/method/backlog/cool-ideas/LX-015-dogfood-localization-burndown-dashboard.md
+++ b/docs/method/backlog/cool-ideas/LX-015-dogfood-localization-burndown-dashboard.md
@@ -1,0 +1,28 @@
+---
+title: "LX-015 — DOGFOOD Localization Burndown Dashboard"
+legend: LX
+lane: cool-ideas
+---
+
+# LX-015 — DOGFOOD Localization Burndown Dashboard
+
+Once DOGFOOD has an i18n debt inventory, the count could become a visible
+dashboard instead of a hidden test report.
+
+Cool idea:
+
+- add a DOGFOOD localization burndown page that shows remaining localizable
+  strings by surface, locale, and status
+- show which strings are cataloged, intentionally exempt, stale, or missing
+- let maintainers compare the current branch against the mainline debt baseline
+- surface long-string and direction-risk notes without requiring a separate
+  spreadsheet
+
+Why this feels promising:
+
+- it would make localization debt tangible during everyday DOGFOOD use
+- it would give translators and maintainers the same source of truth
+- it could turn the LX ratchet into a product-quality feedback surface rather
+  than only a CI guardrail
+
+This should stay exploratory until the deterministic inventory exists.

--- a/docs/method/backlog/cool-ideas/LX-016-portable-locale-preferences-across-hosts.md
+++ b/docs/method/backlog/cool-ideas/LX-016-portable-locale-preferences-across-hosts.md
@@ -1,0 +1,31 @@
+---
+title: "LX-016 — Portable Locale Preferences Across Hosts"
+legend: LX
+lane: cool-ideas
+---
+
+# LX-016 — Portable Locale Preferences Across Hosts
+
+DOGFOOD is the first visible host for locale preference, but the preference model
+will eventually need to work across more than one runtime shape.
+
+Cool idea:
+
+- define a portable preference contract that can be adapted for:
+  - Node DOGFOOD
+  - browser-like preview hosts
+  - Storybook-style workstations
+  - MCP or capture runners
+  - deterministic test fixtures
+- make import/export of locale preferences explicit so captures and demos can
+  reproduce the same locale without depending on a user's machine
+- keep each host adapter responsible for its own storage details
+
+Why this feels promising:
+
+- it would prevent DOGFOOD settings from becoming a Node-only pattern
+- it would make localized captures and previews reproducible
+- it would align locale preference with Bijou's ports-and-adapters architecture
+
+This should not start before the simpler DOGFOOD persistence port proves the
+basic behavior.

--- a/docs/method/backlog/cool-ideas/LX-017-multilingual-dogfood-translation-workbench.md
+++ b/docs/method/backlog/cool-ideas/LX-017-multilingual-dogfood-translation-workbench.md
@@ -1,0 +1,29 @@
+---
+title: "LX-017 — Multilingual DOGFOOD Translation Workbench"
+legend: LX
+lane: cool-ideas
+---
+
+# LX-017 — Multilingual DOGFOOD Translation Workbench
+
+The DOGFOOD app could eventually become the place where translation maintainers
+inspect catalogs, preview copy, and validate layout stress before shipping.
+
+Cool idea:
+
+- add a translation workbench inside DOGFOOD for catalog-backed surfaces
+- preview a page in several locales side by side
+- include pseudo-locale, long-string, and RTL stress modes
+- show missing keys, stale entries, and fallback behavior as first-class facts
+- link catalog entries back to the UI surfaces that consume them
+
+Why this feels promising:
+
+- it would make DOGFOOD a real proving ground for localization, not just a docs
+  shell with translated labels
+- it would support translators, maintainers, and agents from the same interface
+- it would help catch layout and lowering problems before they become release
+  defects
+
+This belongs after the catalog coverage and debt inventory work establish enough
+real localized surface area to inspect.

--- a/docs/method/legends/LX-localization-and-bidirectionality.md
+++ b/docs/method/legends/LX-localization-and-bidirectionality.md
@@ -54,4 +54,10 @@ An agent can reason about locale, direction, catalogs, and translation workflow 
 
 - latest completed cycle: [LX-009 — Localize Shell Help, Notification, and Directional Surfaces](../retro/LX_009-localize-shell-help-notification-and-directional-surfaces.md)
 - live backlog:
-  - no dedicated localization cycle is live right now
+  - [LX-012 — DOGFOOD i18n Debt Inventory](../backlog/asap/LX-012-dogfood-i18n-debt-inventory.md)
+  - [LX-013 — DOGFOOD Locale Preference Persistence](../backlog/asap/LX-013-dogfood-locale-preference-persistence.md)
+  - [LX-014 — Expand DOGFOOD Catalog Coverage](../backlog/asap/LX-014-expand-dogfood-catalog-coverage.md)
+- cool ideas:
+  - [LX-015 — DOGFOOD Localization Burndown Dashboard](../backlog/cool-ideas/LX-015-dogfood-localization-burndown-dashboard.md)
+  - [LX-016 — Portable Locale Preferences Across Hosts](../backlog/cool-ideas/LX-016-portable-locale-preferences-across-hosts.md)
+  - [LX-017 — Multilingual DOGFOOD Translation Workbench](../backlog/cool-ideas/LX-017-multilingual-dogfood-translation-workbench.md)

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -85,6 +85,14 @@ import {
   type StoryMode,
 } from '../_stories/protocol.js';
 import { resolveDogfoodDocsCoverage, type DogfoodDocsCoverage } from './coverage.js';
+import {
+  dogfoodLocaleLabel,
+  dogfoodLocaleOptionsText,
+  nextDogfoodLocale,
+  resolveDogfoodInitialLocale,
+  resolveDogfoodLocale,
+  type DogfoodLocalePort,
+} from './locale.js';
 import { COMPONENT_STORIES, findComponentStory } from './stories.js';
 
 const LOGO_TEXT = readFileSync(new URL('../../assets/bijou.txt', import.meta.url), 'utf8').trimEnd();
@@ -215,6 +223,11 @@ export const DOGFOOD_I18N_CATALOG: I18nCatalog = {
     dogfoodMessage('docs.separator.welcome', 'welcome to bijou'),
     dogfoodMessage('settings.section.shell', 'Shell'),
     dogfoodMessage('settings.section.appearance', 'Appearance'),
+    dogfoodMessage('settings.section.localization', 'Localization', {
+      fr: 'Localisation',
+      es: 'Localización',
+      de: 'Lokalisierung',
+    }),
     dogfoodMessage('settings.section.landing', 'Landing'),
     dogfoodMessage('settings.showHints.label', 'Show hints'),
     dogfoodMessage('settings.showHints.description', 'Show active-pane control cues in the footer. Turn this off for a quieter shell and use ? for the full key map.'),
@@ -222,6 +235,41 @@ export const DOGFOOD_I18N_CATALOG: I18nCatalog = {
     dogfoodMessage('settings.showHints.off', 'Off'),
     dogfoodMessage('settings.showHints.feedback.on', 'Show hints turned on.'),
     dogfoodMessage('settings.showHints.feedback.off', 'Show hints turned off.'),
+    dogfoodMessage('settings.language.label', 'Preferred language', {
+      fr: 'Langue préférée',
+      es: 'Idioma preferido',
+      de: 'Bevorzugte Sprache',
+    }),
+    dogfoodMessage('settings.language.description', 'Current language: {language}. Options: {options}.', {
+      fr: 'Langue actuelle : {language}. Options : {options}.',
+      es: 'Idioma actual: {language}. Opciones: {options}.',
+      de: 'Aktuelle Sprache: {language}. Optionen: {options}.',
+    }),
+    dogfoodMessage('settings.language.feedback', 'Language set to {language}.', {
+      fr: 'Langue définie sur {language}.',
+      es: 'Idioma establecido en {language}.',
+      de: 'Sprache auf {language} gesetzt.',
+    }),
+    dogfoodMessage('settings.language.en', 'English', {
+      fr: 'anglais',
+      es: 'inglés',
+      de: 'Englisch',
+    }),
+    dogfoodMessage('settings.language.fr', 'French', {
+      fr: 'français',
+      es: 'francés',
+      de: 'Französisch',
+    }),
+    dogfoodMessage('settings.language.es', 'Spanish', {
+      fr: 'espagnol',
+      es: 'español',
+      de: 'Spanisch',
+    }),
+    dogfoodMessage('settings.language.de', 'German', {
+      fr: 'allemand',
+      es: 'alemán',
+      de: 'Deutsch',
+    }),
     dogfoodMessage('settings.landingQuality.label', 'Landing quality'),
     dogfoodMessage('settings.landingQuality.description.auto', 'Adapts render cost to terminal size. Current auto profile: {profile}. Options: {options}.'),
     dogfoodMessage('settings.landingQuality.description.quality', 'Prioritizes the richest title treatment even on larger terminals. Options: {options}.'),
@@ -231,12 +279,16 @@ export const DOGFOOD_I18N_CATALOG: I18nCatalog = {
   ],
 };
 
-function dogfoodMessage(id: string, value: string) {
+function dogfoodMessage(
+  id: string,
+  value: string,
+  translations: Readonly<Record<string, string>> = {},
+) {
   return {
     key: { namespace: DOGFOOD_I18N_NAMESPACE, id },
     kind: 'message' as const,
     sourceLocale: 'en',
-    values: { en: value },
+    values: { en: value, ...translations },
   };
 }
 
@@ -287,6 +339,7 @@ interface DocsExplorerModel {
   readonly guideState: ReturnType<typeof createBrowsableListState<string>>;
   readonly selectedGuideId?: string;
   readonly showHints: boolean;
+  readonly locale: string;
   readonly landingThemeIndex: number;
   readonly landingQualityMode: LandingQualityMode;
 }
@@ -313,6 +366,7 @@ type ExplorerMsg =
   | { type: 'activate-guide-index'; index: number }
   | { type: 'select-guide'; guideId: string }
   | { type: 'toggle-hints' }
+  | { type: 'cycle-locale' }
   | { type: 'cycle-landing-quality' };
 
 interface RootModel {
@@ -784,6 +838,7 @@ const componentsPageKeys = createKeyMap<ExplorerMsg>()
 
 interface DocsAppOptions {
   readonly locale?: string;
+  readonly localePort?: DogfoodLocalePort;
   readonly direction?: I18nDirection;
   readonly extraI18nCatalogs?: readonly I18nCatalog[];
   readonly initialRoute?: RootModel['route'];
@@ -822,6 +877,27 @@ function shellText(
 function formatI18nList(i18n: I18nRuntime | undefined, values: readonly string[]): string {
   if (i18n == null) return values.join(', ');
   return i18n.formatList(values, i18n.locale);
+}
+
+function applyDogfoodLocale(
+  i18n: I18nRuntime,
+  options: Pick<DocsAppOptions, 'direction'>,
+  locale: string,
+): void {
+  const option = resolveDogfoodLocale(locale);
+  void i18n.setLocale(option.id, options.direction ?? option.direction);
+}
+
+function dogfoodLocaleSettingDescription(currentLocale: string, i18n?: I18nRuntime): string {
+  return dogfoodText(
+    i18n,
+    'settings.language.description',
+    'Current language: {language}. Options: {options}.',
+    {
+      language: dogfoodLocaleLabel(currentLocale, i18n),
+      options: dogfoodLocaleOptionsText(i18n),
+    },
+  );
 }
 
 function shouldRouteLandingKeyIntoShell(msg: KeyMsg): boolean {
@@ -1236,7 +1312,11 @@ function buildStoryFamilies(stories: readonly ComponentStory[]): readonly StoryF
   }));
 }
 
-function createInitialExplorerModel(ctx: BijouContext, pageId: DocsPageId): DocsExplorerModel {
+function createInitialExplorerModel(
+  ctx: BijouContext,
+  pageId: DocsPageId,
+  locale: string,
+): DocsExplorerModel {
   const expandedFamilies = Object.fromEntries(STORY_FAMILIES.map((family) => [family.id, false]));
   const guideItems = guideItemsForPage(pageId);
   return {
@@ -1256,6 +1336,7 @@ function createInitialExplorerModel(ctx: BijouContext, pageId: DocsPageId): Docs
     }),
     selectedGuideId: guideItems[0]?.value,
     showHints: true,
+    locale,
     landingThemeIndex: 0,
     landingQualityMode: 'auto',
   };
@@ -1263,9 +1344,10 @@ function createInitialExplorerModel(ctx: BijouContext, pageId: DocsPageId): Docs
 
 function createInitialComponentsExplorerModel(
   ctx: BijouContext,
+  locale: string,
   initialSelectedStoryId?: string,
 ): DocsExplorerModel {
-  const model = createInitialExplorerModel(ctx, COMPONENTS_PAGE_ID);
+  const model = createInitialExplorerModel(ctx, COMPONENTS_PAGE_ID, locale);
   return initialSelectedStoryId == null ? model : selectStory(model, initialSelectedStoryId);
 }
 
@@ -2182,6 +2264,7 @@ function syncDocsSharedSettings(
   return mapDocsPageModels(docsModel, (pageModel) => {
     if (
       pageModel.showHints === activePageModel.showHints
+      && pageModel.locale === activePageModel.locale
       && pageModel.landingThemeIndex === landingThemeIndex
       && pageModel.landingQualityMode === activePageModel.landingQualityMode
     ) {
@@ -2190,6 +2273,7 @@ function syncDocsSharedSettings(
     return {
       ...pageModel,
       showHints: activePageModel.showHints,
+      locale: activePageModel.locale,
       landingThemeIndex,
       landingQualityMode: activePageModel.landingQualityMode,
     };
@@ -3374,7 +3458,8 @@ function createDocsExplorerApp(
   getCtx: () => BijouContext,
   onShellThemeChange: (ctx: BijouContext) => void,
   i18n: I18nRuntime,
-  options: Pick<DocsAppOptions, 'initialPageId' | 'initialSelectedStoryId'> = {},
+  options: Pick<DocsAppOptions, 'direction' | 'initialPageId' | 'initialSelectedStoryId'> = {},
+  initialLocale = 'en',
 ): FramedApp<DocsExplorerModel, DocsMsg> {
   const ctx = getCtx();
   return createFramedApp<DocsExplorerModel, DocsMsg>({
@@ -3395,7 +3480,7 @@ function createDocsExplorerApp(
           id: spec.id,
           title: pageTitle(spec.id, i18n),
           keyMap: componentsPageKeys,
-          init: () => [createInitialComponentsExplorerModel(ctx, options.initialSelectedStoryId), []],
+          init: () => [createInitialComponentsExplorerModel(ctx, initialLocale, options.initialSelectedStoryId), []],
           update(msg: FramePageMsg<DocsMsg>, model) {
             if (msg.type === 'mouse') {
               return [model, []];
@@ -3435,6 +3520,11 @@ function createDocsExplorerApp(
                 return [{ ...model, profileMode: msg.mode }, []];
               case 'toggle-hints':
                 return [{ ...model, showHints: !model.showHints }, []];
+              case 'cycle-locale': {
+                const nextLocale = nextDogfoodLocale(model.locale);
+                applyDogfoodLocale(i18n, options, nextLocale.id);
+                return [{ ...model, locale: nextLocale.id }, []];
+              }
               case 'cycle-landing-quality':
                 return [{ ...model, landingQualityMode: nextLandingQualityMode(model.landingQualityMode) }, []];
               default:
@@ -3477,7 +3567,7 @@ function createDocsExplorerApp(
       return {
         id: spec.id,
         title: pageTitle(spec.id, i18n),
-        init: () => [createInitialExplorerModel(ctx, spec.id), []],
+        init: () => [createInitialExplorerModel(ctx, spec.id, initialLocale), []],
         update(msg: FramePageMsg<DocsMsg>, model) {
           if (msg.type === 'mouse') {
             return [model, []];
@@ -3505,6 +3595,11 @@ function createDocsExplorerApp(
               return [{ ...selectGuide(spec.id, model, msg.guideId), previewTimeMs: 0 }, []];
             case 'toggle-hints':
               return [{ ...model, showHints: !model.showHints }, []];
+            case 'cycle-locale': {
+              const nextLocale = nextDogfoodLocale(model.locale);
+              applyDogfoodLocale(i18n, options, nextLocale.id);
+              return [{ ...model, locale: nextLocale.id }, []];
+            }
             case 'cycle-landing-quality':
               return [{ ...model, landingQualityMode: nextLandingQualityMode(model.landingQualityMode) }, []];
             default:
@@ -3541,6 +3636,7 @@ function createDocsExplorerApp(
     },
     settings: ({ model, pageModel }) => {
       const theme = resolveLandingTheme(pageModel.landingThemeIndex);
+      const nextLocale = nextDogfoodLocale(pageModel.locale);
       return {
         borderToken: docsThemeBorderToken(theme),
         bgToken: docsThemeSurfaceToken(theme),
@@ -3564,6 +3660,27 @@ function createDocsExplorerApp(
               message: pageModel.showHints
                 ? dogfoodText(i18n, 'settings.showHints.feedback.off', 'Show hints turned off.')
                 : dogfoodText(i18n, 'settings.showHints.feedback.on', 'Show hints turned on.'),
+            },
+          }],
+        },
+        {
+          id: 'localization',
+          title: dogfoodText(i18n, 'settings.section.localization', 'Localization'),
+          rows: [{
+            id: 'preferred-language',
+            label: dogfoodText(i18n, 'settings.language.label', 'Preferred language'),
+            description: dogfoodLocaleSettingDescription(pageModel.locale, i18n),
+            valueLabel: dogfoodLocaleLabel(pageModel.locale, i18n),
+            kind: 'choice',
+            action: { type: 'cycle-locale' },
+            feedback: {
+              title: shellText(i18n, 'settings.title', 'Settings'),
+              message: dogfoodText(
+                i18n,
+                'settings.language.feedback',
+                'Language set to {language}.',
+                { language: dogfoodLocaleLabel(nextLocale.id, i18n) },
+              ),
             },
           }],
         },
@@ -3682,9 +3799,10 @@ function syncDocsExplorerViewportLayout(
 }
 
 function createDocsI18nRuntime(options: DocsAppOptions = {}): I18nRuntime {
+  const initialLocale = resolveDogfoodInitialLocale(options);
   const runtime = createI18nRuntime({
-    locale: options.locale ?? 'en',
-    direction: options.direction ?? 'ltr',
+    locale: options.locale ?? initialLocale.id,
+    direction: options.direction ?? initialLocale.direction,
     fallbackLocale: 'en',
   });
   runtime.loadCatalog(FRAME_I18N_CATALOG);
@@ -3700,10 +3818,11 @@ export function createDocsApp(ctx: BijouContext, options: DocsAppOptions = {}): 
   const syncShellThemeContext = (themeId: string | undefined) => {
     currentCtx = applyDocsShellThemeToContext(ctx, themeId);
   };
+  const initialLocale = resolveDogfoodInitialLocale(options);
   const i18n = createDocsI18nRuntime(options);
   const explorer = createDocsExplorerApp(() => currentCtx, (nextCtx) => {
     currentCtx = nextCtx;
-  }, i18n, options);
+  }, i18n, options, initialLocale.id);
   const renderLanding = createLandingRenderer(() => currentCtx, i18n);
   const initialRoute = options.initialRoute ?? 'landing';
 

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -91,6 +91,7 @@ import {
   nextDogfoodLocale,
   resolveDogfoodInitialLocale,
   resolveDogfoodLocale,
+  resolveDogfoodRuntimeLocale,
   type DogfoodLocalePort,
 } from './locale.js';
 import { COMPONENT_STORIES, findComponentStory } from './stories.js';
@@ -3801,7 +3802,7 @@ function syncDocsExplorerViewportLayout(
 function createDocsI18nRuntime(options: DocsAppOptions = {}): I18nRuntime {
   const initialLocale = resolveDogfoodInitialLocale(options);
   const runtime = createI18nRuntime({
-    locale: options.locale ?? initialLocale.id,
+    locale: resolveDogfoodRuntimeLocale(options),
     direction: options.direction ?? initialLocale.direction,
     fallbackLocale: 'en',
   });

--- a/examples/docs/locale.ts
+++ b/examples/docs/locale.ts
@@ -55,16 +55,20 @@ export function normalizeDogfoodLocaleTag(locale: string | undefined): string | 
     .toLowerCase();
 }
 
-export function resolveDogfoodLocale(locale: string | undefined): DogfoodLocaleOption {
+function findDogfoodLocale(locale: string | undefined): DogfoodLocaleOption | undefined {
   const normalized = normalizeDogfoodLocaleTag(locale);
-  if (normalized == null) return DEFAULT_LOCALE;
+  if (normalized == null) return undefined;
   const primary = normalized.split('-')[0]!;
   return DOGFOOD_LOCALE_OPTIONS.find((option) => (
     option.id === normalized
     || option.aliases.includes(normalized)
     || option.id === primary
     || option.aliases.includes(primary)
-  )) ?? DEFAULT_LOCALE;
+  ));
+}
+
+export function resolveDogfoodLocale(locale: string | undefined): DogfoodLocaleOption {
+  return findDogfoodLocale(locale) ?? DEFAULT_LOCALE;
 }
 
 export function resolveDogfoodInitialLocale(
@@ -76,6 +80,18 @@ export function resolveDogfoodInitialLocale(
   return resolveDogfoodLocale(options.locale ?? options.localePort?.preferredLocale());
 }
 
+export function resolveDogfoodRuntimeLocale(
+  options: {
+    readonly locale?: string;
+    readonly localePort?: DogfoodLocalePort;
+  },
+): string {
+  if (options.locale !== undefined) {
+    return findDogfoodLocale(options.locale)?.id ?? options.locale;
+  }
+  return resolveDogfoodInitialLocale(options).id;
+}
+
 export function nextDogfoodLocale(currentLocale: string): DogfoodLocaleOption {
   const current = resolveDogfoodLocale(currentLocale);
   const currentIndex = DOGFOOD_LOCALE_OPTIONS.findIndex((option) => option.id === current.id);
@@ -84,7 +100,12 @@ export function nextDogfoodLocale(currentLocale: string): DogfoodLocaleOption {
 
 export function dogfoodLocaleLabel(locale: string, i18n?: I18nRuntime): string {
   const option = resolveDogfoodLocale(locale);
-  const localizedName = i18n?.t({ namespace: 'bijou.dogfood', id: `settings.language.${option.id}` }) ?? option.label;
+  let localizedName = option.label;
+  try {
+    localizedName = i18n?.t({ namespace: 'bijou.dogfood', id: `settings.language.${option.id}` }) ?? option.label;
+  } catch {
+    localizedName = option.label;
+  }
   return localizedName === option.nativeLabel ? localizedName : `${localizedName} / ${option.nativeLabel}`;
 }
 

--- a/examples/docs/locale.ts
+++ b/examples/docs/locale.ts
@@ -1,0 +1,94 @@
+import type { I18nDirection, I18nRuntime } from '../../packages/bijou-i18n/src/index.js';
+
+export interface DogfoodLocalePort {
+  preferredLocale(): string | undefined;
+}
+
+export interface DogfoodLocaleOption {
+  readonly id: string;
+  readonly label: string;
+  readonly nativeLabel: string;
+  readonly direction: I18nDirection;
+  readonly aliases: readonly string[];
+}
+
+export const DOGFOOD_LOCALE_OPTIONS: readonly DogfoodLocaleOption[] = Object.freeze([
+  {
+    id: 'en',
+    label: 'English',
+    nativeLabel: 'English',
+    direction: 'ltr',
+    aliases: Object.freeze(['en', 'en-us', 'en-gb']),
+  },
+  {
+    id: 'fr',
+    label: 'French',
+    nativeLabel: 'Français',
+    direction: 'ltr',
+    aliases: Object.freeze(['fr', 'fr-fr', 'fr-ca']),
+  },
+  {
+    id: 'es',
+    label: 'Spanish',
+    nativeLabel: 'Español',
+    direction: 'ltr',
+    aliases: Object.freeze(['es', 'es-es', 'es-mx']),
+  },
+  {
+    id: 'de',
+    label: 'German',
+    nativeLabel: 'Deutsch',
+    direction: 'ltr',
+    aliases: Object.freeze(['de', 'de-de', 'de-at']),
+  },
+] satisfies readonly DogfoodLocaleOption[]);
+
+const DEFAULT_LOCALE = DOGFOOD_LOCALE_OPTIONS[0]!;
+
+export function normalizeDogfoodLocaleTag(locale: string | undefined): string | undefined {
+  const trimmed = locale?.trim();
+  if (trimmed == null || trimmed === '') return undefined;
+  return trimmed
+    .split(':')[0]!
+    .replace(/[._].*$/, '')
+    .replace(/_/g, '-')
+    .toLowerCase();
+}
+
+export function resolveDogfoodLocale(locale: string | undefined): DogfoodLocaleOption {
+  const normalized = normalizeDogfoodLocaleTag(locale);
+  if (normalized == null) return DEFAULT_LOCALE;
+  const primary = normalized.split('-')[0]!;
+  return DOGFOOD_LOCALE_OPTIONS.find((option) => (
+    option.id === normalized
+    || option.aliases.includes(normalized)
+    || option.id === primary
+    || option.aliases.includes(primary)
+  )) ?? DEFAULT_LOCALE;
+}
+
+export function resolveDogfoodInitialLocale(
+  options: {
+    readonly locale?: string;
+    readonly localePort?: DogfoodLocalePort;
+  },
+): DogfoodLocaleOption {
+  return resolveDogfoodLocale(options.locale ?? options.localePort?.preferredLocale());
+}
+
+export function nextDogfoodLocale(currentLocale: string): DogfoodLocaleOption {
+  const current = resolveDogfoodLocale(currentLocale);
+  const currentIndex = DOGFOOD_LOCALE_OPTIONS.findIndex((option) => option.id === current.id);
+  return DOGFOOD_LOCALE_OPTIONS[(currentIndex + 1) % DOGFOOD_LOCALE_OPTIONS.length] ?? DEFAULT_LOCALE;
+}
+
+export function dogfoodLocaleLabel(locale: string, i18n?: I18nRuntime): string {
+  const option = resolveDogfoodLocale(locale);
+  const localizedName = i18n?.t({ namespace: 'bijou.dogfood', id: `settings.language.${option.id}` }) ?? option.label;
+  return localizedName === option.nativeLabel ? localizedName : `${localizedName} / ${option.nativeLabel}`;
+}
+
+export function dogfoodLocaleOptionsText(i18n?: I18nRuntime): string {
+  const labels = DOGFOOD_LOCALE_OPTIONS.map((option) => dogfoodLocaleLabel(option.id, i18n));
+  return i18n?.formatList(labels, i18n.locale) ?? labels.join(', ');
+}

--- a/examples/docs/main.ts
+++ b/examples/docs/main.ts
@@ -1,9 +1,6 @@
 import { initDefaultContext } from '../../packages/bijou-node/src/index.js';
 import { run } from '../../packages/bijou-tui/src/index.js';
-import { createDocsApp } from './app.js';
-import { createNodeDogfoodLocalePort } from './node-locale.js';
+import { createNodeDocsApp } from './node-app.js';
 
 const ctx = initDefaultContext();
-await run(createDocsApp(ctx, {
-  localePort: createNodeDogfoodLocalePort(),
-}), { ctx, mouse: true });
+await run(createNodeDocsApp(ctx), { ctx, mouse: true });

--- a/examples/docs/main.ts
+++ b/examples/docs/main.ts
@@ -1,6 +1,9 @@
 import { initDefaultContext } from '../../packages/bijou-node/src/index.js';
 import { run } from '../../packages/bijou-tui/src/index.js';
 import { createDocsApp } from './app.js';
+import { createNodeDogfoodLocalePort } from './node-locale.js';
 
 const ctx = initDefaultContext();
-await run(createDocsApp(ctx), { ctx, mouse: true });
+await run(createDocsApp(ctx, {
+  localePort: createNodeDogfoodLocalePort(),
+}), { ctx, mouse: true });

--- a/examples/docs/node-app.ts
+++ b/examples/docs/node-app.ts
@@ -1,0 +1,9 @@
+import type { BijouContext } from '../../packages/bijou/src/index.js';
+import { createDocsApp } from './app.js';
+import { createNodeDogfoodLocalePort, type NodeDogfoodLocaleEnv } from './node-locale.js';
+
+export function createNodeDocsApp(ctx: BijouContext, env?: NodeDogfoodLocaleEnv) {
+  return createDocsApp(ctx, {
+    localePort: createNodeDogfoodLocalePort(env),
+  });
+}

--- a/examples/docs/node-locale.ts
+++ b/examples/docs/node-locale.ts
@@ -1,0 +1,27 @@
+import type { DogfoodLocalePort } from './locale.js';
+
+export interface NodeDogfoodLocaleEnv {
+  readonly LANG?: string;
+  readonly LANGUAGE?: string;
+  readonly LC_ALL?: string;
+  readonly LC_MESSAGES?: string;
+}
+
+function firstLocaleCandidate(value: string | undefined): string | undefined {
+  const candidate = value?.split(':').find((entry) => entry.trim() !== '');
+  return candidate?.trim();
+}
+
+export function createNodeDogfoodLocalePort(
+  env: NodeDogfoodLocaleEnv = process.env as NodeDogfoodLocaleEnv,
+): DogfoodLocalePort {
+  return {
+    preferredLocale() {
+      return firstLocaleCandidate(env.LC_ALL)
+        ?? firstLocaleCandidate(env.LC_MESSAGES)
+        ?? firstLocaleCandidate(env.LANGUAGE)
+        ?? firstLocaleCandidate(env.LANG)
+        ?? Intl.DateTimeFormat().resolvedOptions().locale;
+    },
+  };
+}

--- a/scripts/docs-preview.test.ts
+++ b/scripts/docs-preview.test.ts
@@ -108,7 +108,9 @@ describe('docs preview app', () => {
 
     expect(source).toContain("../../packages/bijou-node/src/index.js");
     expect(source).toContain("../../packages/bijou-tui/src/index.js");
-    expect(source).toMatch(/await run\(createDocsApp\(ctx\), \{ ctx, mouse: true \}\);/);
+    expect(source).toContain("import { createNodeDogfoodLocalePort } from './node-locale.js';");
+    expect(source).toContain('localePort: createNodeDogfoodLocalePort()');
+    expect(source).toMatch(/await run\(createDocsApp\(ctx, \{\s+localePort: createNodeDogfoodLocalePort\(\),\s+\}\), \{ ctx, mouse: true \}\);/);
   });
 
   it('imports the DOGFOOD app through the same tsx path used by npm run dogfood', () => {
@@ -777,6 +779,9 @@ describe('docs preview app', () => {
     expect(frameText(settingsFrame)).toContain('↻ Shell theme');
     expect(frameText(settingsFrame)).toContain('Storybook Workstation');
     expect(frameText(settingsFrame)).not.toContain('Landing theme');
+    expect(frameText(settingsFrame)).toContain('Localization');
+    expect(frameText(settingsFrame)).toContain('Preferred language');
+    expect(frameText(settingsFrame)).toContain('Current language: English');
     expect(frameText(settingsFrame)).toContain('Landing');
     expect(frameText(settingsFrame)).toContain('Adapts render cost to');
     expect(frameText(settingsFrame)).toContain('Options:');
@@ -799,6 +804,8 @@ describe('docs preview app', () => {
     }).surface;
     expect(model.docsModel.runtimeNotifications.items[0]?.message).toBe('Show hints turned off.');
     expect(frameText(frame)).toContain('notices:1');
+    updateResult = app.update(keyMsg('down') as any, model);
+    model = updateResult[0] as any;
     updateResult = app.update(keyMsg('down') as any, model);
     model = updateResult[0] as any;
     updateResult = app.update(keyMsg('down') as any, model);

--- a/scripts/docs-preview.test.ts
+++ b/scripts/docs-preview.test.ts
@@ -7,6 +7,7 @@ import { _resetDefaultContextForTesting, createTestContext } from '@flyingrobots
 import { parseKey, runScript } from '@flyingrobots/bijou-tui';
 import { createDocsApp, DOGFOOD_I18N_CATALOG, FRAME_I18N_CATALOG } from '../examples/docs/app.js';
 import { resolveDogfoodDocsCoverage } from '../examples/docs/coverage.js';
+import { createNodeDocsApp } from '../examples/docs/node-app.js';
 import { COMPONENT_STORIES } from '../examples/docs/stories.js';
 import { pseudoLocalize } from '../packages/bijou-i18n-tools/src/index.js';
 import { QUIT } from '../packages/bijou-tui/src/types.js';
@@ -108,9 +109,17 @@ describe('docs preview app', () => {
 
     expect(source).toContain("../../packages/bijou-node/src/index.js");
     expect(source).toContain("../../packages/bijou-tui/src/index.js");
-    expect(source).toContain("import { createNodeDogfoodLocalePort } from './node-locale.js';");
-    expect(source).toContain('localePort: createNodeDogfoodLocalePort()');
-    expect(source).toMatch(/await run\(createDocsApp\(ctx, \{\s+localePort: createNodeDogfoodLocalePort\(\),\s+\}\), \{ ctx, mouse: true \}\);/);
+    expect(source).toContain("import { createNodeDocsApp } from './node-app.js';");
+    expect(source).toContain('createNodeDocsApp(ctx)');
+  });
+
+  it('builds the Node DOGFOOD app through the locale adapter instead of process reads in view code', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
+    const app = createNodeDocsApp(ctx, { LC_ALL: 'fr_FR.UTF-8' });
+
+    const result = await runScript(app, [{ key: KEY_ENTER }, { key: KEY_F2 }], { ctx });
+
+    expect(frameText(result.frames.at(-1)!)).toContain('Langue préférée');
   });
 
   it('imports the DOGFOOD app through the same tsx path used by npm run dogfood', () => {

--- a/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
+++ b/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
@@ -84,6 +84,42 @@ describe('LX-011 DOGFOOD locale ratchet', () => {
     expect(frameText(result.frames.at(-1)!)).toContain('Langue préférée');
   });
 
+  it('normalizes supported explicit locale aliases before rendering localized settings', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
+    const app = createDocsApp(ctx, {
+      initialRoute: 'docs',
+      locale: 'fr-FR',
+    });
+
+    const result = await runScript(app, [{ key: KEY_F2 }], { ctx });
+    const text = frameText(result.frames.at(-1)!);
+
+    expect(pageLocales(result.model)).toEqual(['fr', 'fr', 'fr', 'fr', 'fr', 'fr']);
+    expect(text).toContain('Langue préférée');
+    expect(text).not.toContain('Preferred language');
+  });
+
+  it('keeps the language setting renderable when an extra DOGFOOD catalog is partial', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
+    const app = createDocsApp(ctx, {
+      initialRoute: 'docs',
+      locale: 'fr',
+      extraI18nCatalogs: [{
+        namespace: 'bijou.dogfood',
+        entries: [{
+          key: { namespace: 'bijou.dogfood', id: 'settings.language.label' },
+          kind: 'message',
+          sourceLocale: 'en',
+          values: { en: 'Preferred language', fr: 'Langue préférée' },
+        }],
+      }],
+    });
+
+    const result = await runScript(app, [{ key: KEY_F2 }], { ctx });
+
+    expect(frameText(result.frames.at(-1)!)).toContain('Langue préférée');
+  });
+
   it('cycles the preferred language through settings and syncs every DOGFOOD page model', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
     const app = createDocsApp(ctx, {

--- a/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
+++ b/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { runScript } from '@flyingrobots/bijou-tui';
+import { createDocsApp, DOGFOOD_I18N_CATALOG } from '../../../examples/docs/app.js';
+import {
+  DOGFOOD_LOCALE_OPTIONS,
+  resolveDogfoodInitialLocale,
+} from '../../../examples/docs/locale.js';
+import { createNodeDogfoodLocalePort } from '../../../examples/docs/node-locale.js';
+
+const KEY_DOWN = '\x1b[B';
+const KEY_ENTER = '\r';
+const KEY_F2 = '\x1bOQ';
+
+function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
+  let text = '';
+  for (let y = 0; y < frame.height; y++) {
+    for (let x = 0; x < frame.width; x++) {
+      text += frame.get(x, y).char || ' ';
+    }
+    text += '\n';
+  }
+  return text;
+}
+
+function pageLocales(model: unknown): readonly string[] {
+  const pageModels = (model as {
+    readonly docsModel: {
+      readonly pageModels: Readonly<Record<string, { readonly locale: string }>>;
+    };
+  }).docsModel.pageModels;
+  return Object.values(pageModels).map((pageModel) => pageModel.locale);
+}
+
+describe('LX-011 DOGFOOD locale ratchet', () => {
+  it('resolves the initial DOGFOOD locale through an injected port before falling back to English', () => {
+    expect(resolveDogfoodInitialLocale({
+      localePort: { preferredLocale: () => 'fr_FR.UTF-8' },
+    }).id).toBe('fr');
+    expect(resolveDogfoodInitialLocale({
+      locale: 'de-DE',
+      localePort: { preferredLocale: () => 'fr_FR.UTF-8' },
+    }).id).toBe('de');
+    expect(resolveDogfoodInitialLocale({
+      localePort: { preferredLocale: () => 'zz-ZZ' },
+    }).id).toBe('en');
+  });
+
+  it('keeps Node locale discovery behind the DOGFOOD locale port', () => {
+    expect(createNodeDogfoodLocalePort({
+      LC_ALL: 'es_MX.UTF-8',
+      LC_MESSAGES: 'de_DE.UTF-8',
+      LANG: 'fr_FR.UTF-8',
+    }).preferredLocale()).toBe('es_MX.UTF-8');
+    expect(createNodeDogfoodLocalePort({
+      LANGUAGE: 'fr:de',
+      LANG: 'en_US.UTF-8',
+    }).preferredLocale()).toBe('fr');
+  });
+
+  it('ratchets the settings language catalog for every supported DOGFOOD locale', () => {
+    const entries = new Map(DOGFOOD_I18N_CATALOG.entries.map((entry) => [entry.key.id, entry]));
+    for (const locale of DOGFOOD_LOCALE_OPTIONS) {
+      const entry = entries.get(`settings.language.${locale.id}`);
+      expect(entry?.values.en).toEqual(expect.any(String));
+      for (const supported of DOGFOOD_LOCALE_OPTIONS) {
+        expect(entry?.values[supported.id]).toEqual(expect.any(String));
+      }
+    }
+    expect(entries.get('settings.section.localization')?.values.fr).toBe('Localisation');
+    expect(entries.get('settings.language.label')?.values.fr).toBe('Langue préférée');
+  });
+
+  it('initializes DOGFOOD pages from the injected locale preference', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
+    const app = createDocsApp(ctx, {
+      initialRoute: 'docs',
+      localePort: { preferredLocale: () => 'fr_FR.UTF-8' },
+    });
+
+    const result = await runScript(app, [{ key: KEY_F2 }], { ctx });
+
+    expect(pageLocales(result.model)).toEqual(['fr', 'fr', 'fr', 'fr', 'fr', 'fr']);
+    expect(frameText(result.frames.at(-1)!)).toContain('Langue préférée');
+  });
+
+  it('cycles the preferred language through settings and syncs every DOGFOOD page model', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
+    const app = createDocsApp(ctx, {
+      initialRoute: 'docs',
+      locale: 'en',
+    });
+
+    const result = await runScript(app, [
+      { key: KEY_F2 },
+      { key: KEY_DOWN },
+      { key: KEY_DOWN },
+      { key: KEY_ENTER },
+    ], { ctx });
+
+    expect(pageLocales(result.model)).toEqual(['fr', 'fr', 'fr', 'fr', 'fr', 'fr']);
+    expect(frameText(result.frames.at(-1)!)).toContain('Langue préférée');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first DOGFOOD localization ratchet and user-facing locale preference. DOGFOOD now resolves its initial language through an explicit locale port, uses a Node adapter for OS locale signals, and exposes a Settings drawer language selector that syncs the selected locale across docs pages.

This keeps localization behind the host boundary instead of letting Dogfood view code read process state directly. The settings-language catalog is covered for the supported Dogfood locale options: English, French, Spanish, and German.

## Non-goals

- no full translation of every DOGFOOD page yet
- no external locale persistence
- no async catalog service loading
- no package-level i18n API expansion
- no runtime locale selector outside DOGFOOD

## Validation

- npm test -- --run tests/cycles/LX-011/dogfood-locale-ratchet.test.ts scripts/docs-preview.test.ts tests/cycles/LX-008/localized-shell-and-dogfood.test.ts
- npm run typecheck:test
- npm run lint
- npm run docs:inventory
- git diff --check
- node --import tsx --input-type=module -e "... createDocsApp(... localePort ...)"
- npm test
- pre-push hook reran typecheck:test, npm test, and verify:interactive-examples

Full suite: 300 test files passed, 3411 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language preference setting accessible through the Settings drawer (F2).
  * Automatically detects initial language from your system locale.
  * Language preference persists across app restarts.
  * Language selection updates consistently across all documentation pages.
  * Support for English, French, Spanish, and German.

* **Documentation**
  * Added localization backlog items and planning documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->