### PR TITLE
fix(tui): update animation command docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -425,6 +425,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🐛 Bug Fixes
 
+- **Animation command source docs** — `createSpringCmd()` and
+  `createTweenCmd()` internals now describe the current pulse-driven runtime
+  path instead of the old timer-based `setInterval` / `Date.now()` model.
 - **Node development floor for Vitest 4.1** — The root workspace preinstall
   guard, engine metadata, README, and CI matrix now require Node.js
   `^20.19.0 || >=22.12.0`, matching Vitest 4.1's Vite/Rolldown runtime instead

--- a/packages/bijou-tui/src/animate.test.ts
+++ b/packages/bijou-tui/src/animate.test.ts
@@ -1,6 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { animate, sequence } from './animate.js';
 import type { CmdCapabilities } from './types.js';
+
+const sourcePath = resolve(dirname(fileURLToPath(import.meta.url)), 'animate.ts');
 
 /** Create mock capabilities that can be manually pulsed. */
 function createMockCaps(): CmdCapabilities & { pulse(dt: number): void } {
@@ -14,6 +19,19 @@ function createMockCaps(): CmdCapabilities & { pulse(dt: number): void } {
       for (const h of handlers) h(dt);
     },
   };
+}
+
+function docsForInternalCommand(source: string, functionName: string): string {
+  const functionIndex = source.indexOf(`function ${functionName}`);
+  if (functionIndex < 0) {
+    return '';
+  }
+  const beforeFunction = source.slice(0, functionIndex);
+  const docStart = beforeFunction.lastIndexOf('/**');
+  if (docStart < 0) {
+    return '';
+  }
+  return beforeFunction.slice(docStart);
 }
 
 describe('animate', () => {
@@ -186,6 +204,26 @@ describe('animate', () => {
       expect(frames).toEqual([50]);
       expect(emitted).toEqual([50]);
     });
+  });
+});
+
+describe('animation command docs', () => {
+  it('documents pulse-driven spring and tween commands', () => {
+    const source = readFileSync(sourcePath, 'utf8');
+    const springDocs = docsForInternalCommand(source, 'createSpringCmd');
+    const tweenDocs = docsForInternalCommand(source, 'createTweenCmd');
+
+    expect(springDocs).toContain('runtime pulses');
+    expect(springDocs).toContain('fixed-step');
+    expect(springDocs).toContain('maxPulseSeconds');
+    expect(tweenDocs).toContain('pulse');
+    expect(tweenDocs).toContain('dt');
+
+    for (const docs of [springDocs, tweenDocs]) {
+      expect(docs).not.toContain('setInterval');
+      expect(docs).not.toContain('Date.now');
+      expect(docs).not.toContain('@param fps');
+    }
   });
 });
 

--- a/packages/bijou-tui/src/animate.ts
+++ b/packages/bijou-tui/src/animate.ts
@@ -146,15 +146,20 @@ interface SpringIntegrationOptions {
 }
 
 /**
- * Build a TEA command that runs a spring animation via `setInterval`.
+ * Build a TEA command that advances a spring animation from runtime pulses.
+ *
+ * The command subscribes through `caps.onPulse`, caps each accepted pulse with
+ * `maxPulseSeconds`, and accumulates that time into fixed-step spring physics
+ * updates. Slow runtime pulses may delay progress, but they do not feed one
+ * large raw delta into the spring integrator.
  *
  * @template M - The message type emitted into the TEA update cycle.
- * @param from       - Starting value.
- * @param to         - Target value.
- * @param config     - Resolved spring physics parameters.
- * @param fps        - Frames per second for the interval timer.
- * @param onFrame    - Callback invoked each frame with the interpolated value.
- * @param onComplete - Optional callback invoked when the spring settles.
+ * @param from        - Starting value.
+ * @param to          - Target value.
+ * @param config      - Resolved spring physics parameters.
+ * @param integration - `fixedStepSeconds` and `maxPulseSeconds` integration policy.
+ * @param onFrame     - Callback invoked after spring physics advances.
+ * @param onComplete  - Optional callback invoked when the spring settles.
  * @returns A TEA command that resolves when the spring is done.
  */
 function createSpringCmd<M>(
@@ -220,19 +225,17 @@ function acceptedPulseSeconds(dt: number, maxPulseSeconds: number): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Build a TEA command that runs a tween animation via `setInterval`.
+ * Build a TEA command that advances a tween animation from runtime pulse `dt`.
  *
- * Uses wall-clock time (`Date.now()`) to compute actual elapsed time
- * per frame, so animations run at the correct speed regardless of
- * timer jitter or system load.
+ * The command subscribes through `caps.onPulse`; each pulse supplies elapsed
+ * seconds, which are converted to milliseconds before calling `tweenStep()`.
  *
  * @template M - The message type emitted into the TEA update cycle.
  * @param from       - Starting value.
  * @param to         - Target value.
  * @param duration   - Total animation duration in milliseconds.
  * @param ease       - Easing function applied to normalized progress.
- * @param fps        - Frames per second for the interval timer.
- * @param onFrame    - Callback invoked each frame with the interpolated value.
+ * @param onFrame    - Callback invoked after tween progress advances.
  * @param onComplete - Optional callback invoked when the tween completes.
  * @returns A TEA command that resolves when the tween is done.
  */
@@ -251,7 +254,7 @@ function createTweenCmd<M>(
       let state = createTweenState(from);
 
       const handle = caps.onPulse((dt) => {
-        // TweenStep expects milliseconds for delta
+        // tweenStep expects the pulse delta in milliseconds.
         state = tweenStep(state, config, dt * 1000);
         emit(onFrame(state.value));
 


### PR DESCRIPTION
## Summary

- update internal `createSpringCmd()` JSDoc to describe `caps.onPulse`, `fixedStepSeconds`, and `maxPulseSeconds`
- update internal `createTweenCmd()` JSDoc to describe pulse `dt` instead of wall-clock timers
- add a focused source-doc regression so the stale `setInterval` / `Date.now()` / `fps` wording does not return
- record the source-doc fix in the changelog

## Validation

- `npm test -- --run packages/bijou-tui/src/animate.test.ts packages/bijou-tui/src/spring.test.ts`
- `npm run lint`
- pre-push `npm run typecheck:test`
- pre-push full `npm test` (316 files / 3598 tests)
- pre-push `npm run verify:interactive-examples`

Closes #247