### PR TITLE
Neutralize Design Thinking wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -33,7 +33,7 @@ body:
     id: hill
     attributes:
       label: Hill
-      description: Name the user value in Method/IBM Design Thinking style.
+      description: Name the user value in Method/Design Thinking style.
       placeholder: As a contributor, I want ..., so that ...
     validations:
       required: true

--- a/docs/design/RE-035-mandatory-layout-envelope-and-constraint-negotiation.md
+++ b/docs/design/RE-035-mandatory-layout-envelope-and-constraint-negotiation.md
@@ -537,7 +537,7 @@ differently, but the underlying layout truth should be shared.
 
 ## Design Thinking Slice Plan
 
-This cycle uses the Method loop with an IBM Design Thinking posture: sponsored
+This cycle uses the Method loop with a Design Thinking posture: sponsored
 users, measurable Hills, explicit assumptions, low-ceremony prototypes, and
 playback after each slice. The team should keep asking whether the slice helps
 a maintainer or agent inspect layout truth before render.


### PR DESCRIPTION
## Summary\n\n- Replace explicit vendor-specific Design Thinking wording in the work-item issue template and RE-035 design doc.\n- Updated GitHub Issue bodies/titles directly for the 45 issue cards that contained the same explicit phrase.\n- Verified GitHub issue comments had no matching explicit phrase.\n\nCloses #261\n\n## Validation\n\n- Self-review against origin/main: no findings.\n- git grep -n -i -E 'IBM[ -]+Design[ -]+Thinking' returned no tracked repo hits.\n- GitHub issue body/title search returned no matching issue cards after the replacement.\n- GitHub issue comment search returned no matches.\n- git diff --check\n- npm run docs:inventory\n- ruby YAML parse for .github/ISSUE_TEMPLATE/work-item.yml\n- pre-commit lint\n- pre-push full gate: typecheck:test, build, full Vitest 323 files / 3635 tests, verify:interactive-examples\n