### PR TITLE
test(dogfood): lock block preview regressions

### DIFF
--- a/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
+++ b/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
@@ -21,7 +21,7 @@ function blockPreviewGuideId(blockName: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
-  return `blocks-preview-${slug || 'block'}`;
+  return `blocks-preview-${slug || 'family'}`;
 }
 
 function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
@@ -48,6 +48,7 @@ async function renderBlocksGuide(guideId: string, columns = 150, rows = 43) {
       msg: { type: 'select-guide', guideId },
     },
   }], { ctx });
+  expect(result.frames.length).toBeGreaterThan(0);
 
   return {
     ctx,
@@ -163,14 +164,15 @@ describe('DF-068 DOGFOOD block preview regressions', () => {
   });
 
   it('renders the CounterDemoBlock preview page without wrapped border rows and keeps intent keys live', async () => {
-    const selected = await renderBlocksGuide('blocks-preview-counterdemoblock', 150, 43);
+    const guideId = blockPreviewGuideId('CounterDemoBlock');
+    const selected = await renderBlocksGuide(guideId, 150, 43);
     const incremented = await runScript(
       createDocsApp(selected.ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any }),
       [
         {
           msg: {
             type: 'docs',
-            msg: { type: 'select-guide', guideId: 'blocks-preview-counterdemoblock' },
+            msg: { type: 'select-guide', guideId },
           },
         },
         { key: '+' },

--- a/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
+++ b/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  standardBlocks,
+  stripAnsi,
+  surfaceToString,
+} from '@flyingrobots/bijou';
+import {
+  _resetDefaultContextForTesting,
+  createTestContext,
+} from '@flyingrobots/bijou/adapters/test';
+import { runScript } from '@flyingrobots/bijou-tui';
+import { createDocsApp } from '../../../examples/docs/app.js';
+import {
+  counterDemoBlockConfig,
+  counterDemoBlockSurface,
+  createCounterDemoModel,
+} from '../../../examples/docs/counter-block-demo.js';
+
+function blockPreviewGuideId(blockName: string): string {
+  const slug = blockName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `blocks-preview-${slug || 'block'}`;
+}
+
+function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
+  let text = '';
+  for (let y = 0; y < frame.height; y++) {
+    for (let x = 0; x < frame.width; x++) {
+      text += frame.get(x, y).char || ' ';
+    }
+    text += '\n';
+  }
+  return text;
+}
+
+function rowsFor(text: string): readonly string[] {
+  return text.split('\n');
+}
+
+async function renderBlocksGuide(guideId: string, columns = 150, rows = 43) {
+  const ctx = createTestContext({ mode: 'interactive', runtime: { columns, rows } });
+  const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
+  const result = await runScript(app, [{
+    msg: {
+      type: 'docs',
+      msg: { type: 'select-guide', guideId },
+    },
+  }], { ctx });
+
+  return {
+    ctx,
+    result,
+    text: frameText(result.frames.at(-1)!),
+  };
+}
+
+function textBefore(text: string, marker: string): string {
+  const index = text.indexOf(marker);
+  return index === -1 ? text : text.slice(0, index);
+}
+
+function rowContaining(rows: readonly string[], needle: string): string {
+  const row = rows.find((candidate) => candidate.includes(needle));
+  expect(row).toBeDefined();
+  return row!;
+}
+
+function expectBoxTitleRowCloses(row: string): void {
+  const leftCorner = row.indexOf('┌');
+  const rightCorner = row.lastIndexOf('┐');
+
+  expect(leftCorner).toBeGreaterThanOrEqual(0);
+  expect(rightCorner).toBeGreaterThan(leftCorner);
+}
+
+describe('DF-068 DOGFOOD block preview regressions', () => {
+  afterEach(() => _resetDefaultContextForTesting());
+
+  it('renders selected standard block pages as visible preview surfaces before contract documentation', async () => {
+    const expectedPreviewContent = new Map<string, readonly string[]>([
+      ['AppShell', [
+        'Navigation',
+        'Content',
+        'Inspector',
+        'ReaderSurface live content from DOGFOOD Blocks.',
+        'schema-bound; provider-ready; command-aware',
+      ]],
+      ['ReaderSurface', [
+        'Navigation',
+        'Content',
+        'Outline',
+        'ReaderSurface live content from DOGFOOD Blocks.',
+      ]],
+      ['InspectorPanel', [
+        'Selection',
+        'Details',
+        'Actions',
+        'ReaderSurface',
+        'Reveal selection; Focus source',
+      ]],
+    ]);
+
+    for (const block of standardBlocks) {
+      const { text } = await renderBlocksGuide(blockPreviewGuideId(block.metadata.blockName), 150, 43);
+      const previewRegion = textBefore(text, 'documentation');
+
+      expect(text).toContain(`Page: ${block.metadata.blockName}`);
+      expect(previewRegion).toContain(block.metadata.blockName);
+      expect(previewRegion).toContain('mode lowering');
+      expect(previewRegion).toContain('interactive mode');
+      expect(previewRegion).toContain('static mode');
+
+      for (const expected of expectedPreviewContent.get(block.metadata.blockName) ?? []) {
+        expect(previewRegion).toContain(expected);
+      }
+
+      expect(previewRegion).not.toContain('Story Matrix');
+      expect(previewRegion).not.toContain('Package: block package:');
+      expect(previewRegion).not.toContain('Contract: block metadata:');
+      expect(previewRegion).not.toContain('Source: packages/bijou/src/core/standard-blocks.ts');
+      expect(previewRegion).not.toContain('components=AppShellComposition');
+    }
+  });
+
+  it('keeps mode lowering compact instead of rendering nested mini-surfaces inside the summary', async () => {
+    const { text } = await renderBlocksGuide(blockPreviewGuideId('ReaderSurface'), 150, 43);
+    const loweringRegion = text
+      .slice(text.indexOf('mode lowering'))
+      .split('documentation')[0] ?? '';
+
+    expect(loweringRegion).toContain('interactive mode:');
+    expect(loweringRegion).toContain('static mode:');
+    expect(loweringRegion).toContain('pipe mode:');
+    expect(loweringRegion).toContain('accessible mode:');
+    expect(loweringRegion).toContain('facts:');
+    expect(loweringRegion).not.toContain('surface output:');
+    expect(loweringRegion).not.toContain('┌─ ReaderSurface');
+    expect(loweringRegion).not.toContain('┌─ Navigation');
+  });
+
+  it('keeps the CounterDemoBlock fixture box bounded when style output contains ANSI codes', () => {
+    const baseCtx = createTestContext({ mode: 'interactive', runtime: { columns: 100, rows: 40 } });
+    const styledCtx = {
+      ...baseCtx,
+      style: {
+        ...baseCtx.style,
+        styled: (_token: unknown, text: string) => `\x1b[31m${text}\x1b[0m`,
+      },
+    };
+    const surface = counterDemoBlockSurface(counterDemoBlockConfig(createCounterDemoModel(5), styledCtx, 70));
+    const lines = stripAnsi(surfaceToString(surface, styledCtx.style)).split('\n');
+
+    expect(surface.width).toBe(70);
+    expect(lines.every((line) => line.length <= surface.width)).toBe(true);
+    expectBoxTitleRowCloses(rowContaining(lines, 'CounterDemoBlock fixture'));
+    expect(rowContaining(lines, 'Counter: 5')).toContain('│');
+    expect(rowContaining(lines, '[-] decrease')).toContain('[+] increase');
+    expect(rowContaining(lines, 'Intents: - fixture.counter.decrement')).toContain(
+      '+ fixture.counter.increment',
+    );
+  });
+
+  it('renders the CounterDemoBlock preview page without wrapped border rows and keeps intent keys live', async () => {
+    const selected = await renderBlocksGuide('blocks-preview-counterdemoblock', 150, 43);
+    const incremented = await runScript(
+      createDocsApp(selected.ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any }),
+      [
+        {
+          msg: {
+            type: 'docs',
+            msg: { type: 'select-guide', guideId: 'blocks-preview-counterdemoblock' },
+          },
+        },
+        { key: '+' },
+      ],
+      { ctx: selected.ctx },
+    );
+    const selectedRows = rowsFor(selected.text);
+
+    expectBoxTitleRowCloses(rowContaining(selectedRows, 'CounterDemoBlock fixture'));
+    expectBoxTitleRowCloses(rowContaining(selectedRows, 'mode lowering'));
+    expectBoxTitleRowCloses(rowContaining(selectedRows, 'documentation'));
+    expect(selected.text).toContain('Counter: 5');
+    expect(selected.text).toContain('json: {"counter":5}');
+    expect(frameText(incremented.frames.at(-1)!)).toContain('Counter: 6');
+    expect(frameText(incremented.frames.at(-1)!)).toContain('json: {"counter":6}');
+  });
+
+  it('keeps the shell-owned perf HUD toggle available from block preview pages', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 150, rows: 43 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
+    const toggled = await runScript(app, [
+      {
+        msg: {
+          type: 'docs',
+          msg: { type: 'select-guide', guideId: blockPreviewGuideId('AppShell') },
+        },
+      },
+      { key: '`' },
+    ], { ctx });
+    const model = toggled.model as {
+      docsModel: { perfHudOpen: boolean };
+    };
+
+    expect(model.docsModel.perfHudOpen).toBe(true);
+    expect(frameText(toggled.frames.at(-1)!)).toContain('Perf HUD');
+  });
+});


### PR DESCRIPTION
## Summary

Adds DF-068 DOGFOOD block preview regression coverage so the Blocks surface stays visibly correct after the recent rendered block and localization work.

This is a test-only guardrail slice. It renders DOGFOOD frames and block surfaces directly to prove:

- standard block preview pages show live visible surfaces before contract documentation
- mode-lowering summaries stay compact instead of rendering nested mini-surfaces
- `CounterDemoBlock` fixture boxes stay bounded when styled output includes ANSI sequences
- `CounterDemoBlock` `+` intent keys continue to update the visible counter and JSON lowering
- the shell-owned perf HUD backtick toggle remains available from block preview pages

## Non-goals

- no new Blocks API
- no DOGFOOD visual redesign
- no rendered AppShell runtime changes
- no provider subscriptions or command dispatch changes
- no localization behavior changes

## Validation

- `npm test -- --run tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts`
- `npm run typecheck:test`
- `npm run lint`
- `npm run docs:inventory`
- `git diff --check`
- pre-push full `npm test` (310 files, 3491 tests)
- pre-push `npm run verify:interactive-examples`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression test suite for block preview functionality, including tests for standard block rendering, mode display compactness, proper box boundary handling with styled output, interactive component behavior, and performance monitoring utilities accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->