### PR TITLE
docs: close DX-034 data binding

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -28,9 +28,11 @@ Current direction and active tensions. Historical ship data is in
   schema-bound block contracts, first-party `AppShell`, `ReaderSurface`, and
   `InspectorPanel` definitions, rendered multi-mode proof, block-tree
   rendering, and DOGFOOD Blocks preview evidence.
-- `DX-034` — Blocks now have data-binding, command-intent, lifecycle, active
-  binding, provider update, and command-buffer proof. The provider manager and
-  product AppShell integration remain the active release edge.
+- `DX-034` — declarative view data binding landed with immutable snapshots and
+  frames, provider scopes, view data contracts, AppShell composition, active
+  binding lifecycle facts, active runtime binding collection, provider-update
+  frame assembly, command intent routing, provider-bound AppShell proof, and
+  DOGFOOD binding-state evidence.
 - `DF-071` — DOGFOOD shell and docs surfaces moved further through semantic
   Block contracts, including block-owned surface inventory and localized
   inventory descriptions.
@@ -45,9 +47,9 @@ Current direction and active tensions. Historical ship data is in
 
 ### 1. Close The `v6.0.0` Release Boundary
 
-- The live `v6.0.0` milestone has two open tracker items plus twenty-two
-  completed lineage trackers after RE-035, DX-031, and the Vitest dependency
-  hygiene work landed.
+- The live `v6.0.0` milestone has one open tracker item plus twenty-three
+  completed lineage trackers after RE-035, DX-031, DX-034, and the Vitest
+  dependency hygiene work landed.
 - The release thesis is still: frame owns geometry; Blocks prove it.
 - `v6.0.0` should not tag until the remaining open release issues are closed,
   intentionally split, or explicitly moved to another horizon.
@@ -95,18 +97,12 @@ The immediate focus is `v6.0.0` release closure.
 
 Open v6 tracker items:
 
-- [#182](https://github.com/flyingrobots/bijou/issues/182) — `DX-034`
-  declarative view data binding.
 - [#186](https://github.com/flyingrobots/bijou/issues/186) — `DX-030`
   boundary-aware pointer selection and copy.
 
 Recommended pull order:
 
-1. Close [#182](https://github.com/flyingrobots/bijou/issues/182) next by
-   turning the landed DX-034 binding contracts into explicit release closeout
-   evidence, or by adding the one missing provider/AppShell proof if the design
-   audit still finds it necessary for `v6.0.0`.
-2. Close [#186](https://github.com/flyingrobots/bijou/issues/186) with the
+1. Close [#186](https://github.com/flyingrobots/bijou/issues/186) with the
    smallest boundary-aware selection/copy implementation slice that consumes
    retained layout truth and semantic extraction.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 📚 Documentation
 
+- **DX-034 data binding closeout** — BEARING, ROADMAP, the v6 backlog
+  evidence, and cycle tests now mark declarative view data binding as landed
+  through issue #182. The closeout records immutable binding frames, provider
+  scopes, AppShell composition, active binding lifecycle facts, provider-update
+  frame assembly, command intent routing, provider-bound AppShell proof, and
+  DOGFOOD binding-state evidence as the shipped v6 data-binding floor.
 - **DX-031 standard blocks closeout** — BEARING, ROADMAP, the v6 backlog
   evidence, and cycle tests now mark the standard block release floor as
   landed through issue #181. The closeout records `AppShell`, `ReaderSurface`,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Last synced from GitHub Issues: 2026-06-02.
 
 | Horizon | Milestone | Open | Closed | Intent |
 | :--- | :--- | ---: | ---: | :--- |
-| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 2 | 22 | Current layout truth, standard blocks, and release hygiene lane. |
+| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 1 | 23 | Current layout truth, standard blocks, and release hygiene lane. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 27 | 0 | Next major-release candidate after v6 triage. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 18 | 0 | Uncommitted future work, cool ideas, and raw follow-ups. |
 
@@ -27,7 +27,6 @@ the remaining open release issues before tagging.
 
 | Tracker | Lane / Labels | Type | Work |
 | :--- | :--- | :--- | :--- |
-| [#182](https://github.com/flyingrobots/bijou/issues/182) | `lane:release` | `type:enhancement` | DX-034 declarative view data binding |
 | [#186](https://github.com/flyingrobots/bijou/issues/186) | `lane:release` | `type:enhancement` | DX-030 boundary-aware pointer selection and copy |
 
 ### Completed Lineage
@@ -38,6 +37,7 @@ These cards are included in the v6 milestone as completed release lineage.
 | :--- | :--- | :--- | :--- |
 | [#180](https://github.com/flyingrobots/bijou/issues/180) | `lane:release` | `type:enhancement` | RE-035 mandatory layout envelope and constraint negotiation |
 | [#181](https://github.com/flyingrobots/bijou/issues/181) | `lane:release` | `type:enhancement` | DX-031 standard Bijou blocks |
+| [#182](https://github.com/flyingrobots/bijou/issues/182) | `lane:release` | `type:enhancement` | DX-034 declarative view data binding |
 | [#250](https://github.com/flyingrobots/bijou/pull/250) | `dependencies` | dependency PR | Vitest `4.0.18` to `4.1.8` release-hygiene bump |
 | [#251](https://github.com/flyingrobots/bijou/pull/251) | `lane:release` | implementation PR | RE-035 layout envelope primitives |
 | [#183](https://github.com/flyingrobots/bijou/issues/183) | `lane:release` | `type:maintenance` | DF-065 audit workspace layout family across real surfaces |

--- a/docs/design/DX-034-declarative-view-data-binding.md
+++ b/docs/design/DX-034-declarative-view-data-binding.md
@@ -988,10 +988,11 @@ flow.
 14. Done: add invalidation flow from provider snapshot updates to new immutable
    binding frames.
 15. Done: add Command intent dispatch proof through the runtime command buffer.
-16. Next: prove rendered AppShell with provider-bound navigation, content, inspector,
-   and status blocks.
-17. Next: add DOGFOOD stories and captures for ready, loading, stale, empty, and
-    error binding states.
+16. Done: prove rendered AppShell with provider-bound navigation, content,
+    inspector, and status blocks.
+17. Done: add DOGFOOD stories and captures for ready, loading, stale, empty,
+    and error binding states through the standard block story and DOGFOOD
+    preview surface.
 
 ## Tests To Write First
 
@@ -1105,3 +1106,22 @@ loop exists yet.
 DX-034I landed command intent emission and runtime command-buffer routing. The
 restraint is that command routes map intent records to command values; business
 logic still applies commands later through the existing runtime command buffer.
+
+DX-034 is landed for the `v6.0.0` release boundary. The shipped release floor is
+the explicit data-binding contract layer: immutable snapshots and frames,
+provider scopes, view data contracts, structural AppShell composition, active
+binding lifecycle facts, active runtime binding collection, provider-update
+frame assembly, command intent routing, and closeout proof that a provider-bound
+AppShell can render `navigation`, `content`, `inspector`, and `status` regions
+from immutable binding frames without exposing provider, subscription, refresh,
+or dispatch handles to rendered output.
+
+Provider-bound AppShell proof is present in the DX-034 closeout cycle test. The
+proof intentionally stays pure: provider subscriptions and cache policy remain
+runtime/provider responsibilities, while the release contract proves the
+boundary that views consume immutable frames and emit command intents.
+
+DOGFOOD binding-state proof is present through the standard block story states
+and Blocks preview lowering checks for ready, loading, stale, empty, and error
+states. Broader production AppShell behavior can now build on the landed
+contract without keeping issue #182 open.

--- a/docs/method/backlog/v6.0.0/README.md
+++ b/docs/method/backlog/v6.0.0/README.md
@@ -50,10 +50,14 @@ The boundary remains:
   beyond the first standard block set remains explicit later work instead of
   hidden v6 release scope.
 
-## Active Design Anchors
+## Landed Data Binding Anchor
 
 - [**DX-034**](../../../design/DX-034-declarative-view-data-binding.md) -
-  declarative view data binding
+  declarative view data binding landed through issue #182 with immutable
+  snapshots and frames, provider scopes, view data contracts, AppShell
+  composition, active binding lifecycle facts, active runtime binding
+  collection, provider-update frame assembly, command intent routing,
+  provider-bound AppShell proof, and DOGFOOD binding-state evidence.
 
 ## Core Runtime Scope
 

--- a/tests/cycles/DX-031/standard-blocks-closeout.test.ts
+++ b/tests/cycles/DX-031/standard-blocks-closeout.test.ts
@@ -85,19 +85,13 @@ describe('DX-031 standard blocks closeout', () => {
     const roadmapOpenWork = sectionBetween(roadmap, '### Open Work', '### Completed Lineage');
     const roadmapCompletedLineage = sectionBetween(roadmap, '### Completed Lineage', '## v7.0.0');
 
-    expect(bearing).toContain('two open tracker items plus twenty-two');
     expect(bearing).not.toContain('[#181](https://github.com/flyingrobots/bijou/issues/181) — `DX-031`');
-    expect(bearing).toContain('[#182](https://github.com/flyingrobots/bijou/issues/182)');
-    expect(bearing).toContain('[#186](https://github.com/flyingrobots/bijou/issues/186)');
 
-    expect(roadmap).toContain('| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 2 | 22 |');
     expect(roadmapOpenWork).not.toContain('[#181](https://github.com/flyingrobots/bijou/issues/181)');
     expect(roadmapCompletedLineage).toContain('| [#181](https://github.com/flyingrobots/bijou/issues/181) | `lane:release` | `type:enhancement` | DX-031 standard Bijou blocks |');
 
     expect(backlog).toContain('## Landed Standard Blocks Anchor');
     expect(backlog).toContain('issue #181');
-    expect(backlog).toContain('## Active Design Anchors');
-    expect(backlog).toContain('DX-034');
   });
 });
 

--- a/tests/cycles/DX-034/data-binding-closeout.test.ts
+++ b/tests/cycles/DX-034/data-binding-closeout.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activeBindingCollection,
+  activeBindingEntry,
+  appShellBlock,
+  bindingFrameUpdateFromSnapshots,
+  bindingSnapshot,
+  defineAppShellComposition,
+  defineBindingLifecycleOwner,
+  defineDataProvider,
+  defineDataRequirement,
+  inspectorPanelBlock,
+  provide,
+  providerScope,
+  readerSurfaceBlock,
+  standardBlockStories,
+} from '../../../packages/bijou/src/index.js';
+import { readRepoFile } from '../repo.js';
+
+interface ArticleData {
+  readonly body: string;
+  readonly outline: readonly string[];
+}
+
+interface InspectorData {
+  readonly selection: string;
+  readonly details: readonly string[];
+}
+
+describe('DX-034 data binding closeout', () => {
+  it('renders a provider-bound AppShell from immutable binding frames', () => {
+    const owner = defineBindingLifecycleOwner({ id: 'docs.shell', kind: 'app-shell' });
+    const navigation = defineDataRequirement({ id: 'navigation', resource: 'docs.navigation' });
+    const content = defineDataRequirement({ id: 'content', resource: 'docs.article' });
+    const inspector = defineDataRequirement({ id: 'inspector', resource: 'docs.selection' });
+    const status = defineDataRequirement({ id: 'status', resource: 'docs.status' });
+    const scope = providerScope([
+      provide(defineDataProvider({ id: 'docs.navigationProvider', resource: navigation.resource })),
+      provide(defineDataProvider({ id: 'docs.articleProvider', resource: content.resource })),
+      provide(defineDataProvider({ id: 'docs.selectionProvider', resource: inspector.resource })),
+      provide(defineDataProvider({ id: 'docs.statusProvider', resource: status.resource })),
+    ], { id: 'docs.shell.providers' });
+    const collection = activeBindingCollection([
+      activeBindingEntry({ owner, requirement: navigation, providerId: 'docs.navigationProvider' }),
+      activeBindingEntry({ owner, requirement: content, providerId: 'docs.articleProvider' }),
+      activeBindingEntry({ owner, requirement: inspector, providerId: 'docs.selectionProvider' }),
+      activeBindingEntry({ owner, requirement: status, providerId: 'docs.statusProvider' }),
+    ]);
+    const composition = defineAppShellComposition({
+      id: 'docs.shell',
+      providers: scope,
+      slots: {
+        navigation: readerSurfaceBlock,
+        content: readerSurfaceBlock,
+        inspector: inspectorPanelBlock,
+        status: inspectorPanelBlock,
+      },
+    });
+
+    const update = bindingFrameUpdateFromSnapshots({
+      collection,
+      scope,
+      snapshots: [
+        bindingSnapshot({
+          providerId: 'docs.navigationProvider',
+          requirementId: 'navigation',
+          version: 1,
+          status: 'ready',
+          data: 'Docs navigation',
+        }),
+        bindingSnapshot({
+          providerId: 'docs.articleProvider',
+          requirementId: 'content',
+          version: 2,
+          status: 'ready',
+          data: {
+            body: 'DX-034 provider-bound content',
+            outline: ['providers', 'commands'],
+          } satisfies ArticleData,
+        }),
+        bindingSnapshot({
+          providerId: 'docs.selectionProvider',
+          requirementId: 'inspector',
+          version: 3,
+          status: 'ready',
+          data: {
+            selection: 'DX-034',
+            details: ['ready', 'version 3'],
+          } satisfies InspectorData,
+        }),
+        bindingSnapshot({
+          providerId: 'docs.statusProvider',
+          requirementId: 'status',
+          version: 4,
+          status: 'stale',
+          data: 'cache updating',
+        }),
+      ],
+    });
+
+    const article = update.frame.require<ArticleData>('content');
+    const selection = update.frame.require<InspectorData>('inspector');
+    const renderedReader = readerSurfaceBlock.render({
+      mode: 'pipe',
+      slots: {
+        content: article.body,
+        outline: article.outline,
+      },
+    }).output;
+    const renderedInspector = inspectorPanelBlock.render({
+      mode: 'pipe',
+      slots: {
+        selection: selection.selection,
+        details: selection.details,
+      },
+    }).output;
+    const renderedShell = appShellBlock.render({
+      mode: 'pipe',
+      slots: {
+        navigation: update.frame.require<string>('navigation'),
+        content: renderedReader,
+        inspector: renderedInspector,
+        status: `${update.frame.status('status')}: ${update.frame.get<string>('status')}`,
+      },
+    });
+
+    expect(composition.providerScope()).toBe(scope);
+    expect(composition.slotIds()).toEqual(['navigation', 'content', 'inspector', 'status']);
+    expect(update.issues).toEqual([]);
+    expect(update.records.map((record) => record.requirementId)).toEqual([
+      'navigation',
+      'content',
+      'inspector',
+      'status',
+    ]);
+    expect(String(renderedShell.output)).toContain('AppShell');
+    expect(String(renderedShell.output)).toContain('navigation: Docs navigation');
+    expect(String(renderedShell.output)).toContain('DX-034 provider-bound content');
+    expect(String(renderedShell.output)).toContain('selection: DX-034');
+    expect(String(renderedShell.output)).toContain('status: stale: cache updating');
+    expect('provider' in update).toBe(false);
+    expect('subscribe' in update).toBe(false);
+    expect('refresh' in update).toBe(false);
+    expect('dispatch' in update).toBe(false);
+  });
+
+  it('keeps binding-state story coverage visible for DOGFOOD and lower modes', () => {
+    const storiesByBlock = new Map(
+      ['ReaderSurface', 'InspectorPanel'].map((blockName) => [
+        blockName,
+        standardBlockStories
+          .filter((story) => story.blockName === blockName)
+          .map((story) => story.state),
+      ]),
+    );
+
+    expect(storiesByBlock.get('ReaderSurface')).toEqual([
+      'ready',
+      'loading',
+      'stale',
+      'empty',
+      'error',
+    ]);
+    expect(storiesByBlock.get('InspectorPanel')).toEqual([
+      'ready',
+      'empty',
+      'loading',
+      'stale',
+      'error',
+    ]);
+
+    const dogfoodBlocksTest = readRepoFile('tests/cycles/DX-031/dogfood-blocks-section.test.ts');
+    expect(dogfoodBlocksTest).toContain('lowering summary');
+    expect(dogfoodBlocksTest).toContain('standardBlockStories');
+  });
+
+  it('marks DX-034 landed in Method evidence after closing issue 182', () => {
+    const design = readRepoFile('docs/design/DX-034-declarative-view-data-binding.md');
+    const changelog = readRepoFile('docs/CHANGELOG.md');
+
+    expect(design).toContain('DX-034 is landed for the `v6.0.0` release boundary.');
+    expect(design).toContain('Provider-bound AppShell proof is present');
+    expect(design).toContain('DOGFOOD binding-state proof is present');
+    expect(design).not.toContain('16. Next: prove rendered AppShell');
+    expect(design).not.toContain('17. Next: add DOGFOOD stories');
+
+    expect(changelog).toContain('DX-034 data binding closeout');
+    expect(changelog).toContain('provider-bound AppShell');
+  });
+
+  it('keeps v6 tracker docs aligned after closing issue 182', () => {
+    const bearing = readRepoFile('docs/BEARING.md');
+    const roadmap = readRepoFile('docs/ROADMAP.md');
+    const backlog = readRepoFile('docs/method/backlog/v6.0.0/README.md');
+    const roadmapOpenWork = sectionBetween(roadmap, '### Open Work', '### Completed Lineage');
+    const roadmapCompletedLineage = sectionBetween(roadmap, '### Completed Lineage', '## v7.0.0');
+
+    expect(bearing).not.toContain('[#182](https://github.com/flyingrobots/bijou/issues/182) — `DX-034`');
+    expect(roadmapOpenWork).not.toContain('[#182](https://github.com/flyingrobots/bijou/issues/182)');
+    expect(roadmapCompletedLineage).toContain('| [#182](https://github.com/flyingrobots/bijou/issues/182) | `lane:release` | `type:enhancement` | DX-034 declarative view data binding |');
+
+    expect(backlog).toContain('## Landed Data Binding Anchor');
+    expect(backlog).toContain('issue #182');
+  });
+});
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}


### PR DESCRIPTION
## Summary

- closes the DX-034 release tracker with provider-bound AppShell closeout proof
- marks declarative data binding as landed in BEARING, ROADMAP, the v6 backlog, and the DX-034 Method artifact
- keeps older closeout regressions focused on their own completed lineage instead of stale v6 counts

Closes #182

## Validation

- npm test -- --run tests/cycles/DX-034/data-binding-closeout.test.ts tests/cycles/DX-031/standard-blocks-closeout.test.ts
- npm test -- --run tests/cycles/DX-034 tests/cycles/DX-031/standard-blocks-closeout.test.ts tests/cycles/RE-035/layout-envelope-closeout.test.ts packages/bijou/src/core/binding.test.ts packages/bijou/src/core/binding-frame-update.test.ts packages/bijou-tui/src/runtime-binding.test.ts
- npm run typecheck:test
- npm run docs:inventory
- git diff --check
- npm run lint
- pre-push: npm run typecheck:test, full npm test, npm run verify:interactive-examples