### PR TITLE
Sync v7 tracker docs

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -86,21 +86,22 @@ Current direction and active tensions. Historical ship data is in
 - Any issue moved between `v6.0.0`, `v7.0.0`, and `Beyond` should get a GitHub
   comment and a matching roadmap update.
 
-### 3. `v7.0.0` Is The Active Product-Truth Horizon
+### 3. `v7.0.0` Is Issue-Complete Product Truth
 
-- `v7.0.0` holds the active V7 Product Truth closeout: DOGFOOD docs truth,
-  completed component-family audits, `tableSurface()` responsive parity,
-  scoped Node I/O documentation, and the DOGFOOD release-title proof surface.
-- Its current open count is three: #245, #246, and #281. This closeout branch
-  also carries workflow evidence (#266), CI policy evidence (#267), and the
-  BlockLab rename (#271) as support work for the release boundary.
+- `v7.0.0` now has zero open milestone items and twenty-seven closed milestone
+  items after the tracker-sync cleanup closes. The closed lineage includes
+  DOGFOOD docs truth, completed component-family audits, `tableSurface()`
+  responsive parity, scoped Node I/O documentation, BlockLab naming, workflow
+  evidence, the DOGFOOD release-title proof surface, and post-merge review
+  regression fixes.
+- The next release-facing action is release-readiness validation against the
+  issue-complete V7 Product Truth lane.
 - DF-030 is the first product-truth slice: DOGFOOD's docs surface became one
   inspectable Block contract instead of adjacent docs rendering concepts. The
   component-family six-packs extend the standard Block catalog across grouping,
   explainability, document, navigation, structure, input, disclosure, and path
-  progress families. V7 Product Truth closes the remaining release-facing gap:
-  the docs app now has a release identity that points at the proof lanes still
-  under active validation.
+  progress families. V7 Product Truth closes the release-facing gap: the docs
+  app now has a release identity that points at shipped proof lanes.
 
 ## Tensions
 
@@ -116,36 +117,26 @@ Current direction and active tensions. Historical ship data is in
   evidence files can now disagree. GitHub wins; docs must be updated when
   milestone triage changes.
 - **DOGFOOD Truth Debt**: DF-030 converts the docs app into a named Block
-  contract. The current v7 DOGFOOD debt is focused: table surface parity,
-  scoped Node I/O docs, BlockLab naming, workflow evidence, and the release
-  title screen need code-backed proof instead of prose-only closeouts.
+  contract. The current V7 DOGFOOD proof lane is issue-complete; any new
+  DOGFOOD truth work should be shaped as a new release lane or a Beyond issue
+  rather than reopening the closed V7 closeout queue.
 
 ## Next Target
 
-The immediate focus is the active V7 Product Truth closeout for
-[#245](https://github.com/flyingrobots/bijou/issues/245),
-[#246](https://github.com/flyingrobots/bijou/issues/246),
-[#266](https://github.com/flyingrobots/bijou/issues/266),
-[#267](https://github.com/flyingrobots/bijou/issues/267),
-[#271](https://github.com/flyingrobots/bijou/issues/271), and
-[#281](https://github.com/flyingrobots/bijou/issues/281).
+The immediate focus is V7 release-readiness validation now that the Product
+Truth tracker is issue-complete.
 
-The PR must prove:
+The validation pass must prove:
 
-- `tableSurface()` honors bounded widths without regressing the existing
-  surface primitive tests
-- scoped Node I/O docs state realpath and symlink escape behavior precisely
-- CI policy tests parse the workflow instead of text-sniffing it
-- BlockLab is the current visible story/workstation name while old npm script
-  aliases continue to work
-- DOGFOOD has a V7 Product Truth title guide with lower-mode release facts and
-  translated strings
-- BEARING and ROADMAP mirror the live v7 tracker
+- release-readiness checks pass against the closed V6 and V7 lanes
+- BEARING and ROADMAP mirror the live V7 tracker
+- no unresolved review comments or failed CI remain from the closeout PRs
+- package/version metadata is ready for the release boundary
 
 Recommended pull order:
 
-1. Finish and merge the V7 Product Truth closeout branch.
-2. Run release-readiness validation against the now-closed v6 and v7 lanes.
+1. Finish this tracker-sync cleanup branch.
+2. Run release-readiness validation against the now-closed V6 and V7 lanes.
 3. Cut release title treatment variants for the next release boundary only
    after the tracker, docs, and CI proof are green.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🐛 Fixes
 
+- **V7 tracker docs sync** — BEARING, ROADMAP, and WF-126 now mirror the
+  issue-complete V7 milestone after the post-merge review follow-up: zero open
+  milestone items, twenty-seven closed milestone items after this cleanup
+  closes, and release-readiness validation as the next action. This closes
+  issue #285.
 - **V7 review regression fixes** — DOGFOOD release-title interactive rendering
   now stays within the requested width for compact viewports, and fitted
   `tableSurface()` string cells preserve word boundaries by default instead of

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ GitHub milestones and issue labels are the live tracker. This file is the
 human-readable release index for the current plan. When an issue moves between
 release horizons in GitHub, update this file in the same planning pass.
 
-Last synced from GitHub Issues and the V7 Product Truth closeout branch:
+Last synced from GitHub Issues and the V7 tracker-sync cleanup branch:
 2026-06-03.
 
 ## Release Snapshot
@@ -14,7 +14,7 @@ Last synced from GitHub Issues and the V7 Product Truth closeout branch:
 | Horizon | Milestone | Open | Closed | Intent |
 | :--- | :--- | ---: | ---: | :--- |
 | `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 28 | Issue-complete layout truth, standard blocks, and status/feedback Block lane. |
-| `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 3 | 20 | Active V7 Product Truth closeout candidate after the component-family audits. |
+| `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Issue-complete V7 Product Truth, BlockLab naming, and release-facing proof. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 22 | 0 | Uncommitted future work, cool ideas, and raw follow-ups. |
 
 ## v6.0.0
@@ -69,17 +69,14 @@ These cards are included in the v6 milestone as completed release lineage.
 
 Theme: DOGFOOD truth, BlockLab naming, and release-facing proof.
 
-The v7 lane is active closeout work. The component-family audit queue is
-issue-complete; the remaining open items prove width parity, scoped Node I/O
-semantics, and the DOGFOOD release identity.
+The v7 lane is issue-complete. The component-family audit queue, width parity,
+scoped Node I/O semantics, BlockLab naming, workflow evidence, DOGFOOD release
+identity, and post-merge review regression fixes are complete. It should run
+release-readiness validation before tagging.
 
-### Product And Docs Truth
+### Open Work
 
-| Issue | Priority | Type | Work |
-| :--- | :--- | :--- | :--- |
-| [#245](https://github.com/flyingrobots/bijou/issues/245) | `priority:medium` | `type:enhancement` | DX-037 tableSurface responsive width parity |
-| [#246](https://github.com/flyingrobots/bijou/issues/246) | `priority:medium` | `type:docs` | DX-029 document scopedNodeIO realpath and symlink semantics |
-| [#281](https://github.com/flyingrobots/bijou/issues/281) | `priority:medium` | `type:enhancement` | DOGFOOD release title screen |
+No open v7 tracker issues remain as of 2026-06-03.
 
 ### Completed Lineage
 
@@ -88,7 +85,14 @@ These cards are included in the v7 milestone as completed release lineage.
 | Tracker | Lane | Type | Work |
 | :--- | :--- | :--- | :--- |
 | [#244](https://github.com/flyingrobots/bijou/issues/244) | `lane:release` | `type:docs` / `type:enhancement` | DF-030 DOGFOOD docs surface Block |
+| [#245](https://github.com/flyingrobots/bijou/issues/245) | `lane:release` | `type:enhancement` | DX-037 tableSurface responsive width parity |
+| [#246](https://github.com/flyingrobots/bijou/issues/246) | `lane:up-next` | `type:docs` | DX-029 scopedNodeIO realpath and symlink semantics |
+| [#278](https://github.com/flyingrobots/bijou/pull/278) | `lane:up-next` | implementation PR | DF-054 through DF-059 late-family DOGFOOD standard Blocks |
 | [#279](https://github.com/flyingrobots/bijou/issues/279) | `lane:release` | `type:enhancement` | WF-125 draft-first cycle start workflow |
+| [#280](https://github.com/flyingrobots/bijou/pull/280) | `lane:release` | implementation PR | WF-125 draft-first cycle start workflow |
+| [#281](https://github.com/flyingrobots/bijou/issues/281) | `lane:release` | `type:enhancement` | DOGFOOD release title screen |
+| [#283](https://github.com/flyingrobots/bijou/issues/283) | `lane:bad-code` / `lane:release` | `type:bug` | V7 Codex review regression fixes |
+| [#285](https://github.com/flyingrobots/bijou/issues/285) | `lane:bad-code` / `lane:release` | `type:docs` / `type:maintenance` | V7 tracker docs sync after review follow-up |
 | [#226](https://github.com/flyingrobots/bijou/issues/226) | `lane:up-next` | `type:maintenance` | DF-039 framed grouping standard Block |
 | [#227](https://github.com/flyingrobots/bijou/issues/227) | `lane:up-next` | `type:maintenance` | DF-040 explainability walkthrough standard Block |
 | [#228](https://github.com/flyingrobots/bijou/issues/228) | `lane:up-next` | `type:maintenance` | DF-042 formatted document standard Block |

--- a/docs/design/WF-127-v7-issue-complete-tracker-sync.md
+++ b/docs/design/WF-127-v7-issue-complete-tracker-sync.md
@@ -16,9 +16,10 @@ keywords:
 
 ## Framing
 
-GitHub is the live tracker for Bijou work. After the V7 Product Truth closeout
-and the post-merge Codex review follow-up, GitHub reports the `v7.0.0`
-milestone as issue-complete: zero open issues and twenty-six closed issues.
+GitHub is the live tracker for Bijou work. After the V7 Product Truth closeout,
+the post-merge Codex review follow-up, and this tracker-sync cleanup, the
+`v7.0.0` milestone should be issue-complete: zero open milestone items and
+twenty-seven closed milestone items.
 
 The repository mirrors did not fully follow that state. `BEARING.md`,
 `ROADMAP.md`, and the WF-126 regression still describe the pre-merge V7
@@ -37,13 +38,16 @@ tracker/docs drift the Method calls out as bad code.
 ## Hill
 
 A maintainer preparing V7 can read BEARING, ROADMAP, and the WF-126 regression
-and see the same truth as the GitHub milestone: V7 has no open tracker issues,
-has twenty-six closed tracker issues, and should move to release-readiness
-validation.
+and see the same truth as the GitHub milestone after this PR closes #285: V7
+has no open milestone items, has twenty-seven closed milestone items, and
+should move to release-readiness validation.
 
 ## Current Truth
 
-- GitHub milestone `v7.0.0`: `0` open / `26` closed.
+- GitHub milestone `v7.0.0` before this cleanup issue: `1` open / `26` closed,
+  because #285 is now the only open V7 item.
+- GitHub milestone `v7.0.0` after this cleanup issue closes: `0` open / `27`
+  closed. The milestone count includes milestone PRs as well as issues.
 - `docs/BEARING.md` still says the V7 current open count is three.
 - `docs/ROADMAP.md` still reports V7 as `3` open / `20` closed.
 - `tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts` still expects #245,
@@ -62,7 +66,7 @@ Active Gravity
 ### ROADMAP
 
 ```text
-| v7.0.0 | 0 open | 26 closed | Issue-complete V7 Product Truth |
+| v7.0.0 | 0 open | 27 closed | Issue-complete V7 Product Truth |
 
 Open Work
   No open v7 tracker issues remain as of 2026-06-03.
@@ -72,8 +76,8 @@ Open Work
 
 ```text
 WF-126
-  expect roadmap v7 row to contain | 0 | 26 |
-  expect closed issue lineage to include #245, #246, #281, #283
+  expect roadmap v7 row to contain | 0 | 27 |
+  expect closed issue lineage to include #245, #246, #281, #283, #285
   expect no open-work rows for #245/#246/#281
 ```
 
@@ -98,8 +102,8 @@ No lower-mode product output changes are intended.
 
 - Issue #285 is closed by the PR.
 - BEARING no longer lists #245, #246, or #281 as open V7 work.
-- ROADMAP reports `v7.0.0` as `0` open and `26` closed.
-- ROADMAP lists #245, #246, #281, and #283 in V7 completed lineage.
+- ROADMAP reports `v7.0.0` as `0` open and `27` closed.
+- ROADMAP lists #245, #246, #281, #283, and #285 in V7 completed lineage.
 - WF-126 passes.
 - CHANGELOG records the bad-code tracker sync fix.
 

--- a/docs/design/WF-127-v7-issue-complete-tracker-sync.md
+++ b/docs/design/WF-127-v7-issue-complete-tracker-sync.md
@@ -1,0 +1,111 @@
+---
+title: WF-127 V7 issue-complete tracker sync
+legend: WF
+lane: bad-code
+priority: medium
+issue: https://github.com/flyingrobots/bijou/issues/285
+keywords:
+  - tracker
+  - roadmap
+  - bearing
+  - v7
+  - release-readiness
+---
+
+# WF-127 V7 Issue-Complete Tracker Sync
+
+## Framing
+
+GitHub is the live tracker for Bijou work. After the V7 Product Truth closeout
+and the post-merge Codex review follow-up, GitHub reports the `v7.0.0`
+milestone as issue-complete: zero open issues and twenty-six closed issues.
+
+The repository mirrors did not fully follow that state. `BEARING.md`,
+`ROADMAP.md`, and the WF-126 regression still describe the pre-merge V7
+closeout with #245, #246, and #281 as open work. That creates the exact
+tracker/docs drift the Method calls out as bad code.
+
+## Sponsored Users
+
+- A release maintainer needs BEARING and ROADMAP to match GitHub before running
+  release-readiness validation.
+- A review agent needs the tracker-sync regression to encode the issue-complete
+  state, not the old closeout state.
+- A contributor scanning the repo needs to see release-readiness as the next
+  action instead of chasing already-closed V7 issues.
+
+## Hill
+
+A maintainer preparing V7 can read BEARING, ROADMAP, and the WF-126 regression
+and see the same truth as the GitHub milestone: V7 has no open tracker issues,
+has twenty-six closed tracker issues, and should move to release-readiness
+validation.
+
+## Current Truth
+
+- GitHub milestone `v7.0.0`: `0` open / `26` closed.
+- `docs/BEARING.md` still says the V7 current open count is three.
+- `docs/ROADMAP.md` still reports V7 as `3` open / `20` closed.
+- `tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts` still expects #245,
+  #246, and #281 in the open-work area.
+
+## Product Shape
+
+### BEARING
+
+```text
+Active Gravity
+  v7.0.0 is issue-complete
+  next action: release-readiness validation
+```
+
+### ROADMAP
+
+```text
+| v7.0.0 | 0 open | 26 closed | Issue-complete V7 Product Truth |
+
+Open Work
+  No open v7 tracker issues remain as of 2026-06-03.
+```
+
+### Regression
+
+```text
+WF-126
+  expect roadmap v7 row to contain | 0 | 26 |
+  expect closed issue lineage to include #245, #246, #281, #283
+  expect no open-work rows for #245/#246/#281
+```
+
+## Runtime And API Contract
+
+This is a documentation and workflow-proof cycle. It does not change runtime
+APIs, package exports, or user-facing DOGFOOD behavior.
+
+## Lower Modes
+
+No lower-mode product output changes are intended.
+
+## Tests To Write First
+
+- Update `tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts` so it fails
+  against the current stale BEARING and ROADMAP state.
+- Keep the test scoped to local repo evidence. The GitHub query remains the
+  operator's source of truth; the regression prevents the checked-in mirror from
+  drifting again.
+
+## Acceptance Criteria
+
+- Issue #285 is closed by the PR.
+- BEARING no longer lists #245, #246, or #281 as open V7 work.
+- ROADMAP reports `v7.0.0` as `0` open and `26` closed.
+- ROADMAP lists #245, #246, #281, and #283 in V7 completed lineage.
+- WF-126 passes.
+- CHANGELOG records the bad-code tracker sync fix.
+
+## Risks And Guardrails
+
+- Do not cut, tag, or publish V7 in this cycle.
+- Do not implement the broader tracker-sync sentinel from #268 here.
+- Do not move Beyond issues into V7 as part of this cleanup.
+- Do not make BEARING or ROADMAP the source of truth. They mirror GitHub.

--- a/tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts
+++ b/tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts
@@ -2,24 +2,43 @@ import { describe, expect, it } from 'vitest';
 import { readRepoFile } from '../repo.js';
 
 describe('WF-126 v7 closeout tracker sync', () => {
-  it('keeps BEARING next target on the live v7 closeout issues', () => {
+  it('keeps BEARING on the live issue-complete v7 tracker state', () => {
     const bearing = readRepoFile('docs/BEARING.md');
 
     expect(bearing).toContain('V7 Product Truth');
-    expect(bearing).toContain('https://github.com/flyingrobots/bijou/issues/245');
-    expect(bearing).toContain('https://github.com/flyingrobots/bijou/issues/246');
-    expect(bearing).toContain('https://github.com/flyingrobots/bijou/issues/281');
+    expect(bearing).toMatch(/zero open milestone\s+items and twenty-seven closed milestone\s+items/);
+    expect(bearing).toContain('release-readiness validation');
+    expect(bearing).not.toContain('Its current open count is three');
+    expect(bearing).not.toContain('https://github.com/flyingrobots/bijou/issues/245');
+    expect(bearing).not.toContain('https://github.com/flyingrobots/bijou/issues/246');
+    expect(bearing).not.toContain('https://github.com/flyingrobots/bijou/issues/281');
     expect(bearing).not.toContain('https://github.com/flyingrobots/bijou/issues/238');
     expect(bearing).not.toContain('After this PR merges');
   });
 
   it('keeps ROADMAP v7 counts and open-work rows aligned with the current tracker', () => {
     const roadmap = readRepoFile('docs/ROADMAP.md');
+    const v7 = sectionBetween(roadmap, '## v7.0.0', '## Beyond');
+    const openWork = sectionBetween(v7, '### Open Work', '### Completed Lineage');
+    const completedLineage = sectionBetween(v7, '### Completed Lineage', '### Component-Family Audits');
 
-    expect(roadmap).toContain('| `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 3 |');
-    expect(roadmap).toContain('[#245](https://github.com/flyingrobots/bijou/issues/245)');
-    expect(roadmap).toContain('[#246](https://github.com/flyingrobots/bijou/issues/246)');
-    expect(roadmap).toContain('[#281](https://github.com/flyingrobots/bijou/issues/281)');
-    expect(roadmap).toContain('DOGFOOD release title screen');
+    expect(roadmap).toContain('| `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 |');
+    expect(openWork).toContain('No open v7 tracker issues remain as of 2026-06-03.');
+    expect(openWork).not.toContain('https://github.com/flyingrobots/bijou/issues/245');
+    expect(openWork).not.toContain('https://github.com/flyingrobots/bijou/issues/246');
+    expect(openWork).not.toContain('https://github.com/flyingrobots/bijou/issues/281');
+    expect(completedLineage).toContain('[#245](https://github.com/flyingrobots/bijou/issues/245)');
+    expect(completedLineage).toContain('[#246](https://github.com/flyingrobots/bijou/issues/246)');
+    expect(completedLineage).toContain('[#281](https://github.com/flyingrobots/bijou/issues/281)');
+    expect(completedLineage).toContain('[#283](https://github.com/flyingrobots/bijou/issues/283)');
+    expect(completedLineage).toContain('[#285](https://github.com/flyingrobots/bijou/issues/285)');
   });
 });
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}


### PR DESCRIPTION
## Summary

- fixes the bad-code tracker/docs drift after the v7 review follow-up
- updates BEARING, ROADMAP, and WF-126 so they mirror the post-merge v7 milestone state
- records the tracker-sync closeout in CHANGELOG

## Method Artifacts

- Issue: Closes #285
- Design: docs/design/WF-127-v7-issue-complete-tracker-sync.md

## RED/GREEN

- RED: updated WF-126 failed against stale BEARING/ROADMAP. Failures proved BEARING still said v7 had three open items and ROADMAP still reported v7 as 3 open / 20 closed.
- GREEN: WF-126 now passes with v7 as 0 open / 27 closed after this cleanup closes, no open v7 rows, and #245, #246, #281, #283, and #285 in completed lineage.

## Validation

- npm test -- --run tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts
- git diff --check
- npm run docs:inventory
- npm run typecheck:test
- npm run lint
- pre-push: dogfood:i18n:complete
- pre-push: dogfood:i18n:check
- pre-push: npm run typecheck:test
- pre-push: npm test
- pre-push: npm run verify:interactive-examples
- self-review: 0 findings