### PR TITLE
Release v7.0.0

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-bench",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "Headless performance benchmarks for bijou — frame-time, memory, and interactive sandbox.",
   "private": true,
   "type": "module",
@@ -10,9 +10,9 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "5.0.1",
-    "@flyingrobots/bijou-node": "5.0.1",
-    "@flyingrobots/bijou-tui": "5.0.1"
+    "@flyingrobots/bijou": "7.0.0",
+    "@flyingrobots/bijou-node": "7.0.0",
+    "@flyingrobots/bijou-tui": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-bench",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Headless performance benchmarks for bijou — frame-time, memory, and interactive sandbox.",
   "private": true,
   "type": "module",
@@ -10,9 +10,9 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "5.0.0",
-    "@flyingrobots/bijou-node": "5.0.0",
-    "@flyingrobots/bijou-tui": "5.0.0"
+    "@flyingrobots/bijou": "5.0.1",
+    "@flyingrobots/bijou-node": "5.0.1",
+    "@flyingrobots/bijou-tui": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-06-03
+
 ### 🐛 Fixes
 
 - **Live notification word wrapping** — active `@flyingrobots/bijou-tui`

--- a/docs/releases/7.0.0/migration-guide.md
+++ b/docs/releases/7.0.0/migration-guide.md
@@ -1,0 +1,85 @@
+# Migrating to Bijou 7.0.0
+
+Bijou 7.0.0 carries the V6 layout floor and V7 Product Truth lane into one
+major release. Most application code that stayed on public APIs should keep
+working, but maintainers should check the areas below before upgrading.
+
+## Keep The 5.0 Hosted App Entrypoints
+
+The preferred hosted app path from 5.0.0 remains the right path:
+
+```ts
+const app = createFramedApp(options);
+await app.run({ ctx });
+```
+
+or:
+
+```ts
+await runFramedApp(options, { ctx });
+```
+
+If your app still calls lower-level runners directly, this is a good release
+to move back to the frame-owned hosted entrypoints so shell timing, theme, and
+runtime behavior stay in one place.
+
+## Check Table Width Expectations
+
+`table()` and `tableSurface()` now use bounded-width behavior by default for
+human-mode output. If your app expected tables to grow to intrinsic content
+width regardless of terminal size, opt into intrinsic layout explicitly.
+
+For most terminal UIs, the new default is what you want: columns fit the target
+width, wrapped cells preserve word boundaries when possible, and lower-mode
+pipe formats remain deterministic.
+
+## Prefer Standard Blocks For Product Semantics
+
+Bijou 7.0.0 exports a much broader standard Block catalog. If your app has
+custom semantic surfaces for status, feedback, navigation, disclosure, dense
+comparison, hierarchy, text entry, or documentation-like content, evaluate the
+new standard Blocks before inventing another local schema.
+
+Blocks should own product semantics, data contracts, command intents, and
+lowering facts. Leaf components should remain the rendering vocabulary.
+
+## Route Localization Through The Runtime Port
+
+`@flyingrobots/bijou-i18n` now provides structured localization results instead
+of only returning strings. New localization code should preserve the returned
+metadata: key, locale, direction, entry kind, fallback or missing status,
+issues, and facts.
+
+If your app persists locale preference, keep that persistence in a host adapter
+or other boundary-owned port. DOGFOOD uses this shape so runtime locale changes
+are visible without making app logic read process globals directly.
+
+## Notification Overlays Need No Workaround
+
+Live notification rows now wrap at word boundaries when possible. Remove any
+app-local workaround that pre-wrapped notification titles, bodies, or action
+labels only to avoid split words in Bijou overlays.
+
+Long unbroken text still hard-wraps inside the assigned notification width, so
+callers do not need to pre-truncate machine identifiers or hashes for layout
+safety.
+
+## Release And DOGFOOD Proof Are Stricter
+
+DOGFOOD now reads version-specific release docs from:
+
+```text
+docs/releases/<package-version>/whats-new.md
+docs/releases/<package-version>/migration-guide.md
+```
+
+When preparing a release branch, bumping package versions without adding those
+docs will fail the docs and DOGFOOD test lanes. This is intentional: the
+package version and current release documentation must move together.
+
+## Compatibility Stance
+
+Bijou 7.0.0 is a major release because public contracts are broader and more
+explicit, not because every app must rewrite. The main migration work is to
+remove local workarounds that are now framework-owned and to adopt the standard
+contracts where they replace app-local semantic surfaces.

--- a/docs/releases/7.0.0/whats-new.md
+++ b/docs/releases/7.0.0/whats-new.md
@@ -1,0 +1,96 @@
+# What's New in Bijou 7.0.0
+
+Bijou 7.0.0 ships the V6 layout floor and the V7 Product Truth lane as one
+release boundary. The short version: frame geometry, standard Blocks, DOGFOOD
+docs truth, localization posture, release proof, and notification polish now
+live on firmer public contracts instead of scattered demo-specific wiring.
+
+## Product Truth Is Block-Owned
+
+DOGFOOD now routes its release-facing docs surface through named Block
+contracts. The docs workspace, navigation, documentation article, guide
+inspector, settings menu, BlockLab workbench, title screen, footer hints, frame
+search, notifications, performance HUD, keyboard help, command palette, and
+surface inventory all have inspectable semantic contracts.
+
+That matters because product behavior is no longer only visible as pixels. A
+reviewer or agent can inspect metadata, schema-bound inputs, command intents,
+lower-mode facts, and rendered output for the same surface.
+
+## The Standard Block Catalog Is Broader
+
+The release expands first-party Blocks across the DOGFOOD component families:
+
+- grouping, explainability, document, destination, divider, and text-entry
+  Blocks
+- single-choice, multiple-choice, binary-decision, peer-navigation,
+  progressive-disclosure, and path-progress Blocks
+- brand-emphasis, mode-aware primitive, dense comparison, hierarchy,
+  exploration-list, and temporal-dependency Blocks
+- status and feedback Blocks for inline status, in-flow status, transient
+  overlays, activity streams, shortcut cues, and progress indicators
+
+Each family lands with public metadata, schema adapters, command-intent
+posture, visual/static rendering, lower-mode output, and stable semantic facts.
+
+## Layout, Tables, And Selection Got Stricter
+
+The V6 floor brings pure layout envelope primitives to `@flyingrobots/bijou`:
+immutable constraints, preferences, assigned rectangles, direction, fit policy,
+content measurement seams, parent-owned assignment, minimal stack/place
+resolution, and explanation facts.
+
+Table rendering also moves to a more honest bounded-width model:
+
+- `table()` fits human-mode output to the available terminal width by default
+- `tableSurface()` matches that bounded-width posture for surface rendering
+- wrapped cells preserve word boundaries when possible
+- intrinsic layout remains available as an explicit opt-in
+- pipe lowerings now cover TSV, CSV, Markdown, and ASCII grid
+
+Selection and copy are now pure retained-geometry primitives: selection owners,
+viewport-aware ranges, semantic prose/surface/table extraction, mixed-region
+ordering, blocker arbitration, terminal-native fallback, and clipboard-effect
+records without hidden OS clipboard side effects.
+
+## Localization And DOGFOOD Are More Honest
+
+`@flyingrobots/bijou-i18n` now exposes a structured localization port with
+immutable localized objects, fallback and missing metadata, issue facts, and
+explicit resource/data behavior. DOGFOOD routes ordinary docs text lookup
+through that port, persists locale preference through host-owned storage, and
+keeps catalog completeness under local and CI gates.
+
+The DOGFOOD app also gained a release identity and release-title proof surface
+for V7 Product Truth, plus clearer package, philosophy, architecture, doctrine,
+guide, and release documentation inside the terminal docs reader.
+
+## Runtime And Workflow Proof Tightened
+
+This release hardens operator-facing surfaces:
+
+- command backpressure diagnostics and async render middleware diagnostics are
+  exposed in `@flyingrobots/bijou-tui`
+- DOGFOOD and docs smoke paths have tighter non-interactive guardrails
+- CI can skip expensive DOGFOOD-only gates for unrelated pull-request paths
+  while still running the full proof path on `main` and tags
+- GitHub comment workflow docs now require file-backed Markdown comments so
+  commands, backticks, and tables survive review automation
+
+## Notification Text Wraps Like Human Prose
+
+The live `@flyingrobots/bijou-tui` notification stack now wraps title, body,
+and action rows at word boundaries when possible instead of splitting ordinary
+words in the overlay. Long unbroken words still hard-wrap so notifications
+cannot exceed their assigned width.
+
+This is the fix Jedit needs for normal-mode runtime feedback: the notification
+surface stays readable without giving up bounded terminal layout.
+
+## Compatibility
+
+Bijou 7.0.0 is a major release because it publishes a broader product-truth
+surface and tighter runtime contracts. Apps using the documented public APIs
+should see the upgrade mostly as new capability, but maintainers should read
+the migration guide before bumping because table fitting, Block exports, and
+release-proof DOGFOOD behavior are intentionally stricter than the 5.0.0 line.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -25,11 +25,13 @@ docs/releases/next/
 
 ## Current Shaped Release Docs
 
-- [What's New (v5.0.0)](./5.0.0/whats-new.md)
-- [Migration Guide (v5.0.0)](./5.0.0/migration-guide.md)
+- [What's New (v7.0.0)](./7.0.0/whats-new.md)
+- [Migration Guide (v7.0.0)](./7.0.0/migration-guide.md)
 
 ## Previous Release Docs
 
+- [What's New (v5.0.0)](./5.0.0/whats-new.md)
+- [Migration Guide (v5.0.0)](./5.0.0/migration-guide.md)
 - [What's New (v4.4.1)](./4.4.1/whats-new.md)
 - [Migration Guide (v4.4.1)](./4.4.1/migration-guide.md)
 - [What's New (v4.4.0)](./4.4.0/whats-new.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,12 @@
     },
     "bench": {
       "name": "@flyingrobots/bijou-bench",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "5.0.0",
-        "@flyingrobots/bijou-node": "5.0.0",
-        "@flyingrobots/bijou-tui": "5.0.0"
+        "@flyingrobots/bijou": "5.0.1",
+        "@flyingrobots/bijou-node": "5.0.1",
+        "@flyingrobots/bijou-tui": "5.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3106,7 +3106,7 @@
     },
     "packages/bijou": {
       "name": "@flyingrobots/bijou",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3120,7 +3120,7 @@
     },
     "packages/bijou-i18n": {
       "name": "@flyingrobots/bijou-i18n",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3133,10 +3133,10 @@
     },
     "packages/bijou-i18n-tools": {
       "name": "@flyingrobots/bijou-i18n-tools",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "5.0.0"
+        "@flyingrobots/bijou-i18n": "5.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3149,11 +3149,11 @@
     },
     "packages/bijou-i18n-tools-node": {
       "name": "@flyingrobots/bijou-i18n-tools-node",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "5.0.0",
-        "@flyingrobots/bijou-i18n-tools": "5.0.0"
+        "@flyingrobots/bijou-i18n": "5.0.1",
+        "@flyingrobots/bijou-i18n-tools": "5.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3166,10 +3166,10 @@
     },
     "packages/bijou-i18n-tools-xlsx": {
       "name": "@flyingrobots/bijou-i18n-tools-xlsx",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n-tools": "5.0.0",
+        "@flyingrobots/bijou-i18n-tools": "5.0.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
@@ -3183,7 +3183,7 @@
     },
     "packages/bijou-mcp": {
       "name": "@flyingrobots/bijou-mcp",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -3200,15 +3200,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.0"
+        "@flyingrobots/bijou": "5.0.1"
       }
     },
     "packages/bijou-node": {
       "name": "@flyingrobots/bijou-node",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-tui": "5.0.0",
+        "@flyingrobots/bijou-tui": "5.0.1",
         "chalk": "^5.6.2",
         "gifenc": "^1.0.3",
         "oled-font-5x7": "^1.0.3"
@@ -3221,15 +3221,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.0"
+        "@flyingrobots/bijou": "5.0.1"
       }
     },
     "packages/bijou-tui": {
       "name": "@flyingrobots/bijou-tui",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "5.0.0"
+        "@flyingrobots/bijou-i18n": "5.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3240,16 +3240,16 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.0"
+        "@flyingrobots/bijou": "5.0.1"
       }
     },
     "packages/bijou-tui-app": {
       "name": "@flyingrobots/bijou-tui-app",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "5.0.0",
-        "@flyingrobots/bijou-tui": "5.0.0"
+        "@flyingrobots/bijou": "5.0.1",
+        "@flyingrobots/bijou-tui": "5.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3261,7 +3261,7 @@
       }
     },
     "packages/create-bijou-tui-app": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "bin": {
         "create-bijou-tui-app": "dist/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,12 @@
     },
     "bench": {
       "name": "@flyingrobots/bijou-bench",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "5.0.1",
-        "@flyingrobots/bijou-node": "5.0.1",
-        "@flyingrobots/bijou-tui": "5.0.1"
+        "@flyingrobots/bijou": "7.0.0",
+        "@flyingrobots/bijou-node": "7.0.0",
+        "@flyingrobots/bijou-tui": "7.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3106,7 +3106,7 @@
     },
     "packages/bijou": {
       "name": "@flyingrobots/bijou",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3120,7 +3120,7 @@
     },
     "packages/bijou-i18n": {
       "name": "@flyingrobots/bijou-i18n",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3133,10 +3133,10 @@
     },
     "packages/bijou-i18n-tools": {
       "name": "@flyingrobots/bijou-i18n-tools",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "5.0.1"
+        "@flyingrobots/bijou-i18n": "7.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3149,11 +3149,11 @@
     },
     "packages/bijou-i18n-tools-node": {
       "name": "@flyingrobots/bijou-i18n-tools-node",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "5.0.1",
-        "@flyingrobots/bijou-i18n-tools": "5.0.1"
+        "@flyingrobots/bijou-i18n": "7.0.0",
+        "@flyingrobots/bijou-i18n-tools": "7.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3166,10 +3166,10 @@
     },
     "packages/bijou-i18n-tools-xlsx": {
       "name": "@flyingrobots/bijou-i18n-tools-xlsx",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n-tools": "5.0.1",
+        "@flyingrobots/bijou-i18n-tools": "7.0.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
@@ -3183,7 +3183,7 @@
     },
     "packages/bijou-mcp": {
       "name": "@flyingrobots/bijou-mcp",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -3200,15 +3200,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.1"
+        "@flyingrobots/bijou": "7.0.0"
       }
     },
     "packages/bijou-node": {
       "name": "@flyingrobots/bijou-node",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-tui": "5.0.1",
+        "@flyingrobots/bijou-tui": "7.0.0",
         "chalk": "^5.6.2",
         "gifenc": "^1.0.3",
         "oled-font-5x7": "^1.0.3"
@@ -3221,15 +3221,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.1"
+        "@flyingrobots/bijou": "7.0.0"
       }
     },
     "packages/bijou-tui": {
       "name": "@flyingrobots/bijou-tui",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "5.0.1"
+        "@flyingrobots/bijou-i18n": "7.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3240,16 +3240,16 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.1"
+        "@flyingrobots/bijou": "7.0.0"
       }
     },
     "packages/bijou-tui-app": {
       "name": "@flyingrobots/bijou-tui-app",
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "5.0.1",
-        "@flyingrobots/bijou-tui": "5.0.1"
+        "@flyingrobots/bijou": "7.0.0",
+        "@flyingrobots/bijou-tui": "7.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -3261,7 +3261,7 @@
       }
     },
     "packages/create-bijou-tui-app": {
-      "version": "5.0.1",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "bin": {
         "create-bijou-tui-app": "dist/cli.js"

--- a/packages/bijou-i18n-tools-node/package.json
+++ b/packages/bijou-i18n-tools-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools-node",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "Node filesystem helpers for Bijou localization exchange workflows.",
   "type": "module",
   "sideEffects": false,
@@ -24,8 +24,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "5.0.1",
-    "@flyingrobots/bijou-i18n-tools": "5.0.1"
+    "@flyingrobots/bijou-i18n": "7.0.0",
+    "@flyingrobots/bijou-i18n-tools": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-i18n-tools-node/package.json
+++ b/packages/bijou-i18n-tools-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools-node",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Node filesystem helpers for Bijou localization exchange workflows.",
   "type": "module",
   "sideEffects": false,
@@ -24,8 +24,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "5.0.0",
-    "@flyingrobots/bijou-i18n-tools": "5.0.0"
+    "@flyingrobots/bijou-i18n": "5.0.1",
+    "@flyingrobots/bijou-i18n-tools": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-i18n-tools-xlsx/package.json
+++ b/packages/bijou-i18n-tools-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools-xlsx",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "XLSX workbook adapters for Bijou localization exchange workflows.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n-tools": "5.0.0",
+    "@flyingrobots/bijou-i18n-tools": "5.0.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {

--- a/packages/bijou-i18n-tools-xlsx/package.json
+++ b/packages/bijou-i18n-tools-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools-xlsx",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "XLSX workbook adapters for Bijou localization exchange workflows.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n-tools": "5.0.1",
+    "@flyingrobots/bijou-i18n-tools": "7.0.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {

--- a/packages/bijou-i18n-tools/package.json
+++ b/packages/bijou-i18n-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "Localization workflow tooling for Bijou — authoring catalogs, stale detection, tabular export/import, and runtime compilation.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "5.0.1"
+    "@flyingrobots/bijou-i18n": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-i18n-tools/package.json
+++ b/packages/bijou-i18n-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Localization workflow tooling for Bijou — authoring catalogs, stale detection, tabular export/import, and runtime compilation.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "5.0.0"
+    "@flyingrobots/bijou-i18n": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-i18n/package.json
+++ b/packages/bijou-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "In-memory localization runtime for Bijou — catalogs, locale direction, and runtime-safe lookups.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou-i18n/package.json
+++ b/packages/bijou-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "In-memory localization runtime for Bijou — catalogs, locale direction, and runtime-safe lookups.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou-mcp/package.json
+++ b/packages/bijou-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-mcp",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "MCP server exposing Bijou terminal components as rendering tools.",
   "type": "module",
   "sideEffects": false,
@@ -32,7 +32,7 @@
     "zod": "^3.24.0"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "5.0.1"
+    "@flyingrobots/bijou": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-mcp/package.json
+++ b/packages/bijou-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-mcp",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "MCP server exposing Bijou terminal components as rendering tools.",
   "type": "module",
   "sideEffects": false,
@@ -32,7 +32,7 @@
     "zod": "^3.24.0"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "5.0.0"
+    "@flyingrobots/bijou": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -24,13 +24,13 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-tui": "5.0.0",
+    "@flyingrobots/bijou-tui": "5.0.1",
     "chalk": "^5.6.2",
     "gifenc": "^1.0.3",
     "oled-font-5x7": "^1.0.3"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "5.0.0"
+    "@flyingrobots/bijou": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -24,13 +24,13 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-tui": "5.0.1",
+    "@flyingrobots/bijou-tui": "7.0.0",
     "chalk": "^5.6.2",
     "gifenc": "^1.0.3",
     "oled-font-5x7": "^1.0.3"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "5.0.1"
+    "@flyingrobots/bijou": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui-app/package.json
+++ b/packages/bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui-app",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Batteries-included TUI app skeleton built on bijou-tui createFramedApp().",
   "type": "module",
   "sideEffects": false,
@@ -24,8 +24,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "5.0.0",
-    "@flyingrobots/bijou-tui": "5.0.0"
+    "@flyingrobots/bijou": "5.0.1",
+    "@flyingrobots/bijou-tui": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui-app/package.json
+++ b/packages/bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui-app",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "Batteries-included TUI app skeleton built on bijou-tui createFramedApp().",
   "type": "module",
   "sideEffects": false,
@@ -24,8 +24,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "5.0.1",
-    "@flyingrobots/bijou-tui": "5.0.1"
+    "@flyingrobots/bijou": "7.0.0",
+    "@flyingrobots/bijou-tui": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,10 +24,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "5.0.0"
+    "@flyingrobots/bijou-i18n": "5.0.1"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "5.0.0"
+    "@flyingrobots/bijou": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,10 +24,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "5.0.1"
+    "@flyingrobots/bijou-i18n": "7.0.0"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "5.0.1"
+    "@flyingrobots/bijou": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/create-bijou-tui-app/package.json
+++ b/packages/create-bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bijou-tui-app",
-  "version": "5.0.1",
+  "version": "7.0.0",
   "description": "Scaffold a new Bijou TUI app with batteries-included defaults.",
   "type": "module",
   "bin": {

--- a/packages/create-bijou-tui-app/package.json
+++ b/packages/create-bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bijou-tui-app",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Scaffold a new Bijou TUI app with batteries-included defaults.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bumps all Bijou workspace packages and internal package references to `7.0.0`
- adds `docs/releases/7.0.0/` release notes and migration guide for DOGFOOD's version-derived release docs
- promotes the accumulated changelog entries under `7.0.0` and updates the release-docs index

## Why

Bijou `main` contains the issue-complete V6/V7 release boundary, including the notification word-wrap fix needed by Jedit. The repo's Bearing and Roadmap identify V7 release-readiness as the next release-facing step, so this prepares the normal release commit for review before tagging.

## Validation

- `npm run release:preflight`
- `npx vitest run --config vitest.config.ts scripts/docs-preview.test.ts tests/cycles/LX-008/localized-shell-and-dogfood.test.ts tests/cycles/DF-030/dogfood-docs-surface-block.test.ts`
- `npm run dogfood:i18n:complete`
- `npm run dogfood:i18n:check`
- `npm run build`
- `git diff --check`
- pre-commit `npm run lint --workspaces`
- pre-push full `npm test`: 335 test files, 3686 tests passed
- pre-push `npm run verify:interactive-examples -- --skip-build --mode=interactive-scripted`

## Notes

The first local release bump commit started as `5.0.1`; the follow-up commit corrects the branch to `7.0.0` without amending history, in line with repo git policy. The pull request diff is the intended `7.0.0` release state.
