### PR TITLE
Standardize Method intake template

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,5 +1,5 @@
 name: Method work item
-description: Propose shaped Bijou work with a hill, scope, and witness plan.
+description: Propose shaped Bijou work with a design-doc-ready contract and proof plan.
 title: ""
 labels:
   - lane:inbox
@@ -9,8 +9,12 @@ body:
     attributes:
       value: |
         Use a short, branch-safe title. Active work uses a branch slug derived from this title.
+
         Labels are canonical tracker metadata. If you want a lane or legend other than inbox triage,
         request it below; a maintainer or agent must apply the actual label.
+
+        Implementation work must name software behavior proof. Documentation-only proof is
+        acceptable only for documentation or process work.
   - type: textarea
     id: requested-classification
     attributes:
@@ -23,84 +27,302 @@ body:
     validations:
       required: false
   - type: textarea
-    id: finding
+    id: decision-summary
     attributes:
-      label: Finding
-      description: What repo truth, user need, defect, or opportunity motivates this work?
+      label: Decision summary
+      description: What decision or work shape should this issue establish?
+      placeholder: |
+        This issue will establish ...
+    validations:
+      required: true
+  - type: textarea
+    id: sponsored-human
+    attributes:
+      label: Sponsored human
+      description: Name the human perspective and job this work serves.
+      placeholder: |
+        A <type of user> wants <capability/outcome> so that <reason>, without having to <current pain or unsafe workaround>.
+    validations:
+      required: true
+  - type: textarea
+    id: sponsored-agent
+    attributes:
+      label: Sponsored agent
+      description: Name the automation, implementation, review, or reproducibility perspective this work serves.
+      placeholder: |
+        An agent needs <inspectable contract/tool/surface> so it can <operation>, without inferring <unstable/private/visual-only state>.
     validations:
       required: true
   - type: textarea
     id: hill
     attributes:
       label: Hill
-      description: Name the user value in Method/Design Thinking style.
-      placeholder: As a contributor, I want ..., so that ...
+      description: State the observable outcome, not the task list.
+      placeholder: |
+        By the end of this cycle, <user/agent> can <observable outcome> through <surface/API/command>, and the repo proves it with <tests/witnesses>.
     validations:
       required: true
   - type: textarea
-    id: sponsored-perspectives
+    id: current-truth
     attributes:
-      label: Sponsored perspectives
-      description: Name abstract sponsored human and agent seats, not literal people or model brands.
-      value: |
-        - Sponsored Human: Name the served operator, maintainer, contributor, or user perspective.
-        - Sponsored Agent: Name the automation, implementation, review, or reproducibility perspective.
+      label: Current truth
+      description: What is already true on current main?
+      placeholder: |
+        Verified against main at <commit>.
 
-        These are Method sponsorship seats, not literal people, accounts, or model brands.
+        Current anchors:
+        - File/API/command:
+        - Current test coverage:
+        - Current failure mode or gap:
     validations:
       required: true
   - type: textarea
-    id: current-repo-note
+    id: problem
     attributes:
-      label: Current repo note
-      description: What is already true on the current main branch, if anything?
-      placeholder: Verified against main at <commit>. ...
+      label: Problem
+      description: What exact defect, gap, ambiguity, or opportunity motivates this work?
+      placeholder: |
+        The problem is ...
     validations:
-      required: false
+      required: true
   - type: textarea
     id: scope
     attributes:
       label: Scope
       description: What is in bounds?
       placeholder: |
+        This issue includes:
         - ...
     validations:
       required: true
   - type: textarea
-    id: out-of-scope
+    id: non-goals
     attributes:
-      label: Out of scope
+      label: Non-goals
       description: What should not be solved in this issue?
       placeholder: |
+        This issue does not include:
         - ...
     validations:
       required: true
   - type: textarea
-    id: acceptance
+    id: user-experience-product-shape
+    attributes:
+      label: User experience / product shape
+      description: Describe what the user sees or does. Include TUI mockups for user-visible surfaces.
+      value: |
+        If this work changes a user-visible surface, include concrete sketches.
+
+        ### Wide TUI mockup
+
+        ```text
+        <ASCII sketch>
+        ```
+
+        ### Narrow TUI mockup
+
+        ```text
+        <ASCII sketch>
+        ```
+
+        If this work is not user-visible, explain why this section is not applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: lower-modes
+    attributes:
+      label: Lower modes
+      description: State how this work behaves in static, pipe, and accessible modes.
+      value: |
+        ### Static mode
+
+        ```text
+        <stable readable output, or Not applicable with reason>
+        ```
+
+        ### Pipe mode
+
+        ```text
+        <deterministic machine-friendly output, or Not applicable with reason>
+        ```
+
+        ### Accessible mode
+
+        ```text
+        <state, actions, and facts, or Not applicable with reason>
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: runtime-api-contract
+    attributes:
+      label: Runtime / API contract
+      description: Name the software contract this work will create, change, or preserve.
+      placeholder: |
+        Relevant contracts:
+        - Exported functions/types:
+        - Block metadata:
+        - Command intents:
+        - Schema input/output:
+        - Facts emitted:
+        - State transitions:
+        - Layout/focus/input boundaries:
+        - Error behavior:
+        - Compatibility aliases or migration behavior:
+    validations:
+      required: true
+  - type: textarea
+    id: data-state-model
+    attributes:
+      label: Data / state model
+      description: Describe state that persists, mutates, or crosses boundaries.
+      placeholder: |
+        Source of truth:
+        Derived state:
+        Invalid states:
+        Reset behavior:
+        Serialization:
+        Deterministic clock/runtime assumptions:
+    validations:
+      required: true
+  - type: textarea
+    id: accessibility-posture
+    attributes:
+      label: Accessibility posture
+      description: How does the result preserve semantic meaning and keyboard/assistive access?
+      placeholder: |
+        - Semantic labels or facts:
+        - Focus order or focus ownership:
+        - Hidden visual-only information that must still be available:
+        - Keyboard behavior:
+        - Secret/redaction behavior:
+    validations:
+      required: true
+  - type: textarea
+    id: localization-directionality-posture
+    attributes:
+      label: Localization / directionality posture
+      description: Required when visible strings are added or changed. Otherwise explain why it is not applicable.
+      placeholder: |
+        - User-visible strings:
+        - Catalog keys:
+        - Supported locale rows needed:
+        - Directionality assumptions:
+        - `npm run dogfood:i18n:complete` applicability:
+    validations:
+      required: true
+  - type: textarea
+    id: agent-inspectability-explainability-posture
+    attributes:
+      label: Agent inspectability / explainability posture
+      description: How can an agent inspect the result without scraping pixels or prose?
+      placeholder: |
+        - Stable ids:
+        - Metadata fields:
+        - Emitted facts:
+        - Deterministic pipe output:
+        - Registry entries:
+        - Schema descriptions:
+        - Command ids:
+        - Machine-readable witness output:
+    validations:
+      required: true
+  - type: textarea
+    id: linked-invariants
+    attributes:
+      label: Linked invariants
+      description: Which Bijou invariants must this work preserve?
+      placeholder: |
+        - Tests Are the Spec
+        - Runtime Truth Wins
+        - Layout Owns Interaction Geometry
+        - Commands Change State, Effects Do Not
+        - Docs Are the Demo
+        - Blocks Own Product Semantics
+    validations:
+      required: true
+  - type: textarea
+    id: implementation-slices
+    attributes:
+      label: Implementation slices
+      description: Split the work into small testable steps.
+      placeholder: |
+        1. <Smallest testable slice>
+        2. <Next slice>
+        3. <Next slice>
+    validations:
+      required: true
+  - type: textarea
+    id: tests-to-write-first
+    attributes:
+      label: Tests to write first
+      description: Name the RED tests that prove the work.
+      value: |
+        ### Behavior/software proof required for implementation work
+
+        - [ ] Name at least one test against package API, runtime behavior, rendered output, scripted app flow, command behavior, schema validation, lower-mode output, or CI/tooling behavior.
+        - [ ] Name the expected RED failure before implementation.
+        - [ ] Name the focused GREEN command after implementation.
+
+        ### Documentation/process proof
+
+        - [ ] Documentation-only proof is acceptable only for documentation/process work.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
     attributes:
       label: Acceptance criteria
       description: Concrete checks that prove the issue is complete.
-      placeholder: |
-        - [ ] ...
+      value: |
+        - [ ] Behavior test proves the runtime/API/render/command/tooling contract, or this is documentation/process-only work.
+        - [ ] Rendered output or runtime API proves the user-visible outcome, if relevant.
+        - [ ] Lower modes are covered, if relevant.
+        - [ ] New visible strings include supported translations, if relevant.
+        - [ ] DOGFOOD/docs/changelog are updated, if behavior or direction changed.
+        - [ ] Issue and PR are linked correctly.
+        - [ ] CI and local validation are green.
     validations:
       required: true
   - type: textarea
-    id: witness
+    id: validation-plan
     attributes:
-      label: Expected evidence
-      description: Expected evidence for tests, playback, docs, and retro.
+      label: Validation plan
+      description: Name the commands expected before PR.
       value: |
-        ### Tests
-        Name the deterministic test command, failing-before-fix reproduction, or reason no code test applies.
+        ```bash
+        npm test -- --run <focused behavior tests>
+        npm run typecheck:test
+        npm run lint
+        npm run docs:inventory
+        npm run dogfood:i18n:complete
+        npm run dogfood:i18n:check
+        ```
 
-        ### Playback
-        Name the human-visible playback, demo, transcript, or reproduction that proves the result.
+        Trim commands that do not apply. Add package-specific commands when needed.
+    validations:
+      required: true
+  - type: textarea
+    id: playback-witness
+    attributes:
+      label: Playback / witness
+      description: What can a reviewer run or inspect to prove this is real?
+      placeholder: |
+        Commands, routes, key sequences, terminal sizes, screenshots, transcripts, or CI artifacts:
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: risks-follow-on-debt
+    attributes:
+      label: Risks and follow-on debt
+      description: Name known risks and create GitHub issues for anything intentionally deferred.
+      placeholder: |
+        Risks:
+        - ...
 
-        ### Docs
-        Name the documentation, issue template, signpost, or changelog surface updated, or explain why none is required.
-
-        ### Retro / Closeout
-        Name the closeout note, follow-up issue links, shipped retro, or close reason that will preserve the decision.
+        Follow-on issues to create:
+        - ...
     validations:
       required: true
   - type: textarea
@@ -120,6 +342,9 @@ body:
     attributes:
       label: Triage rule
       description: What decision should move, close, split, or merge this issue?
-      placeholder: Move to lane:asap when ... Close if ...
+      placeholder: |
+        Move to lane:asap when ...
+        Close if ...
+        Split if ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -110,7 +110,7 @@ body:
     attributes:
       label: User experience / product shape
       description: Describe what the user sees or does. Include TUI mockups for user-visible surfaces.
-      value: |
+      placeholder: |
         If this work changes a user-visible surface, include concrete sketches.
 
         ### Wide TUI mockup
@@ -133,7 +133,7 @@ body:
     attributes:
       label: Lower modes
       description: State how this work behaves in static, pipe, and accessible modes.
-      value: |
+      placeholder: |
         ### Static mode
 
         ```text
@@ -257,7 +257,7 @@ body:
     attributes:
       label: Tests to write first
       description: Name the RED tests that prove the work.
-      value: |
+      placeholder: |
         ### Behavior/software proof required for implementation work
 
         - [ ] Name at least one test against package API, runtime behavior, rendered output, scripted app flow, command behavior, schema validation, lower-mode output, or CI/tooling behavior.
@@ -274,7 +274,7 @@ body:
     attributes:
       label: Acceptance criteria
       description: Concrete checks that prove the issue is complete.
-      value: |
+      placeholder: |
         - [ ] Behavior test proves the runtime/API/render/command/tooling contract, or this is documentation/process-only work.
         - [ ] Rendered output or runtime API proves the user-visible outcome, if relevant.
         - [ ] Lower modes are covered, if relevant.
@@ -289,7 +289,7 @@ body:
     attributes:
       label: Validation plan
       description: Name the commands expected before PR.
-      value: |
+      placeholder: |
         ```bash
         npm test -- --run <focused behavior tests>
         npm run typecheck:test
@@ -330,7 +330,7 @@ body:
     attributes:
       label: Method artifacts
       description: Fill these links as the work proceeds.
-      value: |
+      placeholder: |
         - Design: Link `docs/design/<LEGEND>-<issue>-<slug>.md`, or state why issue-only triage is sufficient.
         - Witness: Link committed witness evidence or the issue/PR comment that records verification.
         - Retro: Link the retro/closeout artifact or the issue close comment.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 📚 Documentation
 
+- **Design-document-ready Method intake** — The GitHub Method work-item issue
+  template now guides new work through the standard design document shape:
+  decision summary, sponsored human and agent perspectives, current truth,
+  problem, scope, non-goals, product shape, lower modes, runtime/API contract,
+  accessibility, localization, inspectability, implementation slices, tests to
+  write first, validation, playback, risks, follow-on debt, and Method
+  artifacts. `docs/METHOD.md` now makes issue templates the default shaping
+  enforcement and explicitly avoids blanket branch-name-to-design-doc commit
+  blocking for hotfixes, CI repairs, dependency repairs, and small maintenance
+  work. This closes issue #275.
 - **DX-034 data binding closeout** — BEARING, ROADMAP, the v6 backlog
   evidence, and cycle tests now mark declarative view data binding as landed
   through issue #182. The closeout records immutable binding frames, provider

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -27,15 +27,38 @@ honest bookkeeping.
 New intake starts as a GitHub Issue. Use the repo issue forms so every card
 names:
 
+- the decision summary
 - the hill
 - sponsored human and agent perspectives
+- current truth and the exact problem
 - scope and out-of-scope boundaries
+- runtime/API or product-surface contract
+- lower-mode, accessibility, localization, and inspectability posture
+- implementation slices and tests to write first
 - acceptance criteria
 - expected tests, playback, docs, and retro/closeout evidence
 - Method artifact links for design, witness, retro, and PR
 
 Labels are canonical tracker metadata. Maintainers and agents apply them after
 triage; contributors may request labels in the issue body.
+
+## Design Document Intake
+
+Issue templates are the default shaping enforcement. The work-item form should
+produce an issue body that can be lifted into a design document without
+inventing missing sections after the fact.
+
+For implementation work, the issue or design document must name at least one
+behavior/software proof against an actual product surface: package API, runtime
+behavior, rendered output, scripted app flow, command behavior, schema
+validation, lower-mode output, or CI/tooling behavior. Documentation-only proof
+is acceptable only for documentation/process work.
+
+Do not block every commit on branch-name-to-design-doc matching. Hotfixes, CI
+repairs, dependency repairs, and small maintenance work may not have a full
+design doc. Branch/design matching can become a targeted pre-push or CI guard
+later for issues explicitly marked `needs-design`, but it should not be the
+default commit gate.
 
 ## Lane Labels
 

--- a/tests/cycles/WF-124/design-document-intake-template.test.ts
+++ b/tests/cycles/WF-124/design-document-intake-template.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { readRepoFile } from '../repo.js';
+
+const REQUIRED_WORK_ITEM_LABELS = [
+  'Requested classification',
+  'Decision summary',
+  'Sponsored human',
+  'Sponsored agent',
+  'Hill',
+  'Current truth',
+  'Problem',
+  'Scope',
+  'Non-goals',
+  'User experience / product shape',
+  'Lower modes',
+  'Runtime / API contract',
+  'Data / state model',
+  'Accessibility posture',
+  'Localization / directionality posture',
+  'Agent inspectability / explainability posture',
+  'Linked invariants',
+  'Implementation slices',
+  'Tests to write first',
+  'Acceptance criteria',
+  'Validation plan',
+  'Playback / witness',
+  'Risks and follow-on debt',
+  'Method artifacts',
+  'Triage rule',
+] as const;
+
+describe('WF-124 design-document intake template', () => {
+  it('keeps the Method work-item issue form aligned with the design document template', () => {
+    const workItemTemplate = readRepoFile('.github/ISSUE_TEMPLATE/work-item.yml');
+    const labels = issueFormFieldLabels(workItemTemplate);
+
+    expect(labels).toEqual(expect.arrayContaining([...REQUIRED_WORK_ITEM_LABELS]));
+    expect(labels.indexOf('Decision summary')).toBeLessThan(labels.indexOf('Tests to write first'));
+    expect(labels.indexOf('Tests to write first')).toBeLessThan(labels.indexOf('Acceptance criteria'));
+  });
+
+  it('requires implementation issues to name software behavior proof instead of doc-only proof', () => {
+    const workItemTemplate = readRepoFile('.github/ISSUE_TEMPLATE/work-item.yml');
+
+    expect(workItemTemplate).toContain('Behavior/software proof required for implementation work');
+    expect(workItemTemplate).toContain('Documentation-only proof is acceptable only for documentation/process work');
+    expect(workItemTemplate).toContain('package API, runtime behavior, rendered output, scripted app flow');
+    expect(workItemTemplate).toContain('schema validation, lower-mode output, or CI/tooling behavior');
+  });
+
+  it('documents issue-template-first enforcement instead of branch-name commit blocking', () => {
+    const method = normalizeWhitespace(readRepoFile('docs/METHOD.md'));
+
+    expect(method).toContain('Issue templates are the default shaping enforcement.');
+    expect(method).toContain('Do not block every commit on branch-name-to-design-doc matching.');
+    expect(method).toContain('Hotfixes, CI repairs, dependency repairs, and small maintenance work may not have a full design doc.');
+  });
+});
+
+function issueFormFieldLabels(source: string): readonly string[] {
+  return [...source.matchAll(/^\s{6}label:\s*(.+)$/gm)]
+    .map((match) => match[1]?.trim())
+    .filter((label): label is string => label !== undefined && label.length > 0);
+}
+
+function normalizeWhitespace(source: string): string {
+  return source.replace(/\s+/g, ' ').trim();
+}

--- a/tests/cycles/WF-124/design-document-intake-template.test.ts
+++ b/tests/cycles/WF-124/design-document-intake-template.test.ts
@@ -48,6 +48,15 @@ describe('WF-124 design-document intake template', () => {
     expect(workItemTemplate).toContain('schema validation, lower-mode output, or CI/tooling behavior');
   });
 
+  it('does not prefill required textareas so issue submitters must supply concrete proof', () => {
+    const workItemTemplate = readRepoFile('.github/ISSUE_TEMPLATE/work-item.yml');
+    const prefilledRequiredLabels = requiredTextareaBlocks(workItemTemplate)
+      .filter((block) => /^\s{6}value:/m.test(block))
+      .map(fieldLabel);
+
+    expect(prefilledRequiredLabels).toEqual([]);
+  });
+
   it('documents issue-template-first enforcement instead of branch-name commit blocking', () => {
     const method = normalizeWhitespace(readRepoFile('docs/METHOD.md'));
 
@@ -61,6 +70,17 @@ function issueFormFieldLabels(source: string): readonly string[] {
   return [...source.matchAll(/^\s{6}label:\s*(.+)$/gm)]
     .map((match) => match[1]?.trim())
     .filter((label): label is string => label !== undefined && label.length > 0);
+}
+
+function requiredTextareaBlocks(source: string): readonly string[] {
+  return source
+    .split(/\n(?=  - type: )/)
+    .filter((block) => block.startsWith('  - type: textarea'))
+    .filter((block) => /^\s{6}required: true$/m.test(block));
+}
+
+function fieldLabel(source: string): string {
+  return source.match(/^\s{6}label:\s*(.+)$/m)?.[1]?.trim() ?? '<missing label>';
 }
 
 function normalizeWhitespace(source: string): string {


### PR DESCRIPTION
## Summary

- Replaces the Method work-item issue form with a design-doc-ready intake shape.
- Requires implementation issues to name behavior/software proof instead of relying on documentation-only assertions.
- Documents the enforcement stance in `docs/METHOD.md`: use issue-template-first shaping, and avoid blanket branch-name-to-design-doc commit blocking for hotfixes, CI repairs, dependency repairs, and small maintenance work.
- Adds a WF-124 regression test guarding the issue-template sections and policy wording.

## Validation

- RED: `npm test -- --run tests/cycles/WF-124/design-document-intake-template.test.ts` failed against the old template and Method docs.
- GREEN: `npm test -- --run tests/cycles/WF-124/design-document-intake-template.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/work-item.yml"); puts "issue template YAML ok"'`
- `npm run docs:inventory`
- `npm run typecheck:test`
- `npm run lint`
- `git diff --check`
- Pre-push hook: DOGFOOD i18n completeness/check, `typecheck:test`, full `npm test` (328 files / 3659 tests), and `verify:interactive-examples`

Closes #275
