### PR TITLE
build(deps): refresh hono and qs lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1768,9 +1768,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2151,9 +2151,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "version": "bash scripts/version.sh"
   },
   "overrides": {
-    "hono": "4.12.21",
+    "hono": "4.12.22",
     "picomatch": "^4.0.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },


### PR DESCRIPTION
## Summary

Refreshes the follow-up Dependabot npm group update on a clean branch from current `main`.

Updates:
- `hono` override: `4.12.21` -> `4.12.22`
- lockfile entries for `hono` and `qs`

This keeps the SheetJS CDN `xlsx` lock entry intact while applying the dependency refresh.

## Validation

- `npm test -- --run packages/bijou-i18n-tools-xlsx/src/xlsx.test.ts packages/bijou-i18n/src/runtime.test.ts packages/bijou-tui/src/keybindings.test.ts`
- `npm run typecheck:test`
- `npm run lint`
- `git diff --check`
- pre-push hook reran `npm run typecheck:test`, `npm test`, and `npm run verify:interactive-examples`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for maintenance purposes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->