### PR TITLE
Path-gate DOGFOOD CI lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,67 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      dogfood: ${{ steps.dogfood.outputs.dogfood }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Classify DOGFOOD relevance
+        id: dogfood
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "dogfood=true" >> "$GITHUB_OUTPUT"
+            echo "DOGFOOD CI path gate: full proof for ${GITHUB_EVENT_NAME}" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          is_dogfood_relevant() {
+            case "$1" in
+              .github/workflows/*) return 0 ;;
+              package.json|package-lock.json) return 0 ;;
+              packages/*) return 0 ;;
+              examples/docs/*) return 0 ;;
+              scripts/dogfood-*) return 0 ;;
+              scripts/smoke-dogfood*) return 0 ;;
+              tests/cycles/DF-*) return 0 ;;
+              tests/cycles/*dogfood*) return 0 ;;
+              docs/DOGFOOD.md) return 0 ;;
+              docs/design/DF-*) return 0 ;;
+              docs/legends/DF-*) return 0 ;;
+              docs/method/legends/DF-*) return 0 ;;
+            esac
+
+            return 1
+          }
+
+          if git rev-parse HEAD^1 >/dev/null 2>&1; then
+            diff_args=(HEAD^1 HEAD)
+          else
+            git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
+            diff_args=(FETCH_HEAD...HEAD)
+          fi
+
+          dogfood=false
+          while IFS= read -r path; do
+            if is_dogfood_relevant "$path"; then
+              dogfood=true
+            fi
+          done < <(git diff --name-only "${diff_args[@]}")
+
+          echo "dogfood=${dogfood}" >> "$GITHUB_OUTPUT"
+          echo "DOGFOOD CI path gate: ${dogfood}" >> "$GITHUB_STEP_SUMMARY"
+
   test:
     runs-on: ubuntu-latest
+    needs: changes
     strategy:
       matrix:
         node-version: [20, 22]
@@ -28,10 +87,10 @@ jobs:
         if: matrix.node-version == 22
         run: npm run docs:design-system:preflight
       - name: DOGFOOD coverage gate
-        if: matrix.node-version == 22
+        if: matrix.node-version == 22 && needs.changes.outputs.dogfood == 'true'
         run: npm run dogfood:coverage:gate
       - name: DOGFOOD i18n policy gate
-        if: matrix.node-version == 22
+        if: matrix.node-version == 22 && needs.changes.outputs.dogfood == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -75,6 +134,7 @@ jobs:
   smoke_dogfood:
     name: Smoke DOGFOOD (${{ matrix.lane.label }})
     runs-on: ubuntu-latest
+    needs: changes
     strategy:
       matrix:
         lane:
@@ -83,14 +143,23 @@ jobs:
           - label: docs
             command: smoke:dogfood:docs
     steps:
+      - name: Skip unrelated DOGFOOD smoke
+        if: needs.changes.outputs.dogfood != 'true'
+        run: echo "DOGFOOD smoke skipped because no DOGFOOD-relevant paths changed."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.dogfood == 'true'
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.dogfood == 'true'
         with:
           node-version: "22"
           cache: npm
-      - run: npm ci
-      - run: npm run build
-      - run: npm run ${{ matrix.lane.command }}
+      - if: needs.changes.outputs.dogfood == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.dogfood == 'true'
+        run: npm run build
+      - if: needs.changes.outputs.dogfood == 'true'
+        run: npm run ${{ matrix.lane.command }}
 
   bench_gradient:
     name: Bench Gradient

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🐛 Fixes
 
+- **DOGFOOD CI path gates** — CI now classifies changed paths before test jobs
+  run, skips DOGFOOD coverage/i18n policy steps and expensive DOGFOOD
+  docs/landing smoke steps on pull requests that do not touch
+  DOGFOOD-relevant paths, and still runs the full DOGFOOD proof path for `main`
+  pushes and tags. This closes issue #293.
 - **Safe GitHub comments and milestone item mirrors** —
   `docs/WORKFLOW.md`, `docs/METHOD.md`, `AGENTS.md`, and `CONTRIBUTING.md`
   now prefer `--body-file` with quoted heredocs for Markdown-heavy GitHub

--- a/docs/design/WF-129-path-gate-dogfood-ci.md
+++ b/docs/design/WF-129-path-gate-dogfood-ci.md
@@ -1,0 +1,133 @@
+---
+title: WF-129 Path-Gate DOGFOOD CI
+legend: WF
+lane: bad-code
+priority: medium
+issue: https://github.com/flyingrobots/bijou/issues/293
+keywords:
+  - ci
+  - dogfood
+  - path-gates
+  - iteration-time
+  - workflow
+---
+
+# WF-129 Path-Gate DOGFOOD CI
+
+## Framing
+
+The CI loop is intentionally conservative, but ordinary workflow/documentation
+PRs currently run DOGFOOD-heavy gates even when they do not touch DOGFOOD,
+runtime components, localization, or CI scripts. That makes rapid-fire cycles
+pay duplicate install/build/smoke costs before review can close.
+
+This cycle adds a CI change classifier so DOGFOOD-specific checks run when they
+are relevant and skip when a PR is unrelated to DOGFOOD. Pushes to `main` and
+tag workflows remain full-strength.
+
+## Sponsored Users
+
+- A maintainer iterating on workflow documentation needs PR CI to avoid
+  DOGFOOD smoke work when the branch cannot affect DOGFOOD.
+- A release maintainer needs `main` pushes and tags to continue running the
+  full DOGFOOD proof path.
+- A review agent needs the path-gating contract to be visible in the workflow
+  file and covered by a regression test.
+
+## Hill
+
+A contributor can open a PR that only changes non-DOGFOOD docs or workflow
+bookkeeping and see DOGFOOD-heavy CI lanes skipped, while any PR touching
+DOGFOOD, packages, localization, DOGFOOD scripts/tests, or CI workflows still
+runs DOGFOOD proof.
+
+## Current Truth
+
+- `scripts/hooks/pre-push` runs DOGFOOD i18n, test typecheck, full Vitest, and
+  interactive example smoke before every push.
+- `.github/workflows/ci.yml` runs DOGFOOD coverage and i18n policy inside the
+  Ubuntu Node 22 `test` job for every PR.
+- `.github/workflows/ci.yml` runs separate DOGFOOD landing/docs smoke jobs for
+  every PR, with their own checkout, install, and build.
+- The latest main CI run after PR #291 had a `test (22)` critical path just
+  under two minutes, plus separate DOGFOOD smoke jobs.
+
+## Product Shape
+
+### CI Classifier
+
+```text
+CI
+  changes
+    dogfood = true on main pushes and tags
+    dogfood = true on PRs touching:
+      .github/workflows/**
+      packages/**
+      bench/**
+      examples/docs/**
+      scripts/dogfood-*
+      scripts/smoke-dogfood*
+      tests/cycles/DF-*
+      docs/DOGFOOD.md
+      docs/design/DF-*
+      docs/legends/DF-*
+```
+
+### Gated DOGFOOD Proof
+
+```text
+test (22)
+  always: build, lint, npm test
+  when dogfood-relevant: DOGFOOD coverage + DOGFOOD i18n policy
+
+Smoke DOGFOOD (landing/docs)
+  when dogfood-relevant: run smoke job matrix
+  otherwise: skipped by job-level if
+```
+
+## Runtime And API Contract
+
+This cycle changes CI workflow behavior only. It does not change package APIs,
+runtime behavior, DOGFOOD rendering, localization catalogs, or release
+workflows.
+
+## Lower Modes
+
+No TUI output changes are included.
+
+- Static mode: not applicable.
+- Pipe mode: not applicable.
+- Accessible mode: not applicable.
+
+## Tests To Write First
+
+- Add `tests/cycles/WF-129/path-gate-dogfood-ci.test.ts`.
+- RED state:
+  - CI lacks a `changes` job exposing `dogfood` output
+  - DOGFOOD coverage/i18n policy steps are not guarded by the classifier
+  - DOGFOOD smoke job is not guarded by the classifier
+  - `main`/tag pushes are not documented as full DOGFOOD proof
+- GREEN state:
+  - workflow text includes the classifier and relevant trigger paths
+  - workflow text gates DOGFOOD-heavy PR work on `needs.changes.outputs.dogfood`
+  - changelog records the CI iteration-time cleanup
+
+## Acceptance Criteria
+
+- Issue #293 is closed by the PR.
+- PR CI has an explicit `changes` job.
+- DOGFOOD coverage/i18n policy steps run only when the classifier says DOGFOOD
+  proof is needed.
+- DOGFOOD landing/docs smoke jobs run only when the classifier says DOGFOOD
+  proof is needed.
+- Pushes to `main` and tags still set the DOGFOOD classifier to true.
+- WF-129 passes.
+- `docs/CHANGELOG.md` records the change.
+
+## Risks And Guardrails
+
+- Do not path-gate release dry-run or publish workflows in this cycle.
+- Do not skip full `npm test` in the core Ubuntu matrix yet.
+- Do not weaken DOGFOOD proof when `packages/**`, `examples/docs/**`, or
+  DOGFOOD-specific scripts/tests change.
+- Keep the classifier readable enough to audit in review.

--- a/docs/design/WF-129-path-gate-dogfood-ci.md
+++ b/docs/design/WF-129-path-gate-dogfood-ci.md
@@ -62,15 +62,18 @@ CI
     dogfood = true on main pushes and tags
     dogfood = true on PRs touching:
       .github/workflows/**
+      package.json
+      package-lock.json
       packages/**
-      bench/**
       examples/docs/**
       scripts/dogfood-*
       scripts/smoke-dogfood*
       tests/cycles/DF-*
+      tests/cycles/*dogfood*
       docs/DOGFOOD.md
       docs/design/DF-*
       docs/legends/DF-*
+      docs/method/legends/DF-*
 ```
 
 ### Gated DOGFOOD Proof
@@ -81,8 +84,8 @@ test (22)
   when dogfood-relevant: DOGFOOD coverage + DOGFOOD i18n policy
 
 Smoke DOGFOOD (landing/docs)
-  when dogfood-relevant: run smoke job matrix
-  otherwise: skipped by job-level if
+  when dogfood-relevant: run checkout, install, build, and smoke command
+  otherwise: keep check names present and skip expensive smoke steps
 ```
 
 ## Runtime And API Contract
@@ -118,8 +121,8 @@ No TUI output changes are included.
 - PR CI has an explicit `changes` job.
 - DOGFOOD coverage/i18n policy steps run only when the classifier says DOGFOOD
   proof is needed.
-- DOGFOOD landing/docs smoke jobs run only when the classifier says DOGFOOD
-  proof is needed.
+- DOGFOOD landing/docs smoke commands run only when the classifier says DOGFOOD
+  proof is needed, while the check names remain present.
 - Pushes to `main` and tags still set the DOGFOOD classifier to true.
 - WF-129 passes.
 - `docs/CHANGELOG.md` records the change.

--- a/tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
+++ b/tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { existsRepoPath, readRepoFile } from '../repo.js';
+
+describe('WF-129 path-gate DOGFOOD CI', () => {
+  it('documents the cycle and classifier contract', () => {
+    const design = readRepoFile('docs/design/WF-129-path-gate-dogfood-ci.md');
+
+    expect(existsRepoPath('docs/design/WF-129-path-gate-dogfood-ci.md')).toBe(true);
+    expect(design).toContain('Issue #293 is closed by the PR.');
+    expect(design).toContain('Pushes to `main` and tags still set the DOGFOOD classifier to true.');
+  });
+
+  it('classifies DOGFOOD-relevant PR paths before CI jobs run', () => {
+    const ci = readRepoFile('.github/workflows/ci.yml');
+
+    expect(ci).toContain('changes:');
+    expect(ci).toContain('name: Classify changed paths');
+    expect(ci).toContain('dogfood: ${{ steps.dogfood.outputs.dogfood }}');
+    expect(ci).toContain('id: dogfood');
+    expect(ci).toContain('if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then');
+    expect(ci).toContain('echo "dogfood=true" >> "$GITHUB_OUTPUT"');
+    expect(ci).toContain('diff_args=(HEAD^1 HEAD)');
+    expect(ci).toContain('git diff --name-only "${diff_args[@]}"');
+
+    for (const triggerPath of [
+      '.github/workflows/*',
+      'package.json',
+      'package-lock.json',
+      'packages/*',
+      'examples/docs/*',
+      'scripts/dogfood-*',
+      'scripts/smoke-dogfood*',
+      'tests/cycles/DF-*',
+      'tests/cycles/*dogfood*',
+      'docs/DOGFOOD.md',
+      'docs/design/DF-*',
+      'docs/legends/DF-*',
+      'docs/method/legends/DF-*',
+    ]) {
+      expect(ci).toContain(triggerPath);
+    }
+  });
+
+  it('gates DOGFOOD-heavy CI lanes on the classifier for PRs', () => {
+    const ci = readRepoFile('.github/workflows/ci.yml');
+
+    expect(ci).toMatch(/test:\n(?:[\s\S]*?)needs: changes/);
+    expect(ci).toContain("if: matrix.node-version == 22 && needs.changes.outputs.dogfood == 'true'");
+    expect(ci).toMatch(/name: DOGFOOD coverage gate[\s\S]*?needs\.changes\.outputs\.dogfood == 'true'/);
+    expect(ci).toMatch(/name: DOGFOOD i18n policy gate[\s\S]*?needs\.changes\.outputs\.dogfood == 'true'/);
+
+    expect(ci).toMatch(/smoke_dogfood:\n(?:[\s\S]*?)needs: changes/);
+    expect(ci).toContain('name: Skip unrelated DOGFOOD smoke');
+    expect(ci).toContain("if: needs.changes.outputs.dogfood != 'true'");
+    expect(ci).toMatch(/uses: actions\/checkout@v6[\s\S]*?if: needs\.changes\.outputs\.dogfood == 'true'/);
+    expect(ci).toMatch(/run: npm run \$\{\{ matrix\.lane\.command \}\}[\s\S]*?if: needs\.changes\.outputs\.dogfood == 'true'|if: needs\.changes\.outputs\.dogfood == 'true'[\s\S]*?run: npm run \$\{\{ matrix\.lane\.command \}\}/);
+  });
+
+  it('records the CI speedup in the changelog', () => {
+    const changelog = readRepoFile('docs/CHANGELOG.md');
+    const normalizedChangelog = normalizeWhitespace(changelog);
+
+    expect(changelog).toContain('DOGFOOD CI path gates');
+    expect(normalizedChangelog).toContain('This closes issue #293.');
+  });
+});
+
+function normalizeWhitespace(source: string): string {
+  return source.replace(/\s+/g, ' ').trim();
+}

--- a/tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
+++ b/tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
@@ -52,8 +52,12 @@ describe('WF-129 path-gate DOGFOOD CI', () => {
     expect(ci).toMatch(/smoke_dogfood:\n(?:[\s\S]*?)needs: changes/);
     expect(ci).toContain('name: Skip unrelated DOGFOOD smoke');
     expect(ci).toContain("if: needs.changes.outputs.dogfood != 'true'");
-    expect(ci).toMatch(/uses: actions\/checkout@v6[\s\S]*?if: needs\.changes\.outputs\.dogfood == 'true'/);
-    expect(ci).toMatch(/run: npm run \$\{\{ matrix\.lane\.command \}\}[\s\S]*?if: needs\.changes\.outputs\.dogfood == 'true'|if: needs\.changes\.outputs\.dogfood == 'true'[\s\S]*?run: npm run \$\{\{ matrix\.lane\.command \}\}/);
+    expect(ci).toContain(
+      "- uses: actions/checkout@v6\n        if: needs.changes.outputs.dogfood == 'true'",
+    );
+    expect(ci).toContain(
+      "- if: needs.changes.outputs.dogfood == 'true'\n        run: npm run ${{ matrix.lane.command }}",
+    );
   });
 
   it('records the CI speedup in the changelog', () => {


### PR DESCRIPTION
## Summary
- add a CI path classifier for DOGFOOD-relevant changes
- gate DOGFOOD coverage/i18n steps and expensive DOGFOOD smoke steps on that classifier
- document the WF-129 cycle and add regression coverage for the workflow contract

## Verification
- npx vitest run tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
- npx vitest run tests/cycles/WF-003/replace-smoke-examples-with-smoke-dogfood.test.ts tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
- node --input-type=module -e "import { readFileSync } from 'node:fs'; import { parseDocument } from 'yaml'; const doc = parseDocument(readFileSync('.github/workflows/ci.yml', 'utf8')); if (doc.errors.length) { console.error(doc.errors.map(String).join('\\n')); process.exit(1); }"\n- npm run typecheck:test\n- npm run docs:inventory\n- npm run lint\n- git diff --check\n- pre-push full gate\n\nCloses #293