### PR TITLE
docs(readme): describe block data binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,32 @@ Blocks are Bijou's higher-level authoring contract for reusable, inspectable UI
 surfaces. A block can declare metadata, slots, variants, data requirements,
 command intents, stories, schema posture, and mode-lowering behavior.
 
+### Unidirectional Binding
+
+Blocks participate in Bijou's declarative binding system. The loop is
+intentionally one-way:
+
+```text
+business logic / providers
+  -> immutable BindingSnapshots
+  -> BindingFrame render input
+  -> blocks and views render
+  -> CommandIntent records leave as user intent
+  -> business logic decides the next state
+```
+
+That separation keeps Blocks from becoming prop-and-callback containers. Blocks
+declare what data they need; providers publish immutable snapshots; frames
+deliver read-only render input; views emit command intents; business logic owns
+change. There is no hidden provider registry, render-time refresh hook, mutable
+view store, or two-way binding path in the block contract.
+
+The public contracts live in [`@flyingrobots/bijou`](./packages/bijou/) so
+tooling, DOGFOOD, MCP payloads, and future block packages can inspect them
+without running the TUI runtime. Runtime lifecycle and host integration belong
+in the TUI layer. The architecture is described in
+[`DX-034 - Declarative View Data Binding`](./docs/design/DX-034-declarative-view-data-binding.md).
+
 Current DOGFOOD pages include:
 
 - What are Blocks


### PR DESCRIPTION
## Summary
- adds a README subsection for the unidirectional binding loop behind Blocks
- explains providers/business logic -> immutable snapshots -> BindingFrame -> block/view render -> CommandIntent -> business logic
- clarifies that public contracts live in @flyingrobots/bijou while runtime lifecycle and host integration stay in the TUI layer
- links the DX-034 declarative view data binding design

## Validation
- `git diff --check`
- `npm run docs:inventory`
- `npm test -- --run tests/cycles/WF-006/cut-clean-4-1-0-release-boundary.test.ts tests/cycles/DF-025/make-dogfood-the-only-human-facing-docs-surface.test.ts scripts/docs-preview.test.ts`
- pre-commit: `npm run lint`
- pre-push: `npm run typecheck:test`
- pre-push: `npm test` (310 files, 3491 tests)
- pre-push: `npm run verify:interactive-examples`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation on the unidirectional binding architecture and design constraints, including references to public contracts and architecture documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->