### PR TITLE
Fix DOGFOOD i18n policy gate CI history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         node-version: [20, 22]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}

--- a/scripts/hooks.test.ts
+++ b/scripts/hooks.test.ts
@@ -29,4 +29,17 @@ describe('git hooks', () => {
     expect(workflow).toContain('npm run dogfood:i18n:complete');
     expect(workflow).toContain('npm run dogfood:i18n:check');
   });
+
+  it('CI fetches enough history before comparing DOGFOOD i18n source rows to HEAD^', () => {
+    const workflow = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf8');
+    const checkoutIndex = workflow.indexOf('- uses: actions/checkout@v6');
+    const fetchDepthIndex = workflow.indexOf('fetch-depth: 2', checkoutIndex);
+    const i18nGateIndex = workflow.indexOf('DOGFOOD i18n policy gate');
+    const headParentBaseIndex = workflow.indexOf('npm run dogfood:i18n:complete -- --base HEAD^');
+
+    expect(checkoutIndex).toBeGreaterThanOrEqual(0);
+    expect(fetchDepthIndex).toBeGreaterThan(checkoutIndex);
+    expect(fetchDepthIndex).toBeLessThan(i18nGateIndex);
+    expect(headParentBaseIndex).toBeGreaterThan(i18nGateIndex);
+  });
 });


### PR DESCRIPTION
## Summary
- Fetch two commits in the Linux CI test job so the push/tag path can compare DOGFOOD i18n source rows against `HEAD^`.
- Add a workflow regression test that keeps the `HEAD^` policy gate paired with sufficient checkout history.

## Context
- Addresses the Codex review thread from PR #264: https://github.com/flyingrobots/bijou/pull/264#discussion_r3345690410
- Fixes the failed main CI push run for merge commit `1e3ff5b2`: https://github.com/flyingrobots/bijou/actions/runs/26861384483

## Validation
- RED: `npm test -- --run scripts/hooks.test.ts` failed before the workflow fix on missing `fetch-depth: 2`.
- GREEN: `npm test -- --run scripts/hooks.test.ts`
- `npm run dogfood:i18n:complete -- --base HEAD^`
- `npm run dogfood:i18n:check`
- `git diff --check`
- `npm run typecheck:test`
- `npm run lint`
- pre-push: `dogfood:i18n:complete`, `dogfood:i18n:check`, `typecheck:test`, full `npm test` (326 files, 3654 tests), `verify:interactive-examples`