### PR TITLE
Adopt draft-first cycle workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -280,7 +280,7 @@ body:
         - [ ] Lower modes are covered, if relevant.
         - [ ] New visible strings include supported translations, if relevant.
         - [ ] DOGFOOD/docs/changelog are updated, if behavior or direction changed.
-        - [ ] Issue and PR are linked correctly.
+        - [ ] Issue, design doc, and draft PR are linked correctly.
         - [ ] CI and local validation are green.
     validations:
       required: true
@@ -288,7 +288,7 @@ body:
     id: validation-plan
     attributes:
       label: Validation plan
-      description: Name the commands expected before PR.
+      description: Name the commands expected before marking the PR ready for review.
       placeholder: |
         ```bash
         npm test -- --run <focused behavior tests>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,18 @@ This guide is for AI agents and human operators recovering context in the Bijou 
 - **NEVER** push to `main` without explicit permission.
 - Always use standard commits and regular pushes.
 
+## Cycle Start Protocol
+
+- Start cycles from a synced merge target branch. Run `git fetch`, switch to the
+  merge target, and sync it with a regular fast-forward merge before branching.
+- Create a new `cycle/<cycle_name>` branch for the cycle.
+- Create or update the GitHub Issue and write the cycle design document before
+  implementation. Stage and commit the shaping artifact, push the branch, open
+  a draft pull request to `main`, link the issue and draft PR, and apply
+  `work-in-progress` to the GitHub Issue.
+- Draft PRs are expected at cycle start. Mark the PR ready for review only
+  after implementation, validation, and self-review are complete.
+
 ## Documentation & Planning Map
 
 Do not audit the repository by recursively walking the filesystem. Follow the authoritative manifests:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,8 @@ This guide is for AI agents and human operators recovering context in the Bijou 
 - Create a new `cycle/<cycle_name>` branch for the cycle.
 - Create or update the GitHub Issue and write the cycle design document before
   implementation. Stage and commit the shaping artifact, push the branch, open
-  a draft pull request to `main`, link the issue and draft PR, and apply
-  `work-in-progress` to the GitHub Issue.
+  a draft pull request to `main`, link the issue, design doc, and draft PR, and
+  apply `work-in-progress` to the GitHub Issue.
 - Draft PRs are expected at cycle start. Mark the PR ready for review only
   after implementation, validation, and self-review are complete.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,11 @@ points for contributors:
   files as the source of live queue state.
 - **Branch naming**: `cycle/<cycle-name>` for cycle work, or a
   descriptive branch name for smaller changes.
+- **Open a draft PR at cycle start**: After syncing the merge target, branch,
+  create or update the GitHub Issue, and commit the design artifact, push the
+  branch and open a draft PR against `main`. Link the issue, design doc, and
+  draft PR, then mark it ready for review only after validation and self-review
+  pass.
 - **Commits**: Use [Conventional Commits](https://www.conventionalcommits.org/)
   (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`).
 - **Tests first**: Write failing tests before implementing. Never
@@ -55,7 +60,9 @@ wrappers, or registry workflow behavior.
 
 ## Pull Requests
 
-- Open PRs against `main`.
+- Open draft PRs against `main` at cycle start for visibility.
+- Mark draft PRs ready for review only after local validation and self-review
+  pass.
 - Keep PRs focused — one concern per PR.
 - Update `docs/CHANGELOG.md` if the change is user-facing.
 - Update relevant documentation when behavior changes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 📚 Documentation
 
+- **Draft-first cycle workflow** — `AGENTS.md`, `docs/METHOD.md`,
+  `docs/WORKFLOW.md`, `CONTRIBUTING.md`, and the Method work-item issue
+  template now define the cycle-start sequence as fetch/sync merge target,
+  branch, write the GitHub Issue and design doc, commit and push shaping
+  artifacts, open a draft PR to `main`, link the issue/design/PR, and apply
+  `work-in-progress` before implementation begins. PRs move to ready-for-review
+  only after implementation, validation, and self-review pass. This closes
+  issue #279.
 - **Design-document-ready Method intake** — The GitHub Method work-item issue
   template now guides new work through the standard design document shape:
   decision summary, sponsored human and agent perspectives, current truth,

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -72,7 +72,8 @@ default commit gate.
 
 Supporting state labels:
 
-- **`work-in-progress`** means a branch or PR is actively carrying the issue.
+- **`work-in-progress`** means a branch or draft/ready PR is actively carrying
+  the issue.
 - **`blocked`** means a decision or external state is preventing progress.
 - **`needs-design`**, **`needs-witness`**, and **`needs-retro`** mean the
   evidence ledger is missing a required artifact.
@@ -96,25 +97,32 @@ labels. Use repo files to recover context, evidence, and history.
 ```mermaid
 stateDiagram-v2
     direction LR
-    [*] --> Pull: GitHub issue
-    Pull --> Branch: cycle/
-    Branch --> Red: failing tests
+    [*] --> Sync: git fetch + target
+    Sync --> Branch: cycle/
+    Branch --> Shape: issue + design doc + draft PR
+    Shape --> Red: failing tests
     Red --> Green: passing tests
-    Green --> Retro: findings/debt
-    Retro --> Ship: PR to main
+    Green --> Review: validation + self-review
+    Review --> Ship: ready PR to main
     Ship --> [*]
 ```
 
-1. **Pull**: Select a shaped GitHub issue, usually from `lane:asap`.
-   Create or link the design artifact under `docs/design/` when the work needs
-   a design record.
-2. **Branch**: Create `cycle/<cycle_name>`.
-3. **Red**: Write failing tests based on the design's playback questions.
-4. **Green**: Implement the solution until tests pass.
-5. **Retro**: Document findings and follow-on debt in the cycle doc.
-6. **Ship**: Push the cycle branch and open a pull request to `main`.
-   Link the PR from the issue and update `BEARING.md` and `CHANGELOG.md` when
-   the change affects direction or user-facing behavior.
+1. **Sync**: Run `git fetch`. Sync to the merge target branch, almost always
+   `origin/main`, using a regular fast-forward merge before starting local
+   work.
+2. **Branch**: Create `cycle/<cycle_name>` from the synced merge target.
+3. **Shape**: Create or update the GitHub Issue and write the design artifact
+   under `docs/design/`. Stage and commit the shaping artifact, push the branch,
+   open a draft pull request to `main`, link the issue and PR, and apply
+   `work-in-progress` to the GitHub Issue. The draft counts as the open pull
+   request to `main` for visibility, not as the merge-ready review artifact.
+4. **Red**: Write failing tests based on the design's playback questions.
+5. **Green**: Implement the solution until tests pass.
+6. **Review**: Update witness/retro/debt notes, run local validation, and do the
+   required self-review before marking the draft PR ready for review.
+7. **Ship**: Mark the PR ready, keep it linked from the issue, and update
+   `BEARING.md` and `CHANGELOG.md` when the change affects direction or
+   user-facing behavior.
 
 ## Naming Convention
 Design and retro files follow: `<LEGEND>-<id>-<slug>.md`

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -113,9 +113,10 @@ stateDiagram-v2
 2. **Branch**: Create `cycle/<cycle_name>` from the synced merge target.
 3. **Shape**: Create or update the GitHub Issue and write the design artifact
    under `docs/design/`. Stage and commit the shaping artifact, push the branch,
-   open a draft pull request to `main`, link the issue and PR, and apply
-   `work-in-progress` to the GitHub Issue. The draft counts as the open pull
-   request to `main` for visibility, not as the merge-ready review artifact.
+   open a draft pull request to `main`, link the issue, design doc, and draft
+   PR, and apply `work-in-progress` to the GitHub Issue. The draft counts as the
+   open pull request to `main` for visibility, not as the merge-ready review
+   artifact.
 4. **Red**: Write failing tests based on the design's playback questions.
 5. **Green**: Implement the solution until tests pass.
 6. **Review**: Update witness/retro/debt notes, run local validation, and do the

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -29,17 +29,20 @@ Bijou now tracks work through:
 
 ## Working Loop
 
-1. Pull from `docs/method/backlog/asap/`, `docs/method/backlog/up-next/`,
-   or the active shaped release lane.
+1. Sync to the merge target branch after `git fetch`.
 2. Create a branch named `cycle/<cycle_name>` for that cycle.
-3. Move the file into `docs/design/` and enrich it into a real cycle doc.
-4. Write failing tests. Playback questions become the executable spec.
-5. Green the tests.
-6. Record witness material when needed.
-7. Close honestly: retrospective, drift notes, and follow-on backlog.
-8. Push the cycle branch and open a pull request to `main`.
-9. After merge, sync `BEARING.md`, `CHANGELOG.md`, and any other
-   signposts that changed.
+3. Write or enrich the GitHub Issue and the `docs/design/` cycle doc.
+4. Stage and commit the shaping artifact, push the branch, and open a draft
+   pull request to `main` before implementation work starts.
+5. Link the GitHub Issue, design doc, and draft PR. Apply
+   `work-in-progress` to the GitHub Issue.
+6. Write failing tests. Playback questions become the executable spec.
+7. Green the tests.
+8. Record witness material when needed.
+9. Close honestly: retrospective, drift notes, and follow-on backlog.
+10. Run validation and self-review, then mark the draft PR ready for review.
+11. After merge, sync `BEARING.md`, `CHANGELOG.md`, and any other
+    signposts that changed.
 
 ## PR Size Discipline
 
@@ -48,11 +51,11 @@ Release-boundary work must still move through reviewable PRs.
 Use precursor PRs before the final release sync when a branch is likely to
 cross automated review limits.
 
-Hard stop before opening a PR:
+Hard stop before marking a PR ready for review:
 
 - more than 140 changed files
 
-Caution threshold before opening a PR:
+Caution threshold before marking a PR ready for review:
 
 - more than 10 commits
 - unrelated legends or cycle families on one branch

--- a/docs/design/WF-125-draft-first-cycle-start-workflow.md
+++ b/docs/design/WF-125-draft-first-cycle-start-workflow.md
@@ -1,0 +1,111 @@
+---
+title: WF-125 Draft-first cycle start workflow
+legend: WF
+lane: design
+priority: medium
+keywords:
+  - workflow
+  - method
+  - draft-pr
+  - design-thinking
+---
+
+# WF-125 Draft-first cycle start workflow
+
+## Framing
+
+Issue [#279](https://github.com/flyingrobots/bijou/issues/279) changes the
+Bijou cycle loop from "open the pull request at ship time" to "open a draft
+pull request at cycle start." The intent is to make issue, branch, design doc,
+and PR state visible before implementation expands, while keeping the final
+ready-for-review and merge gates strict.
+
+The work follows a Design Thinking loop:
+
+- observe that cycle work can stay invisible until late implementation
+- frame draft PRs as early coordination artifacts rather than merge-ready
+  review artifacts
+- prototype the new loop in Method, Workflow, Contributor, Agent, and issue
+  template docs
+- prove the policy with a workflow regression that reads those docs
+
+## Sponsored Users
+
+- Maintainers who need early visibility into the branch and linked artifacts.
+- Contributors who need one explicit start-of-cycle checklist.
+- Agents that need a deterministic order for sync, branch, shape, push, draft
+  PR, and work-in-progress labeling.
+- Reviewers who should see draft context early without treating it as ready.
+
+## Hills
+
+1. A contributor can start a cycle by syncing the merge target, creating a
+   `cycle/<cycle_name>` branch, shaping the issue and design doc, committing
+   and pushing that shape, opening a draft PR, and applying
+   `work-in-progress`.
+2. A reviewer can distinguish an early draft coordination PR from a ready PR
+   that has passed implementation, validation, and self-review.
+3. A maintainer can run one workflow regression that prevents the docs and
+   issue template from drifting back to the old "PR only at ship" loop.
+
+## Playback Questions
+
+- Does every workflow surface say to run `git fetch` and sync the merge target
+  before branching?
+- Does the cycle branch start from the synced target instead of stale local
+  state?
+- Does the shaping commit include the GitHub Issue and design doc before
+  implementation work begins?
+- Does a draft PR to `main` exist before implementation starts?
+- Does the issue carry `work-in-progress` while the branch or draft PR is
+  actively carrying it?
+- Does the draft PR move to ready only after implementation, validation, and
+  self-review?
+
+## Workflow Contract
+
+```text
+git fetch
+sync merge target branch
+checkout cycle/<cycle_name>
+write or update GitHub Issue
+write docs/design/<cycle>.md
+stage + commit + push shaping artifact
+open draft PR to main
+link issue + design doc + draft PR
+apply work-in-progress to issue
+do RED/GREEN cycle work
+validate + self-review
+mark PR ready for review
+```
+
+## Implementation Notes
+
+- `AGENTS.md` owns the short agent recovery protocol.
+- `docs/METHOD.md` owns the doctrine and cycle-state diagram.
+- `docs/WORKFLOW.md` owns the operator checklist.
+- `CONTRIBUTING.md` owns contributor-facing expectations.
+- `.github/ISSUE_TEMPLATE/work-item.yml` owns the issue-form acceptance text.
+- `tests/cycles/WF-001/workflow-adoption.test.ts` freezes the contract.
+
+## Tests
+
+- `tests/cycles/WF-001/workflow-adoption.test.ts` adds a regression that reads
+  `AGENTS.md`, `CONTRIBUTING.md`, `docs/METHOD.md`, `docs/WORKFLOW.md`, and
+  the Method work-item issue template.
+- The RED pass failed because `docs/METHOD.md` did not contain the new
+  `git fetch` and draft-PR cycle-start language.
+- The GREEN pass updates the docs and normalizes Markdown whitespace in the
+  regression so wrapped prose can still carry exact policy sentences.
+
+## Closeout
+
+The cycle is landed when:
+
+- the workflow docs require merge-target sync before branching
+- the workflow docs require a draft PR to `main` at cycle start
+- the issue template requires issue, design doc, and draft PR links
+- the draft PR is marked ready only after implementation, validation, and
+  self-review
+- the WF-001 regression, docs inventory, lint, and whitespace checks pass
+- the pull request closes #279

--- a/tests/cycles/WF-001/workflow-adoption.test.ts
+++ b/tests/cycles/WF-001/workflow-adoption.test.ts
@@ -19,14 +19,46 @@ describe('WF-001 workflow adoption', () => {
 
     const workflow = read('docs/WORKFLOW.md');
     const method = read('docs/METHOD.md');
+    const normalizedWorkflow = normalizeWhitespace(workflow);
+    const normalizedMethod = normalizeWhitespace(method);
     expect(workflow).toContain('Legends');
     expect(workflow).toContain('Cycles');
     expect(workflow).toContain('tests/cycles/<cycle>/');
     expect(workflow).toContain('docs/specs/');
     expect(workflow).toContain('cycle/<cycle_name>');
-    expect(workflow).toContain('open a pull request to `main`');
+    expect(normalizedWorkflow).toContain('open a draft pull request to `main`');
     expect(method).toContain('cycle/<cycle_name>');
-    expect(method).toContain('open a pull request to `main`');
+    expect(normalizedMethod).toContain('open a draft pull request to `main`');
+  });
+
+  it('starts cycles with a synced branch, design issue, and draft PR', () => {
+    const agents = read('AGENTS.md');
+    const contributing = read('CONTRIBUTING.md');
+    const workflow = read('docs/WORKFLOW.md');
+    const method = read('docs/METHOD.md');
+    const issueTemplate = read('.github/ISSUE_TEMPLATE/work-item.yml');
+    const normalizedAgents = normalizeWhitespace(agents);
+    const normalizedContributing = normalizeWhitespace(contributing);
+    const normalizedWorkflow = normalizeWhitespace(workflow);
+    const normalizedMethod = normalizeWhitespace(method);
+
+    expect(normalizedMethod).toContain('git fetch');
+    expect(normalizedMethod).toContain('Sync to the merge target branch');
+    expect(normalizedMethod).toContain('Create `cycle/<cycle_name>` from the synced merge target');
+    expect(normalizedMethod).toContain('open a draft pull request to `main`');
+    expect(normalizedMethod).toContain('apply `work-in-progress` to the GitHub Issue');
+
+    expect(normalizedWorkflow).toContain('Sync to the merge target branch after `git fetch`.');
+    expect(normalizedWorkflow).toContain('open a draft pull request to `main` before implementation work starts.');
+    expect(normalizedWorkflow).toContain('Apply `work-in-progress` to the GitHub Issue.');
+
+    expect(normalizedContributing).toContain('Open a draft PR at cycle start');
+    expect(normalizedContributing).toContain('mark it ready for review only after validation and self-review pass');
+
+    expect(normalizedAgents).toContain('Start cycles from a synced merge target branch.');
+    expect(normalizedAgents).toContain('Draft PRs are expected at cycle start.');
+
+    expect(issueTemplate).toContain('Issue, design doc, and draft PR are linked correctly.');
   });
 
   it('adds explicit legend and invariant docs', () => {
@@ -62,3 +94,7 @@ describe('WF-001 workflow adoption', () => {
     expect(existsSync(resolve(ROOT, 'docs/specs/bijou-i18n-tools.spec.json'))).toBe(false);
   });
 });
+
+function normalizeWhitespace(source: string): string {
+  return source.replace(/\s+/g, ' ').trim();
+}

--- a/tests/cycles/WF-001/workflow-adoption.test.ts
+++ b/tests/cycles/WF-001/workflow-adoption.test.ts
@@ -57,6 +57,8 @@ describe('WF-001 workflow adoption', () => {
 
     expect(normalizedAgents).toContain('Start cycles from a synced merge target branch.');
     expect(normalizedAgents).toContain('Draft PRs are expected at cycle start.');
+    expect(normalizedAgents).toContain('link the issue, design doc, and draft PR');
+    expect(normalizedMethod).toContain('link the issue, design doc, and draft PR');
 
     expect(issueTemplate).toContain('Issue, design doc, and draft PR are linked correctly.');
   });


### PR DESCRIPTION
## Summary

Adopts the draft-first cycle-start workflow requested in issue #279:

- sync the merge target after `git fetch`
- branch from the synced target
- write/link the GitHub Issue and design doc
- commit and push the shaping artifact
- open a draft PR to `main` before implementation begins
- link issue/design/PR and apply `work-in-progress`
- mark the draft ready only after implementation, validation, and self-review

This updates `AGENTS.md`, `docs/METHOD.md`, `docs/WORKFLOW.md`, `CONTRIBUTING.md`, the Method work-item issue template, changelog, and the WF-125 design doc.

## Validation

- RED: `npm test -- --run tests/cycles/WF-001/workflow-adoption.test.ts` failed before the docs contained the new `git fetch` and draft-PR cycle-start language.
- GREEN: `npm test -- --run tests/cycles/WF-001/workflow-adoption.test.ts` passed, 5 tests.
- `npm run docs:inventory`
- `npm run typecheck:test`
- `npm run lint`
- `git diff --check`
- Pre-push hook: DOGFOOD i18n completeness, generated catalog check, `typecheck:test`, full `npm test` (328 files / 3662 tests), scripted interactive example smoke

Closes #279
