### PR TITLE
DL-013 design token and theme builder API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🛠 Maintenance
 
+- **Design token and theme builder planning** — `docs/design/DL-013-design-token-theme-builder-api.md`
+  now specifies the first official fluent-builder shape for semantic color
+  tokens, dark/light theme modes, token-backed style rendering, lower-mode
+  color resolution, and inspectability facts. `docs/ROADMAP.md` now tracks
+  issue #308 as the Beyond candidate goalpost for Design Tokens And Theme
+  Modes.
 - **Roadmap goalpost policy** — `docs/method/releases/README.md` now defines
   Bijou release packets, versioned releases, goalposts, umbrella issues,
   user-story issues, slice budgets, release gates, proof policy, and authority

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,12 +58,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🛠 Maintenance
 
-- **Design token and theme builder planning** — `docs/design/DL-013-design-token-theme-builder-api.md`
-  now specifies the first official fluent-builder shape for semantic color
-  tokens, dark/light theme modes, token-backed style rendering, lower-mode
-  color resolution, and inspectability facts. `docs/ROADMAP.md` now tracks
-  issue #308 as the Beyond candidate goalpost for Design Tokens And Theme
-  Modes.
+- **Design token and theme builder planning** —
+  `docs/design/DL-013-design-token-theme-builder-api.md` now specifies the
+  first official fluent-builder shape for semantic color tokens, dark/light
+  theme modes, token-backed style rendering, lower-mode color resolution, and
+  inspectability facts. `docs/ROADMAP.md` now tracks issue #308 as the Beyond
+  candidate goalpost for Design Tokens And Theme Modes.
 - **Roadmap goalpost policy** — `docs/method/releases/README.md` now defines
   Bijou release packets, versioned releases, goalposts, umbrella issues,
   user-story issues, slice budgets, release gates, proof policy, and authority

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ Last synced from GitHub milestone items: 2026-06-06.
 | :--- | :--- | ---: | ---: | :--- |
 | `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 30 | Issue-complete layout truth, standard blocks, and status/feedback Block lane. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Issue-complete V7 Product Truth, BlockLab naming, and release-facing proof. |
-| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 29 | 1 | Uncommitted future work, cool ideas, and raw follow-ups. |
+| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 30 | 1 | Uncommitted future work, cool ideas, and raw follow-ups. |
 
 ## v6.0.0
 
@@ -140,6 +140,7 @@ packet and assigned umbrella issues.
 | :--- | :--- | :--- | :--- |
 | Runtime Graph And Scene IR | [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#302](https://github.com/flyingrobots/bijou/issues/302) | Bijou keeps accumulating DAG, Mermaid, MCP, and GraphQL-authored scene ideas. These should become one runtime/IR goalpost instead of drifting as unrelated ideas. | Schema fixtures, lowering tests, DOGFOOD graph examples, lower-mode rendering, and failure-mode contracts. |
 | DOGFOOD And BlockLab Product Surface | [#204](https://github.com/flyingrobots/bijou/issues/204), [#205](https://github.com/flyingrobots/bijou/issues/205), [#214](https://github.com/flyingrobots/bijou/issues/214), [#215](https://github.com/flyingrobots/bijou/issues/215), [#217](https://github.com/flyingrobots/bijou/issues/217), [#218](https://github.com/flyingrobots/bijou/issues/218), [#248](https://github.com/flyingrobots/bijou/issues/248), [#272](https://github.com/flyingrobots/bijou/issues/272) | DOGFOOD, BlockLab, file exploration, semantic lists, terminal shaders, and artifact matrices all point at a stronger product-facing component lab. | Scripted DOGFOOD flows, BlockLab story fixtures, image/capture witnesses, keyboard/focus proof, and localized docs. |
+| Design Tokens And Theme Modes | [#308](https://github.com/flyingrobots/bijou/issues/308) | Lip Gloss-like styling is valuable only if Bijou preserves its own theme truth: tokens describe semantic color slots, themes own dark/light values, and styles consume resolved colors at render time. | Builder API tests, theme validation fixtures, style-render resolution tests, lower-mode color proof, DOGFOOD examples, and inspectability facts. |
 | Workflow And CI Determinism | [#203](https://github.com/flyingrobots/bijou/issues/203), [#268](https://github.com/flyingrobots/bijou/issues/268), [#269](https://github.com/flyingrobots/bijou/issues/269), [#270](https://github.com/flyingrobots/bijou/issues/270), [#290](https://github.com/flyingrobots/bijou/issues/290), [#298](https://github.com/flyingrobots/bijou/issues/298), [#299](https://github.com/flyingrobots/bijou/issues/299), [#300](https://github.com/flyingrobots/bijou/issues/300), [#301](https://github.com/flyingrobots/bijou/issues/301) | The open bad-code and Method ideas share a dependency-injection, fake-clock, replay, and tracker-sync theme. They should become one proof and determinism goalpost. | Fake clocks, injected git/GitHub clients, fixture-backed DOGFOOD harnesses, path-gated CI proof, and merge-gate tests. |
 | Localization And Documentation Operations | [#206](https://github.com/flyingrobots/bijou/issues/206), [#207](https://github.com/flyingrobots/bijou/issues/207), [#208](https://github.com/flyingrobots/bijou/issues/208) | DOGFOOD Markdown localization now has a debt ratchet; the next shaped step is an operator-facing translation and preference workflow. | Localization debt tests, preference persistence fixtures, DOGFOOD dashboards, and all-supported-locale proof. |
 
@@ -176,6 +177,7 @@ packet and assigned umbrella issues.
 | [#300](https://github.com/flyingrobots/bijou/issues/300) | `lane:bad-code` | `type:maintenance` | Inject git and GitHub clients into policy scripts |
 | [#301](https://github.com/flyingrobots/bijou/issues/301) | `lane:cool-ideas` | `type:enhancement` / `type:maintenance` | Native Bijou frame-capture format |
 | [#302](https://github.com/flyingrobots/bijou/issues/302) | `lane:cool-ideas` | `type:enhancement` / `type:spike` | Compile GraphQL-authored UI scenes into Bijou Blocks |
+| [#308](https://github.com/flyingrobots/bijou/issues/308) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | DL-013 design token and theme builder API |
 
 ### Closed Beyond Lineage
 

--- a/docs/design/DL-013-design-token-theme-builder-api.md
+++ b/docs/design/DL-013-design-token-theme-builder-api.md
@@ -1,0 +1,469 @@
+---
+title: DL-013 Design token and theme builder API
+legend: DL
+lane: cool-ideas
+priority: medium
+github_issue: 308
+keywords:
+  - design-language
+  - themes
+  - tokens
+  - styles
+  - builder-api
+---
+
+# DL-013 Design token and theme builder API
+
+## Decision Summary
+
+Tokens describe semantic color slots in a theme.
+
+Themes own mode-specific token values.
+
+Dark and light are the required first theme modes.
+
+Styles consume resolved tokens at render time.
+
+Styles do not register tokens, own theme values, or decide dark/light mode.
+
+This design records the first official Bijou shape for a Lip Gloss-like builder
+API without copying Lip Gloss' object model wholesale. Bijou should expose a
+declarative style builder, but the theme graph must remain explicit because
+Bijou already treats rendering, lowering, and inspectability as first-class
+contracts.
+
+The short relationship is:
+
+```text
+Theme
+  contains modes
+    contain token color values
+
+Style
+  contains layout and rendering rules
+  may reference token ids
+  resolves those references through one theme mode during render
+```
+
+## Sponsored Human
+
+A Bijou app author wants to declare semantic colors once and reuse them across
+dark and light modes so that components can stay visually coherent without
+passing raw RGB values through every call site.
+
+## Sponsored Agent
+
+An agent auditing a Bijou app wants theme tokens and style use to be separable
+and inspectable so that it can explain whether a rendered cell came from a
+semantic theme slot, a raw color override, or a lower-mode fallback.
+
+## Problem
+
+Bijou has styleable surfaces, palettes, theme presets, and DOGFOOD chrome, but
+the authoring API still makes authors think in implementation details too
+early. A Lip Gloss-like builder can make styling feel natural, but a naive
+builder can blur three different responsibilities:
+
+- declaring which semantic colors exist
+- assigning concrete colors to those semantic colors for dark and light modes
+- applying resolved colors and layout rules to rendered content
+
+The user-facing syntax should be fluent, but the model should stay strict.
+Theme data is application and product identity. Style data is component
+presentation. Token references are the bridge.
+
+## Scope
+
+This spec covers the first color-token API only:
+
+- semantic color token ids
+- dark and light theme modes
+- theme-local token registration and validation
+- token references inside styles
+- raw color escape hatches inside styles
+- deterministic lower-mode color resolution
+- runtime inspectability facts for token resolution
+
+## Non-Goals
+
+This slice does not design every future design-token category.
+
+- No spacing tokens yet.
+- No typography tokens yet.
+- No motion tokens yet.
+- No border-shape tokens yet.
+- No global mutable token registry.
+- No runtime terminal background-color query requirement.
+- No implementation of the builder API in this planning slice.
+
+Those can become follow-on issues once the color-token and theme-mode contract
+is landed.
+
+## Core Vocabulary
+
+### Token
+
+A token is a semantic color slot inside a theme. It has a stable id such as
+`color.status.danger.bg`, but it does not carry a single universal color by
+itself. Its value comes from a theme mode.
+
+Good token ids name intent, not pigment:
+
+```text
+color.surface.canvas.bg
+color.surface.canvas.fg
+color.status.danger.bg
+color.status.danger.fg
+color.chrome.focusGutter
+color.chrome.scrollThumb
+color.brand.primary
+```
+
+Bad token ids encode mode or raw color:
+
+```text
+color.dark.red900
+color.light.blueAccent
+color.hex.ff0000
+```
+
+### Theme
+
+A theme is an immutable named collection of modes. It is the owner of token
+values. A theme can declare that the same token has different concrete colors
+in dark and light modes.
+
+### Mode
+
+A mode is a named token-value map inside a theme. `dark` and `light` are the
+required first modes because they cover the highest-value terminal theme split
+without requiring terminal background probing in the first implementation.
+
+Additional modes can be designed later, for example `highContrast`,
+`deuteranopia`, or `print`.
+
+### Style
+
+A style is an immutable builder for presentation. It can hold foreground,
+background, border, padding, margin, width, wrapping, alignment, and other
+rendering rules. When a style uses a token, it stores a token reference rather
+than a concrete color.
+
+The concrete color is resolved only when rendering receives a theme and mode.
+
+## Proposed API
+
+The primary API should optimize for the common case: define a theme, define
+styles that reference semantic tokens, then render with a selected mode.
+
+```ts
+import {
+  defineTheme,
+  style,
+  tokenRef,
+} from '@flyingrobots/bijou';
+
+const theme = defineTheme()
+  .id('bijou.default')
+  .label('Bijou Default')
+  .mode("dark", mode => mode
+    .token('color.status.danger.bg')
+    .color({ r: 144, g: 0, b: 0 })
+    .token('color.status.danger.fg')
+    .color({ r: 255, g: 230, b: 230 }))
+  .mode("light", mode => mode
+    .token('color.status.danger.bg')
+    .color({ r: 255, g: 230, b: 230 })
+    .token('color.status.danger.fg')
+    .color({ r: 144, g: 0, b: 0 }))
+  .build();
+
+const warning = style()
+  .padding(0, 1)
+  .foreground(tokenRef("color.status.danger.fg"))
+  .background(tokenRef("color.status.danger.bg"));
+
+const surface = warning.render(surfaceText, { theme, mode: "dark" });
+```
+
+The exact authoring names can still move during implementation, but the
+responsibility split should not.
+
+## Token Builder Variant
+
+The user-proposed token builder shape is useful, but it should be scoped to
+theme modes rather than become a global registry:
+
+```ts
+const theme = defineTheme()
+  .id('bijou.default')
+  .mode('dark', mode => mode
+    .token()
+    .id('color.status.danger.bg')
+    .color({ r: 144, g: 0, b: 0 })
+    .register())
+  .mode('light', mode => mode
+    .token()
+    .id('color.status.danger.bg')
+    .color({ r: 255, g: 230, b: 230 })
+    .register())
+  .build();
+```
+
+The shorter `.token(id).color(value)` form should exist for dense theme files.
+The longer `.token().id(...).color(...).register()` form is useful when an
+author wants comments, metadata, or validation hooks attached to one token
+entry.
+
+## Why Tokens Are Theme-Scoped
+
+Theme-scoped token registration prevents three failure modes:
+
+1. A token definition cannot silently survive without mode values.
+2. A style cannot accidentally become the source of product theme truth.
+3. A future theme inspector can show all missing mode values from one theme
+   object instead of chasing global state.
+
+If Bijou later adds package-level token catalogs, those catalogs should declare
+allowed ids and descriptions. They should still not own the concrete dark and
+light mode colors for every consuming app.
+
+## Relationship Diagram
+
+```text
+              +------------------+
+              | Theme            |
+              | id, label        |
+              +--------+---------+
+                       |
+              owns mode maps
+                       |
+          +------------+------------+
+          |                         |
++---------v---------+     +---------v---------+
+| Mode: dark        |     | Mode: light       |
+| token -> color    |     | token -> color    |
++---------+---------+     +---------+---------+
+          |                         |
+          +------------+------------+
+                       |
+                 resolves refs
+                       |
+              +--------v---------+
+              | Style            |
+              | fg: tokenRef(...)|
+              | bg: tokenRef(...)|
+              | layout rules     |
+              +--------+---------+
+                       |
+                 render context
+                       |
+              +--------v---------+
+              | Surface cells    |
+              | concrete colors  |
+              +------------------+
+```
+
+## Style Builder Surface
+
+The style builder should feel familiar to authors who know fluent terminal
+style APIs, while still returning Bijou surfaces and facts.
+
+Candidate methods:
+
+```ts
+style()
+  .foreground(tokenRef('color.text.primary'))
+  .background(tokenRef('color.surface.canvas.bg'))
+  .bold(true)
+  .italic(true)
+  .underline(true)
+  .padding(1, 2)
+  .margin(0, 1)
+  .width(40)
+  .height(8)
+  .maxWidth(80)
+  .align('center')
+  .border('single')
+  .borderForeground(tokenRef('color.chrome.border'))
+  .render(surfaceText, { theme, mode: 'dark' });
+```
+
+The style builder can support raw colors as an escape hatch:
+
+```ts
+style().foreground({ r: 250, g: 250, b: 250 });
+```
+
+Raw colors should be visible in inspectability facts so an agent can
+distinguish deliberate hard-coded color from semantic token use.
+
+## Resolution Contract
+
+Rendering a token-backed style requires:
+
+- a theme
+- a mode id
+- a lowering profile
+- an unresolved-token policy
+
+The default unresolved-token policy should fail in development and use a
+visible fallback in production-like rendering. The fallback must be
+deterministic and inspectable.
+
+```ts
+type TokenResolutionFact = {
+  tokenId: string;
+  themeId: string;
+  mode: string;
+  source: 'theme' | 'fallback' | 'raw-color';
+  requestedColor?: RgbColor;
+  resolvedColor: LoweredColor;
+  profile: 'truecolor' | 'ansi256' | 'ansi16' | 'mono' | 'plain';
+};
+```
+
+## Lower Modes
+
+Color lowering belongs to the resolver, not to each style call site.
+
+The first resolver should support:
+
+- `truecolor`: preserve RGB
+- `ansi256`: nearest palette index
+- `ansi16`: nearest named ANSI color
+- `mono`: intensity and emphasis only
+- `plain`: no color, style facts preserved
+
+This keeps the style syntax stable even when output moves from rich terminal to
+pipe, static snapshot, accessible text, or future frame capture.
+
+## Inheritance And Composition
+
+Bijou should support value-style copying and inheritance, but unset rules must
+stay distinguishable from intentionally raw or token-backed rules.
+
+Candidate API:
+
+```ts
+const base = style()
+  .foreground(tokenRef('color.text.primary'))
+  .background(tokenRef('color.surface.canvas.bg'));
+
+const danger = style()
+  .inherit(base)
+  .background(tokenRef('color.status.danger.bg'))
+  .foreground(tokenRef('color.status.danger.fg'));
+```
+
+Inheritance should copy only unset rules on the receiver, matching the useful
+part of Lip Gloss while keeping the resolved-token facts intact.
+
+## Inspectability
+
+Every rendered token-backed style should be able to expose:
+
+- style id, when provided
+- theme id
+- mode id
+- token ids used
+- raw colors used
+- fallback tokens used
+- lowered output profile
+- concrete cell color results
+
+This is a Bijou-specific requirement. The goal is not only nice terminal
+styling, but explainable rendering.
+
+## Accessibility
+
+Token ids should be semantic enough that an accessible renderer can report
+meaning even when color is stripped.
+
+For example, `color.status.danger.bg` gives better assistive context than
+`color.red.900`. The style resolver should preserve facts for accessible
+surfaces even when the final text has no color escape sequences.
+
+## Localization
+
+No localized strings are introduced by this design. Public docs and DOGFOOD
+examples introduced during implementation must follow the repository
+localization policy and provide all supported DOGFOOD locales when new
+localized copy is added.
+
+## Compatibility
+
+The builder should be additive. Existing theme preset and surface APIs should
+continue to work while the builder is introduced.
+
+Migration can be staged:
+
+1. Add token references and theme builder types.
+2. Convert one DOGFOOD shell theme path to prove the model.
+3. Add docs and examples.
+4. Expand first-party components to accept `Style` values.
+5. Deprecate ad hoc raw color plumbing only after call sites have a builder
+   alternative.
+
+## Acceptance Criteria
+
+- `defineTheme()` creates immutable theme definitions with required dark and
+  light mode maps.
+- Theme builders reject duplicate token ids within one mode.
+- Theme builders reject themes missing required dark or light mode values for
+  declared tokens.
+- `tokenRef(id)` is accepted by style color setters.
+- `style()` produces immutable styles and does not mutate copied styles.
+- `render(surfaceText, { theme, mode: "dark" })` resolves token-backed colors
+  through the selected mode.
+- The resolver emits inspectability facts for token, theme, mode, fallback, and
+  lowering decisions.
+- Lower modes prove that token-backed styles render in truecolor, ANSI, mono,
+  and plain profiles.
+- DOGFOOD includes one theme-builder example and one style-builder example
+  once implementation lands.
+
+## Implementation Slices
+
+1. Token and theme type contracts with focused tests.
+2. `defineTheme()` builder with dark/light validation.
+3. `tokenRef()` and color-reference resolution.
+4. `style()` builder for foreground, background, emphasis, padding, width, and
+   render.
+5. Lower-mode resolver facts and fallback behavior.
+6. DOGFOOD docs, examples, and package exports.
+
+## Tests To Write First
+
+- Theme builder rejects missing `dark` or `light` modes.
+- Theme builder rejects duplicate mode token ids.
+- Style render resolves foreground and background token refs by selected mode.
+- Copied styles stay immutable after chained modifications.
+- Lower-mode rendering produces deterministic truecolor, ANSI, mono, and plain
+  output.
+- Inspectability facts identify theme id, mode id, token id, and fallback
+  status.
+
+## Roadmap Placement
+
+This belongs in the Beyond lane as issue
+[#308](https://github.com/flyingrobots/bijou/issues/308) until implementation
+is scheduled into a versioned release. It should be grouped as the candidate
+goalpost `Design Tokens And Theme Modes` because it crosses design language,
+runtime rendering, DOGFOOD docs, and public package exports.
+
+## Open Questions
+
+- Should `Style.render()` accept strings only, surfaces only, or both?
+- Should style ids be required for inspectability, or optional metadata?
+- Should high-contrast mode land in the first implementation or immediately
+  after dark/light?
+- Should token catalogs exist as package-level declarations separate from
+  app-owned theme values?
+
+## Retrospective
+
+This slice is intentionally documentation and roadmap only. The important
+decision is the object model: tokens belong to themes, themes own modes, and
+styles consume resolved tokens. Implementation should start with failing
+runtime tests that prove that split instead of only matching fluent syntax.

--- a/docs/design/DL-013-design-token-theme-builder-api.md
+++ b/docs/design/DL-013-design-token-theme-builder-api.md
@@ -14,6 +14,8 @@ keywords:
 
 # DL-013 Design token and theme builder API
 
+Legend: [DL - Design Language](../legends/DL-design-language.md)
+
 ## Decision Summary
 
 Tokens describe semantic color slots in a theme.
@@ -57,6 +59,13 @@ An agent auditing a Bijou app wants theme tokens and style use to be separable
 and inspectable so that it can explain whether a rendered cell came from a
 semantic theme slot, a raw color override, or a lower-mode fallback.
 
+## Hill
+
+A Bijou app author can define semantic color tokens once inside a theme,
+provide required dark and light mode values, and apply those tokens through a
+fluent style builder without allowing styles to become the owner of product
+theme truth.
+
 ## Problem
 
 Bijou has styleable surfaces, palettes, theme presets, and DOGFOOD chrome, but
@@ -71,6 +80,17 @@ builder can blur three different responsibilities:
 The user-facing syntax should be fluent, but the model should stay strict.
 Theme data is application and product identity. Style data is component
 presentation. Token references are the bridge.
+
+## Playback Questions
+
+1. Can a theme define the same token id with separate dark and light values?
+2. Does a style keep token references unresolved until render receives a theme
+   and mode?
+3. Can an inspector explain which theme, mode, token id, and lowering profile
+   produced a rendered cell color?
+4. Do unresolved tokens fail or fall back through an explicit policy instead of
+   silently degrading?
+5. Does the lower-mode path preserve meaning when truecolor is unavailable?
 
 ## Scope
 
@@ -359,7 +379,7 @@ const danger = style()
 Inheritance should copy only unset rules on the receiver, matching the useful
 part of Lip Gloss while keeping the resolved-token facts intact.
 
-## Inspectability
+## Agent Inspectability / Explainability Posture
 
 Every rendered token-backed style should be able to expose:
 
@@ -375,7 +395,7 @@ Every rendered token-backed style should be able to expose:
 This is a Bijou-specific requirement. The goal is not only nice terminal
 styling, but explainable rendering.
 
-## Accessibility
+## Accessibility / Assistive Reading Posture
 
 Token ids should be semantic enough that an accessible renderer can report
 meaning even when color is stripped.
@@ -384,12 +404,26 @@ For example, `color.status.danger.bg` gives better assistive context than
 `color.red.900`. The style resolver should preserve facts for accessible
 surfaces even when the final text has no color escape sequences.
 
-## Localization
+## Localization / Directionality Posture
 
 No localized strings are introduced by this design. Public docs and DOGFOOD
 examples introduced during implementation must follow the repository
 localization policy and provide all supported DOGFOOD locales when new
-localized copy is added.
+localized copy is added. Token ids are logical semantic identifiers and should
+not encode physical direction, locale, or translated prose.
+
+## Linked Invariants
+
+- [Runtime Truth Wins](../invariants/runtime-truth-wins.md): resolved cell
+  colors and resolver facts are stronger evidence than design prose.
+- [Graceful Lowering Preserves Meaning](../invariants/graceful-lowering-preserves-meaning.md):
+  color cannot be the only carrier of status, focus, or warning meaning.
+- [Tests Are The Spec](../invariants/tests-are-the-spec.md): the builder API
+  should land through focused runtime tests, not just examples.
+- [Buffer Holds Facts](../invariants/buffer-holds-facts.md): rendered cells
+  should preserve token-resolution facts for inspection and replay.
+- [Docs Are The Demo](../invariants/docs-are-the-demo.md): DOGFOOD examples
+  should exercise the same public builder API as consumers.
 
 ## Compatibility
 
@@ -423,7 +457,7 @@ Migration can be staged:
 - DOGFOOD includes one theme-builder example and one style-builder example
   once implementation lands.
 
-## Implementation Slices
+## Implementation Outline
 
 1. Token and theme type contracts with focused tests.
 2. `defineTheme()` builder with dark/light validation.

--- a/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
+++ b/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
@@ -11,7 +11,9 @@ describe('DL-013 design token and theme builder spec', () => {
     expect(design).toContain('Themes own mode-specific token values.');
     expect(design).toContain('Dark and light are the required first theme modes.');
     expect(design).toContain('Styles consume resolved tokens at render time.');
-    expect(design).toContain('Styles do not register tokens, own theme values, or decide dark/light mode.');
+    expect(design).toContain(
+      'Styles do not register tokens, own theme values, or decide dark/light mode.',
+    );
     expect(design).toContain('defineTheme()');
     expect(design).toContain('.mode("dark"');
     expect(design).toContain('.mode("light"');
@@ -20,10 +22,30 @@ describe('DL-013 design token and theme builder spec', () => {
     expect(design).toContain('render(surfaceText, { theme, mode: "dark" })');
   });
 
+  it('follows the modern Method design document shape', () => {
+    const design = readRepoFile('docs/design/DL-013-design-token-theme-builder-api.md');
+
+    expect(design).toContain('Legend: [DL - Design Language]');
+    expect(design).toContain('## Sponsored Human');
+    expect(design).toContain('## Sponsored Agent');
+    expect(design).toContain('## Hill');
+    expect(design).toContain('## Playback Questions');
+    expect(design).toContain('## Accessibility / Assistive Reading Posture');
+    expect(design).toContain('## Localization / Directionality Posture');
+    expect(design).toContain('## Agent Inspectability / Explainability Posture');
+    expect(design).toContain('## Linked Invariants');
+    expect(design).toContain('## Implementation Outline');
+    expect(design).toContain('## Tests To Write First');
+    expect(design).toContain('## Retrospective');
+  });
+
   it('puts DL-013 onto the GitHub-backed roadmap', () => {
     const roadmap = readRepoFile('docs/ROADMAP.md');
 
-    expect(roadmap).toContain('| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 30 | 1 |');
+    expect(roadmap).toContain(
+      '| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | ' +
+        '30 | 1 |',
+    );
     expect(roadmap).toContain('Design Tokens And Theme Modes');
     expect(roadmap).toContain('[#308](https://github.com/flyingrobots/bijou/issues/308)');
     expect(roadmap).toContain('DL-013 design token and theme builder API');

--- a/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
+++ b/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
@@ -43,8 +43,7 @@ describe('DL-013 design token and theme builder spec', () => {
     const roadmap = readRepoFile('docs/ROADMAP.md');
 
     expect(roadmap).toContain(
-      '| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | ' +
-        '30 | 1 |',
+      '| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) |',
     );
     expect(roadmap).toContain('Design Tokens And Theme Modes');
     expect(roadmap).toContain('[#308](https://github.com/flyingrobots/bijou/issues/308)');

--- a/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
+++ b/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { existsRepoPath, readRepoFile } from '../repo.js';
+
+describe('DL-013 design token and theme builder spec', () => {
+  it('defines the token, theme, mode, and style relationship', () => {
+    expect(existsRepoPath('docs/design/DL-013-design-token-theme-builder-api.md')).toBe(true);
+
+    const design = readRepoFile('docs/design/DL-013-design-token-theme-builder-api.md');
+
+    expect(design).toContain('Tokens describe semantic color slots in a theme.');
+    expect(design).toContain('Themes own mode-specific token values.');
+    expect(design).toContain('Dark and light are the required first theme modes.');
+    expect(design).toContain('Styles consume resolved tokens at render time.');
+    expect(design).toContain('Styles do not register tokens, own theme values, or decide dark/light mode.');
+    expect(design).toContain('defineTheme()');
+    expect(design).toContain('.mode("dark"');
+    expect(design).toContain('.mode("light"');
+    expect(design).toContain('tokenRef("color.status.danger.bg")');
+    expect(design).toContain('style()');
+    expect(design).toContain('render(surfaceText, { theme, mode: "dark" })');
+  });
+
+  it('puts DL-013 onto the GitHub-backed roadmap', () => {
+    const roadmap = readRepoFile('docs/ROADMAP.md');
+
+    expect(roadmap).toContain('| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 30 | 1 |');
+    expect(roadmap).toContain('Design Tokens And Theme Modes');
+    expect(roadmap).toContain('[#308](https://github.com/flyingrobots/bijou/issues/308)');
+    expect(roadmap).toContain('DL-013 design token and theme builder API');
+  });
+});

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -41,10 +41,11 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`v7.0.0`');
     expect(roadmap).toContain('0 | 27');
     expect(roadmap).toContain('`Beyond`');
-    expect(roadmap).toContain('29 | 1');
+    expect(roadmap).toContain('30 | 1');
     expect(roadmap).toContain('Candidate Goalposts From Open GitHub Issues');
     expect(roadmap).toContain('Runtime Graph And Scene IR');
     expect(roadmap).toContain('DOGFOOD And BlockLab Product Surface');
+    expect(roadmap).toContain('Design Tokens And Theme Modes');
     expect(roadmap).toContain('Workflow And CI Determinism');
     expect(roadmap).toContain('Localization And Documentation Operations');
     expect(roadmap).toContain('[#306]');


### PR DESCRIPTION
## Summary

- Adds the official DL-013 design document for the theme-token builder model.
- Records the relationship: tokens describe semantic color slots, themes own dark/light mode values, and styles consume resolved tokens at render time.
- Adds DL-013 to the Beyond roadmap as the `Design Tokens And Theme Modes` candidate goalpost.
- Adds a focused cycle test for the design/roadmap contract and refreshes the roadmap policy test count after issue #308 entered the Beyond milestone.

## Tracker

Refs #308

Issue #308 should remain open as the implementation goalpost. This PR locks the design/spec and roadmap placement.

## Validation

- RED: `npm test -- --run tests/cycles/DL-013/design-token-theme-builder-spec.test.ts` failed before the DL-013 design doc and roadmap entry existed.
- GREEN: `npm test -- --run tests/cycles/DL-013/design-token-theme-builder-spec.test.ts`
- `npm test -- --run tests/cycles/DL-013/design-token-theme-builder-spec.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
- `npm run lint`
- `npm run docs:inventory`
- `npm run typecheck:test`
- Pre-push suite: DOGFOOD i18n completeness, DOGFOOD i18n catalog check, DOGFOOD i18n debt ratchet, `typecheck:test`, full `npm test` with 342 files / 3,751 tests, and scripted interactive example smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design documentation describing the planned design tokens and theme builder (modes, token resolution, accessibility, acceptance criteria, and roadmap placement).
  * Updated changelog with an unreleased maintenance entry reflecting this work.
  * Updated roadmap to track design tokens and theme modes as a future "Beyond" milestone.

* **Tests**
  * Added and updated validation tests to ensure the design doc and roadmap entries are present and aligned with the plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->