### PR TITLE
Adopt roadmap goalpost policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -12,6 +12,7 @@ body:
 
         Labels are canonical tracker metadata. If you want a lane or legend other than inbox triage,
         request it below; a maintainer or agent must apply the actual label.
+        Goalpost and user-story roles also have query labels for roadmap planning.
 
         Implementation work must name software behavior proof. Documentation-only proof is
         acceptable only for documentation or process work.
@@ -24,6 +25,51 @@ body:
         Suggested lane:
         Suggested legend:
         Suggested priority:
+    validations:
+      required: false
+  - type: dropdown
+    id: roadmap-role
+    attributes:
+      label: Roadmap role
+      description: Classify this card in the roadmap hierarchy.
+      options:
+        - Ordinary work item
+        - Goalpost umbrella
+        - User story
+        - Release gate
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: roadmap-linkage
+    attributes:
+      label: Roadmap linkage
+      description: Link the release packet, goalpost, umbrella issue, or child user-story issues when applicable.
+      placeholder: |
+        Versioned release:
+        Goalpost:
+        Umbrella issue:
+        Child user-story issues:
+    validations:
+      required: false
+  - type: input
+    id: slice-budget
+    attributes:
+      label: Slice budget
+      description: Estimate the smallest useful reviewable increments for this card. Use 1 for tiny one-slice work.
+      placeholder: "6"
+    validations:
+      required: false
+  - type: textarea
+    id: release-gate
+    attributes:
+      label: Release gate impact
+      description: State the release gate this work creates, changes, satisfies, or does not affect.
+      placeholder: |
+        This work affects the release gate by ...
+
+        If not applicable:
+        This work is not release-gated because ...
     validations:
       required: false
   - type: textarea
@@ -280,7 +326,7 @@ body:
         - [ ] Lower modes are covered, if relevant.
         - [ ] New visible strings include supported translations, if relevant.
         - [ ] DOGFOOD/docs/changelog are updated, if behavior or direction changed.
-        - [ ] Issue, design doc, and draft PR are linked correctly.
+        - [ ] Issue, design doc, and non-draft PR are linked correctly.
         - [ ] CI and local validation are green.
     validations:
       required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,10 @@ This guide is for AI agents and human operators recovering context in the Bijou 
 - Create a new `cycle/<cycle_name>` branch for the cycle.
 - Create or update the GitHub Issue and write the cycle design document before
   implementation. Stage and commit the shaping artifact, push the branch, open
-  a draft pull request to `main`, link the issue, design doc, and draft PR, and
+  a non-draft pull request to `main`, link the issue, design doc, and PR, and
   apply `work-in-progress` to the GitHub Issue.
-- Draft PRs are expected at cycle start. Mark the PR ready for review only
-  after implementation, validation, and self-review are complete.
+- PRs are non-draft at cycle start. Request final review only after
+  implementation, validation, and self-review are complete.
 
 ## Documentation & Planning Map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,10 @@ points for contributors:
   files as the source of live queue state.
 - **Branch naming**: `cycle/<cycle-name>` for cycle work, or a
   descriptive branch name for smaller changes.
-- **Open a draft PR at cycle start**: After syncing the merge target, branch,
+- **Open a non-draft PR at cycle start**: After syncing the merge target, branch,
   create or update the GitHub Issue, and commit the design artifact, push the
-  branch and open a draft PR against `main`. Link the issue, design doc, and
-  draft PR, then mark it ready for review only after validation and self-review
-  pass.
+  branch and open a non-draft PR against `main`. Link the issue, design doc,
+  and PR, then request final review only after validation and self-review pass.
 - **Commits**: Use [Conventional Commits](https://www.conventionalcommits.org/)
   (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`).
 - **Tests first**: Write failing tests before implementing. Never
@@ -62,9 +61,8 @@ wrappers, or registry workflow behavior.
 
 ## Pull Requests
 
-- Open draft PRs against `main` at cycle start for visibility.
-- Mark draft PRs ready for review only after local validation and self-review
-  pass.
+- Open non-draft PRs against `main` at cycle start for visibility.
+- Request final review only after local validation and self-review pass.
 - Use `--body-file` for Markdown-heavy GitHub comments. Inline `--body "..."`
   is only safe for short literal comments that do not contain backticks,
   `$()` text, command examples, or Markdown tables.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,15 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🛠 Maintenance
 
+- **Roadmap goalpost policy** — `docs/method/releases/README.md` now defines
+  Bijou release packets, versioned releases, goalposts, umbrella issues,
+  user-story issues, slice budgets, release gates, proof policy, and authority
+  order. `docs/ROADMAP.md` is refreshed from the live GitHub milestone counts
+  as of 2026-06-06 and groups the open Beyond backlog into candidate goalposts.
+  The Method issue template now captures roadmap role, linkage, slice budget,
+  and release-gate impact; GitHub now has `roadmap`, `goalpost`, and
+  `user-story` query labels; and cycle-start docs are aligned back to non-draft
+  pull requests.
 - **Node 26 tsx deprecation cleanup** — The workspace now uses `tsx` 4.22.4
   so `node --import tsx` prefers Node's `module.registerHooks()` path when
   available instead of emitting the Node 26 `DEP0205` `module.register()`

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -60,6 +60,34 @@ design doc. Branch/design matching can become a targeted pre-push or CI guard
 later for issues explicitly marked `needs-design`, but it should not be the
 default commit gate.
 
+## Roadmap Planning
+
+Release-scale work uses release packets under `docs/method/releases/`.
+GitHub milestones and issue labels remain the live tracker; release packets and
+`docs/ROADMAP.md` explain how tracker items compose into versioned releases,
+goalposts, user stories, slice budgets, release gates, and proof.
+
+Use this hierarchy when work is larger than one ordinary issue:
+
+```text
+Roadmap
+  -> Versioned Release
+    -> Goalpost
+      -> Umbrella Issue
+        -> User Story Issue
+          -> Slice
+            -> Commit
+              -> Pull Request
+```
+
+A versioned release must use leading-`v` SemVer such as `v7.0.0`. A goalpost
+must name its umbrella issue, child user-story issues, slice budget, acceptance
+criteria, release-gate impact, and validation plan. Runtime and product
+goalposts require executable or inspectable proof; documentation alone is proof
+only for documentation and process work.
+
+See `docs/method/releases/README.md` for the full release-packet contract.
+
 ## Lane Labels
 
 | Lane | Purpose |
@@ -72,8 +100,10 @@ default commit gate.
 
 Supporting state labels:
 
-- **`work-in-progress`** means a branch or draft/ready PR is actively carrying
-  the issue.
+- **`roadmap`** means the issue participates in roadmap planning.
+- **`goalpost`** means the issue is an umbrella milestone issue.
+- **`user-story`** means the issue is a child story under a goalpost.
+- **`work-in-progress`** means a branch or PR is actively carrying the issue.
 - **`blocked`** means a decision or external state is preventing progress.
 - **`needs-design`**, **`needs-witness`**, and **`needs-retro`** mean the
   evidence ledger is missing a required artifact.
@@ -99,7 +129,7 @@ stateDiagram-v2
     direction LR
     [*] --> Sync: git fetch + target
     Sync --> Branch: cycle/
-    Branch --> Shape: issue + design doc + draft PR
+    Branch --> Shape: issue + design doc + non-draft PR
     Shape --> Red: failing tests
     Red --> Green: passing tests
     Green --> Review: validation + self-review
@@ -113,21 +143,18 @@ stateDiagram-v2
 2. **Branch**: Create `cycle/<cycle_name>` from the synced merge target.
 3. **Shape**: Create or update the GitHub Issue and write the design artifact
    under `docs/design/`. Stage and commit the shaping artifact, push the branch,
-   open a draft pull request to `main`, link the issue, design doc, and draft
-   PR, and apply `work-in-progress` to the GitHub Issue. The draft counts as the
-   open pull request to `main` for visibility, not as the merge-ready review
-   artifact.
+   open a non-draft pull request to `main`, link the issue, design doc, and PR,
+   and apply `work-in-progress` to the GitHub Issue.
 4. **Red**: Write failing tests based on the design's playback questions.
 5. **Green**: Implement the solution until tests pass.
 6. **Review**: Update witness/retro/debt notes, run local validation, and do the
-   required self-review before marking the draft PR ready for review. Use the
-   GitHub Comment Safety pattern in `docs/WORKFLOW.md` when posting
-   Markdown-heavy self-review, Code Lawyer, or activity-summary comments. Do
-   not use inline `--body "..."` for review bodies that contain backticks,
-   `$()` text, command examples, or Markdown tables.
-7. **Ship**: Mark the PR ready, keep it linked from the issue, and update
-   `BEARING.md` and `CHANGELOG.md` when the change affects direction or
-   user-facing behavior.
+   required self-review before requesting final review. Use the GitHub Comment
+   Safety pattern in `docs/WORKFLOW.md` when posting Markdown-heavy
+   self-review, Code Lawyer, or activity-summary comments. Do not use inline
+   `--body "..."` for review bodies that contain backticks, `$()` text, command
+   examples, or Markdown tables.
+7. **Ship**: Keep the PR linked from the issue, and update `BEARING.md` and
+   `CHANGELOG.md` when the change affects direction or user-facing behavior.
 
 ## Naming Convention
 Design and retro files follow: `<LEGEND>-<id>-<slug>.md`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,16 +13,15 @@ lineage includes milestone PR rows when those PRs contribute to the totals. Do
 not compare release snapshot item totals to issue-only `gh issue list` output
 without also accounting for milestone pull requests.
 
-Last synced from GitHub milestone items and the WF-128 workflow cleanup branch:
-2026-06-03.
+Last synced from GitHub milestone items: 2026-06-06.
 
 ## Release Snapshot
 
 | Horizon | Milestone | Open Items | Closed Items | Intent |
 | :--- | :--- | ---: | ---: | :--- |
-| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 28 | Issue-complete layout truth, standard blocks, and status/feedback Block lane. |
+| `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 30 | Issue-complete layout truth, standard blocks, and status/feedback Block lane. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Issue-complete V7 Product Truth, BlockLab naming, and release-facing proof. |
-| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 22 | 0 | Uncommitted future work, cool ideas, and raw follow-ups. |
+| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 29 | 1 | Uncommitted future work, cool ideas, and raw follow-ups. |
 
 ## v6.0.0
 
@@ -33,7 +32,7 @@ package checks before tagging.
 
 ### Open Work
 
-No open v6 tracker issues remain as of 2026-06-02.
+No open v6 tracker issues remain as of 2026-06-06.
 
 ### Completed Lineage
 
@@ -83,7 +82,7 @@ release-readiness validation before tagging.
 
 ### Open Work
 
-No open v7 tracker issues remain as of 2026-06-03.
+No open v7 tracker issues remain as of 2026-06-06.
 
 ### Completed Lineage
 
@@ -95,8 +94,8 @@ These cards are included in the v7 milestone as completed release lineage.
 | [#245](https://github.com/flyingrobots/bijou/issues/245) | `lane:release` | `type:enhancement` | DX-037 tableSurface responsive width parity |
 | [#246](https://github.com/flyingrobots/bijou/issues/246) | `lane:up-next` | `type:docs` | DX-029 scopedNodeIO realpath and symlink semantics |
 | [#278](https://github.com/flyingrobots/bijou/pull/278) | `lane:up-next` | implementation PR | DF-054 through DF-059 late-family DOGFOOD standard Blocks |
-| [#279](https://github.com/flyingrobots/bijou/issues/279) | `lane:release` | `type:enhancement` | WF-125 draft-first cycle start workflow |
-| [#280](https://github.com/flyingrobots/bijou/pull/280) | `lane:release` | implementation PR | WF-125 draft-first cycle start workflow |
+| [#279](https://github.com/flyingrobots/bijou/issues/279) | `lane:release` | `type:enhancement` | WF-125 cycle start workflow |
+| [#280](https://github.com/flyingrobots/bijou/pull/280) | `lane:release` | implementation PR | WF-125 cycle start workflow |
 | [#281](https://github.com/flyingrobots/bijou/issues/281) | `lane:release` | `type:enhancement` | DOGFOOD release title screen |
 | [#283](https://github.com/flyingrobots/bijou/issues/283) | `lane:bad-code` / `lane:release` | `type:bug` | V7 Codex review regression fixes |
 | [#285](https://github.com/flyingrobots/bijou/issues/285) | `lane:bad-code` / `lane:release` | `type:docs` / `type:maintenance` | V7 tracker docs sync after review follow-up |
@@ -125,38 +124,74 @@ No open component-family audit cards remain in the v7 milestone.
 
 ## Beyond
 
-Theme: future bets, cool ideas, and uncommitted follow-ups.
+Theme: future bets, cool ideas, debt cleanup, and uncommitted follow-ups.
 
-The Beyond lane is not a release commitment. Items here should be pulled into
-`v7.0.0` or a later concrete milestone only after they are shaped.
+The Beyond lane is not a release commitment. Items here should be pulled into a
+concrete versioned milestone only after they are shaped into goalposts or child
+user-story issues.
 
-### Runtime And Visualization Ideas
+### Candidate Goalposts From Open GitHub Issues
+
+These groupings are planning recommendations from the open tracker state as of
+2026-06-06. They are not commitments until moved into a versioned release
+packet and assigned umbrella issues.
+
+| Candidate Goalpost | Open Issues | Why It Exists | Proof Direction |
+| :--- | :--- | :--- | :--- |
+| Runtime Graph And Scene IR | [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#302](https://github.com/flyingrobots/bijou/issues/302) | Bijou keeps accumulating DAG, Mermaid, MCP, and GraphQL-authored scene ideas. These should become one runtime/IR goalpost instead of drifting as unrelated ideas. | Schema fixtures, lowering tests, DOGFOOD graph examples, lower-mode rendering, and failure-mode contracts. |
+| DOGFOOD And BlockLab Product Surface | [#204](https://github.com/flyingrobots/bijou/issues/204), [#205](https://github.com/flyingrobots/bijou/issues/205), [#214](https://github.com/flyingrobots/bijou/issues/214), [#215](https://github.com/flyingrobots/bijou/issues/215), [#217](https://github.com/flyingrobots/bijou/issues/217), [#218](https://github.com/flyingrobots/bijou/issues/218), [#248](https://github.com/flyingrobots/bijou/issues/248), [#272](https://github.com/flyingrobots/bijou/issues/272) | DOGFOOD, BlockLab, file exploration, semantic lists, terminal shaders, and artifact matrices all point at a stronger product-facing component lab. | Scripted DOGFOOD flows, BlockLab story fixtures, image/capture witnesses, keyboard/focus proof, and localized docs. |
+| Workflow And CI Determinism | [#203](https://github.com/flyingrobots/bijou/issues/203), [#268](https://github.com/flyingrobots/bijou/issues/268), [#269](https://github.com/flyingrobots/bijou/issues/269), [#270](https://github.com/flyingrobots/bijou/issues/270), [#290](https://github.com/flyingrobots/bijou/issues/290), [#298](https://github.com/flyingrobots/bijou/issues/298), [#299](https://github.com/flyingrobots/bijou/issues/299), [#300](https://github.com/flyingrobots/bijou/issues/300), [#301](https://github.com/flyingrobots/bijou/issues/301) | The open bad-code and Method ideas share a dependency-injection, fake-clock, replay, and tracker-sync theme. They should become one proof and determinism goalpost. | Fake clocks, injected git/GitHub clients, fixture-backed DOGFOOD harnesses, path-gated CI proof, and merge-gate tests. |
+| Localization And Documentation Operations | [#206](https://github.com/flyingrobots/bijou/issues/206), [#207](https://github.com/flyingrobots/bijou/issues/207), [#208](https://github.com/flyingrobots/bijou/issues/208) | DOGFOOD Markdown localization now has a debt ratchet; the next shaped step is an operator-facing translation and preference workflow. | Localization debt tests, preference persistence fixtures, DOGFOOD dashboards, and all-supported-locale proof. |
+
+### Open Beyond Issues
 
 | Issue | Lane | Type | Work |
 | :--- | :--- | :--- | :--- |
 | [#202](https://github.com/flyingrobots/bijou/issues/202) | `lane:cool-ideas` | `type:enhancement` | CI-001 mermaidSurface component |
 | [#203](https://github.com/flyingrobots/bijou/issues/203) | `lane:cool-ideas` | `type:spike` | CI-002 deterministic time-travel debugger |
+| [#204](https://github.com/flyingrobots/bijou/issues/204) | `lane:inbox` / `lane:cool-ideas` | `type:enhancement` / `type:docs` | DX-027 choose-your-lane starter for README and DOGFOOD |
+| [#205](https://github.com/flyingrobots/bijou/issues/205) | `lane:cool-ideas` | `type:enhancement` | HT-009 file explorer surface |
+| [#206](https://github.com/flyingrobots/bijou/issues/206) | `lane:cool-ideas` | `type:enhancement` | LX-015 DOGFOOD localization burndown dashboard |
+| [#207](https://github.com/flyingrobots/bijou/issues/207) | `lane:cool-ideas` | `type:enhancement` | LX-016 portable locale preferences across hosts |
+| [#208](https://github.com/flyingrobots/bijou/issues/208) | `lane:cool-ideas` | `type:enhancement` | LX-017 multilingual DOGFOOD translation workbench |
 | [#209](https://github.com/flyingrobots/bijou/issues/209) | `lane:cool-ideas` | `type:enhancement` | RE-025 DAG path emphasis |
 | [#210](https://github.com/flyingrobots/bijou/issues/210) | `lane:cool-ideas` | `type:enhancement` | RE-026 DAG edge labels |
 | [#211](https://github.com/flyingrobots/bijou/issues/211) | `lane:cool-ideas` | `type:enhancement` | RE-027 DAG compact legend mode |
 | [#212](https://github.com/flyingrobots/bijou/issues/212) | `lane:cool-ideas` | `type:enhancement` | RE-028 DAG edge semantics and metadata |
 | [#213](https://github.com/flyingrobots/bijou/issues/213) | `lane:cool-ideas` | `type:enhancement` | RE-029 DAG adaptive density and lowering |
+| [#214](https://github.com/flyingrobots/bijou/issues/214) | `lane:cool-ideas` / `lane:up-next` | `type:enhancement` / `type:spike` | BigBro audit tool |
+| [#215](https://github.com/flyingrobots/bijou/issues/215) | `lane:cool-ideas` | `type:docs` / `type:spike` | Terminal shader extensions |
+| [#216](https://github.com/flyingrobots/bijou/issues/216) | `lane:cool-ideas` / `lane:up-next` | `type:enhancement` / `type:spike` | MCP-driven UI generation |
+| [#217](https://github.com/flyingrobots/bijou/issues/217) | `lane:cool-ideas` / `lane:up-next` | `type:enhancement` | bijou-fix-rhythm CLI |
+| [#218](https://github.com/flyingrobots/bijou/issues/218) | `lane:cool-ideas` / `lane:up-next` | `type:enhancement` / `type:maintenance` | Semantic list component |
 | [#219](https://github.com/flyingrobots/bijou/issues/219) | `lane:inbox` | `type:enhancement` | RE-027 generalize crash-mode auto-exit beyond TTY detection |
+| [#248](https://github.com/flyingrobots/bijou/issues/248) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | Capture artifacts as first-class docs artifact matrix |
+| [#268](https://github.com/flyingrobots/bijou/issues/268) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | Method tracker-sync sentinel for GitHub milestones |
+| [#269](https://github.com/flyingrobots/bijou/issues/269) | `lane:bad-code` | `type:maintenance` | Review-cooldown merge sentinel |
+| [#270](https://github.com/flyingrobots/bijou/issues/270) | `lane:bad-code` / `lane:release` | `type:docs` / `type:maintenance` | Release-readiness gate for issue-complete milestones |
+| [#272](https://github.com/flyingrobots/bijou/issues/272) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | BlockLab toward Storybook-grade product workflows |
+| [#290](https://github.com/flyingrobots/bijou/issues/290) | `lane:cool-ideas` | `type:enhancement` / `type:docs` / `type:maintenance` | Method cycle artifact manifest |
+| [#298](https://github.com/flyingrobots/bijou/issues/298) | `lane:bad-code` | `type:maintenance` | Fixture-backed DOGFOOD view harness |
+| [#299](https://github.com/flyingrobots/bijou/issues/299) | `lane:bad-code` | `type:maintenance` | Split smoke gates from real PTY and subprocess dependencies |
+| [#300](https://github.com/flyingrobots/bijou/issues/300) | `lane:bad-code` | `type:maintenance` | Inject git and GitHub clients into policy scripts |
+| [#301](https://github.com/flyingrobots/bijou/issues/301) | `lane:cool-ideas` | `type:enhancement` / `type:maintenance` | Native Bijou frame-capture format |
+| [#302](https://github.com/flyingrobots/bijou/issues/302) | `lane:cool-ideas` | `type:enhancement` / `type:spike` | Compile GraphQL-authored UI scenes into Bijou Blocks |
 
-### Product, Localization, And Tooling Ideas
+### Closed Beyond Lineage
 
 | Issue | Lane | Type | Work |
 | :--- | :--- | :--- | :--- |
-| [#204](https://github.com/flyingrobots/bijou/issues/204) | `lane:cool-ideas` | `type:enhancement` | DX-027 choose-your-lane starter for README and DOGFOOD |
-| [#205](https://github.com/flyingrobots/bijou/issues/205) | `lane:cool-ideas` | `type:enhancement` | HT-009 file explorer surface |
-| [#206](https://github.com/flyingrobots/bijou/issues/206) | `lane:cool-ideas` | `type:enhancement` | LX-015 DOGFOOD localization burndown dashboard |
-| [#207](https://github.com/flyingrobots/bijou/issues/207) | `lane:cool-ideas` | `type:enhancement` | LX-016 portable locale preferences across hosts |
-| [#208](https://github.com/flyingrobots/bijou/issues/208) | `lane:cool-ideas` | `type:enhancement` | LX-017 multilingual DOGFOOD translation workbench |
-| [#214](https://github.com/flyingrobots/bijou/issues/214) | `lane:cool-ideas` | `type:spike` | BigBro audit tool |
-| [#215](https://github.com/flyingrobots/bijou/issues/215) | `lane:cool-ideas` | `type:spike` | Terminal shader extensions |
-| [#216](https://github.com/flyingrobots/bijou/issues/216) | `lane:cool-ideas` | `type:spike` | MCP-driven UI generation |
-| [#217](https://github.com/flyingrobots/bijou/issues/217) | `lane:cool-ideas` | `type:enhancement` | bijou-fix-rhythm CLI |
-| [#218](https://github.com/flyingrobots/bijou/issues/218) | `lane:cool-ideas` | `type:enhancement` | Semantic list component |
+| [#289](https://github.com/flyingrobots/bijou/issues/289) | `lane:cool-ideas` / `lane:release` | `type:enhancement` / `type:docs` | Release title screens as first-class artifact gallery |
+
+### Open Unmilestoned Triage
+
+These issues are open but not assigned to a release horizon. Move them into
+`Beyond` or a versioned release after shaping.
+
+| Issue | Lane | Type | Recommendation |
+| :--- | :--- | :--- | :--- |
+| [#249](https://github.com/flyingrobots/bijou/issues/249) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | Attach to the Workflow And CI Determinism goalpost if it becomes an enforceable quality gate. |
+| [#306](https://github.com/flyingrobots/bijou/issues/306) | `lane:cool-ideas` | `type:enhancement` / `type:spike` | Attach to the Workflow And CI Determinism goalpost because it overlaps replay, output capture, and timing proof. |
 
 ## Maintenance Rule
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -32,15 +32,15 @@ Bijou now tracks work through:
 1. Sync to the merge target branch after `git fetch`.
 2. Create a branch named `cycle/<cycle_name>` for that cycle.
 3. Write or enrich the GitHub Issue and the `docs/design/` cycle doc.
-4. Stage and commit the shaping artifact, push the branch, and open a draft
+4. Stage and commit the shaping artifact, push the branch, and open a non-draft
    pull request to `main` before implementation work starts.
-5. Link the GitHub Issue, design doc, and draft PR. Apply
-   `work-in-progress` to the GitHub Issue.
+5. Link the GitHub Issue, design doc, and PR. Apply `work-in-progress` to the
+   GitHub Issue.
 6. Write failing tests. Playback questions become the executable spec.
 7. Green the tests.
 8. Record witness material when needed.
 9. Close honestly: retrospective, drift notes, and follow-on backlog.
-10. Run validation and self-review, then mark the draft PR ready for review.
+10. Run validation and self-review, then request final review.
 11. After merge, sync `BEARING.md`, `CHANGELOG.md`, and any other
     signposts that changed.
 

--- a/docs/design/WF-130-roadmap-goalpost-policy.md
+++ b/docs/design/WF-130-roadmap-goalpost-policy.md
@@ -1,0 +1,215 @@
+# WF-130 Roadmap Goalpost Policy
+
+## Linked Legend
+
+WF - Workflow and Delivery
+
+## Decision Summary
+
+Adopt a Bijou roadmap planning system that maps GitHub milestone items into
+versioned releases, candidate goalposts, umbrella issues, user-story issues,
+slice budgets, release gates, and proof requirements.
+
+## Sponsor Human
+
+A maintainer wants to see the current release path and backlog shape without
+reconstructing it from memory, stale Markdown, and raw GitHub lists, so that
+release planning can stay issue-backed and inspectable.
+
+## Sponsor Agent
+
+An agent needs a documented roadmap hierarchy and issue-template fields so it
+can classify work as ordinary issues, goalpost umbrellas, or user stories
+without inventing planning structure in each turn.
+
+## Hill
+
+By the end of this cycle, Bijou has a release-packet policy, a GitHub-backed
+roadmap snapshot, issue-template fields for roadmap roles and slice budgets,
+and tests that prevent the docs from drifting back to draft-first cycle
+language.
+
+## Current Truth
+
+Verified against `origin/main` on 2026-06-06 after PR #304 merged.
+
+Current anchors:
+
+- GitHub milestone `v6.0.0`: 0 open, 30 closed milestone items.
+- GitHub milestone `v7.0.0`: 0 open, 27 closed milestone items.
+- GitHub milestone `Beyond`: 29 open, 1 closed milestone item.
+- Open unmilestoned issues: #249 and #306.
+- `docs/method/releases/README.md` is a stub.
+- `docs/METHOD.md`, `docs/WORKFLOW.md`, `CONTRIBUTING.md`, `AGENTS.md`, and
+  WF-001 tests still describe draft-first cycle PRs.
+
+## Problem
+
+Bijou has strong issue intake and cycle docs, but it lacks the intermediate
+roadmap structure that explains how individual issues become release-scale
+goalposts. The docs also contain stale draft-first language that conflicts with
+current repo instructions.
+
+## Scope
+
+This cycle includes:
+
+- defining the release-packet contract under `docs/method/releases/`
+- refreshing `docs/ROADMAP.md` from live GitHub milestone and issue data
+- grouping the open Beyond backlog into candidate goalposts
+- adding roadmap role, linkage, slice budget, and release-gate fields to the
+  Method work-item issue form
+- aligning operator docs to non-draft PRs at cycle start
+- adding tests that prove the policy and the non-draft alignment
+
+## Non-Goals
+
+This cycle does not:
+
+- create new release milestones
+- move GitHub issues between milestones
+- create umbrella issues for the candidate goalposts
+- close or rewrite the existing Beyond issues
+- implement any product features from the candidate goalposts
+
+## User Experience / Product Shape
+
+This is process and documentation work. There is no TUI surface change.
+
+The reviewer-facing shape is:
+
+```text
+docs/ROADMAP.md
+  Release Snapshot
+  v6.0.0
+  v7.0.0
+  Beyond
+    Candidate Goalposts From Open GitHub Issues
+    Open Beyond Issues
+    Open Unmilestoned Triage
+```
+
+## Lower Modes
+
+### Static Mode
+
+Markdown documents remain readable as plain text.
+
+### Pipe Mode
+
+The relevant proof is deterministic command output from tests and GitHub CLI
+queries.
+
+### Accessible Mode
+
+No interactive surface changes. The issue form uses explicit labels and field
+names that screen-reader users can navigate in GitHub.
+
+## Runtime / API Contract
+
+No runtime API changes.
+
+Process contract changes:
+
+- `docs/method/releases/README.md` defines versioned releases, goalposts,
+  umbrella issues, user-story issues, slices, release gates, and proof.
+- `.github/ISSUE_TEMPLATE/work-item.yml` exposes roadmap role, roadmap linkage,
+  slice budget, and release-gate fields.
+- Cycle-start docs require a non-draft PR.
+
+## Data / State Model
+
+GitHub remains the live tracker. `docs/ROADMAP.md` is a mirror of:
+
+- GitHub milestone counts
+- GitHub issue labels
+- GitHub issue milestone assignment
+- GitHub pull request milestone assignment when milestone counts include PRs
+
+Markdown release packets explain the structure, but GitHub owns the current
+state.
+
+## Accessibility Posture
+
+No new visible product controls are added. Markdown tables use explicit column
+headers. The issue-template additions use field labels that state their
+purpose without relying on placeholder-only instructions.
+
+## Localization / Directionality Posture
+
+No app-visible localized strings are added. GitHub issue-template prose is not
+part of the DOGFOOD runtime localization catalog.
+
+## Agent Inspectability / Explainability Posture
+
+Agents can inspect the policy through stable files:
+
+- `docs/method/releases/README.md`
+- `docs/ROADMAP.md`
+- `.github/ISSUE_TEMPLATE/work-item.yml`
+- `tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
+
+The roadmap records the exact sync date and GitHub issue groupings.
+
+## Linked Invariants
+
+- Tests Are the Spec
+- Runtime Truth Wins
+- Docs Are the Demo
+- Work Is Issue-Backed
+- Release Claims Need Proof
+
+## Implementation Outline
+
+1. Add a failing WF-130 regression for release packets, roadmap counts,
+   non-draft cycle docs, and issue-template fields.
+2. Write the release-packet policy.
+3. Refresh the roadmap from live GitHub milestones and issues.
+4. Align METHOD, WORKFLOW, AGENTS, CONTRIBUTING, and WF-001 tests to
+   non-draft PRs.
+5. Extend the work-item issue template.
+6. Record the changelog entry and run validation.
+
+## Tests To Write First
+
+- `npm test -- --run tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
+  should fail before the policy and docs exist.
+- The same focused command should pass after the policy is implemented.
+- WF-001 workflow tests should continue passing with the non-draft wording.
+
+## Validation Plan
+
+```bash
+npm test -- --run tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+npm test -- --run tests/cycles/WF-001/workflow-adoption.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+npm run docs:inventory
+npm run typecheck:test
+npm run lint
+git diff --check
+```
+
+## Closeout Notes
+
+Completed on `cycle/roadmap-goalpost-policy`.
+
+Proof:
+
+- RED: `npm test -- --run tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
+  failed on the release-packet stub, stale roadmap counts, draft-first cycle
+  docs, and missing issue-template roadmap fields.
+- GREEN: WF-130 passes after the release policy, roadmap refresh, issue form,
+  label model, and non-draft workflow alignment landed.
+- WF-001 was updated and rerun with WF-130 so the older workflow invariant
+  agrees with the new non-draft cycle policy.
+- GitHub labels `roadmap`, `goalpost`, and `user-story` were created for
+  queryable roadmap role tracking.
+
+Validation:
+
+```bash
+npm test -- --run tests/cycles/WF-001/workflow-adoption.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+npm run docs:inventory
+npm run typecheck:test
+npm run lint
+git diff --check
+```

--- a/docs/method/releases/README.md
+++ b/docs/method/releases/README.md
@@ -1,3 +1,264 @@
 # Release Packets
 
-Store internal release design and verification artifacts here.
+Release packets are Bijou's roadmap planning surface. GitHub milestones and
+issues remain the live tracker; release packets explain how those tracker items
+compose into release promises, goalposts, slices, and proof.
+
+## Purpose
+
+Bijou uses a roadmap-driven, issue-backed, slice-budgeted delivery system.
+
+The system separates intent, coordination, execution, and proof:
+
+- Markdown documents define intent, scope, contracts, and acceptance criteria.
+- GitHub Issues coordinate goalposts, user stories, labels, ownership, and
+  tracker state.
+- Branches, commits, and pull requests execute reviewable changes.
+- Tests, DOGFOOD witnesses, generated artifacts, command output, and runtime
+  facts prove implementation.
+
+A design document may define intent, but it does not prove implementation. A
+goalpost is complete only when the repo can prove the claimed behavior through
+an executable or inspectable software surface.
+
+## System Model
+
+| Entity | Purpose | Location |
+| :--- | :--- | :--- |
+| Roadmap | Orders release horizons | `docs/ROADMAP.md` |
+| Versioned Release | SemVer product target | `docs/method/releases/vX.Y.Z/` |
+| Release Gate | Release completion checklist | Release packet |
+| Goalpost | Major milestone inside a release | Goalpost doc and umbrella issue |
+| Umbrella Issue | Goalpost tracking root | GitHub issue with goalpost role |
+| User Story | User-centered behavior | Child issue and goalpost section |
+| Slice | Reviewable increment | Goalpost checklist |
+| Slice Budget | Planning denominator | Roadmap, goalpost doc, issue body |
+| Acceptance Criteria | Completion contract | Docs and issue bodies |
+| Validation Plan | Required proof commands | Design docs and PR bodies |
+| Pull Request | Review and merge vehicle | GitHub PR |
+| Changelog Entry | Historical ledger | `docs/CHANGELOG.md` |
+
+The planning-to-merge path is:
+
+```text
+Roadmap doc
+  -> versioned release packet
+    -> goalpost doc
+      -> umbrella issue
+        -> child user-story issues
+          -> slices
+            -> commits
+              -> pull request
+                -> merge
+```
+
+## Versioned Release
+
+A Versioned Release is a bounded product target with a leading-`v` SemVer
+identifier:
+
+```text
+vMAJOR.MINOR.PATCH
+```
+
+Use a versioned release when the work has a release-level definition of done.
+Do not create a new version for every feature. Feature work belongs inside the
+current active version unless it changes the release promise.
+
+```text
+VersionedRelease = {
+  id: "vX.Y.Z",
+  name: string,
+  roadmapDoc: MarkdownDocument,
+  goalposts: Goalpost[],
+  releaseGate: ChecklistItem[],
+  totalSliceBudget: PositiveInteger,
+  status: "planned" | "active" | "landed" | "superseded"
+}
+```
+
+## Release Gate
+
+A Release Gate is the checklist that must be true before a version can be
+called landed. Release gates should reference executable or inspectable proof:
+tests, DOGFOOD routes, lower-mode output, schema checks, CI commands, generated
+artifacts, or release-readiness commands.
+
+Release-gate examples:
+
+- Runtime and public API behavior is covered by focused tests.
+- DOGFOOD exposes the shipped behavior as a canonical docs surface.
+- Localized visible strings exist for every supported locale.
+- `npm run release:readiness` and required CI checks are green.
+- `docs/CHANGELOG.md`, `docs/BEARING.md`, and `docs/ROADMAP.md` reflect the
+  release state.
+
+## Goalpost
+
+A Goalpost is a major milestone inside a versioned release. It is larger than a
+single implementation issue and smaller than a whole release.
+
+```text
+Goalpost = {
+  id: "V<major>-GP<n>",
+  title: string,
+  umbrellaIssue: GitHubIssue,
+  designDoc: MarkdownDocument,
+  sliceBudget: PositiveInteger,
+  userStories: UserStory[],
+  checklist: Slice[],
+  acceptanceCriteria: ChecklistItem[],
+  validationPlan: CommandOrWitness[],
+  completionState: "planned" | "active" | "landed" | "superseded"
+}
+```
+
+A goalpost must answer:
+
+- What user or agent outcome does this milestone unlock?
+- What inspectable contract exists?
+- What is explicitly in scope?
+- What is explicitly out of scope?
+- Which stories make up the goalpost?
+- How many slices are budgeted?
+- What must be true before the goalpost is done?
+- What tests, witnesses, generated artifacts, or facts prove it?
+
+## Umbrella Issue
+
+An Umbrella Issue tracks one goalpost. It owns the goalpost checklist and links
+child User Story Issues. Its body should link the goalpost doc, release packet,
+and active PRs.
+
+Umbrella issues should use:
+
+- roadmap role: `Goalpost umbrella`
+- `lane:release` when the goalpost is committed to a release
+- a versioned milestone when the goalpost has a release target
+- `work-in-progress` only while a branch or PR is actively carrying it
+
+## User Story Issue
+
+A User Story Issue represents one behavior, workflow, or capability under a
+goalpost.
+
+```text
+UserStory = {
+  issue: GitHubIssue,
+  actor: "user" | "agent" | "maintainer" | "designer-engineer",
+  need: string,
+  reason: string,
+  proof: ChecklistItem[],
+  sliceBudget: PositiveInteger
+}
+```
+
+A well-formed story uses this shape:
+
+```text
+A <type of user> wants <capability/outcome> so that <reason>,
+without having to <current workaround or failure mode>.
+```
+
+Intent alone is not enough. A user story must name proof.
+
+## Slice Budget
+
+A Slice is the smallest useful execution unit. A good slice can usually be
+reviewed independently and has one obvious proof.
+
+```text
+Slice = {
+  number: PositiveInteger,
+  description: string,
+  expectedProof: "test" | "witness" | "docUpdate" | "issueUpdate" | "runtimeBehavior",
+  status: "open" | "inProgress" | "complete"
+}
+```
+
+Slice budgets provide progress denominators:
+
+```text
+GoalProgress = completed slices / total slices
+OverallProgress = landed goalposts / total goalposts
+```
+
+Progress reports should use concrete denominators:
+
+```text
+Runtime Graph IR (slice 3 of 12) [###-------] 25%
+```
+
+## Proof Policy
+
+No implementation goalpost is complete through documentation alone.
+
+Acceptable proof includes:
+
+- unit tests against runtime modules
+- fixture-table tests
+- DOGFOOD scripted app flows
+- lower-mode static, pipe, or accessible output
+- generated artifact checks
+- schema validation
+- deterministic command output
+- CI checks
+- accessibility and focus witnesses
+- inspectable app facts
+
+Docs can explain the contract. They cannot be the only evidence that the
+contract works.
+
+## Label Model
+
+Labels are query indexes, not prose decoration.
+
+| Label | Meaning |
+| :--- | :--- |
+| `lane:inbox` | Raw intake that still needs triage or shaping. |
+| `lane:asap` | Imminent work to pull into the next cycle. |
+| `lane:bad-code` | Technical debt or structural risk. |
+| `lane:cool-ideas` | Uncommitted experiments and optional explorations. |
+| `lane:release` | Release-boundary shaping or blockers. |
+| `roadmap` | Participates in roadmap planning. |
+| `goalpost` | Umbrella milestone issue for a roadmap goalpost. |
+| `user-story` | Child issue scoped to one user story under a goalpost. |
+| `work-in-progress` | Current active implementation cycle. |
+| `needs-design` | Missing Method design artifact. |
+| `needs-witness` | Missing reproducible witness evidence. |
+| `needs-retro` | Missing closeout or retro evidence. |
+
+The issue form captures roadmap role as structured prose, and maintainers or
+agents apply the matching query labels during triage. The important invariant
+is that `goalpost` and `user-story` should not be mixed casually: umbrella
+issues get `goalpost`; child story issues get `user-story`.
+
+## Authority Model
+
+Authority flows in this order:
+
+1. Runtime behavior and saved/rendered output.
+2. Tests, DOGFOOD witnesses, schema checks, generated artifacts, and command
+   output.
+3. GitHub Issues and pull requests.
+4. Design docs and roadmap docs.
+5. Changelog entries.
+6. Coordination memory.
+
+Memory notes help coordination, but they do not override files, commits,
+commands, GitHub Issues, pull requests, tests, or generated output.
+
+## Operating Invariants
+
+- Every versioned release has a roadmap entry.
+- Every versioned release uses leading-`v` SemVer: `vMAJOR.MINOR.PATCH`.
+- Every release-scale milestone has a goalpost Markdown document.
+- Every goalpost has one umbrella GitHub issue.
+- Every umbrella issue collects child user-story issues as task-list items.
+- Every child issue maps to a user story, not a vague task.
+- Every goalpost has a slice budget.
+- Every goalpost doc has a checklist.
+- Runtime and product work must have executable proof.
+- Markdown docs are planning artifacts, not proof artifacts.
+- Branches, commits, and PRs do not use a `codex` prefix.
+- PRs are non-draft unless repo policy changes.

--- a/tests/cycles/WF-001/workflow-adoption.test.ts
+++ b/tests/cycles/WF-001/workflow-adoption.test.ts
@@ -26,12 +26,12 @@ describe('WF-001 workflow adoption', () => {
     expect(workflow).toContain('tests/cycles/<cycle>/');
     expect(workflow).toContain('docs/specs/');
     expect(workflow).toContain('cycle/<cycle_name>');
-    expect(normalizedWorkflow).toContain('open a draft pull request to `main`');
+    expect(normalizedWorkflow).toContain('open a non-draft pull request to `main`');
     expect(method).toContain('cycle/<cycle_name>');
-    expect(normalizedMethod).toContain('open a draft pull request to `main`');
+    expect(normalizedMethod).toContain('open a non-draft pull request to `main`');
   });
 
-  it('starts cycles with a synced branch, design issue, and draft PR', () => {
+  it('starts cycles with a synced branch, design issue, and non-draft PR', () => {
     const agents = read('AGENTS.md');
     const contributing = read('CONTRIBUTING.md');
     const workflow = read('docs/WORKFLOW.md');
@@ -45,22 +45,22 @@ describe('WF-001 workflow adoption', () => {
     expect(normalizedMethod).toContain('git fetch');
     expect(normalizedMethod).toContain('Sync to the merge target branch');
     expect(normalizedMethod).toContain('Create `cycle/<cycle_name>` from the synced merge target');
-    expect(normalizedMethod).toContain('open a draft pull request to `main`');
+    expect(normalizedMethod).toContain('open a non-draft pull request to `main`');
     expect(normalizedMethod).toContain('apply `work-in-progress` to the GitHub Issue');
 
     expect(normalizedWorkflow).toContain('Sync to the merge target branch after `git fetch`.');
-    expect(normalizedWorkflow).toContain('open a draft pull request to `main` before implementation work starts.');
+    expect(normalizedWorkflow).toContain('open a non-draft pull request to `main` before implementation work starts.');
     expect(normalizedWorkflow).toContain('Apply `work-in-progress` to the GitHub Issue.');
 
-    expect(normalizedContributing).toContain('Open a draft PR at cycle start');
-    expect(normalizedContributing).toContain('mark it ready for review only after validation and self-review pass');
+    expect(normalizedContributing).toContain('Open a non-draft PR at cycle start');
+    expect(normalizedContributing).toContain('request final review only after validation and self-review pass');
 
     expect(normalizedAgents).toContain('Start cycles from a synced merge target branch.');
-    expect(normalizedAgents).toContain('Draft PRs are expected at cycle start.');
-    expect(normalizedAgents).toContain('link the issue, design doc, and draft PR');
-    expect(normalizedMethod).toContain('link the issue, design doc, and draft PR');
+    expect(normalizedAgents).toContain('PRs are non-draft at cycle start.');
+    expect(normalizedAgents).toContain('link the issue, design doc, and PR');
+    expect(normalizedMethod).toContain('link the issue, design doc, and PR');
 
-    expect(issueTemplate).toContain('Issue, design doc, and draft PR are linked correctly.');
+    expect(issueTemplate).toContain('Issue, design doc, and non-draft PR are linked correctly.');
   });
 
   it('adds explicit legend and invariant docs', () => {

--- a/tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts
+++ b/tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts
@@ -23,7 +23,7 @@ describe('WF-126 v7 closeout tracker sync', () => {
     const completedLineage = sectionBetween(v7, '### Completed Lineage', '### Component-Family Audits');
 
     expect(roadmap).toContain('| `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 |');
-    expect(openWork).toContain('No open v7 tracker issues remain as of 2026-06-03.');
+    expect(openWork).toContain('No open v7 tracker issues remain as of 2026-06-06.');
     expect(openWork).not.toContain('https://github.com/flyingrobots/bijou/issues/245');
     expect(openWork).not.toContain('https://github.com/flyingrobots/bijou/issues/246');
     expect(openWork).not.toContain('https://github.com/flyingrobots/bijou/issues/281');

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function normalizeWhitespace(source: string): string {
+  return source.replace(/\s+/g, ' ').trim();
+}
+
+describe('WF-130 roadmap goalpost policy', () => {
+  it('documents release packets, goalposts, stories, slices, gates, and proof', () => {
+    expect(existsSync(resolve(ROOT, 'docs/method/releases/README.md'))).toBe(true);
+
+    const releasePolicy = normalizeWhitespace(read('docs/method/releases/README.md'));
+
+    expect(releasePolicy).toContain('Versioned Release');
+    expect(releasePolicy).toContain('Goalpost');
+    expect(releasePolicy).toContain('Umbrella Issue');
+    expect(releasePolicy).toContain('User Story Issue');
+    expect(releasePolicy).toContain('Slice Budget');
+    expect(releasePolicy).toContain('Release Gate');
+    expect(releasePolicy).toContain('Proof Policy');
+    expect(releasePolicy).toContain('vMAJOR.MINOR.PATCH');
+    expect(releasePolicy).toContain('`goalpost`');
+    expect(releasePolicy).toContain('`user-story`');
+    expect(releasePolicy).toContain('No implementation goalpost is complete through documentation alone.');
+  });
+
+  it('makes roadmap state GitHub-backed and groups current open tracker work', () => {
+    const roadmap = normalizeWhitespace(read('docs/ROADMAP.md'));
+
+    expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-06-06.');
+    expect(roadmap).toContain('`v6.0.0`');
+    expect(roadmap).toContain('0 | 30');
+    expect(roadmap).toContain('`v7.0.0`');
+    expect(roadmap).toContain('0 | 27');
+    expect(roadmap).toContain('`Beyond`');
+    expect(roadmap).toContain('29 | 1');
+    expect(roadmap).toContain('Candidate Goalposts From Open GitHub Issues');
+    expect(roadmap).toContain('Runtime Graph And Scene IR');
+    expect(roadmap).toContain('DOGFOOD And BlockLab Product Surface');
+    expect(roadmap).toContain('Workflow And CI Determinism');
+    expect(roadmap).toContain('Localization And Documentation Operations');
+    expect(roadmap).toContain('[#306]');
+    expect(roadmap).toContain('[#249]');
+  });
+
+  it('keeps Method and contributor cycle docs aligned to non-draft PRs', () => {
+    const agents = normalizeWhitespace(read('AGENTS.md'));
+    const contributing = normalizeWhitespace(read('CONTRIBUTING.md'));
+    const method = normalizeWhitespace(read('docs/METHOD.md'));
+    const workflow = normalizeWhitespace(read('docs/WORKFLOW.md'));
+
+    for (const source of [agents, contributing, method, workflow]) {
+      expect(source).not.toContain('open a draft');
+      expect(source).not.toContain('Draft PRs are expected');
+      expect(source).not.toContain('Open draft PRs');
+      expect(source).not.toContain('mark the draft');
+      expect(source).not.toContain('draft-first');
+    }
+
+    expect(method).toContain('open a non-draft pull request to `main`');
+    expect(workflow).toContain('open a non-draft pull request to `main`');
+    expect(contributing).toContain('Open a non-draft PR at cycle start');
+    expect(agents).toContain('open a non-draft pull request to `main`');
+  });
+
+  it('adds issue-template fields for roadmap role and slice accounting', () => {
+    const issueTemplate = read('.github/ISSUE_TEMPLATE/work-item.yml');
+
+    expect(issueTemplate).toContain('id: roadmap-role');
+    expect(issueTemplate).toContain('Goalpost umbrella');
+    expect(issueTemplate).toContain('User story');
+    expect(issueTemplate).toContain('id: roadmap-linkage');
+    expect(issueTemplate).toContain('id: slice-budget');
+    expect(issueTemplate).toContain('id: release-gate');
+    expect(issueTemplate).toContain('Issue, design doc, and non-draft PR are linked correctly.');
+  });
+});


### PR DESCRIPTION
## Summary

- define Bijou release packets, versioned releases, goalposts, umbrella issues, user-story issues, slice budgets, release gates, proof policy, and authority order in `docs/method/releases/README.md`
- refresh `docs/ROADMAP.md` from live GitHub milestone data as of 2026-06-06: `v6.0.0` is `0 open / 30 closed`, `v7.0.0` is `0 open / 27 closed`, and `Beyond` is `29 open / 1 closed`
- group current open `Beyond` and unmilestoned tracker work into candidate goalposts for runtime graph/scene IR, DOGFOOD and BlockLab product surface, workflow/CI determinism, and localization/docs operations
- add Method issue-template fields for roadmap role, roadmap linkage, slice budget, and release-gate impact
- align cycle-start docs and tests back to non-draft pull requests
- create GitHub labels: `roadmap`, `goalpost`, `user-story`

## Issue

Direct housekeeping request; no existing issue cleanly owns this exact policy slice.

## Validation

- RED: `npm test -- --run tests/cycles/WF-130/roadmap-goalpost-policy.test.ts` failed before implementation on release-packet, roadmap-count, non-draft-policy, and issue-template assertions.
- `npm test -- --run tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
- `npm test -- --run tests/cycles/WF-001/workflow-adoption.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
- `npm test -- --run tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts`
- `npm run docs:inventory`
- `npm run typecheck:test`
- `npm run lint`
- `git diff --check`
- pre-push gate: `dogfood:i18n:complete`, `dogfood:i18n:check`, `dogfood:i18n:debt`, `typecheck:test`, full Vitest suite `341 files / 3749 tests`, and scripted interactive example smokes
