### PR TITLE
Design BlockLab rename and product parity

### DIFF
--- a/docs/design/DX-038-blocklab-rename-and-migration.md
+++ b/docs/design/DX-038-blocklab-rename-and-migration.md
@@ -1,0 +1,234 @@
+---
+title: "DX-038 - BlockLab Rename And Migration"
+legend: DX
+lane: design
+issue: https://github.com/flyingrobots/bijou/issues/271
+---
+
+# DX-038 - BlockLab Rename And Migration
+
+## Linked Issue
+
+- https://github.com/flyingrobots/bijou/issues/271
+
+## Sponsored Human
+
+A Bijou maintainer wants the story and component workbench to have a
+project-owned name that does not imply affiliation with the browser Storybook
+product, while keeping the existing workflow understandable for users who
+already know `npm run storybook`.
+
+## Sponsored Agent
+
+An agent needs stable names for scripts, Blocks, command intents, surface ids,
+and docs links. It should not have to infer whether "storybook" means Bijou's
+terminal workbench, the external product, or a generic story-driven workflow.
+
+## Hill
+
+Rename the current Storybook-labeled workstation to **BlockLab** across human
+visible surfaces and future-facing contracts, while preserving a short
+compatibility path for existing commands.
+
+This is product hygiene, not a legal conclusion. The current name creates
+avoidable ambiguity because Storybook is an established external product. Bijou
+can keep story-driven component development while naming its own terminal-native
+surface differently.
+
+## Current Truth
+
+The current repo exposes a story-driven workstation through:
+
+- `npm run storybook`
+- `npm run storybook:index`
+- `npm run dogfood:storybook`
+- `examples/docs/storybook.ts`
+- `examples/docs/storybook-app.ts`
+- `examples/docs/storybook-workstation.ts`
+- visible labels such as `Bijou Storybook`, `Storybook`, and
+  `Storybook Workstation`
+- DOGFOOD Block and registry names such as `StorybookWorkbenchBlock`
+- docs that describe a "Storybook-style" workbench
+
+The product shape is already useful: it has a story catalog, variants, profile
+presets, structured docs fields, matrix capture, AppFrame integration, and a
+text-first index. The naming layer is the weak part.
+
+## Name Decision
+
+Use **BlockLab** as the product name.
+
+Proposed vocabulary:
+
+| Current | Proposed |
+| :--- | :--- |
+| `Bijou Storybook` | `Bijou BlockLab` |
+| `Storybook Workstation` | `BlockLab Workstation` |
+| `StorybookWorkbenchBlock` | `BlockLabWorkbenchBlock` |
+| `storybook.workbench` | `blocklab.workbench` |
+| `storybook.selectStory` | `blocklab.selectStory` |
+| `npm run storybook` | `npm run blocklab` |
+| `npm run storybook:index` | `npm run blocklab:index` |
+
+Compatibility aliases should remain for one migration window:
+
+```bash
+npm run storybook
+npm run storybook:index
+npm run dogfood:storybook
+```
+
+Those aliases should call the BlockLab entrypoints and may print a concise
+deprecation note if the runtime can do so without polluting deterministic index
+output.
+
+## TUI Mockup
+
+Wide terminal:
+
+```text
+Bijou BlockLab | notification-system | Live stack | Rich
++ catalog -------------------++ preview ---------------------------++ lab -----------------------+
+| 72 stories                  || notification-system                || Selection                  |
+| > notification-system       || + Live stack --------------------+ || story=notification-system  |
+|   framed-shell              || | release dashboard              | || variant=live-stack        |
+|   command-palette           || | Canaries stable in eu-west     | || profile=interactive       |
+|   table-responsive          || +-------------------------------+ ||                              |
+|                             || Docs                              || Required modes             |
+| Families                    || Use when                          || interactive: ready         |
+| Feedback overlays           || - surface owns transient state     || static: ready              |
+| Navigation                  || - lower modes preserve message     || pipe: ready                |
+| Blocks                      ||                                   || accessible: ready          |
++-----------------------------++-----------------------------------++-----------------------------+
+q quit | / search | g globals | c controls | a actions | t tests | ,/. variant | 1-4 profile
+```
+
+Narrow terminal:
+
+```text
+Bijou BlockLab
+notification-system
+
++ Live stack --------------------+
+| release dashboard              |
+| Canaries stable in eu-west     |
++-------------------------------+
+
+Profile: Rich / interactive / 60 cols
+Variant: live-stack
+Modes: interactive static pipe accessible
+
+Tabs: preview docs controls tests actions
+```
+
+## Lower Modes
+
+Pipe mode should remain deterministic and artifact-friendly:
+
+```text
+blocklab index
+stories=72
+families=31
+variants=144
+requiredModes=interactive,static,pipe,accessible
+
+family Feedback overlays and history
+- notification-system | package=bijou-tui | variants=live-stack,history-review,framed-routing
+```
+
+Accessible mode should describe purpose and state instead of chrome:
+
+```text
+BlockLab workbench. Story notification-system. Variant Live stack.
+Profile Rich. Required modes are all ready. Source examples/notifications/main.ts.
+Preview summary: release dashboard, canaries stable in eu-west.
+```
+
+## Accessibility / Assistive Posture
+
+The rename must not make the workbench more visual-only. Every renamed surface
+keeps existing lower-mode facts:
+
+- story id
+- story title
+- package
+- source path
+- selected variant
+- selected profile
+- required mode coverage
+- capture matrix status
+
+Future `BlockLab` labels should be localizable visible text. Machine tokens such
+as command ids and event discriminants can use `blocklab.*` but should not be
+translated.
+
+## Localization / Directionality Posture
+
+New visible strings must enter `examples/docs/i18n/source/dogfood-strings.csv`
+with `en`, `fr`, `es`, and `de` rows. The rename should update generated
+catalog files in the same PR, and `npm run dogfood:i18n:complete` should be run
+against the branch.
+
+Directionality does not change for this rename. The UI must continue to route
+localized copy through DOGFOOD's localization port rather than hard-coded view
+helpers.
+
+## Agent Inspectability / Explainability Posture
+
+Agents should be able to tell that `BlockLab` is the canonical surface without
+scraping UI strings. The rename should update:
+
+- Block metadata names and tags
+- surface inventory ids and descriptions
+- command intents
+- story matrix report titles
+- deterministic index title
+- docs references
+
+The compatibility aliases should be treated as command-level affordances, not
+as canonical product names.
+
+## Linked Invariants
+
+- GitHub Issues are the live tracker; this design is linked to #271.
+- DOGFOOD localization completeness gates protect new visible strings.
+- Blocks own product semantics; components remain leaf rendering vocabulary.
+- Text-first outputs stay deterministic for CI, agents, and fixtures.
+
+## Migration Plan
+
+1. Introduce BlockLab docs language and visible product labels.
+2. Add `blocklab` and `blocklab:index` scripts.
+3. Keep `storybook`, `storybook:index`, and `dogfood:storybook` as compatibility
+   aliases for one migration window.
+4. Rename user-visible AppFrame page title and settings label.
+5. Rename DOGFOOD Block contracts and registry entries from
+   `StorybookWorkbenchBlock` to `BlockLabWorkbenchBlock`.
+6. Rename command intents and surface ids from `storybook.*` to `blocklab.*`.
+7. Update localization rows and generated catalogs.
+8. Update docs, tests, and teardown command tables.
+
+## Tests To Write First
+
+- A focused rename test that expects the default title to be `Bijou BlockLab`.
+- A framed AppFrame test that expects the page title `BlockLab`.
+- A DOGFOOD settings test that expects `BlockLab Workstation`.
+- A Block metadata test that expects `BlockLabWorkbenchBlock`.
+- A script-registration test proving `blocklab` and `blocklab:index` exist and
+  legacy scripts still resolve.
+- An i18n completeness run proving every changed visible string has supported
+  locale rows.
+
+## Non-Goals
+
+- No direct Storybook compatibility layer.
+- No browser runtime.
+- No package rename outside the workbench surface.
+- No claim about trademark law.
+- No removal of compatibility scripts in the first rename PR.
+
+## Retrospective Target
+
+The rename is successful when humans see `BlockLab`, agents see `blocklab.*`
+contracts, and legacy `storybook` commands still work long enough for users to
+move without friction.

--- a/docs/design/DX-039-blocklab-product-parity.md
+++ b/docs/design/DX-039-blocklab-product-parity.md
@@ -1,0 +1,338 @@
+---
+title: "DX-039 - BlockLab Product Parity"
+legend: DX
+lane: design
+issue: https://github.com/flyingrobots/bijou/issues/272
+---
+
+# DX-039 - BlockLab Product Parity
+
+## Linked Issue
+
+- https://github.com/flyingrobots/bijou/issues/272
+
+## Sponsored Human
+
+A component author wants BlockLab to feel like a real component development
+product: searchable, controllable, inspectable, test-aware, and useful for
+building the next Bijou Block without dropping into the full DOGFOOD docs app.
+
+## Sponsored Agent
+
+An agent needs one stable story surface that can produce docs, fixtures,
+lower-mode captures, interaction playback, visual evidence, source links, and
+machine-readable reports without scraping terminal frames.
+
+## Hill
+
+Evolve BlockLab from "story catalog plus preview" into a terminal-native
+component and Block laboratory that borrows the strongest workflows from the
+current Storybook product without cloning its browser UI.
+
+## Source Scan
+
+Official Storybook documentation reviewed on 2026-06-03:
+
+- Args: https://storybook.js.org/docs/writing-stories/args
+- Controls: https://storybook.js.org/docs/essentials/controls
+- Toolbars and globals:
+  https://storybook.js.org/docs/essentials/toolbars-and-globals
+- Viewport: https://storybook.js.org/docs/essentials/viewport
+- Decorators: https://storybook.js.org/docs/writing-stories/decorators
+- Docs and Autodocs: https://storybook.js.org/docs/writing-docs/autodocs
+- MDX and doc blocks: https://storybook.js.org/docs/writing-docs/mdx
+- Interaction testing:
+  https://storybook.js.org/docs/writing-tests/interaction-testing
+- Accessibility testing:
+  https://storybook.js.org/docs/writing-tests/accessibility-testing
+- Visual testing: https://storybook.js.org/docs/writing-tests/visual-testing
+- Addon types: https://storybook.js.org/docs/addons/addon-types
+- Storybook composition:
+  https://storybook.js.org/docs/sharing/storybook-composition
+
+The product lesson is not "make a browser Storybook clone." The lesson is that
+a mature story workbench separates story data, controls, global context,
+preview, generated docs, addon panels, and test artifacts while keeping them
+linked by stable story ids.
+
+## Current Bijou Truth
+
+BlockLab's current pre-rename substrate already has:
+
+- `ComponentStory` records with `id`, `family`, `title`, `package`, docs,
+  profile presets, variants, source, and tags
+- canonical profile presets for `interactive`, `static`, `pipe`, and
+  `accessible`
+- `renderDogfoodStorybookIndex()` for deterministic text output
+- `captureDogfoodStorybookMatrix()` for profile x variant capture
+- a three-pane interactive TUI: catalog, preview, and testing
+- AppFrame integration and a surface Block contract
+
+The missing layer is product workflow.
+
+## Gap Table
+
+| Storybook-like product concept | Current BlockLab state | Needed BlockLab feature |
+| :--- | :--- | :--- |
+| args/controls | variants have static `initialState` | serializable story args plus control schema |
+| globals/toolbars | profile keys select mode/width | global toolbar for mode, width, locale, direction, theme, density, reduced motion |
+| decorators | stories manually construct context | story harness/decorator chain for frame, providers, mock IO, and data bindings |
+| docs blocks/autodocs | `storyDocsMarkdown()` renders fixed sections | doc block model composing summary, source, controls, lowerings, captures, related stories |
+| addon panels | testing pane only | addon-like panels for actions, a11y, visual diffs, performance, bindings, events |
+| interaction testing | smoke scripts live elsewhere | story-local play steps and playback reports |
+| accessibility testing | lower-mode prose is documented | a11y fact panel and required accessible capture assertions |
+| visual testing | matrix captures text frames | named visual artifacts, diffs, and update workflow |
+| viewport | profile width presets | viewport presets plus arbitrary terminal size profiles |
+| composition | one DOGFOOD story catalog | composed story catalogs from packages, examples, plugins, and MCP exports |
+
+## TUI Mockup
+
+Wide terminal with product-grade panels:
+
+```text
+Bijou BlockLab                                      story: notification-system
++ catalog -------------------++ preview ---------------------------++ controls ----------------+
+| Search: notification        || + Live stack --------------------+ || Args                     |
+|                             || | release dashboard              | || severity: success        |
+| Feedback overlays           || | Canaries stable in eu-west     | || count: 2                 |
+| > notification-system       || +-------------------------------+ || compact: off             |
+|   toast                     ||                                   ||                           |
+|   modal                     || Docs | Source | Actions | A11y      || Globals                  |
+|                             || Use when                          || mode: interactive        |
+| Blocks                      || - status must stay observable     || locale: en               |
+|   app-shell                 || - lower modes need durable text    || width: 60                |
+|                             ||                                   || direction: ltr           |
++-----------------------------++-----------------------------------++---------------------------+
+tabs: preview docs source actions a11y visual perf bindings
+keys: / search | c controls | g globals | p play | v visual | a a11y | x export
+```
+
+Interaction playback panel:
+
+```text
++ interactions ----------------------------------------------------------------+
+| notification-system / live-stack                                             |
+|                                                                              |
+| 1. mount story                                           PASS  4ms            |
+| 2. press n to add notification                          PASS  2ms            |
+| 3. assert stack announces newest item                    PASS  1ms            |
+| 4. switch to accessible profile                          PASS  1ms            |
+|                                                                              |
+| artifact: artifacts/blocklab/notification-system/live-stack/playback.txt      |
++------------------------------------------------------------------------------+
+```
+
+Visual artifact panel:
+
+```text
++ visual ----------------------------------------------------------------------+
+| profile      variant          baseline       current        result            |
+| interactive  live-stack       60x18          60x18          unchanged         |
+| static       live-stack       60x18          60x18          changed +2 lines  |
+| pipe         framed-routing   52x18          52x18          unchanged         |
+| accessible   history-review   52x18          52x18          unchanged         |
++------------------------------------------------------------------------------+
+```
+
+## Lower Modes
+
+Pipe mode should expose stable machine-readable sections:
+
+```text
+blocklab story notification-system
+variant=live-stack
+profile=interactive
+globals.mode=interactive
+globals.locale=en
+globals.width=60
+args.severity=success
+args.count=2
+
+[preview]
+release dashboard
+Canaries stable in eu-west
+
+[tests]
+interaction=pass
+a11y=pass
+visual=changed +2 lines
+```
+
+Accessible mode should prioritize the selected story and active findings:
+
+```text
+BlockLab story notification-system. Variant Live stack.
+Controls: severity success, count two, compact off.
+Globals: interactive mode, English locale, left to right, sixty columns.
+Accessibility report passed. Visual report changed by two lines in static mode.
+```
+
+## Protocol Sketch
+
+`ComponentStory` can grow without breaking existing records by adding optional
+fields:
+
+```ts
+interface BlockLabControl {
+  readonly id: string;
+  readonly label: string;
+  readonly kind: 'boolean' | 'number' | 'text' | 'select' | 'color' | 'json';
+  readonly defaultValue: unknown;
+  readonly options?: readonly unknown[];
+}
+
+interface BlockLabGlobals {
+  readonly mode?: OutputMode;
+  readonly width?: number;
+  readonly locale?: string;
+  readonly direction?: 'ltr' | 'rtl';
+  readonly theme?: string;
+  readonly density?: string;
+  readonly reducedMotion?: boolean;
+}
+
+interface BlockLabPanelReport {
+  readonly panelId: string;
+  readonly status: 'pass' | 'warn' | 'fail' | 'info';
+  readonly facts: readonly ExplanationFact[];
+  readonly output: string;
+}
+```
+
+The first implementation should keep these fields optional and derive defaults
+from the current profile presets.
+
+## Feature Slices
+
+### 1. Args/Controls
+
+Add serializable controls to stories and a control pane in BlockLab.
+
+Proof:
+
+- controls render in TUI and lower modes
+- control changes feed story render input deterministically
+- CLI output includes selected args
+
+### 2. Globals/Toolbars
+
+Add global context for mode, width, locale, direction, theme, density, and
+reduced motion.
+
+Proof:
+
+- global state affects preview context
+- lower modes report globals
+- locale/direction changes route through DOGFOOD localization ports
+
+### 3. Decorators/Harnesses
+
+Add a story harness chain for common setup: AppFrame, providers, mock IO,
+binding snapshots, theme, and viewport.
+
+Proof:
+
+- harnesses compose without mutating base context
+- a story can declare provider data without bespoke preview code
+
+### 4. Docs Blocks
+
+Replace fixed markdown assembly with docs block composition.
+
+Proof:
+
+- docs view can show source, controls, lowerings, story matrix, and related
+  stories as separate inspectable blocks
+- pipe mode can emit those blocks in deterministic order
+
+### 5. Addon-Like Panels
+
+Introduce panel slots for actions/events, accessibility facts, visual diffs,
+performance facts, binding state, and source.
+
+Proof:
+
+- each panel has a stable id and lower-mode report
+- disabled panels do not affect preview rendering
+
+### 6. Interaction Playback
+
+Let stories declare deterministic play steps that can run in BlockLab, CI, and
+text-first output.
+
+Proof:
+
+- RED/GREEN tests for one story-local playback
+- playback report includes steps, status, elapsed time, and artifacts
+
+### 7. Composition
+
+Allow BlockLab to import multiple story catalogs.
+
+Proof:
+
+- composed catalogs preserve package/source facts
+- duplicate story ids fail loudly
+- CLI can filter by package, family, tag, and source
+
+## Accessibility / Assistive Posture
+
+BlockLab parity must improve lower-mode truth, not just add visual panels.
+Every product feature needs accessible and pipe output:
+
+- controls list active values
+- globals list current context
+- panels list status and findings
+- interactions list steps and outcomes
+- visual reports describe line/cell differences
+- docs blocks preserve heading order
+
+## Localization / Directionality Posture
+
+Controls and globals are visible UI. Labels, panel names, and status text must
+go through DOGFOOD localization when they appear in DOGFOOD-owned surfaces.
+Story ids, arg ids, and artifact paths remain machine tokens.
+
+Directionality belongs in globals. RTL preview should be a first-class context
+state, not a separate story variant unless the variant is semantically
+different.
+
+## Agent Inspectability / Explainability Posture
+
+The text-first command should eventually emit:
+
+- `blocklab index`
+- `blocklab story <id>`
+- `blocklab controls <id>`
+- `blocklab test <id>`
+- `blocklab artifacts <id>`
+
+Each command should produce stable sections that agents can parse without
+screen scraping. JSON output can be added later, but plain text remains the
+first evidence surface because it is easier to review in PRs.
+
+## Tests To Write First
+
+- Protocol tests for optional controls and globals.
+- Workbench model tests proving controls, globals, panels, and docs blocks are
+  discoverable without rendering.
+- TUI tests proving controls and globals change preview output.
+- Lower-mode tests proving pipe and accessible output include args/controls and
+  panel statuses.
+- Interaction playback tests using fake clocks and deterministic input.
+- Visual artifact tests using fixed-size terminal captures.
+
+## Non-Goals
+
+- No browser Storybook runtime.
+- No direct addon API compatibility promise.
+- No screenshots-only acceptance criteria.
+- No story catalog fork separate from DOGFOOD story truth.
+- No hidden global registry.
+
+## Retrospective Target
+
+BlockLab is product-grade when a maintainer can open one terminal workbench,
+adjust story inputs, switch global context, read generated docs, run playback,
+inspect a11y/visual/performance findings, and export deterministic evidence for
+CI or agents.

--- a/tests/cycles/DX-038/blocklab-design-docs.test.ts
+++ b/tests/cycles/DX-038/blocklab-design-docs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { existsRepoPath, readRepoFile } from '../repo.js';
+
+describe('DX-038/DX-039 BlockLab design docs', () => {
+  it('records the BlockLab rename design with issue-backed Method sections', () => {
+    const path = 'docs/design/DX-038-blocklab-rename-and-migration.md';
+
+    expect(existsRepoPath(path)).toBe(true);
+
+    const doc = readRepoFile(path);
+
+    expect(doc).toContain('https://github.com/flyingrobots/bijou/issues/271');
+    expect(doc).toContain('BlockLab');
+    expect(doc).toContain('## Sponsored Human');
+    expect(doc).toContain('## Sponsored Agent');
+    expect(doc).toContain('## Hill');
+    expect(doc).toContain('## TUI Mockup');
+    expect(doc).toContain('## Lower Modes');
+    expect(doc).toContain('## Tests To Write First');
+  });
+
+  it('records the BlockLab product-parity design with actual Storybook source scan', () => {
+    const path = 'docs/design/DX-039-blocklab-product-parity.md';
+
+    expect(existsRepoPath(path)).toBe(true);
+
+    const doc = readRepoFile(path);
+
+    expect(doc).toContain('https://github.com/flyingrobots/bijou/issues/272');
+    expect(doc).toContain('Source Scan');
+    expect(doc).toContain('https://storybook.js.org/docs/writing-stories/args');
+    expect(doc).toContain('https://storybook.js.org/docs/essentials/controls');
+    expect(doc).toContain('https://storybook.js.org/docs/writing-tests/interaction-testing');
+    expect(doc).toContain('args/controls');
+    expect(doc).toContain('addon-like panels');
+    expect(doc).toContain('## TUI Mockup');
+    expect(doc).toContain('## Lower Modes');
+  });
+});


### PR DESCRIPTION
## Summary
- Add DX-038 design doc for renaming the current Storybook-labeled workstation to BlockLab.
- Add DX-039 design doc mapping BlockLab toward Storybook-grade workflows: controls, globals, decorators, docs blocks, addon-like panels, interaction playback, accessibility/visual reports, and catalog composition.
- Add a cycle regression test that keeps both design docs issue-backed and source-scanned.

## Issue Links
- Refs #271
- Refs #272

These are intentionally not closed by this PR. The rename implementation and product-parity feature work remain open follow-up work.

## Validation
- RED: `npm test -- --run tests/cycles/DX-038/blocklab-design-docs.test.ts` failed before the docs existed.
- GREEN: `npm test -- --run tests/cycles/DX-038/blocklab-design-docs.test.ts`
- `npm test -- --run tests/cycles/DF-027/storybook-workstation.test.ts scripts/component-story-protocol.test.ts tests/cycles/DX-038/blocklab-design-docs.test.ts`
- `npm run docs:inventory`
- `npm run typecheck:test`
- `npm run lint`
- `git diff --check`
- pre-push: `dogfood:i18n:complete`, `dogfood:i18n:check`, `typecheck:test`, full `npm test` (327 files, 3656 tests), `verify:interactive-examples`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added design documentation outlining BlockLab rename and migration strategy with compatibility considerations
  * Added product parity specification defining BlockLab capabilities and feature roadmap

* **Tests**
  * Added validation tests for design documentation completeness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->