### PR TITLE
Fix live notification word wrapping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🐛 Fixes
 
+- **Live notification word wrapping** — active `@flyingrobots/bijou-tui`
+  notification stack entries now wrap rendered title, body, and action rows at
+  word boundaries when possible instead of hard-splitting words in the live
+  overlay path. Long unbroken words still hard-wrap to stay inside the
+  notification width. This closes issue #292.
 - **Safe GitHub comments and milestone item mirrors** —
   `docs/WORKFLOW.md`, `docs/METHOD.md`, `AGENTS.md`, and `CONTRIBUTING.md`
   now prefer `--body-file` with quoted heredocs for Markdown-heavy GitHub

--- a/packages/bijou-tui/src/notification.test.ts
+++ b/packages/bijou-tui/src/notification.test.ts
@@ -326,6 +326,44 @@ describe('renderNotificationStack', () => {
     expect(stripAnsi(overlay!.content)).toContain('[ Retry deploy ]');
   });
 
+  it('preserves leading padding for unfocused actionable buttons', () => {
+    let state = createNotificationState<Msg>();
+    state = pushNotification(state, {
+      title: 'Unfocused deploy',
+      message: 'Kept visible behind the focused notification.',
+      variant: 'ACTIONABLE',
+      action: { label: 'Retry deploy', payload: { type: 'retry', id: 7 } },
+      durationMs: null,
+    }, 0);
+    state = pushNotification(state, {
+      title: 'Focused deploy',
+      message: 'Newest actionable notification owns focus.',
+      variant: 'ACTIONABLE',
+      action: { label: 'Open logs', payload: { type: 'ignore' } },
+      durationMs: null,
+    }, 10);
+    state = tickNotifications(state, 250);
+
+    const overlays = renderNotificationStack(state, {
+      screenWidth: 80,
+      screenHeight: 24,
+    });
+    const unfocused = overlays.find((overlay) => stripAnsi(overlay.content).includes('Unfocused deploy'));
+    if (unfocused == null) {
+      throw new Error('expected unfocused actionable notification overlay');
+    }
+
+    const actionLine = stripAnsi(unfocused.content).split('\n')
+      .find((line) => line.includes('Retry deploy'));
+    if (actionLine == null) {
+      throw new Error('expected unfocused actionable notification action row');
+    }
+
+    const labelStart = actionLine.indexOf('Retry deploy');
+    expect(actionLine).not.toContain('[ Retry deploy ]');
+    expect(actionLine.slice(labelStart - 2, labelStart)).toBe('  ');
+  });
+
   it('renders multilingual actionable stack entries without losing wrapped title or action text', () => {
     let state = createNotificationState<Msg>();
     state = pushNotification(state, {

--- a/packages/bijou-tui/src/notification.test.ts
+++ b/packages/bijou-tui/src/notification.test.ts
@@ -469,7 +469,31 @@ describe('renderNotificationStack', () => {
     const lines = stripAnsi(overlay!.content).split('\n');
 
     expect(lines.length).toBeGreaterThan(3);
-    expect(lines.join('\n')).toContain('diagnostic text.');
+    expect(lines.join('\n')).toContain('diagnostic');
+    expect(lines.join('\n')).toContain('text.');
+  });
+
+  it('wraps live notification body copy at word boundaries', () => {
+    let state = createNotificationState<Msg>();
+    state = pushNotification(state, {
+      title: 'Runtime error',
+      message: 'command: Undo must be submitted as explicit causal input before production use.',
+      variant: 'TOAST',
+      width: 52,
+      durationMs: null,
+    }, 0);
+    state = tickNotifications(state, 250);
+
+    const [overlay] = renderNotificationStack(state, {
+      screenWidth: 80,
+      screenHeight: 24,
+    });
+    const lines = stripAnsi(overlay!.content).split('\n')
+      .map((line) => line.replace(/^\s*\S?\s*/, '').trimEnd());
+
+    expect(lines).toContain('command: Undo must be submitted as explicit causal');
+    expect(lines).toContain('input before production use.');
+    expect(lines.join('\n')).not.toContain('causal i\nnput');
   });
 
   it('supports per-notification truncate overflow overrides', () => {

--- a/packages/bijou-tui/src/notification.ts
+++ b/packages/bijou-tui/src/notification.ts
@@ -876,12 +876,49 @@ function wrapLineSurface(surface: Surface, width: number): readonly Surface[] {
   if (surface.width === 0) return [createBlankLineSurface(safeWidth)];
 
   const rows: Surface[] = [];
-  for (let offset = 0; offset < surface.width; offset += safeWidth) {
-    const row = createSurface(safeWidth, 1);
-    row.blit(surface, 0, 0, offset, 0, safeWidth, 1);
-    rows.push(row);
+  let offset = trimLeadingSurfaceWhitespace(surface, 0);
+  while (offset < surface.width) {
+    const hardEnd = Math.min(surface.width, offset + safeWidth);
+    const end = hardEnd >= surface.width
+      ? surface.width
+      : wordBoundarySurfaceEnd(surface, offset, hardEnd);
+    rows.push(sliceLineSurface(surface, offset, end, safeWidth));
+    offset = hardEnd >= surface.width
+      ? surface.width
+      : trimLeadingSurfaceWhitespace(surface, end < hardEnd ? end + 1 : hardEnd);
   }
-  return rows;
+  return rows.length === 0 ? [createBlankLineSurface(safeWidth)] : rows;
+}
+
+function sliceLineSurface(surface: Surface, start: number, end: number, width: number): Surface {
+  const row = createSurface(width, 1);
+  const span = Math.max(0, Math.min(surface.width, end) - start);
+  if (span > 0) {
+    row.blit(surface, 0, 0, start, 0, span, 1);
+  }
+  return row;
+}
+
+function wordBoundarySurfaceEnd(surface: Surface, start: number, hardEnd: number): number {
+  let breakAt = -1;
+  for (let index = start; index < hardEnd; index++) {
+    if (isWhitespaceSurfaceCell(surface, index)) {
+      breakAt = index;
+    }
+  }
+  return breakAt > start ? breakAt : hardEnd;
+}
+
+function trimLeadingSurfaceWhitespace(surface: Surface, start: number): number {
+  let offset = start;
+  while (offset < surface.width && isWhitespaceSurfaceCell(surface, offset)) {
+    offset++;
+  }
+  return offset;
+}
+
+function isWhitespaceSurfaceCell(surface: Surface, col: number): boolean {
+  return /^\s+$/.test(surface.get(col, 0).char);
 }
 
 function renderPlainSurface(surface: Surface): string {

--- a/packages/bijou-tui/src/notification.ts
+++ b/packages/bijou-tui/src/notification.ts
@@ -876,7 +876,7 @@ function wrapLineSurface(surface: Surface, width: number): readonly Surface[] {
   if (surface.width === 0) return [createBlankLineSurface(safeWidth)];
 
   const rows: Surface[] = [];
-  let offset = trimLeadingSurfaceWhitespace(surface, 0);
+  let offset = 0;
   while (offset < surface.width) {
     const hardEnd = Math.min(surface.width, offset + safeWidth);
     const end = hardEnd >= surface.width


### PR DESCRIPTION
## Summary

Fixes the active `@flyingrobots/bijou-tui` notification stack so live notification rows wrap at word boundaries when possible instead of hard-splitting words at fixed column slices.

Closes #292.

## Root Cause

Archived notification history already used the word-aware text wrapping path, but active notification overlays wrapped rendered surfaces by slicing every `width` columns. That split normal prose words such as `input` across rows.

## Changes

- Replaces fixed-column `wrapLineSurface` slicing with boundary-aware surface row wrapping.
- Preserves existing cell styling by blitting wrapped ranges from the original rendered surface.
- Keeps hard wrapping for single words longer than the notification width.
- Adds regression coverage for the Jedit-shaped runtime notification text that previously split `input`.
- Updates the changelog.

## Validation

- `npx vitest run --config vitest.config.ts packages/bijou-tui/src/notification.test.ts`
- `npm run build`
- `npm run lint`
- `npm run typecheck:test`
- `git diff --check`
- Pre-push hook: DOGFOOD i18n complete/check, typecheck:test, build, full Vitest `334` files / `3680` tests, scripted interactive examples
