### PR TITLE
docs(readme): rewrite primary onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,141 +1,340 @@
 # Bijou
 
-An industrial-grade TypeScript engine for terminal software. Use the pure primitives to build your own CLI, or drop into the batteries-included app shell for a full-screen TUI out of the box.
+Bijou is a TypeScript toolkit for building serious terminal software: prompts,
+CLI flows, full-screen TUI apps, documentation workstations, mode-aware
+components, localization pipelines, and machine-readable rendering output.
 
-Bijou is designed for the mechanic who demands geometric lawfulness and the architect who needs a stable substrate. It scales from simple mode-aware prompts to high-fidelity, physics-powered terminal applications.
+It treats the terminal as a real character grid instead of a low-resolution
+browser. That means layout, input, lowering, localization, and performance are
+first-class parts of the system rather than afterthoughts.
 
 [![npm version](https://img.shields.io/npm/v/@flyingrobots/bijou)](https://www.npmjs.com/package/@flyingrobots/bijou)
 [![License](https://img.shields.io/github/license/flyingrobots/bijou)](./LICENSE)
 
 ![Bijou demo](https://github.com/user-attachments/assets/8117f6ad-41e0-470f-aeb6-6722ec44fa2c)
 
+## Start Here
+
+The fastest way to understand Bijou is to run the docs app that Bijou builds
+with itself:
+
+```bash
+git clone https://github.com/flyingrobots/bijou.git
+cd bijou
+npm install
+npm run dogfood
+```
+
+`npm run dogfood` launches DOGFOOD, the canonical documentation app and proving
+surface. It shows the component explorer, Blocks pages, localization settings,
+mode-lowering examples, and the current product direction in one TUI.
+
+Useful keys in DOGFOOD:
+
+| Key | Action |
+| :--- | :--- |
+| `F2` | Open settings, including language selection. |
+| `` ` `` | Toggle the performance HUD. |
+| `Tab` | Move to the next pane. |
+| `j` / `k` or arrow keys | Browse and scroll. |
+| `q` | Quit. |
+
+If you want a smaller starter app instead of the monorepo docs surface:
+
+```bash
+npm create bijou-tui-app@latest my-app
+cd my-app
+npm install
+npm run dev
+```
+
 ## What's New in v5.0.0
 
-Bijou `v5.0.0` turns the hosted shell, Node host bootstrapping, and
-release-proof surface into a cleaner first-class product line.
+Bijou `v5.0.0` made the hosted shell, Node host bootstrapping, localization
+runtime, and release-proof DOGFOOD surface more coherent as a product line.
 
-- `createFramedApp()` now owns its hosted runner through `app.run(...)`
-  and `runFramedApp(...)`, and `startApp(app)` delegates to that path
-  automatically.
-- `@flyingrobots/bijou-node` now makes theme selection easy with
-  `startApp(app, { theme })` and automatic light/dark theme sets through
-  `themes`, `themeMode`, and `themeOverride`.
-- the proof surfaces are more honest: `markdown()` renders pipe tables,
-  `npm run perf` exposes the visual performance demo, and the scripted
-  interactive smoke path is deterministic and isolated in
-  `verify:interactive-examples`.
+- `createFramedApp()`, `runFramedApp(...)`, and `startApp(app)` now share a
+  cleaner hosted runtime path.
+- `@flyingrobots/bijou-node` supports easier theme selection through hosted app
+  options.
+- DOGFOOD is the preferred docs and proof surface for release smoke, Blocks
+  previews, i18n workflow checks, and interactive examples.
+- The i18n packages now separate runtime lookup from CSV/TSV/JSON catalog
+  workflow tools.
 
 Read the short-form [changelog](./docs/CHANGELOG.md), the long-form
 [What's New guide](./docs/releases/5.0.0/whats-new.md), and the
 [migration guide](./docs/releases/5.0.0/migration-guide.md).
 
-## Why Bijou?
+## What You Can Build
 
-Unlike Virtual-DOM wrappers that treat the terminal as a low-resolution browser, Bijou treats the terminal as a physical character grid.
+Bijou can be used at several levels.
 
-- **Deterministic State**: The TEA loop ensures your UI is a pure function of your state history. No hooks, no side-effect soup, and no reconciliation drift.
-- **Byte-Packed Performance**: Rendering happens on zero-allocation byte buffers (`Uint8Array`). It is designed for high-frequency updates and complex layouts that would choke string-heavy engines.
-- **Geometric Honesty**: Portability is not an afterthought. Bijou adapts to CI logs, pipes, and screen readers by changing its rendering strategy, not just stripping colors.
-- **Physics-Powered Motion**: Animations are driven by a unified heartbeat and spring physics, providing fluid movement that remains synchronized with the render loop.
+| Need | Start with |
+| :--- | :--- |
+| Prompts, boxes, plain CLI output | [`@flyingrobots/bijou`](./packages/bijou/) |
+| A hosted Node TUI app | [`@flyingrobots/bijou-node`](./packages/bijou-node/) and [`@flyingrobots/bijou-tui`](./packages/bijou-tui/) |
+| A framed application shell | [`@flyingrobots/bijou-tui-app`](./packages/bijou-tui-app/) or `create-bijou-tui-app` |
+| Runtime localization | [`@flyingrobots/bijou-i18n`](./packages/bijou-i18n/) |
+| CSV/TSV/JSON localization workflow tools | [`@flyingrobots/bijou-i18n-tools`](./packages/bijou-i18n-tools/) |
+| Story and component preview work | `npm run storybook` |
+| Performance and long-running stability checks | `npm run bench` and `npm run soak` |
+| MCP integration | [`@flyingrobots/bijou-mcp`](./packages/bijou-mcp/) |
 
-## Essence
+## Quick Start: Tiny Interactive App
 
-- **Degradation as a Substrate Property**: Write once; render perfectly in local TTYs, CI logs, pipes, and accessible environments.
-- **The Elm Architecture (TEA)**: A deterministic state-update-view loop for industrial-strength interactive UIs.
-- **Physics-Powered Motion**: Declarative spring and tween animations synchronized to a unified heartbeat.
-- **Zero-Dependency Core**: The fundamental toolkit is pure TypeScript, isolated from platform-specific IO.
-
-## Choose Your Lane
-
-- **CLI or script**: start with [`@flyingrobots/bijou`](./packages/bijou/) and host it through [`@flyingrobots/bijou-node`](./packages/bijou-node/).
-- **Interactive TUI**: start with [`@flyingrobots/bijou-tui`](./packages/bijou-tui/) and the hosted Node entrypoint in [`@flyingrobots/bijou-node`](./packages/bijou-node/).
-- **Batteries-included app shell**: scaffold with [`create-bijou-tui-app`](./packages/create-bijou-tui-app/) or study [`@flyingrobots/bijou-tui-app`](./packages/bijou-tui-app/).
-- **MCP server**: use [`@flyingrobots/bijou-mcp`](./packages/bijou-mcp/) and the reference docs in [`docs/MCP.md`](./docs/MCP.md).
-- **Localization**: start with [`@flyingrobots/bijou-i18n`](./packages/bijou-i18n/) plus the catalog tooling packages.
-- **Guided walkthroughs and proof**: use [`GUIDE.md`](./GUIDE.md) and run [`npm run dogfood`](./docs/DOGFOOD.md).
-
-## Quick Start
-
-### 1. Pure CLI Flow
-Standalone primitives for prompts and structured output.
-
-```ts
-import { group, headerBox, input, select } from '@flyingrobots/bijou';
-import { initDefaultContext } from '@flyingrobots/bijou-node';
-
-initDefaultContext();
-
-const answers = await group({
-  project: () => input({ title: 'Project name', required: true }),
-  template: () => select({
-    title: 'Template',
-    options: [
-      { label: 'TypeScript', value: 'ts' },
-      { label: 'Go', value: 'go' },
-    ],
-  }),
-});
-
-console.log(headerBox('Scaffold', { detail: `${answers.project} (${answers.template})` }));
-```
-
-### 2. Interactive Runtime
-Full-screen TEA loop with layout, overlays, and motion.
+This is the shape of a small Bijou TUI: initialize state, update state from
+messages, and render a surface from the current model.
 
 ```ts
 import { stringToSurface } from '@flyingrobots/bijou';
 import { startApp } from '@flyingrobots/bijou-node';
 import { isKeyMsg, quit, type App } from '@flyingrobots/bijou-tui';
 
-const app: App<{ count: number }> = {
+interface Model {
+  readonly count: number;
+}
+
+const app: App<Model> = {
   init: () => [{ count: 0 }, []],
+
   update: (msg, model) => {
-    if (isKeyMsg(msg) && msg.key === 'q') return [model, [quit()]];
-    if (isKeyMsg(msg) && msg.key === 'k') return [{ count: model.count + 1 }, []];
+    if (isKeyMsg(msg) && msg.key === 'q') {
+      return [model, [quit()]];
+    }
+    if (isKeyMsg(msg) && msg.key === '+') {
+      return [{ count: model.count + 1 }, []];
+    }
+    if (isKeyMsg(msg) && msg.key === '-') {
+      return [{ count: model.count - 1 }, []];
+    }
+
     return [model, []];
   },
-  view: (model) => stringToSurface(`Count: ${model.count}\nPress k to increment\nPress q to quit`, 20, 3),
+
+  view: (model) =>
+    stringToSurface(
+      `Counter: ${model.count}\nPress + or - to change\nPress q to quit`,
+      32,
+      3,
+    ),
 };
 
 await startApp(app);
 ```
 
-### 3. Scaffold a Framed App
-Get the batteries-included workspace shell immediately.
+The important rule is simple: views render state; they do not own business
+change. Input becomes intent, update functions change state, and rendering stays
+deterministic.
+
+## DOGFOOD: The Real Tour
+
+DOGFOOD stands for _Documentation Of Good Foundational Onboarding and
+Discovery_. It is not a toy example. It is the repository's live documentation
+application and the place where new ideas have to prove they work in an actual
+Bijou surface.
+
+Run it with:
 
 ```bash
-npm create bijou-tui-app@latest my-app
+npm run dogfood
 ```
 
-## Packages
+Use DOGFOOD to inspect:
+
+- the component explorer
+- the Blocks documentation and block previews
+- localization settings and missing-translation behavior
+- responsive framed layout behavior
+- mode lowering across interactive, static, pipe, and accessible outputs
+- the performance HUD
+- release and architecture guidance
+
+Start with [DOGFOOD](./docs/DOGFOOD.md). The `examples/` tree is
+secondary/internal reference material, not the main public docs path.
+
+Read more in [`docs/DOGFOOD.md`](./docs/DOGFOOD.md).
+
+## Storybook And Preview Workflows
+
+Bijou has a Storybook-style workstation for exercising components and docs
+surfaces outside the main DOGFOOD navigation.
+
+```bash
+npm run storybook
+```
+
+For a deterministic text-first index and capture matrix:
+
+```bash
+npm run storybook:index
+```
+
+The Storybook tools are useful when you want focused component or surface work
+without navigating the full docs app.
+
+## Localization And i18n
+
+Bijou localization is split into runtime and workflow packages.
+
+- [`@flyingrobots/bijou-i18n`](./packages/bijou-i18n/) resolves localized
+  messages and structured resources at runtime.
+- [`@flyingrobots/bijou-i18n-tools`](./packages/bijou-i18n-tools/) handles
+  string tables, CSV/TSV parsing, workbook exchange shapes, JSON bundles,
+  stale checks, pseudo-localization, and runtime catalog generation.
+- [`@flyingrobots/bijou-i18n-tools-node`](./packages/bijou-i18n-tools-node/)
+  provides Node-backed file loading helpers.
+- [`@flyingrobots/bijou-i18n-tools-xlsx`](./packages/bijou-i18n-tools-xlsx/)
+  provides spreadsheet import/export adapters.
+
+DOGFOOD uses a committed CSV source string table:
+
+```text
+examples/docs/i18n/source/dogfood-strings.csv
+```
+
+Generate runtime JSON catalogs from that table:
+
+```bash
+npm run dogfood:i18n:build
+npm run dogfood:i18n:check
+```
+
+Inspect current DOGFOOD localization debt:
+
+```bash
+npm run dogfood:i18n:debt
+npm run dogfood:i18n:coverage
+```
+
+Export translator-friendly files:
+
+```bash
+npm run dogfood:i18n:export -- --locale fr --format csv
+npm run dogfood:i18n:export -- --locale fr --format tsv --out /tmp/dogfood-fr
+npm run dogfood:i18n:export -- --format json --bundle /tmp/dogfood-catalog.json
+```
+
+Runtime catalog loading follows one rule: load English as the fallback catalog,
+then load only the selected locale's generated JSON catalogs. Non-English
+catalog files should not copy English fallback strings. In development,
+missing selected-locale strings render loudly so untranslated UI cannot hide.
+
+### i18n Best Practices
+
+- Keep authoring data in source string tables or catalog files, not scattered
+  across rendering code.
+- Keep runtime payloads JSON-shaped: plain strings, numbers, booleans, null,
+  arrays, and plain objects.
+- Do not put `Date`, class instances, functions, symbols, bigint values,
+  accessors, cycles, or sparse arrays into localized resources.
+- Resolve localization through a port at app and view boundaries. Rendering code
+  should ask for localized objects, not read files, parse CSV, or inspect
+  process locale state.
+- Load fallback catalogs explicitly instead of duplicating fallback strings into
+  every translated locale.
+- Treat missing strings as visible development debt. Do not make screenshots
+  look complete by hiding missing translations.
+
+## Blocks
+
+Blocks are Bijou's higher-level authoring contract for reusable, inspectable UI
+surfaces. A block can declare metadata, slots, variants, data requirements,
+command intents, stories, schema posture, and mode-lowering behavior.
+
+Current DOGFOOD pages include:
+
+- What are Blocks
+- How to Make Your Own Blocks
+- Pre-made Blocks
+- Block Preview
+- How Blocks Lower
+
+The first standard blocks and fixture blocks are visible in DOGFOOD. This area
+is still growing: the architecture is ahead of the finished visual catalog, and
+future work is focused on making more blocks feel like real product surfaces
+instead of just contract examples.
+
+## Tests, Soak, And Performance
+
+Use these commands while working in the repository:
+
+```bash
+npm run lint
+npm run typecheck:test
+npm test
+npm run docs:inventory
+npm run verify:interactive-examples
+```
+
+For DOGFOOD smoke checks:
+
+```bash
+npm run smoke:dogfood
+npm run smoke:dogfood:landing
+npm run smoke:dogfood:docs
+```
+
+For longer-running and performance work:
+
+```bash
+npm run soak
+npm run bench
+npm run bench -- --scenario=paint-gradient-rgb
+npm run bench:ci:gradient
+```
+
+`npm run soak` exercises longer runtime stability scenarios. `npm run bench`
+drives the benchmark harness under [`bench/`](./bench/), including focused
+rendering and diff scenarios.
+
+## Package Map
 
 | Package | Role |
 | :--- | :--- |
-| [`@flyingrobots/bijou`](./packages/bijou/) | Core toolkit: prompts, components, themes, ports. |
-| [`@flyingrobots/bijou-tui`](./packages/bijou-tui/) | Interactive runtime: TEA, layout, motion, overlays. |
-| [`@flyingrobots/bijou-node`](./packages/bijou-node/) | Node.js adapters: IO, styling, worker helpers. |
+| [`@flyingrobots/bijou`](./packages/bijou/) | Core toolkit: prompts, surfaces, components, themes, blocks, ports, and pure contracts. |
+| [`@flyingrobots/bijou-tui`](./packages/bijou-tui/) | Interactive runtime: TEA loop, input, layout, motion, overlays, and framed app shell support. |
+| [`@flyingrobots/bijou-node`](./packages/bijou-node/) | Node.js adapters for IO, terminal hosting, styling, and worker helpers. |
 | [`@flyingrobots/bijou-tui-app`](./packages/bijou-tui-app/) | Batteries-included framed shell and higher-level app composition. |
-| [`create-bijou-tui-app`](./packages/create-bijou-tui-app/) | Project scaffolder for a hosted framed TUI app. |
-| [`@flyingrobots/bijou-mcp`](./packages/bijou-mcp/) | MCP server package for exposing Bijou-backed tooling. |
-| [`@flyingrobots/bijou-i18n`](./packages/bijou-i18n/) | Localization runtime: catalogs, formatting, and translation lookup. |
-| [`@flyingrobots/bijou-i18n-tools`](./packages/bijou-i18n-tools/) | Catalog tooling primitives and workflow helpers. |
-| [`@flyingrobots/bijou-i18n-tools-node`](./packages/bijou-i18n-tools-node/) | Node-hosted localization tooling helpers. |
+| [`create-bijou-tui-app`](./packages/create-bijou-tui-app/) | Project scaffolder for hosted Bijou TUI apps. |
+| [`@flyingrobots/bijou-mcp`](./packages/bijou-mcp/) | MCP server package for exposing Bijou-backed tools and structured render output. |
+| [`@flyingrobots/bijou-i18n`](./packages/bijou-i18n/) | Localization runtime, fallback handling, missing-string reporting, and localization port. |
+| [`@flyingrobots/bijou-i18n-tools`](./packages/bijou-i18n-tools/) | Provider-neutral localization workflow tools for string tables, catalogs, bundles, and pseudo-localization. |
+| [`@flyingrobots/bijou-i18n-tools-node`](./packages/bijou-i18n-tools-node/) | Node-hosted localization file and bundle loader helpers. |
 | [`@flyingrobots/bijou-i18n-tools-xlsx`](./packages/bijou-i18n-tools-xlsx/) | Spreadsheet import/export adapters for localization workflows. |
 
-## Documentation
+## Documentation Map
 
-- **[Guide](./GUIDE.md)**: Orientation, the fast path, and monorepo orchestration.
-- **[Advanced Guide](./ADVANCED_GUIDE.md)**: Deep dives into the pipeline, shaders, and motion.
-- **[DOGFOOD](./docs/DOGFOOD.md)**: The canonical documentation app. Run `npm run dogfood` to see Bijou in action.
-- **[Design System](./docs/design-system/README.md)**: The foundations and component families.
-- **[Architecture](./ARCHITECTURE.md)**: The hexagonal design and core properties.
+| Document | Use it for |
+| :--- | :--- |
+| [`GUIDE.md`](./GUIDE.md) | Orientation, fast paths, and monorepo workflow. |
+| [`ADVANCED_GUIDE.md`](./ADVANCED_GUIDE.md) | Deeper runtime, rendering, shader, and motion topics. |
+| [`docs/DOGFOOD.md`](./docs/DOGFOOD.md) | The docs app, DOGFOOD proof points, i18n workflow, and Storybook commands. |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | Ports, adapters, package stack, and structural rules. |
+| [`docs/VISION.md`](./docs/VISION.md) | Project identity and long-term product intent. |
+| [`docs/BEARING.md`](./docs/BEARING.md) | Current execution gravity and active tensions. |
+| [`docs/ROADMAP.md`](./docs/ROADMAP.md) | Broad strategic horizon. |
+| [`docs/design-system/README.md`](./docs/design-system/README.md) | Design language, components, and UI foundations. |
+| [`docs/CHANGELOG.md`](./docs/CHANGELOG.md) | Historical truth of merged behavior. |
 
-## DOGFOOD
+## Future Direction
 
-DOGFOOD is the canonical human-facing docs surface for Bijou.
+Bijou is moving from architecture-heavy foundations into more visible product
+proof. The next areas of investment are:
 
-If you are learning the framework, start there first. The `examples/` tree is
-secondary/internal reference material, not the main public docs path.
+- more complete first-party Blocks and rendered block previews
+- richer DOGFOOD coverage for Blocks, localization, Storybook, and examples
+- stronger localization workflows, including broader catalog coverage and
+  better translator ergonomics
+- replay and scenario pipelines for deterministic debugging
+- lower-allocation rendering and more soak/performance gates
+- richer MCP and machine-readable interactivity
+- more mature data visualization components
+- ecosystem adapters for additional hosts and workflows
+
+The durable goal is straightforward: build terminal apps that stay inspectable,
+mode-aware, localized, testable, and fast without sacrificing product quality.
 
 ---
-Built with terminal ambition by [FLYING ROBOTS](https://github.com/flyingrobots)
+
+Built with terminal ambition by [FLYING ROBOTS](https://github.com/flyingrobots).


### PR DESCRIPTION
## Summary
- rewrites the root README as a friendly public front door for Bijou
- leads with `npm run dogfood`, starter app scaffolding, DOGFOOD navigation, Storybook, i18n workflows, and soak/bench validation
- documents i18n string-table best practices, Blocks status, package roles, docs map, and future direction without overstating Blocks as finished

## Validation
- `git diff --check`
- `npm run docs:inventory`
- `npm run lint`
- `npm test -- --run tests/cycles/WF-006/cut-clean-4-1-0-release-boundary.test.ts tests/cycles/DF-025/make-dogfood-the-only-human-facing-docs-surface.test.ts scripts/docs-preview.test.ts`
- pre-push: `npm run typecheck:test`
- pre-push: `npm test` (310 files, 3491 tests)
- pre-push: `npm run verify:interactive-examples`