### PR TITLE
Make scripted UI suites deterministic

### DIFF
--- a/scripts/docs-preview.test.ts
+++ b/scripts/docs-preview.test.ts
@@ -3,8 +3,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { colorHex, type ColorRef } from '@flyingrobots/bijou';
-import { _resetDefaultContextForTesting, createTestContext } from '@flyingrobots/bijou/adapters/test';
-import { parseKey, runScript } from '@flyingrobots/bijou-tui';
+import { _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
+import { parseKey } from '@flyingrobots/bijou-tui';
+import {
+  createScriptTestContext as createTestContext,
+  runScriptDeterministic as runScript,
+} from '../tests/helpers/scripted.js';
 import { createDocsApp, DOGFOOD_I18N_CATALOG, FRAME_I18N_CATALOG } from '../examples/docs/app.js';
 import { resolveDogfoodDocsCoverage } from '../examples/docs/coverage.js';
 import { createNodeDocsApp } from '../examples/docs/node-app.js';

--- a/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
+++ b/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
@@ -6,9 +6,11 @@ import {
 } from '@flyingrobots/bijou';
 import {
   _resetDefaultContextForTesting,
-  createTestContext,
 } from '@flyingrobots/bijou/adapters/test';
-import { runScript } from '@flyingrobots/bijou-tui';
+import {
+  createScriptTestContext as createTestContext,
+  runScriptDeterministic as runScript,
+} from '../../helpers/scripted.js';
 import { createDocsApp } from '../../../examples/docs/app.js';
 import {
   counterDemoBlockConfig,

--- a/tests/cycles/DX-031/dogfood-blocks-section.test.ts
+++ b/tests/cycles/DX-031/dogfood-blocks-section.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { standardBlocks, standardBlockStories } from '@flyingrobots/bijou';
-import { _resetDefaultContextForTesting, createTestContext } from '@flyingrobots/bijou/adapters/test';
-import { runScript } from '@flyingrobots/bijou-tui';
+import { _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
+import {
+  createScriptTestContext as createTestContext,
+  runScriptDeterministic as runScript,
+} from '../../helpers/scripted.js';
 import { createDocsApp } from '../../../examples/docs/app.js';
 import { counterDemoBlockSurface } from '../../../examples/docs/counter-block-demo.js';
 

--- a/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
+++ b/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { createTestContext } from '@flyingrobots/bijou/adapters/test';
-import { runScript } from '@flyingrobots/bijou-tui';
+import {
+  createScriptTestContext as createTestContext,
+  runScriptDeterministic as runScript,
+} from '../../helpers/scripted.js';
 import { createDocsApp, DOGFOOD_I18N_CATALOG } from '../../../examples/docs/app.js';
 import { dogfoodI18nCatalogsForLocale } from '../../../examples/docs/i18n/dogfood-catalog.js';
 import {

--- a/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
+++ b/tests/cycles/LX-011/dogfood-locale-ratchet.test.ts
@@ -14,6 +14,7 @@ import { createNodeDogfoodLocalePort } from '../../../examples/docs/node-locale.
 const KEY_DOWN = '\x1b[B';
 const KEY_ENTER = '\r';
 const KEY_F2 = '\x1bOQ';
+const RENDERED_LANGUAGE_CYCLE_TEST_TIMEOUT_MS = 15_000;
 
 function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
   let text = '';
@@ -223,7 +224,7 @@ describe('LX-011 DOGFOOD locale ratchet', () => {
 
     expect(pageLocales(result.model)).toEqual(['fr', 'fr', 'fr', 'fr', 'fr', 'fr']);
     expect(frameText(result.frames.at(-1)!)).toContain('Langue sentinelle');
-  });
+  }, RENDERED_LANGUAGE_CYCLE_TEST_TIMEOUT_MS);
 
   it('refreshes frame page labels from the selected locale after language cycling', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
@@ -284,7 +285,7 @@ describe('LX-011 DOGFOOD locale ratchet', () => {
     expect(text).toContain('Blocs sentinelle');
     expect(text).toContain('Paquets sentinelle');
     expect(text).not.toContain('[Guides]  Components  Blocks');
-  });
+  }, RENDERED_LANGUAGE_CYCLE_TEST_TIMEOUT_MS);
 
   it('cycles the preferred language through settings and syncs every DOGFOOD page model', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
@@ -310,7 +311,7 @@ describe('LX-011 DOGFOOD locale ratchet', () => {
     expect(pageLocales(result.model)).toEqual(['fr', 'fr', 'fr', 'fr', 'fr', 'fr']);
     expect(frameText(result.frames.at(-1)!)).toContain('Langue préférée');
     expect(savedLocales).toEqual(['fr']);
-  });
+  }, RENDERED_LANGUAGE_CYCLE_TEST_TIMEOUT_MS);
 
   it('keeps locale activation when preference persistence fails', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
@@ -337,5 +338,5 @@ describe('LX-011 DOGFOOD locale ratchet', () => {
     expect(pageLocales(result.model)).toEqual(['fr', 'fr', 'fr', 'fr', 'fr', 'fr']);
     expect(frameText(result.frames.at(-1)!)).toContain('Langue préférée');
     expect(attemptedSaves).toEqual(['fr']);
-  });
+  }, RENDERED_LANGUAGE_CYCLE_TEST_TIMEOUT_MS);
 });

--- a/tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts
+++ b/tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { _resetDefaultContextForTesting, createTestContext } from '@flyingrobots/bijou/adapters/test';
-import { runScript } from '@flyingrobots/bijou-tui';
+import { _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
+import {
+  createScriptTestContext as createTestContext,
+  runScriptDeterministic as runScript,
+} from '../../helpers/scripted.js';
 import { createDocsApp } from '../../../examples/docs/app.js';
 
 const KEY_F2 = '\x1bOQ';

--- a/tests/helpers/scripted.ts
+++ b/tests/helpers/scripted.ts
@@ -49,6 +49,18 @@ function normalizeDelay(ms: number): number {
   return Math.max(0, Math.floor(ms));
 }
 
+/**
+ * Creates a deterministic script clock that advances through scheduled timeout work.
+ *
+ * Each timeout queues one global microtask that drains all pending timeouts in
+ * timestamp order, including timeouts scheduled by earlier callbacks. Disposed
+ * timeouts stay in the small in-memory queue and are skipped, which is acceptable
+ * for bounded test scripts.
+ *
+ * Intervals are intentionally unsupported; use explicit pulse steps or a
+ * dedicated mock clock for periodic behavior. Microtasks still delegate to the
+ * host queue so promise ordering matches the runtime.
+ */
 function autoAdvancingScriptClock(): ClockPort {
   let nowMs = 0;
   let nextId = 1;
@@ -106,12 +118,14 @@ function autoAdvancingScriptClock(): ClockPort {
     },
 
     setInterval(): TimerHandle {
+      // Scripted tests should drive periodic behavior through explicit pulse steps.
       throw new Error(
         'autoAdvancingScriptClock does not support intervals; use explicit pulse steps or a dedicated mockClock.',
       );
     },
 
     queueMicrotask(callback: () => void): void {
+      // Preserve host microtask ordering while keeping timeout advancement deterministic.
       globalThis.queueMicrotask(callback);
     },
   };

--- a/tests/helpers/scripted.ts
+++ b/tests/helpers/scripted.ts
@@ -26,7 +26,10 @@ export function createScriptTestContext(options: Omit<TestContextOptions, 'clock
 export function runScriptDeterministic<Model, M>(
   app: App<Model, M>,
   steps: ScriptStep<M>[],
-  options: RunScriptOptions & { readonly ctx: ScriptTestContext },
+  options: Omit<RunScriptOptions, 'pulseFps'> & {
+    readonly ctx: ScriptTestContext;
+    readonly pulseFps?: false;
+  },
 ): Promise<RunScriptResult<Model>> {
   return runScript(app, steps, {
     ...options,

--- a/tests/helpers/scripted.ts
+++ b/tests/helpers/scripted.ts
@@ -1,0 +1,115 @@
+import {
+  createTestContext,
+  type TestContext,
+  type TestContextOptions,
+} from '@flyingrobots/bijou/adapters/test';
+import type { ClockPort, TimerHandle } from '@flyingrobots/bijou';
+import {
+  runScript,
+  type App,
+  type RunScriptOptions,
+  type RunScriptResult,
+  type ScriptStep,
+} from '@flyingrobots/bijou-tui';
+
+export interface ScriptTestContext extends TestContext {
+  readonly clock: ClockPort;
+}
+
+export function createScriptTestContext(options: Omit<TestContextOptions, 'clock'> = {}): ScriptTestContext {
+  return createTestContext({
+    ...options,
+    clock: autoAdvancingScriptClock(),
+  }) as ScriptTestContext;
+}
+
+export function runScriptDeterministic<Model, M>(
+  app: App<Model, M>,
+  steps: ScriptStep<M>[],
+  options: RunScriptOptions & { readonly ctx: ScriptTestContext },
+): Promise<RunScriptResult<Model>> {
+  return runScript(app, steps, {
+    ...options,
+    pulseFps: options.pulseFps ?? false,
+  });
+}
+
+interface ScheduledTimeout {
+  readonly id: number;
+  readonly at: number;
+  readonly callback: () => void;
+  disposed: boolean;
+}
+
+function normalizeDelay(ms: number): number {
+  if (!Number.isFinite(ms)) return 0;
+  return Math.max(0, Math.floor(ms));
+}
+
+function autoAdvancingScriptClock(): ClockPort {
+  let nowMs = 0;
+  let nextId = 1;
+  let flushQueued = false;
+  const timeouts: ScheduledTimeout[] = [];
+
+  function disposeTimeout(id: number): void {
+    const timeout = timeouts.find((candidate) => candidate.id === id);
+    if (timeout !== undefined) {
+      timeout.disposed = true;
+    }
+  }
+
+  function nextTimeout(): ScheduledTimeout | undefined {
+    timeouts.sort((a, b) => a.at - b.at || a.id - b.id);
+    return timeouts.find((timeout) => !timeout.disposed);
+  }
+
+  function queueFlush(): void {
+    if (flushQueued) return;
+    flushQueued = true;
+    globalThis.queueMicrotask(() => {
+      flushQueued = false;
+      for (let timeout = nextTimeout(); timeout !== undefined; timeout = nextTimeout()) {
+        timeout.disposed = true;
+        nowMs = Math.max(nowMs, timeout.at);
+        timeout.callback();
+      }
+    });
+  }
+
+  return {
+    now(): number {
+      return nowMs;
+    },
+
+    date(ms?: number): Date {
+      return new Date(ms ?? nowMs);
+    },
+
+    setTimeout(callback: () => void, ms: number): TimerHandle {
+      const id = nextId++;
+      timeouts.push({
+        id,
+        at: nowMs + normalizeDelay(ms),
+        callback,
+        disposed: false,
+      });
+      queueFlush();
+      return {
+        dispose(): void {
+          disposeTimeout(id);
+        },
+      };
+    },
+
+    setInterval(): TimerHandle {
+      throw new Error(
+        'autoAdvancingScriptClock does not support intervals; use explicit pulse steps or a dedicated mockClock.',
+      );
+    },
+
+    queueMicrotask(callback: () => void): void {
+      globalThis.queueMicrotask(callback);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add a deterministic scripted-test helper with an auto-advancing logical clock.
- Disable implicit `runScript()` pulse intervals by default for converted scripted UI suites.
- Convert the slow/load-sensitive DOGFOOD and AppFrame scripted tests to deterministic time instead of wall-clock sleeps.
- Tighten the helper options so callers cannot request automatic pulse intervals with a clock that intentionally rejects intervals.

Closes #259

## Self-Code Review

- Pre-review gate: clean worktree and fresh `git fetch origin`.
- Reviewed `origin/main...HEAD`; found one P5 helper API mismatch where numeric `pulseFps` was accepted despite the deterministic clock rejecting intervals.
- Fixed in `20e164b8` by restricting `runScriptDeterministic()` to omitted/false `pulseFps`.
- No unresolved self-review findings remain.

## Validation

- `npx vitest run scripts/docs-preview.test.ts tests/cycles/LX-011/dogfood-locale-ratchet.test.ts tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts tests/cycles/DX-031/dogfood-blocks-section.test.ts tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts`
- `npm run typecheck:test`
- `git diff --check origin/main...HEAD`
- Normal `git push` pre-push hook passed:
  - `npm run typecheck:test`
  - `npm run build`
  - `npm test` (323 files, 3635 tests)
  - `npm run verify:interactive-examples`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test infrastructure utilities for improved consistency and maintainability across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->