### PR TITLE
docs: close DX-031 standard blocks

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -24,10 +24,13 @@ Current direction and active tensions. Historical ship data is in
 - `LX-018` / `LX-019` — localization catalog data is honest, fallback catalogs
   are explicit, and DOGFOOD text lookup now goes through an application-facing
   localization port.
-- `DX-031` / `DX-034` — Blocks now have public metadata, schema, data-binding,
-  command-intent, lifecycle, active-binding, first-party definition, DOGFOOD
-  documentation, and fixture-demo proof. The visible product layer is still
-  emerging; the architecture is ahead of the rendered catalog.
+- `DX-031` — the standard block release floor landed with public metadata,
+  schema-bound block contracts, first-party `AppShell`, `ReaderSurface`, and
+  `InspectorPanel` definitions, rendered multi-mode proof, block-tree
+  rendering, and DOGFOOD Blocks preview evidence.
+- `DX-034` — Blocks now have data-binding, command-intent, lifecycle, active
+  binding, provider update, and command-buffer proof. The provider manager and
+  product AppShell integration remain the active release edge.
 - `DF-071` — DOGFOOD shell and docs surfaces moved further through semantic
   Block contracts, including block-owned surface inventory and localized
   inventory descriptions.
@@ -42,9 +45,9 @@ Current direction and active tensions. Historical ship data is in
 
 ### 1. Close The `v6.0.0` Release Boundary
 
-- The live `v6.0.0` milestone has three open tracker items plus twenty-one
-  completed lineage trackers after RE-035 and the Vitest dependency hygiene
-  work landed.
+- The live `v6.0.0` milestone has two open tracker items plus twenty-two
+  completed lineage trackers after RE-035, DX-031, and the Vitest dependency
+  hygiene work landed.
 - The release thesis is still: frame owns geometry; Blocks prove it.
 - `v6.0.0` should not tag until the remaining open release issues are closed,
   intentionally split, or explicitly moved to another horizon.
@@ -92,8 +95,6 @@ The immediate focus is `v6.0.0` release closure.
 
 Open v6 tracker items:
 
-- [#181](https://github.com/flyingrobots/bijou/issues/181) — `DX-031`
-  standard Bijou blocks.
 - [#182](https://github.com/flyingrobots/bijou/issues/182) — `DX-034`
   declarative view data binding.
 - [#186](https://github.com/flyingrobots/bijou/issues/186) — `DX-030`
@@ -101,14 +102,13 @@ Open v6 tracker items:
 
 Recommended pull order:
 
-1. Reassess [#181](https://github.com/flyingrobots/bijou/issues/181) and
-   [#182](https://github.com/flyingrobots/bijou/issues/182) together after
-   RE-035, because standard Blocks and declarative binding are already
-   partially landed and may need split-or-close decisions rather than one broad
-   cycle.
-2. Treat [#186](https://github.com/flyingrobots/bijou/issues/186) as either a
-   focused v6 implementation slice or an explicit move to `v7.0.0`, depending
-   on whether boundary-aware copy is required for the release boundary.
+1. Close [#182](https://github.com/flyingrobots/bijou/issues/182) next by
+   turning the landed DX-034 binding contracts into explicit release closeout
+   evidence, or by adding the one missing provider/AppShell proof if the design
+   audit still finds it necessary for `v6.0.0`.
+2. Close [#186](https://github.com/flyingrobots/bijou/issues/186) with the
+   smallest boundary-aware selection/copy implementation slice that consumes
+   retained layout truth and semantic extraction.
 
 Non-goals for the next cycle:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 📚 Documentation
 
+- **DX-031 standard blocks closeout** — BEARING, ROADMAP, the v6 backlog
+  evidence, and cycle tests now mark the standard block release floor as
+  landed through issue #181. The closeout records `AppShell`, `ReaderSurface`,
+  and `InspectorPanel` as the first shipped block set with public metadata,
+  schema-bound contracts, rendered multi-mode proof, block-tree rendering, and
+  DOGFOOD Blocks preview evidence.
 - **RE-035 layout envelope closeout** — BEARING, ROADMAP, the v6 backlog
   evidence, and cycle tests now mark the mandatory layout envelope floor as
   landed while keeping text measurement, viewport overflow, hit testing,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Last synced from GitHub Issues: 2026-06-02.
 
 | Horizon | Milestone | Open | Closed | Intent |
 | :--- | :--- | ---: | ---: | :--- |
-| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 3 | 21 | Current layout truth, standard blocks, and release hygiene lane. |
+| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 2 | 22 | Current layout truth, standard blocks, and release hygiene lane. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 27 | 0 | Next major-release candidate after v6 triage. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 18 | 0 | Uncommitted future work, cool ideas, and raw follow-ups. |
 
@@ -27,7 +27,6 @@ the remaining open release issues before tagging.
 
 | Tracker | Lane / Labels | Type | Work |
 | :--- | :--- | :--- | :--- |
-| [#181](https://github.com/flyingrobots/bijou/issues/181) | `lane:release` | `type:enhancement` | DX-031 standard Bijou blocks |
 | [#182](https://github.com/flyingrobots/bijou/issues/182) | `lane:release` | `type:enhancement` | DX-034 declarative view data binding |
 | [#186](https://github.com/flyingrobots/bijou/issues/186) | `lane:release` | `type:enhancement` | DX-030 boundary-aware pointer selection and copy |
 
@@ -38,6 +37,7 @@ These cards are included in the v6 milestone as completed release lineage.
 | Tracker | Lane | Type | Work |
 | :--- | :--- | :--- | :--- |
 | [#180](https://github.com/flyingrobots/bijou/issues/180) | `lane:release` | `type:enhancement` | RE-035 mandatory layout envelope and constraint negotiation |
+| [#181](https://github.com/flyingrobots/bijou/issues/181) | `lane:release` | `type:enhancement` | DX-031 standard Bijou blocks |
 | [#250](https://github.com/flyingrobots/bijou/pull/250) | `dependencies` | dependency PR | Vitest `4.0.18` to `4.1.8` release-hygiene bump |
 | [#251](https://github.com/flyingrobots/bijou/pull/251) | `lane:release` | implementation PR | RE-035 layout envelope primitives |
 | [#183](https://github.com/flyingrobots/bijou/issues/183) | `lane:release` | `type:maintenance` | DF-065 audit workspace layout family across real surfaces |

--- a/docs/design/DX-031-standard-bijou-blocks.md
+++ b/docs/design/DX-031-standard-bijou-blocks.md
@@ -3163,15 +3163,15 @@ blocks.
 11. Done: add explicit block-tree rendering so nested block declarations render
    child output without making ordinary `block.render()` recursive.
 12. Next: add an optional Zod schema adapter package or helper.
-13. Next: capture interactive, static, pipe, and accessible outputs for the
-   first implementation set.
-14. Next: prove the first three blocks in DOGFOOD before broadening the
-   catalog.
+13. Done: capture interactive, static, pipe, and accessible outputs for the
+    first implementation set.
+14. Done: prove the first three blocks in DOGFOOD before broadening the
+    catalog.
 15. Next: add catalog-only variant/config metadata for later blocks without
    implementing those blocks yet.
-16. Continue to defer modal stacks, notifications, auth forms, animated
-   carousels, complex controls, and workspace-like behavior until the first
-   rendered block set is proven.
+16. Keep modal stacks, notifications, auth forms, animated carousels, complex
+    controls, and workspace-like behavior outside DX-031; each needs an
+    explicit later block cycle with its own tests and Method evidence.
 
 ## Tests To Write First
 
@@ -3348,6 +3348,23 @@ Still out of scope after this slice:
 - Modal stacks, notifications, auth blocks, workspace docking, and complex
   domain-specific block packages.
 
+DX-031D DOGFOOD Blocks Section publishes the standard blocks through the
+project's proving surface.
+
+What is now true:
+
+- DOGFOOD exposes a top-level Blocks section with "What are Blocks", authoring,
+  pre-made catalog, surface-block, preview, and lowering pages.
+- Standard block preview pages are selectable from side navigation and render
+  live `AppShell`, `ReaderSurface`, and `InspectorPanel` examples instead of
+  raw metadata dumps.
+- The preview keeps lower-mode output visible as a compact lowering summary.
+- The local `CounterDemoBlock` fixture proves a block-shaped command-intent
+  surface can update through DOGFOOD without becoming part of the shipped
+  standard block package.
+- DOGFOOD tests assert the Blocks section, preview routing, curated catalog,
+  live examples, lowering posture, and fixture command keys.
+
 DX-031E Rendered Standard Block Proof replaces the first-party placeholders
 with deterministic render output.
 
@@ -3370,12 +3387,22 @@ Still out of scope after this slice:
 - Active runtime traversal.
 - Command dispatch integration.
 - Production AppShell behavior.
-- DOGFOOD multi-mode captures for rendered blocks.
-- Catalog expansion beyond `AppShell`, `ReaderSurface`, and `InspectorPanel`.
+- Catalog expansion beyond `AppShell`, `ReaderSurface`, and `InspectorPanel`
+  belongs to later issues instead of hidden `v6.0.0` release scope.
 
 ## Retrospective
 
-DX-031 is now partially landed rather than not started. The first slice gives
-the ecosystem a stable block contract to index, review, and publish against,
-but "full block availability" still requires DOGFOOD multi-mode proof, story
-captures, and catalog expansion.
+DX-031 is landed for the `v6.0.0` release boundary. The shipped release floor is
+the first standard block set: public block metadata, package manifests,
+adapter-first schema-bound block contracts, first-party `AppShell`,
+`ReaderSurface`, and `InspectorPanel` definitions, deterministic rendered output
+for interactive, static, pipe, and accessible modes, block-tree rendering, and a
+DOGFOOD Blocks section that proves the first set in product context.
+
+DOGFOOD multi-mode proof is present for the release slice through the standard
+block render tests, DOGFOOD preview tests, lowering posture checks, and story
+declarations. Broader "full block availability" remains intentionally larger
+than this release issue: optional Zod adapters, schema-to-block compilers,
+modal stacks, notifications, auth blocks, workspace docking, and broad catalog
+expansion should land as explicit future issues with their own tests and Method
+evidence.

--- a/docs/method/backlog/v6.0.0/README.md
+++ b/docs/method/backlog/v6.0.0/README.md
@@ -40,10 +40,18 @@ The boundary remains:
   workspace behavior remain explicit later cycles instead of hidden RE-035
   scope.
 
-## Active Design Anchors
+## Landed Standard Blocks Anchor
 
 - [**DX-031**](../../../design/DX-031-standard-bijou-blocks.md) -
-  standard Bijou blocks
+  standard Bijou blocks landed through issue #181 with public block metadata,
+  package manifests, schema-bound block contracts, first-party `AppShell`,
+  `ReaderSurface`, and `InspectorPanel` definitions, rendered multi-mode proof,
+  block-tree rendering, and DOGFOOD Blocks preview evidence. Catalog expansion
+  beyond the first standard block set remains explicit later work instead of
+  hidden v6 release scope.
+
+## Active Design Anchors
+
 - [**DX-034**](../../../design/DX-034-declarative-view-data-binding.md) -
   declarative view data binding
 

--- a/tests/cycles/DX-031/standard-blocks-closeout.test.ts
+++ b/tests/cycles/DX-031/standard-blocks-closeout.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  standardBlocks,
+  standardBlockStories,
+} from '../../../packages/bijou/src/index.js';
+import { readRepoFile } from '../repo.js';
+
+describe('DX-031 standard blocks closeout', () => {
+  it('keeps the first standard block set concrete and mode-aware', () => {
+    expect(standardBlocks.map((block) => block.metadata.blockName)).toEqual([
+      'AppShell',
+      'ReaderSurface',
+      'InspectorPanel',
+    ]);
+
+    for (const block of standardBlocks) {
+      expect(block.metadata.modes).toEqual([
+        'interactive',
+        'static',
+        'pipe',
+        'accessible',
+      ]);
+      expect(block.metadata.storyIds.length).toBeGreaterThan(0);
+
+      for (const mode of block.metadata.modes) {
+        const rendered = block.render({
+          mode,
+          slots: renderSlotsFor(block.metadata.blockName),
+        });
+
+        expect(rendered.output).toBeDefined();
+        expect(rendered.facts).toContainEqual({
+          kind: 'entity',
+          key: 'block',
+          value: block.metadata.blockName,
+        });
+      }
+    }
+  });
+
+  it('keeps first-party story coverage in release scope', () => {
+    const storyStates = new Map(
+      standardBlocks.map((block) => [
+        block.metadata.blockName,
+        standardBlockStories
+          .filter((story) => story.blockName === block.metadata.blockName)
+          .map((story) => story.state),
+      ]),
+    );
+
+    expect(storyStates.get('AppShell')).toEqual(['ready', 'narrow', 'overlay']);
+    expect(storyStates.get('ReaderSurface')).toEqual([
+      'ready',
+      'loading',
+      'stale',
+      'empty',
+      'error',
+    ]);
+    expect(storyStates.get('InspectorPanel')).toEqual([
+      'ready',
+      'empty',
+      'loading',
+      'stale',
+      'error',
+    ]);
+  });
+
+  it('marks DX-031 landed in Method evidence after closing issue 181', () => {
+    const design = readRepoFile('docs/design/DX-031-standard-bijou-blocks.md');
+    const changelog = readRepoFile('docs/CHANGELOG.md');
+
+    expect(design).toContain('DX-031 is landed for the `v6.0.0` release boundary.');
+    expect(design).toContain('DOGFOOD multi-mode proof is present');
+    expect(design).toMatch(/Catalog expansion beyond `AppShell`, `ReaderSurface`, and `InspectorPanel`\s+belongs to later issues/);
+    expect(design).not.toContain('DX-031 is now partially landed rather than not started.');
+
+    expect(changelog).toContain('DX-031 standard blocks closeout');
+    expect(changelog).toContain('AppShell`, `ReaderSurface`, and `InspectorPanel`');
+  });
+
+  it('keeps v6 tracker docs aligned after closing issue 181', () => {
+    const bearing = readRepoFile('docs/BEARING.md');
+    const roadmap = readRepoFile('docs/ROADMAP.md');
+    const backlog = readRepoFile('docs/method/backlog/v6.0.0/README.md');
+    const roadmapOpenWork = sectionBetween(roadmap, '### Open Work', '### Completed Lineage');
+    const roadmapCompletedLineage = sectionBetween(roadmap, '### Completed Lineage', '## v7.0.0');
+
+    expect(bearing).toContain('two open tracker items plus twenty-two');
+    expect(bearing).not.toContain('[#181](https://github.com/flyingrobots/bijou/issues/181) — `DX-031`');
+    expect(bearing).toContain('[#182](https://github.com/flyingrobots/bijou/issues/182)');
+    expect(bearing).toContain('[#186](https://github.com/flyingrobots/bijou/issues/186)');
+
+    expect(roadmap).toContain('| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 2 | 22 |');
+    expect(roadmapOpenWork).not.toContain('[#181](https://github.com/flyingrobots/bijou/issues/181)');
+    expect(roadmapCompletedLineage).toContain('| [#181](https://github.com/flyingrobots/bijou/issues/181) | `lane:release` | `type:enhancement` | DX-031 standard Bijou blocks |');
+
+    expect(backlog).toContain('## Landed Standard Blocks Anchor');
+    expect(backlog).toContain('issue #181');
+    expect(backlog).toContain('## Active Design Anchors');
+    expect(backlog).toContain('DX-034');
+  });
+});
+
+function renderSlotsFor(blockName: string): Readonly<Record<string, unknown>> {
+  switch (blockName) {
+    case 'AppShell':
+      return {
+        navigation: 'Docs nav',
+        content: 'Blocks guide',
+        inspector: 'Current selection',
+        status: 'Ready',
+        overlays: ['Help'],
+      };
+    case 'ReaderSurface':
+      return {
+        content: 'Readable block documentation.',
+        navigation: 'Docs nav',
+        outline: ['Intro', 'Lowering'],
+      };
+    case 'InspectorPanel':
+      return {
+        selection: 'ReaderSurface',
+        details: ['schema-aware', 'command-aware'],
+        actions: ['reveal source'],
+      };
+    default:
+      throw new Error(`unknown standard block ${blockName}`);
+  }
+}
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}

--- a/tests/cycles/DX-031/standard-blocks-closeout.test.ts
+++ b/tests/cycles/DX-031/standard-blocks-closeout.test.ts
@@ -20,7 +20,7 @@ describe('DX-031 standard blocks closeout', () => {
         'pipe',
         'accessible',
       ]);
-      expect(block.metadata.storyIds.length).toBeGreaterThan(0);
+      expect(block.metadata.storyIds ?? []).not.toHaveLength(0);
 
       for (const mode of block.metadata.modes) {
         const rendered = block.render({

--- a/tests/cycles/RE-035/layout-envelope-closeout.test.ts
+++ b/tests/cycles/RE-035/layout-envelope-closeout.test.ts
@@ -41,18 +41,27 @@ describe('RE-035 layout envelope closeout', () => {
     const bearing = readRepoFile('docs/BEARING.md');
     const roadmap = readRepoFile('docs/ROADMAP.md');
     const backlog = readRepoFile('docs/method/backlog/v6.0.0/README.md');
+    const roadmapCompletedLineage = sectionBetween(roadmap, '### Completed Lineage', '## v7.0.0');
 
-    expect(bearing).toContain('three open tracker items');
-    expect(bearing).toContain('[#181](https://github.com/flyingrobots/bijou/issues/181)');
+    expect(bearing).toContain('RE-035');
     expect(bearing).not.toContain('[#180](https://github.com/flyingrobots/bijou/issues/180) — `RE-035`');
 
-    expect(roadmap).toContain('| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 3 | 21 |');
-    expect(roadmap).toContain('| [#180](https://github.com/flyingrobots/bijou/issues/180) | `lane:release` | `type:enhancement` | RE-035 mandatory layout envelope and constraint negotiation |');
-    expect(roadmap).toContain('| [#250](https://github.com/flyingrobots/bijou/pull/250) | `dependencies` | dependency PR | Vitest `4.0.18` to `4.1.8` release-hygiene bump |');
-    expect(roadmap).toContain('| [#251](https://github.com/flyingrobots/bijou/pull/251) | `lane:release` | implementation PR | RE-035 layout envelope primitives |');
+    expect(roadmapCompletedLineage).toContain('| [#180](https://github.com/flyingrobots/bijou/issues/180) | `lane:release` | `type:enhancement` | RE-035 mandatory layout envelope and constraint negotiation |');
+    expect(roadmapCompletedLineage).toContain('| [#250](https://github.com/flyingrobots/bijou/pull/250) | `dependencies` | dependency PR | Vitest `4.0.18` to `4.1.8` release-hygiene bump |');
+    expect(roadmapCompletedLineage).toContain('| [#251](https://github.com/flyingrobots/bijou/pull/251) | `lane:release` | implementation PR | RE-035 layout envelope primitives |');
 
     expect(backlog).toContain('## Landed Layout Anchor');
     expect(backlog).toContain('PR #251');
     expect(backlog).toContain('issue #180');
   });
 });
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}


### PR DESCRIPTION
## Summary

- closes the DX-031 release tracker with executable closeout evidence
- marks the first standard block set as landed in BEARING, ROADMAP, the v6 backlog, and the DX-031 Method artifact
- keeps RE-035 closeout tests focused on RE-035 lineage instead of freezing stale v6 counts

Closes #181

## Validation

- npm test -- --run tests/cycles/DX-031/standard-blocks-closeout.test.ts
- npm test -- --run tests/cycles/DX-031 packages/bijou/src/core/standard-blocks.test.ts packages/bijou/src/core/block-tree-render.test.ts packages/bijou/src/core/schema-block.test.ts
- npm test -- --run tests/cycles/RE-035/layout-envelope-closeout.test.ts tests/cycles/DX-031/standard-blocks-closeout.test.ts
- npm run typecheck:test
- npm run docs:inventory
- git diff --check
- npm run lint
- pre-push: npm run typecheck:test, full npm test, npm run verify:interactive-examples