### PR TITLE
Fix v7 review regressions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### 🐛 Fixes
+
+- **V7 review regression fixes** — DOGFOOD release-title interactive rendering
+  now stays within the requested width for compact viewports, and fitted
+  `tableSurface()` string cells preserve word boundaries by default instead of
+  hard-splitting words when width fitting shrinks a column. This closes issue
+  #283.
+
 ### 📚 Documentation
 
 - **v7 closeout tracker and workflow evidence** — BEARING and ROADMAP now track

--- a/docs/design/DX-040-v7-review-regression-fixes.md
+++ b/docs/design/DX-040-v7-review-regression-fixes.md
@@ -1,0 +1,124 @@
+---
+title: DX-040 V7 post-merge review regression fixes
+legend: DX
+lane: bad-code
+priority: medium
+issue: https://github.com/flyingrobots/bijou/issues/283
+keywords:
+  - dogfood
+  - release-title
+  - table-surface
+  - wrapping
+  - review-follow-up
+---
+
+# DX-040 V7 Post-Merge Review Regression Fixes
+
+## Framing
+
+PR #282 merged the V7 Product Truth closeout. Codex review comments arrived
+after the admin merge and identified two P2 regressions that should be fixed
+before v7 is cut:
+
+| Source | File | Problem |
+| :--- | :--- | :--- |
+| [PR #282 thread](https://github.com/flyingrobots/bijou/pull/282#discussion_r3348547178) | `examples/docs/release-title.ts` | Interactive release-title output can exceed the caller's requested width for widths from 42 through 59 columns. |
+| [PR #282 thread](https://github.com/flyingrobots/bijou/pull/282#discussion_r3348547191) | `packages/bijou/src/core/components/table-v3.ts` | Fitted `tableSurface()` string cells hard-wrap at column boundaries instead of honoring default word wrapping. |
+
+This follow-up keeps the scope intentionally narrow: fix exactly the two review
+comments, preserve the v7 closeout behavior, and leave broader table or title
+treatment redesigns for later cycles.
+
+## Sponsored Users
+
+- A DOGFOOD reader on a medium-width terminal needs the release-title guide to
+  fit the actual viewport instead of drawing a wider box.
+- A TUI author using `tableSurface()` expects readable fitted text by default,
+  matching the word-wrap posture already established by `table()`.
+- A review agent needs the reported regressions captured as deterministic tests
+  so the branch proves the fix instead of relying on prose.
+
+## Hill
+
+A maintainer can run deterministic tests that reproduce both post-merge review
+comments, then see the title renderer stay within requested widths and
+`tableSurface()` preserve word boundaries when fitting string cells.
+
+## Current Truth
+
+- `renderDogfoodReleaseTitleText({ mode: 'interactive', width: 42 })` selects
+  the wide renderer even though wide output is 60 columns.
+- The new fitted `tableSurface()` path wraps shrunk string cells through
+  `wrapSurfaceToWidth()`, which chunks at hard cell boundaries and can split
+  words such as `surface` and `evidence`.
+- PR #282 is already merged, so the fix must be a new branch and PR.
+
+## Product Shape
+
+### Release Title Width
+
+```text
+width 42:
++ BIJOU DOGFOOD ----+
+| V7 Product Truth  |
+| Blocks prove UX.  |
+| lanes: table, io  |
+| gate: closeout    |
++-------------------+
+```
+
+Every emitted line must be `<= width`.
+
+### Table Surface Word Wrapping
+
+```text
+| Release proof     |
+| canonical docs    |
+| surface carries   |
+| release title     |
+```
+
+Default fitted string cells should break at word boundaries when possible.
+Explicit hard wrapping and truncation remain separate behaviors.
+
+## Runtime And API Contract
+
+- Release-title text rendering must honor the supplied `width` for interactive
+  mode.
+- `tableSurface()` must preserve existing `overflow: 'truncate'` behavior.
+- Default fitted string cells should use word-aware wrapping.
+- Surface cells that are already structured `Surface` values may continue to
+  use the existing surface wrapping behavior because the original word
+  boundaries are not recoverable from arbitrary surfaces.
+
+## Lower Modes
+
+No lower-mode contract changes are intended. Existing static, pipe, and
+accessible release-title output should remain unchanged.
+
+## Tests To Write First
+
+- Extend `tests/cycles/DF-060/v7-dogfood-release-title-screen.test.ts` with a
+  width-42 regression that asserts every interactive line is at most 42
+  characters.
+- Extend `tests/cycles/DX-037/table-surface-width-parity.test.ts` with a
+  default word-wrap regression that asserts fitted output does not split
+  `surface` or `evidence` across lines.
+
+## Acceptance Criteria
+
+- Issue #283 is closed by the follow-up PR.
+- The exact Codex review cases are represented by tests that fail before the
+  fix and pass after it.
+- `npm run lint`, focused tests, and relevant DOGFOOD checks pass.
+- No broad redesign of release-title art, `table()`, or `tableSurface()` is
+  included.
+
+## Risks And Guardrails
+
+- Do not change the public `tableSurface()` signature unless the tests prove it
+  is necessary.
+- Do not make title rendering depend on terminal state outside the supplied
+  width.
+- Do not remove Storybook compatibility aliases while fixing BlockLab-adjacent
+  follow-up behavior.

--- a/examples/docs/release-title.ts
+++ b/examples/docs/release-title.ts
@@ -109,8 +109,8 @@ export function renderDogfoodReleaseTitleText(options: RenderDogfoodReleaseTitle
     ].join(' ');
   }
 
-  return options.width < 42
-    ? renderNarrowReleaseTitle({ title, subtitle, proofLanes, gate })
+  return options.width < 60
+    ? renderNarrowReleaseTitle({ title, subtitle, proofLanes, gate }, options.width)
     : renderWideReleaseTitle({ title, subtitle, proofLanes, gate, navigation });
 }
 
@@ -160,15 +160,32 @@ function renderNarrowReleaseTitle(input: {
   readonly subtitle: string;
   readonly proofLanes: readonly string[];
   readonly gate: string;
-}): string {
+}, width: number): string {
+  const frameWidth = Math.max(1, Math.floor(width));
+  if (frameWidth < 4) return fitLine(input.title, frameWidth);
+  const contentWidth = Math.max(0, frameWidth - 4);
   return [
-    '+ BIJOU DOGFOOD ----+',
-    `| ${fitLine(input.title, 18)} |`,
-    `| ${fitLine(shortenSubtitle(input.subtitle), 18)} |`,
-    `| ${fitLine(`lanes: ${input.proofLanes.slice(0, 2).join(', ')}`, 18)} |`,
-    `| ${fitLine(input.gate.includes('closeout') ? 'gate: closeout' : input.gate, 18)} |`,
-    '+-------------------+',
+    labeledRule(' BIJOU DOGFOOD ', frameWidth),
+    `| ${fitLine(input.title, contentWidth)} |`,
+    `| ${fitLine(shortenSubtitle(input.subtitle), contentWidth)} |`,
+    `| ${fitLine(`lanes: ${input.proofLanes.slice(0, 2).join(', ')}`, contentWidth)} |`,
+    `| ${fitLine(input.gate.includes('closeout') ? 'gate: closeout' : input.gate, contentWidth)} |`,
+    framedRule(frameWidth),
   ].join('\n');
+}
+
+function labeledRule(label: string, width: number): string {
+  if (width <= 0) return '';
+  if (width === 1) return '+';
+  const innerWidth = Math.max(0, width - 2);
+  const text = label.slice(0, innerWidth);
+  return `+${text}${'-'.repeat(Math.max(0, innerWidth - text.length))}+`;
+}
+
+function framedRule(width: number): string {
+  if (width <= 0) return '';
+  if (width === 1) return '+';
+  return `+${'-'.repeat(Math.max(0, width - 2))}+`;
 }
 
 function shortenSubtitle(subtitle: string): string {

--- a/packages/bijou/src/core/components/table-v3.ts
+++ b/packages/bijou/src/core/components/table-v3.ts
@@ -2,8 +2,14 @@ import type { BijouContext } from '../../ports/context.js';
 import { createSurface, isPackedSurface, type Cell, type Surface } from '../../ports/surface.js';
 import { resolveSafeCtx as resolveCtx } from '../resolve-ctx.js';
 import { colorRgb, type ColorRef } from '../theme/color.js';
-import { interactiveTableBorderOverhead, type TableColumn, type TableLayout, type TableOptions } from './table.js';
-import { createTextSurface, tokenToCellStyle, wrapSurfaceToWidth } from './surface-text.js';
+import {
+  interactiveTableBorderOverhead,
+  type TableColumn,
+  type TableLayout,
+  type TableOptions,
+  type TableWrapMode,
+} from './table.js';
+import { createTextSurface, tokenToCellStyle, type CellTextStyle, wrapSurfaceToWidth } from './surface-text.js';
 import { resolveOverflowBehavior } from './overflow.js';
 import { encodeModifiers } from '../render/packed-cell.js';
 import {
@@ -11,12 +17,19 @@ import {
   sanitizeOptionalPositiveInt,
   sanitizePositiveInt,
 } from '../numeric.js';
+import { wrapToWidth } from '../text/wrap.js';
 
 export type TableSurfaceCell = string | Surface;
 export type TableSurfaceRow = readonly TableSurfaceCell[];
 
 export interface TableSurfaceOptions extends Omit<TableOptions, 'rows'> {
   readonly rows: readonly TableSurfaceRow[];
+}
+
+interface PreparedTableSurfaceCell {
+  readonly surface: Surface;
+  readonly text?: string;
+  readonly style?: CellTextStyle;
 }
 
 function isTableSurfaceOptions(
@@ -176,6 +189,28 @@ function resolveColumns(
   return Array.from({ length: inferredCount }, () => ({ header: '' }));
 }
 
+function createPreparedTextCell(text: string, style: CellTextStyle = {}): PreparedTableSurfaceCell {
+  return { text, style, surface: createTextSurface(text, style) };
+}
+
+function createPreparedSurfaceCell(cell: TableSurfaceCell, style: CellTextStyle = {}): PreparedTableSurfaceCell {
+  if (typeof cell === 'string') return createPreparedTextCell(cell, style);
+  return { surface: cell };
+}
+
+function fitPreparedCell(
+  cell: PreparedTableSurfaceCell,
+  width: number,
+  overflow: ReturnType<typeof resolveOverflowBehavior>,
+  wrapMode: TableWrapMode,
+): Surface {
+  if (cell.surface.width <= width || overflow === 'truncate') return cell.surface;
+  if (cell.text !== undefined && wrapMode === 'word') {
+    return createTextSurface(wrapToWidth(cell.text, width).join('\n'), cell.style ?? {});
+  }
+  return wrapSurfaceToWidth(cell.surface, width);
+}
+
 /**
  * Render a bordered data table as a Surface for V3-native composition.
  */
@@ -208,12 +243,16 @@ export function tableSurface(
   const headerStyle = tokenToCellStyle(headerToken);
   const borderStyle = tokenToCellStyle(options.borderToken ?? ctx?.border('muted'));
   const headerBg = options.headerBgToken == null ? undefined : tokenToCellStyle(options.headerBgToken);
-  const headerSurfaces = columns.map((column) => createTextSurface(column.header ?? '', {
+  const headerCellStyle = {
     ...headerStyle,
     bg: headerBg?.bg ?? headerStyle.bg,
-  }));
-  const cellSurfaces = rows.map((row) => row.map((cell) => typeof cell === 'string' ? createTextSurface(cell) : cell));
+  };
+  const headerCells = columns.map((column) => createPreparedTextCell(column.header ?? '', headerCellStyle));
+  const headerSurfaces = headerCells.map((cell) => cell.surface);
+  const preparedCells = rows.map((row) => row.map((cell) => createPreparedSurfaceCell(cell)));
+  const cellSurfaces = preparedCells.map((row) => row.map((cell) => cell.surface));
   const layout = options.layout ?? 'auto';
+  const wrapMode = options.wrap ?? 'word';
   const colWidths = fitTableSurfaceColumnWidths(
     columns,
     headerSurfaces,
@@ -221,16 +260,14 @@ export function tableSurface(
     layout,
     resolveTargetWidth(options, ctx, layout),
   );
-  const fittedHeaderSurfaces = headerSurfaces.map((cell, index) => {
+  const fittedHeaderSurfaces = headerSurfaces.map((_cell, index) => {
     const cellWidth = colWidths[index] ?? 0;
-    if (cell.width <= cellWidth || overflow === 'truncate') return cell;
-    return wrapSurfaceToWidth(cell, cellWidth);
+    return fitPreparedCell(headerCells[index]!, cellWidth, overflow, wrapMode);
   });
   const headerHeight = fittedHeaderSurfaces.reduce((max, cell) => Math.max(max, cell.height), 1);
-  const fittedCellSurfaces = cellSurfaces.map((row) => row.map((cell, index) => {
+  const fittedCellSurfaces = preparedCells.map((row) => row.map((cell, index) => {
     const cellWidth = colWidths[index] ?? 0;
-    if (cell.width <= cellWidth || overflow === 'truncate') return cell;
-    return wrapSurfaceToWidth(cell, cellWidth);
+    return fitPreparedCell(cell, cellWidth, overflow, wrapMode);
   }));
   const rowHeights = fittedCellSurfaces.map((row) => row.reduce((max, cell, index) => {
     const cellWidth = colWidths[index] ?? 0;

--- a/tests/cycles/DF-060/v7-dogfood-release-title-screen.test.ts
+++ b/tests/cycles/DF-060/v7-dogfood-release-title-screen.test.ts
@@ -43,6 +43,14 @@ describe('DF-060 v7 DOGFOOD release title screen', () => {
     );
   });
 
+  it('keeps interactive release-title output within the requested width', () => {
+    const output = renderDogfoodReleaseTitleText({ mode: 'interactive', width: 42 });
+    const lineWidths = output.split('\n').map((line) => line.length);
+
+    expect(lineWidths.every((width) => width <= 42)).toBe(true);
+    expect(output).toContain('V7 Product Truth');
+  });
+
   it('renders the v7 release title as the first DOGFOOD Release guide', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 42 } });
     const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'release' as any });

--- a/tests/cycles/DX-037/table-surface-width-parity.test.ts
+++ b/tests/cycles/DX-037/table-surface-width-parity.test.ts
@@ -21,8 +21,29 @@ describe('DX-037 tableSurface responsive width parity', () => {
 
     expect(surface.width).toBeLessThanOrEqual(36);
     expect(text).toContain('canonical docs');
-    expect(text).toContain('layout evid');
-    expect(text).toContain('ence');
+    expect(text).toContain('layout evidence');
     expect(text).toContain('workspace shell');
+  });
+
+  it('preserves word boundaries when fitted string cells wrap by default', () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 36, rows: 20 } });
+    const surface = tableSurface({
+      columns: [
+        { header: 'Package', minWidth: 6 },
+        { header: 'Release proof', minWidth: 8, weight: 3 },
+      ],
+      rows: [
+        ['bijou', 'canonical docs surface carries release title and layout evidence'],
+      ],
+      width: 36,
+      ctx,
+    });
+    const text = stripAnsi(surfaceToString(surface, ctx.style));
+    const lines = text.split('\n');
+
+    expect(text).toContain('surface');
+    expect(text).toContain('evidence');
+    expect(lines.some((line) => line.includes('layout evid') && !line.includes('layout evidence'))).toBe(false);
+    expect(lines.some((line) => line.includes('│ ence'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- fixes the two post-merge review regressions from PR #282
- keeps DOGFOOD release-title interactive output within compact requested widths
- makes fitted `tableSurface()` string cells preserve word boundaries by default

## Issue

Closes #283

## Design

- `docs/design/DX-040-v7-review-regression-fixes.md`

## Review Threads Addressed

- https://github.com/flyingrobots/bijou/pull/282#discussion_r3348547178
- https://github.com/flyingrobots/bijou/pull/282#discussion_r3348547191

## Validation

- `npm run docs:inventory`
- `git diff --check`
- RED focused tests failed for release-title width and tableSurface word wrapping
- `npm test -- --run tests/cycles/DF-060/v7-dogfood-release-title-screen.test.ts tests/cycles/DX-037/table-surface-width-parity.test.ts packages/bijou/src/core/components/surface-primitives.test.ts` (`3` files, `35` tests)
- `npm run typecheck:test`
- `npm run lint`
- `npm test` (`333` files, `3677` tests)
- pre-commit `npm run lint`
- pre-push `npm run dogfood:i18n:complete`
- pre-push `npm run dogfood:i18n:check`
- pre-push `npm run typecheck:test`
- pre-push `npm test` (`333` files, `3677` tests)
- pre-push `npm run verify:interactive-examples`
