### PR TITLE
feat(tui): add input gestures and polish block previews

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **Input feature action maps for `bijou-tui`** — `@flyingrobots/bijou-tui`
+  now exports `createInputGestureRecognizer()` and `createInputActionMap()` so
+  apps and shells can map raw key features to semantic events such as `tap`,
+  `double-tap`, and compound patterns like `ctrl held + tab double-tap`. The
+  recognizer uses caller-provided timestamps instead of owning a timer, keeping
+  gesture behavior deterministic under test.
+- **AppFrame double-Tab footer toggle** — `createFramedApp()` now treats a
+  double tap of plain `Tab` as a frame-level footer visibility toggle while
+  preserving single-Tab pane cycling. The footer slides offscreen by one footer
+  height over 0.2 seconds with ease-out timing and slides back onscreen over 0.2
+  seconds with ease-in timing.
 - **DOGFOOD block-authored shell surfaces** — DOGFOOD now routes footer hint
   text through `FooterHintBlock`, routes frame search title text through
   `SearchPanelBlock`, and publishes registry-backed block contracts for

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -1243,24 +1243,13 @@ function standardBlockLivePreviewSurface(
   const safeWidth = Math.max(30, width);
   const contentWidth = Math.max(24, safeWidth - 4);
 
-  return boxSurface(column([
+  return column([
     standardBlockExampleSurface(block, contentWidth, ctx),
     spacer(1, 1),
     standardBlockLoweringPreviewSurface(block, contentWidth, ctx, theme, localization),
     spacer(1, 1),
     standardBlockDocumentationSurface(block, contentWidth, ctx, theme, localization),
-  ]), {
-    title: dogfoodText(
-      localization,
-      'blocks.preview.pageTitle',
-      '{blockName}',
-      { blockName: block.metadata.blockName },
-    ),
-    width: safeWidth,
-    borderToken: docsThemeBorderToken(theme),
-    padding: { left: 1, right: 1 },
-    ctx,
-  });
+  ]);
 }
 
 function standardBlockExampleSurface(

--- a/packages/bijou-tui/ADVANCED_GUIDE.md
+++ b/packages/bijou-tui/ADVANCED_GUIDE.md
@@ -220,6 +220,41 @@ handled/stopped owners, hit targets, command/effect labels or counts, swallowed
 input, and no-op handlers. Use it alongside `layoutInspectorOverlay()` when a
 bug could be either geometry ownership or input priority.
 
+## Input Feature Action Maps
+
+`createInputGestureRecognizer()` turns raw key messages into inspectable input
+feature events. `createInputActionMap()` then maps one or more feature events to
+an app or shell action.
+
+```typescript
+import {
+  createInputActionMap,
+  createInputGestureRecognizer,
+} from '@flyingrobots/bijou-tui';
+
+const recognizer = createInputGestureRecognizer({ doubleTapMs: 300 });
+const actions = createInputActionMap<{ type: 'toggle-footer' }>()
+  .bind('footer.doubleTab', 'Toggle footer', [
+    { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
+  ], { type: 'toggle-footer' });
+
+const inputEvent = recognizer.observeKey(keyMsg, ctx.runtime.clock.now());
+const action = actions.handle(inputEvent);
+```
+
+Feature-event patterns are arrays so compound inputs can stay declarative:
+
+```typescript
+actions.bind('ctrlDoubleTab', 'Ctrl double-tap Tab', [
+  { deviceId: 'keyboard', featureId: 'modifier.ctrl', type: 'held' },
+  { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
+], { type: 'toggle-footer' });
+```
+
+The recognizer uses caller-provided timestamps instead of owning a timer. That
+keeps gesture recognition deterministic in tests and lets hosts decide which
+clock is authoritative.
+
 ## Focus Map Surface
 
 `inspectFocusMap()` keeps focus diagnostics separate from the focus system

--- a/packages/bijou-tui/README.md
+++ b/packages/bijou-tui/README.md
@@ -279,6 +279,26 @@ const history = appendInputRoutingRecord({ records: [] }, {
 console.log(inputRoutingInspectorText(history));
 ```
 
+Use `createInputGestureRecognizer()` and `createInputActionMap()` when raw input
+needs to become semantic gestures before routing. Bijou ships standard feature
+event names such as `press`, `held`, `release`, `tap`, `double-tap`,
+`long-press`, and lets apps provide their own event type strings.
+
+```typescript
+import {
+  createInputActionMap,
+  createInputGestureRecognizer,
+} from '@flyingrobots/bijou-tui';
+
+const recognizer = createInputGestureRecognizer({ doubleTapMs: 300 });
+const actions = createInputActionMap<{ type: 'toggle-footer' }>()
+  .bind('footer.doubleTab', 'Toggle footer', [
+    { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
+  ], { type: 'toggle-footer' });
+
+const action = actions.handle(recognizer.observeKey(keyMsg, ctx.runtime.clock.now()));
+```
+
 Use `focusMapText()` or `focusMapSurface()` when focus ownership and tab order
 need the same deterministic treatment:
 

--- a/packages/bijou-tui/src/app-frame-actions.ts
+++ b/packages/bijou-tui/src/app-frame-actions.ts
@@ -51,8 +51,10 @@ import {
 } from './app-frame-utils.js';
 import { framePaneOutputToSurface, renderFrameNode } from './app-frame-render.js';
 import type { ViewOutput } from './view-output.js';
+import { animate } from './animate.js';
 
 let focusedPaneMeasureScratch: Surface | null = null;
+const FOOTER_TOGGLE_DURATION_MS = 200;
 
 function renderPaneSurfaceForMeasurement(output: ViewOutput, width: number, height: number): Surface {
   const scratch = focusedPaneMeasureScratch;
@@ -79,6 +81,8 @@ export function applyFrameAction<PageModel, Msg>(
       return [{ ...model, helpOpen: !model.helpOpen }, []];
     case 'toggle-perf-hud':
       return [{ ...model, perfHudOpen: !model.perfHudOpen }, []];
+    case 'toggle-footer':
+      return toggleFooter(model);
     case 'toggle-settings': {
       const activePage = pagesById.get(model.activePageId)!;
       const settings = options.settings?.({
@@ -166,10 +170,58 @@ export function applyFrameAction<PageModel, Msg>(
     case 'runtime-issue':
     case 'notification-tick':
       return [model, []];
+    case 'footer-transition':
+      if (action.generation !== (model.footerAnimationGeneration ?? 0)) return [model, []];
+      return [{
+        ...model,
+        footerTranslateY: Math.max(0, Math.min(1, action.translateY)),
+      }, []];
+    case 'footer-transition-complete':
+      if (action.generation !== (model.footerAnimationGeneration ?? 0)) return [model, []];
+      return [{
+        ...model,
+        footerVisible: action.visible,
+        footerTranslateY: action.visible ? 0 : 1,
+      }, []];
     case 'transition':
     case 'transition-complete':
       return [model, []];
   }
+}
+
+function toggleFooter<PageModel, Msg>(
+  model: InternalFrameModel<PageModel, Msg>,
+): [InternalFrameModel<PageModel, Msg>, Cmd<FramedAppMsg<Msg>>[]] {
+  const currentVisible = model.footerVisible ?? true;
+  const visible = !currentVisible;
+  const generation = (model.footerAnimationGeneration ?? 0) + 1;
+  const defaultTranslateY = currentVisible ? 0 : 1;
+  const from = Math.max(0, Math.min(1, model.footerTranslateY ?? defaultTranslateY));
+  const to = visible ? 0 : 1;
+  const ease = visible ? EASINGS.easeIn : EASINGS.easeOut;
+  return [{
+    ...model,
+    footerVisible: visible,
+    footerAnimationGeneration: generation,
+  }, [
+    animate<FramedAppMsg<Msg>>({
+      type: 'tween',
+      from,
+      to,
+      duration: FOOTER_TOGGLE_DURATION_MS,
+      ease,
+      onFrame: (translateY) => wrapFrameMsg({
+        type: 'footer-transition',
+        translateY,
+        generation,
+      }),
+      onComplete: () => wrapFrameMsg({
+        type: 'footer-transition-complete',
+        visible,
+        generation,
+      }),
+    }),
+  ]];
 }
 
 function hasNotificationCenter<PageModel, Msg>(

--- a/packages/bijou-tui/src/app-frame-types.ts
+++ b/packages/bijou-tui/src/app-frame-types.ts
@@ -118,6 +118,12 @@ export interface FrameModel<PageModel> {
   readonly perfHudOpen: boolean;
   /** Help visibility flag. */
   readonly helpOpen: boolean;
+  /** Footer visibility target. The footer may still be mid-animation. */
+  readonly footerVisible?: boolean;
+  /** Footer translate offset in footer heights: 0 is onscreen, 1 is below the viewport. */
+  readonly footerTranslateY?: number;
+  /** Monotonic counter to discard stale footer animation ticks. */
+  readonly footerAnimationGeneration?: number;
   /** Command palette state (undefined when closed). */
   readonly commandPalette?: CommandPaletteState;
   /** Kind of active shell palette (`search` vs `command`). */
@@ -215,6 +221,7 @@ export interface RenderResult {
 export type FrameAction =
   | { type: 'toggle-help' }
   | { type: 'toggle-perf-hud' }
+  | { type: 'toggle-footer' }
   | { type: 'toggle-settings' }
   | { type: 'toggle-notifications' }
   | { type: 'push-notification'; notification: FrameNotificationSpec }
@@ -240,6 +247,8 @@ export type FrameAction =
   | { type: 'dock-right' }
   | { type: 'runtime-issue'; issue: RuntimeIssue }
   | { type: 'notification-tick'; atMs: number }
+  | { type: 'footer-transition'; translateY: number; generation: number }
+  | { type: 'footer-transition-complete'; visible: boolean; generation: number }
   | { type: 'transition'; progress: number; generation: number; dt: number; elapsedMs: number }
   | { type: 'transition-complete'; generation: number };
 

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -92,6 +92,38 @@ function createInteractiveContext(options: Parameters<typeof createTestContext>[
   return { clock, ctx };
 }
 
+async function collectCommandMessages<M>(
+  cmd: Cmd<M>,
+  pulses: readonly number[],
+): Promise<M[]> {
+  const messages: M[] = [];
+  const pulseHandlers = new Set<(dt: number) => void>();
+  let settled = false;
+  const promise = Promise.resolve(cmd((message) => messages.push(message), {
+    onPulse(handler) {
+      pulseHandlers.add(handler);
+      return {
+        dispose() {
+          pulseHandlers.delete(handler);
+        },
+      };
+    },
+  })).then(() => {
+    settled = true;
+  });
+
+  for (const dt of pulses) {
+    if (settled) break;
+    for (const handler of [...pulseHandlers]) {
+      handler(dt);
+    }
+    await Promise.resolve();
+  }
+
+  await promise;
+  return messages;
+}
+
 function scheduleKeys(
   ctx: ReturnType<typeof createTestContext>,
   clock: ReturnType<typeof mockClock>,
@@ -499,6 +531,70 @@ describe('createFramedApp', () => {
     expect(result.model.pageModels.home?.leftHits).toBe(1);
     expect(result.model.pageModels.home?.rightHits).toBe(1);
     expect(result.model.focusedPaneByPage.home).toBe('right');
+  });
+
+  it('toggles the footer with a double Tab gesture while preserving single Tab pane focus', async () => {
+    const page: FramePage<PageModel, Msg> = {
+      id: 'home',
+      title: 'Home',
+      init: () => [{ count: 0 }, []],
+      update: (_msg, model) => [model, []],
+      layout: () => ({
+        kind: 'split',
+        splitId: 's1',
+        state: createSplitPaneState({ ratio: 0.5 }),
+        paneA: { kind: 'pane', paneId: 'left', render: () => textView('left') },
+        paneB: { kind: 'pane', paneId: 'right', render: () => textView('right') },
+      }),
+    };
+    const app = createFramedApp({
+      title: 'Test',
+      pages: [page],
+    });
+    const tab = { type: 'key' as const, key: 'tab', ctrl: false, alt: false, shift: false };
+
+    let [model] = app.init();
+    const [afterSingleTab, singleTabCmds] = app.update(tab, model);
+
+    expect(afterSingleTab.focusedPaneByPage.home).toBe('right');
+    expect(afterSingleTab.footerVisible).toBe(true);
+    expect(afterSingleTab.footerTranslateY).toBe(0);
+    expect(singleTabCmds).toHaveLength(0);
+
+    let footerCmds: Cmd<FramedAppMsg<Msg>>[];
+    [model, footerCmds] = app.update(tab, afterSingleTab);
+
+    expect(model.focusedPaneByPage.home).toBe('right');
+    expect(model.footerVisible).toBe(false);
+    expect(footerCmds).toHaveLength(1);
+
+    const hideMessages = await collectCommandMessages(footerCmds[0]!, [0.1, 0.1]);
+    for (const message of hideMessages) {
+      [model] = app.update(message, model);
+    }
+
+    expect(model.footerVisible).toBe(false);
+    expect(model.footerTranslateY).toBe(1);
+    expect(surfaceToString(
+      normalizeViewOutput(app.view(model), { width: model.columns, height: model.rows }).surface,
+      testCtx.style,
+    )).not.toContain('[NORMAL]');
+
+    [model] = app.update(tab, model);
+    [model, footerCmds] = app.update(tab, model);
+    expect(model.footerVisible).toBe(true);
+
+    const showMessages = await collectCommandMessages(footerCmds[0]!, [0.1, 0.1]);
+    for (const message of showMessages) {
+      [model] = app.update(message, model);
+    }
+
+    expect(model.footerVisible).toBe(true);
+    expect(model.footerTranslateY).toBe(0);
+    expect(surfaceToString(
+      normalizeViewOutput(app.view(model), { width: model.columns, height: model.rows }).surface,
+      testCtx.style,
+    )).toContain('[NORMAL]');
   });
 
   it('triggers transition animation when switching tabs', async () => {

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -167,6 +167,10 @@ import {
   openCommandPalette,
   openSearchPalette,
 } from './app-frame-palette.js';
+import {
+  createInputActionMap,
+  createInputGestureRecognizer,
+} from './input-map.js';
 import type { RenderStageTiming } from './pipeline/pipeline.js';
 
 // ---------------------------------------------------------------------------
@@ -506,6 +510,7 @@ export {
 const FRAME_NOTIFICATION_TICK_MS = 40;
 const DEFAULT_FRAME_NOTIFICATION_DURATION_MS = 6_000;
 const SETTINGS_FEEDBACK_TOAST_WIDTH = 40;
+const FRAME_FOOTER_DOUBLE_TAB_MS = 300;
 const EMPTY_RUNTIME_LAYOUTS = createRuntimeRetainedLayouts();
 
 interface ResolvedFrameNotificationOptions {
@@ -810,6 +815,13 @@ export function createFramedApp<PageModel, Msg>(
     enableNotifications: options.notificationCenter != null || options.runtimeNotifications !== false,
     i18n: options.i18n,
   });
+  const frameInputRecognizer = createInputGestureRecognizer({
+    doubleTapMs: FRAME_FOOTER_DOUBLE_TAB_MS,
+  });
+  const frameInputActions = createInputActionMap<FrameAction>()
+    .bind('frame.footer.doubleTab', 'Toggle footer', [
+      { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
+    ], { type: 'toggle-footer' });
   const quitHelpKeys = createQuitHelpKeys(options.i18n);
   const helpLayerHelpKeys = createHelpLayerHelpKeys(options.i18n);
   const settingsHelpKeys = createSettingsHelpKeys(options.i18n);
@@ -1218,6 +1230,25 @@ export function createFramedApp<PageModel, Msg>(
     return [{ type: 'observed-key', msg, route }, { type: 'open-quit-confirm' }];
   }
 
+  function resolveFrameInputActionCommands(
+    msg: KeyMsg,
+    route: ObservedKeyRoute,
+  ): FrameShellCommand<Msg>[] | undefined {
+    const inputEvent = frameInputRecognizer.observeKey(msg, resolveClock(resolveFrameCtx()).now());
+    const inputAction = frameInputActions.handle(inputEvent);
+    if (inputAction == null || msg.ctrl || msg.alt || msg.shift) {
+      return undefined;
+    }
+    return [{ type: 'observed-key', msg, route }, { type: 'apply-frame-action', action: inputAction }];
+  }
+
+  function routeForFrameInputAction(layerKind: FrameLayerKind): ObservedKeyRoute {
+    if (layerKind === 'search' || layerKind === 'command-palette') return 'palette';
+    if (layerKind === 'help') return 'help';
+    if (layerKind === 'page-modal') return 'page';
+    return 'frame';
+  }
+
   function resolveFrameActionCommands(
     msg: KeyMsg,
     action: FrameAction,
@@ -1489,6 +1520,13 @@ export function createFramedApp<PageModel, Msg>(
       ({ layer }) => {
         const frameLayer = layer.model;
         if (frameLayer == null) return undefined;
+        const inputActionCommands = resolveFrameInputActionCommands(
+          msg,
+          routeForFrameInputAction(frameLayer.kind),
+        );
+        if (inputActionCommands != null) {
+          return { handled: true, commands: inputActionCommands };
+        }
 
         if (frameLayer.kind === 'search' || frameLayer.kind === 'command-palette') {
           return { handled: true, commands: handlePaletteLayerKeyCommands(msg, frameLayer.kind) };
@@ -2194,6 +2232,9 @@ export function createFramedApp<PageModel, Msg>(
         frameOverBudget: false,
         perfHudOpen: false,
         helpOpen: false,
+        footerVisible: true,
+        footerTranslateY: 0,
+        footerAnimationGeneration: 0,
         helpScrollY: 0,
         commandPaletteKind: undefined,
         settingsOpen: false,
@@ -2395,7 +2436,12 @@ export function createFramedApp<PageModel, Msg>(
       frameSurface.clear();
       frameSurface.blit(header, 0, 0);
       if (model.rows > 1) {
-        frameSurface.blit(helpLine, 0, model.rows - 1);
+        const footerVisible = model.footerVisible ?? true;
+        const footerTranslateY = Math.max(0, Math.min(1, model.footerTranslateY ?? (footerVisible ? 0 : 1)));
+        const footerRow = model.rows - helpLine.height + Math.floor(footerTranslateY * helpLine.height);
+        if (footerRow < model.rows) {
+          frameSurface.blit(helpLine, 0, footerRow);
+        }
       }
 
       let activeResult: { paneRects: ReadonlyMap<string, LayoutRect>; paneOrder: readonly string[] };

--- a/packages/bijou-tui/src/index.ts
+++ b/packages/bijou-tui/src/index.ts
@@ -585,6 +585,31 @@ export {
   formatKeyCombo,
 } from './keybindings.js';
 
+// Input feature events and semantic action maps
+export {
+  type InputActionBinding,
+  type InputActionMap,
+  type InputDevice,
+  type InputEvent,
+  type InputFeature,
+  type InputFeatureEvent,
+  type InputFeatureEventPattern,
+  type InputFeatureEventType,
+  type InputGestureRecognizer,
+  type InputGestureRecognizerOptions,
+  type StandardInputFeatureEventType,
+  DEFAULT_DOUBLE_TAP_MS,
+  KEYBOARD_INPUT_DEVICE_ID,
+  createInputActionMap,
+  createInputGestureRecognizer,
+  defineInputDevice,
+  defineInputFeature,
+  inputEventMatches,
+  inputFeatureEvent,
+  keyboardFeature,
+  keyboardModifierFeature,
+} from './input-map.js';
+
 // Help generation
 export {
   type BindingSource,

--- a/packages/bijou-tui/src/input-map.test.ts
+++ b/packages/bijou-tui/src/input-map.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInputActionMap,
+  createInputGestureRecognizer,
+  inputEventMatches,
+} from './input-map.js';
+import type { KeyMsg } from './types.js';
+
+function key(keyName: string, modifiers: Partial<Pick<KeyMsg, 'ctrl' | 'alt' | 'shift'>> = {}): KeyMsg {
+  return {
+    type: 'key',
+    key: keyName,
+    ctrl: modifiers.ctrl ?? false,
+    alt: modifiers.alt ?? false,
+    shift: modifiers.shift ?? false,
+  };
+}
+
+describe('input feature events', () => {
+  it('recognizes deterministic key double taps without emitting a timer', () => {
+    const recognizer = createInputGestureRecognizer({ doubleTapMs: 250 });
+    const first = recognizer.observeKey(key('tab'), 1_000);
+    const second = recognizer.observeKey(key('tab'), 1_200);
+
+    expect(inputEventMatches(first, [{ featureId: 'key.tab', type: 'tap' }])).toBe(true);
+    expect(inputEventMatches(first, [{ featureId: 'key.tab', type: 'double-tap' }])).toBe(false);
+    expect(inputEventMatches(second, [{ featureId: 'key.tab', type: 'double-tap' }])).toBe(true);
+  });
+
+  it('keeps modifier-held features available for compound input actions', () => {
+    const recognizer = createInputGestureRecognizer({ doubleTapMs: 300 });
+    recognizer.observeKey(key('tab', { ctrl: true }), 5);
+    const event = recognizer.observeKey(key('tab', { ctrl: true }), 100);
+    const actions = createInputActionMap<{ readonly type: 'ctrl-double-tab' }>()
+      .bind('ctrlDoubleTab', 'Ctrl double-tap Tab', [
+        { featureId: 'modifier.ctrl', type: 'held', deviceId: 'keyboard' },
+        { featureId: 'key.tab', type: 'double-tap', deviceId: 'keyboard' },
+      ], { type: 'ctrl-double-tab' });
+
+    expect(actions.handle(event)).toEqual({ type: 'ctrl-double-tab' });
+  });
+
+  it('does not treat slow repeated key taps as double taps', () => {
+    const recognizer = createInputGestureRecognizer({ doubleTapMs: 100 });
+
+    recognizer.observeKey(key('tab'), 10);
+    const event = recognizer.observeKey(key('tab'), 200);
+
+    expect(inputEventMatches(event, [{ featureId: 'key.tab', type: 'double-tap' }])).toBe(false);
+  });
+});

--- a/packages/bijou-tui/src/input-map.ts
+++ b/packages/bijou-tui/src/input-map.ts
@@ -1,0 +1,270 @@
+/**
+ * Input feature events and semantic action maps.
+ *
+ * This module sits above raw terminal input parsing and below app/frame
+ * reducers. It lets shells bind actions to semantic input feature events such
+ * as "keyboard.tab double-tap" without hard-coding gesture state into a single
+ * component.
+ */
+
+import type { KeyMsg } from './types.js';
+
+export const DEFAULT_DOUBLE_TAP_MS = 300;
+export const KEYBOARD_INPUT_DEVICE_ID = 'keyboard';
+
+export type StandardInputFeatureEventType =
+  | 'press'
+  | 'held'
+  | 'long-press'
+  | 'release'
+  | 'tap'
+  | 'double-tap';
+
+export type InputFeatureEventType = StandardInputFeatureEventType | (string & {});
+
+export interface InputDevice {
+  readonly id: string;
+  readonly kind: string;
+  readonly label?: string;
+}
+
+export interface InputFeature {
+  readonly deviceId: string;
+  readonly id: string;
+  readonly kind: string;
+  readonly label?: string;
+}
+
+export interface InputFeatureEvent {
+  readonly feature: InputFeature;
+  readonly type: InputFeatureEventType;
+  readonly atMs: number;
+}
+
+export interface InputEvent {
+  readonly device: InputDevice;
+  readonly featureEvents: readonly InputFeatureEvent[];
+  readonly atMs: number;
+}
+
+export interface InputFeatureEventPattern {
+  readonly featureId: string;
+  readonly type: InputFeatureEventType;
+  readonly deviceId?: string;
+}
+
+export interface InputActionBinding<Action> {
+  readonly id: string;
+  readonly description: string;
+  readonly featureEvents: readonly InputFeatureEventPattern[];
+  readonly action: Action;
+  readonly enabled: boolean;
+}
+
+export interface InputActionMap<Action> {
+  bind(
+    id: string,
+    description: string,
+    featureEvents: readonly InputFeatureEventPattern[],
+    action: Action,
+  ): InputActionMap<Action>;
+  handle(event: InputEvent): Action | undefined;
+  bindings(): readonly InputActionBinding<Action>[];
+}
+
+export interface InputGestureRecognizer {
+  observeKey(msg: KeyMsg, atMs: number): InputEvent;
+  reset(): void;
+}
+
+export interface InputGestureRecognizerOptions {
+  readonly doubleTapMs?: number;
+  readonly device?: InputDevice;
+}
+
+interface LastTap {
+  readonly signature: string;
+  readonly atMs: number;
+}
+
+export function defineInputDevice(device: InputDevice): InputDevice {
+  return freezePlain({
+    ...device,
+    id: normalizeId(device.id, 'input device id'),
+    kind: normalizeId(device.kind, 'input device kind'),
+  });
+}
+
+export function defineInputFeature(feature: InputFeature): InputFeature {
+  return freezePlain({
+    ...feature,
+    deviceId: normalizeId(feature.deviceId, 'input feature device id'),
+    id: normalizeId(feature.id, 'input feature id'),
+    kind: normalizeId(feature.kind, 'input feature kind'),
+  });
+}
+
+export function keyboardFeature(key: string): InputFeature {
+  const normalizedKey = normalizeId(key, 'keyboard feature key');
+  return defineInputFeature({
+    deviceId: KEYBOARD_INPUT_DEVICE_ID,
+    id: `key.${normalizedKey}`,
+    kind: 'key',
+    label: normalizedKey,
+  });
+}
+
+export function keyboardModifierFeature(modifier: 'ctrl' | 'alt' | 'shift'): InputFeature {
+  return defineInputFeature({
+    deviceId: KEYBOARD_INPUT_DEVICE_ID,
+    id: `modifier.${modifier}`,
+    kind: 'modifier',
+    label: modifier,
+  });
+}
+
+export function inputFeatureEvent(
+  feature: InputFeature,
+  type: InputFeatureEventType,
+  atMs: number,
+): InputFeatureEvent {
+  return freezePlain({
+    feature,
+    type: normalizeId(type, 'input feature event type') as InputFeatureEventType,
+    atMs: normalizeTimestamp(atMs),
+  });
+}
+
+export function createInputGestureRecognizer(
+  options: InputGestureRecognizerOptions = {},
+): InputGestureRecognizer {
+  const device = defineInputDevice(options.device ?? {
+    id: KEYBOARD_INPUT_DEVICE_ID,
+    kind: 'keyboard',
+    label: 'Keyboard',
+  });
+  const doubleTapMs = normalizePositiveDuration(options.doubleTapMs, DEFAULT_DOUBLE_TAP_MS);
+  let lastTap: LastTap | undefined;
+
+  return {
+    observeKey(msg, atMs) {
+      const timestamp = normalizeTimestamp(atMs);
+      const featureEvents: InputFeatureEvent[] = [];
+
+      if (msg.ctrl) {
+        featureEvents.push(inputFeatureEvent(keyboardModifierFeature('ctrl'), 'held', timestamp));
+      }
+      if (msg.alt) {
+        featureEvents.push(inputFeatureEvent(keyboardModifierFeature('alt'), 'held', timestamp));
+      }
+      if (msg.shift) {
+        featureEvents.push(inputFeatureEvent(keyboardModifierFeature('shift'), 'held', timestamp));
+      }
+
+      const keyFeature = keyboardFeature(msg.key);
+      featureEvents.push(inputFeatureEvent(keyFeature, 'press', timestamp));
+      featureEvents.push(inputFeatureEvent(keyFeature, 'tap', timestamp));
+
+      const signature = keySignature(msg);
+      const isDoubleTap = lastTap != null
+        && lastTap.signature === signature
+        && timestamp - lastTap.atMs <= doubleTapMs;
+
+      if (isDoubleTap) {
+        featureEvents.push(inputFeatureEvent(keyFeature, 'double-tap', timestamp));
+        lastTap = undefined;
+      } else {
+        lastTap = { signature, atMs: timestamp };
+      }
+
+      return freezePlain({
+        device,
+        featureEvents: Object.freeze(featureEvents),
+        atMs: timestamp,
+      });
+    },
+    reset() {
+      lastTap = undefined;
+    },
+  };
+}
+
+export function createInputActionMap<Action>(): InputActionMap<Action> {
+  const bindings: InputActionBinding<Action>[] = [];
+
+  return {
+    bind(id, description, featureEvents, action) {
+      const normalizedFeatureEvents = featureEvents.map((featureEvent) => freezePlain({
+        ...featureEvent,
+        featureId: normalizeId(featureEvent.featureId, 'input action feature id'),
+        type: normalizeId(featureEvent.type, 'input action event type') as InputFeatureEventType,
+        deviceId: featureEvent.deviceId != null
+          ? normalizeId(featureEvent.deviceId, 'input action device id')
+          : undefined,
+      }));
+      bindings.push(freezePlain({
+        id: normalizeId(id, 'input action id'),
+        description,
+        featureEvents: Object.freeze(normalizedFeatureEvents),
+        action,
+        enabled: true,
+      }));
+      return this;
+    },
+    handle(event) {
+      return bindings.find((binding) => binding.enabled && inputEventMatches(event, binding.featureEvents))?.action;
+    },
+    bindings() {
+      return Object.freeze([...bindings]);
+    },
+  };
+}
+
+export function inputEventMatches(
+  event: InputEvent,
+  patterns: readonly InputFeatureEventPattern[],
+): boolean {
+  return patterns.every((pattern) =>
+    event.featureEvents.some((featureEvent) =>
+      featureEvent.type === pattern.type
+      && featureEvent.feature.id === pattern.featureId
+      && (pattern.deviceId == null || featureEvent.feature.deviceId === pattern.deviceId),
+    ),
+  );
+}
+
+function keySignature(msg: KeyMsg): string {
+  return [
+    msg.ctrl ? 'ctrl' : '',
+    msg.alt ? 'alt' : '',
+    msg.shift ? 'shift' : '',
+    msg.key,
+  ].join('|');
+}
+
+function normalizeId(value: string, label: string): string {
+  const normalized = value.trim();
+  if (normalized === '') {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function normalizeTimestamp(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error('input event timestamp must be finite');
+  }
+  return value;
+}
+
+function normalizePositiveDuration(value: number | undefined, fallback: number): number {
+  if (value == null) return fallback;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error('input gesture doubleTapMs must be a positive finite number');
+  }
+  return value;
+}
+
+function freezePlain<T extends object>(value: T): T {
+  return Object.freeze(value);
+}

--- a/scripts/docs-preview.test.ts
+++ b/scripts/docs-preview.test.ts
@@ -1079,7 +1079,7 @@ describe('docs preview app', () => {
       { key: KEY_DOWN },
       { key: KEY_ENTER },
       { key: KEY_TAB },
-      { key: KEY_TAB },
+      { key: KEY_TAB, delay: 350 },
     ], { ctx });
 
     const frame = result.frames[result.frames.length - 1]!;

--- a/tests/cycles/DX-031/dogfood-blocks-section.test.ts
+++ b/tests/cycles/DX-031/dogfood-blocks-section.test.ts
@@ -190,6 +190,7 @@ describe('DX-031D DOGFOOD Blocks section', () => {
     expect(text).toContain('lowering summary');
     expect(text).toContain('interactive mode');
     expect(text).toContain('static mode');
+    expect(frameRows(result.frames.at(-1)!).filter((row) => row.includes('┌─ ReaderSurface')).length).toBe(1);
     expect(text).not.toContain('Available Blocks');
     expect(text).not.toContain('Contract: block metadata:');
     expect(text).not.toContain('Source: packages/bijou/src/core/standard-blocks.ts');


### PR DESCRIPTION
## Summary

- flattens DOGFOOD standard block previews so each selected block page renders its live surface before contract documentation
- adds a public `bijou-tui` input feature/action-map seam for deterministic semantic gestures such as tap, double-tap, and compound modifier patterns
- wires AppFrame plain double-Tab to toggle the footer with a 0.2s translate animation while preserving single-Tab pane focus

## Validation

- npm test -- --run packages/bijou-tui/src/input-map.test.ts packages/bijou-tui/src/app-frame.test.ts scripts/docs-preview.test.ts
- npm run typecheck:test
- npm run lint
- npm run docs:inventory
- git diff --check
- npm test
- npm run verify:interactive-examples
- pre-push reran typecheck:test, npm test, and verify:interactive-examples

## Non-goals

- no generalized long-press/release recognizer implementation beyond the exported event vocabulary
- no input configuration UI
- no changes to page-specific keybinding maps beyond respecting the new double-Tab footer gesture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double-Tab now toggles footer visibility with smooth slide animation; single-Tab maintains pane cycling.
  * Added input gesture recognition and action mapping helpers for deterministic input event handling in testing.

* **Documentation**
  * Extended ADVANCED_GUIDE and README with input gesture mapping usage examples and configuration guidance.
  * Updated CHANGELOG with new feature entries.

* **Tests**
  * Added test coverage for double-Tab footer toggle behavior and input gesture recognition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flyingrobots/bijou/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->