### PR TITLE
docs: close RE-035 layout envelope

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -5,6 +5,10 @@ Current direction and active tensions. Historical ship data is in
 
 ## Recent Ships
 
+- `RE-035` — mandatory layout envelope and constraint negotiation landed as a
+  pure `@flyingrobots/bijou` layout floor: immutable constraints, preferences,
+  assigned rectangles, stack/place proof helpers, content measurement seams,
+  render-facing assigned-rect gating, and explanation facts.
 - `DX-036` — responsive `table()` layout, width fitting, visual table variants,
   explicit pipe formats, and DOGFOOD documentation jump search have landed.
 - Day 0 audit hardening — onboarding, Method intake, cross-platform CI posture,
@@ -38,8 +42,9 @@ Current direction and active tensions. Historical ship data is in
 
 ### 1. Close The `v6.0.0` Release Boundary
 
-- The live `v6.0.0` milestone has five open tracker items: four release issues
-  and one dependency-hygiene PR, plus eighteen completed lineage issues.
+- The live `v6.0.0` milestone has three open tracker items plus twenty-one
+  completed lineage trackers after RE-035 and the Vitest dependency hygiene
+  work landed.
 - The release thesis is still: frame owns geometry; Blocks prove it.
 - `v6.0.0` should not tag until the remaining open release issues are closed,
   intentionally split, or explicitly moved to another horizon.
@@ -68,10 +73,9 @@ Current direction and active tensions. Historical ship data is in
 - **Release Scope Creep**: `v6.0.0` is close enough to become tempting to
   widen. Resist that. Close, split, or move the remaining issues instead of
   dragging v7 work into the current release boundary.
-- **Geometry Before Product Chrome**: Standard Blocks and DOGFOOD polish are
-  easier to see than layout truth, but RE-035 remains the release's structural
-  keystone. Product surfaces should consume geometry contracts, not bypass
-  them with bespoke string/surface measurement.
+- **Geometry Before Product Chrome**: RE-035 has landed the release's
+  structural layout floor. Remaining product-facing v6 work should consume
+  geometry contracts, not bypass them with bespoke string/surface measurement.
 - **Block Boundary Drift**: It is tempting to wrap every component in a Block.
   Blocks should own product semantics, data contracts, and lowering facts;
   Components should remain the leaf rendering vocabulary.
@@ -88,33 +92,23 @@ The immediate focus is `v6.0.0` release closure.
 
 Open v6 tracker items:
 
-- [#180](https://github.com/flyingrobots/bijou/issues/180) — `RE-035`
-  mandatory layout envelope and constraint negotiation.
 - [#181](https://github.com/flyingrobots/bijou/issues/181) — `DX-031`
   standard Bijou blocks.
 - [#182](https://github.com/flyingrobots/bijou/issues/182) — `DX-034`
   declarative view data binding.
 - [#186](https://github.com/flyingrobots/bijou/issues/186) — `DX-030`
   boundary-aware pointer selection and copy.
-- [#250](https://github.com/flyingrobots/bijou/pull/250) — Dependabot Vitest
-  `4.0.18` to `4.1.8` dependency-hygiene PR.
 
 Recommended pull order:
 
-1. Pull [#180](https://github.com/flyingrobots/bijou/issues/180) first unless a
-   sharper release-management reason appears. Layout envelope truth is the
-   structural dependency for the rest of the release thesis.
-2. Reassess [#181](https://github.com/flyingrobots/bijou/issues/181) and
+1. Reassess [#181](https://github.com/flyingrobots/bijou/issues/181) and
    [#182](https://github.com/flyingrobots/bijou/issues/182) together after
-   #180, because standard Blocks and declarative binding are already partially
-   landed and may need split-or-close decisions rather than one broad cycle.
-3. Treat [#186](https://github.com/flyingrobots/bijou/issues/186) as either a
+   RE-035, because standard Blocks and declarative binding are already
+   partially landed and may need split-or-close decisions rather than one broad
+   cycle.
+2. Treat [#186](https://github.com/flyingrobots/bijou/issues/186) as either a
    focused v6 implementation slice or an explicit move to `v7.0.0`, depending
    on whether boundary-aware copy is required for the release boundary.
-4. Keep [#250](https://github.com/flyingrobots/bijou/pull/250) in the v6
-   boundary as validation hygiene; merge it when checks are clean, but do not
-   let it displace the RE-035 layout-envelope work unless the Vitest bump
-   changes local validation behavior.
 
 Non-goals for the next cycle:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 📚 Documentation
 
+- **RE-035 layout envelope closeout** — BEARING, ROADMAP, the v6 backlog
+  evidence, and cycle tests now mark the mandatory layout envelope floor as
+  landed while keeping text measurement, viewport overflow, hit testing,
+  responsive fallbacks, accessible layout lowering, and workspace behavior in
+  their explicit follow-on cycles.
 - **Issues-first Method intake** — Contributor and Method docs now describe
   GitHub Issues as Bijou's live work tracker, define the `lane:*` and
   `work-in-progress` labels for contributors, and reframe

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Last synced from GitHub Issues: 2026-06-02.
 
 | Horizon | Milestone | Open | Closed | Intent |
 | :--- | :--- | ---: | ---: | :--- |
-| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 5 | 18 | Current layout truth, standard blocks, and release hygiene lane. |
+| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 3 | 21 | Current layout truth, standard blocks, and release hygiene lane. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 27 | 0 | Next major-release candidate after v6 triage. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 18 | 0 | Uncommitted future work, cool ideas, and raw follow-ups. |
 
@@ -27,18 +27,19 @@ the remaining open release issues before tagging.
 
 | Tracker | Lane / Labels | Type | Work |
 | :--- | :--- | :--- | :--- |
-| [#180](https://github.com/flyingrobots/bijou/issues/180) | `lane:release` | `type:enhancement` | RE-035 mandatory layout envelope and constraint negotiation |
 | [#181](https://github.com/flyingrobots/bijou/issues/181) | `lane:release` | `type:enhancement` | DX-031 standard Bijou blocks |
 | [#182](https://github.com/flyingrobots/bijou/issues/182) | `lane:release` | `type:enhancement` | DX-034 declarative view data binding |
 | [#186](https://github.com/flyingrobots/bijou/issues/186) | `lane:release` | `type:enhancement` | DX-030 boundary-aware pointer selection and copy |
-| [#250](https://github.com/flyingrobots/bijou/pull/250) | `dependencies`, `javascript` | dependency PR | Vitest `4.0.18` to `4.1.8` release-hygiene bump |
 
 ### Completed Lineage
 
 These cards are included in the v6 milestone as completed release lineage.
 
-| Issue | Lane | Type | Work |
+| Tracker | Lane | Type | Work |
 | :--- | :--- | :--- | :--- |
+| [#180](https://github.com/flyingrobots/bijou/issues/180) | `lane:release` | `type:enhancement` | RE-035 mandatory layout envelope and constraint negotiation |
+| [#250](https://github.com/flyingrobots/bijou/pull/250) | `dependencies` | dependency PR | Vitest `4.0.18` to `4.1.8` release-hygiene bump |
+| [#251](https://github.com/flyingrobots/bijou/pull/251) | `lane:release` | implementation PR | RE-035 layout envelope primitives |
 | [#183](https://github.com/flyingrobots/bijou/issues/183) | `lane:release` | `type:maintenance` | DF-065 audit workspace layout family across real surfaces |
 | [#184](https://github.com/flyingrobots/bijou/issues/184) | `lane:release` | `type:maintenance` | DF-060 audit viewport masking and scrollable inspection panes |
 | [#185](https://github.com/flyingrobots/bijou/issues/185) | `lane:release` | `type:enhancement` | DL-012 separate focus gutter chrome from scrollbar UI tokens |

--- a/docs/method/backlog/v6.0.0/README.md
+++ b/docs/method/backlog/v6.0.0/README.md
@@ -31,10 +31,17 @@ The boundary remains:
 - modes lower
 - inspector explains
 
-## Active Design Anchors
+## Landed Layout Anchor
 
 - [**RE-035**](../../../design/RE-035-mandatory-layout-envelope-and-constraint-negotiation.md) -
-  mandatory layout envelope and constraint negotiation
+  mandatory layout envelope and constraint negotiation landed through PR #251
+  and issue #180. Follow-on renderer adoption, text measurement, viewport
+  overflow, hit-testing, responsive fallback, accessible layout lowering, and
+  workspace behavior remain explicit later cycles instead of hidden RE-035
+  scope.
+
+## Active Design Anchors
+
 - [**DX-031**](../../../design/DX-031-standard-bijou-blocks.md) -
   standard Bijou blocks
 - [**DX-034**](../../../design/DX-034-declarative-view-data-binding.md) -
@@ -81,8 +88,8 @@ The boundary remains:
 - [**WF-009**](../../../design/WF-009-keep-release-prs-under-automated-review-file-limits.md) -
   keep release PRs under automated review file limits
 - [**PR #250**](https://github.com/flyingrobots/bijou/pull/250) -
-  keep the v6 release validation toolchain current with the Vitest `4.0.18` to
-  `4.1.8` dependency-hygiene bump
+  landed the v6 release validation toolchain update from Vitest `4.0.18` to
+  `4.1.8`
 
 ## Execution Order
 

--- a/packages/bijou/src/core/layout/envelope.test.ts
+++ b/packages/bijou/src/core/layout/envelope.test.ts
@@ -17,9 +17,9 @@ import {
 } from './envelope.js';
 
 describe('RE-035 layout envelope scope', () => {
-  it('records the active cycle and deferred layout work', () => {
+  it('records the landed cycle and deferred layout work', () => {
     expect(RE035_LAYOUT_SCOPE.design).toBe('RE-035');
-    expect(RE035_LAYOUT_SCOPE.status).toBe('active');
+    expect(RE035_LAYOUT_SCOPE.status).toBe('landed');
     expect(RE035_LAYOUT_SCOPE.included).toEqual([
       'layout-envelope',
       'constraint-negotiation',

--- a/packages/bijou/src/core/layout/envelope.ts
+++ b/packages/bijou/src/core/layout/envelope.ts
@@ -179,7 +179,7 @@ export interface LayoutRenderResult<Output> {
 
 export const RE035_LAYOUT_SCOPE = Object.freeze({
   design: 'RE-035',
-  status: 'active',
+  status: 'landed',
   included: Object.freeze([
     'layout-envelope',
     'constraint-negotiation',

--- a/tests/cycles/RE-035/layout-envelope-closeout.test.ts
+++ b/tests/cycles/RE-035/layout-envelope-closeout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { RE035_LAYOUT_SCOPE } from '../../../packages/bijou/src/index.js';
+import { readRepoFile } from '../repo.js';
+
+describe('RE-035 layout envelope closeout', () => {
+  it('marks the first layout-envelope cycle as landed with explicit future scope', () => {
+    expect(RE035_LAYOUT_SCOPE).toMatchObject({
+      design: 'RE-035',
+      status: 'landed',
+      included: [
+        'layout-envelope',
+        'constraint-negotiation',
+        'stack',
+        'place',
+        'content-measurement-seam',
+        'render-assignment-seam',
+      ],
+      deferred: [
+        'RE-036 text measurement and inline flow',
+        'RE-037 overflow, viewports, scroll anchoring, and scrollbars',
+        'RE-038 box model, chrome regions, hit testing, and focus maps',
+        'RE-039 responsive variants, compression, and constraint fallbacks',
+        'RE-040 accessible layout semantics',
+        'WS-001 workspace tree',
+      ],
+    });
+  });
+
+  it('preserves closeout evidence in the Method design artifact', () => {
+    const design = readRepoFile('docs/design/RE-035-mandatory-layout-envelope-and-constraint-negotiation.md');
+
+    expect(design).toContain('## Drift Check');
+    expect(design).toContain('## Playback');
+    expect(design).toContain('## Retrospective');
+    expect(design).toContain('The first ten slices establish the boring floor');
+    expect(design).toContain('Follow-on adoption should be separate and test-led');
+    expect(design).toContain('RE-036 Text Measurement And Inline Flow');
+  });
+
+  it('keeps v6 tracker docs aligned after closing issue 180', () => {
+    const bearing = readRepoFile('docs/BEARING.md');
+    const roadmap = readRepoFile('docs/ROADMAP.md');
+    const backlog = readRepoFile('docs/method/backlog/v6.0.0/README.md');
+
+    expect(bearing).toContain('three open tracker items');
+    expect(bearing).toContain('[#181](https://github.com/flyingrobots/bijou/issues/181)');
+    expect(bearing).not.toContain('[#180](https://github.com/flyingrobots/bijou/issues/180) — `RE-035`');
+
+    expect(roadmap).toContain('| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 3 | 21 |');
+    expect(roadmap).toContain('| [#180](https://github.com/flyingrobots/bijou/issues/180) | `lane:release` | `type:enhancement` | RE-035 mandatory layout envelope and constraint negotiation |');
+    expect(roadmap).toContain('| [#250](https://github.com/flyingrobots/bijou/pull/250) | `dependencies` | dependency PR | Vitest `4.0.18` to `4.1.8` release-hygiene bump |');
+    expect(roadmap).toContain('| [#251](https://github.com/flyingrobots/bijou/pull/251) | `lane:release` | implementation PR | RE-035 layout envelope primitives |');
+
+    expect(backlog).toContain('## Landed Layout Anchor');
+    expect(backlog).toContain('PR #251');
+    expect(backlog).toContain('issue #180');
+  });
+});


### PR DESCRIPTION
## Summary

- mark `RE035_LAYOUT_SCOPE` as landed now that the first RE-035 layout-envelope slices are merged
- add a cycle closeout test tying the landed scope to the Method design artifact and v6 tracker docs
- update BEARING, ROADMAP, the v6 backlog evidence, and the changelog for the post-closeout v6 state
- keep RE-036+ text measurement, overflow, hit testing, responsive fallback, accessible lowering, and workspace behavior as explicit follow-on cycles

## Validation

- `npm test -- --run tests/cycles/RE-035/layout-envelope-closeout.test.ts packages/bijou/src/core/layout/envelope.test.ts`
- `npm run docs:inventory`
- `npm run lint`
- pre-push `npm run typecheck:test`
- pre-push full `npm test` (317 files / 3601 tests)
- pre-push `npm run verify:interactive-examples`

Closes #180