### PR TITLE
Strengthen Bijou release policy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Documentation
+
+- **Release policy evidence gates** — `docs/release.md` now adapts the
+  release-runbook pattern to Bijou's npm-only workspace publishing model,
+  requires branch-first release prep, release evidence packets, human review
+  dispositions, deterministic replay records, GitHub milestone gates, and
+  final tagging from the exact merged `origin/main` commit.
+
 ### ✨ Features
 
 - **Theme token builder API slices** — `@flyingrobots/bijou` now exports the
@@ -2103,7 +2111,8 @@ First public release.
 - **Screen control** — `enterScreen()`, `exitScreen()`, `clearAndHome()`, `renderFrame()`
 - **Layout helpers** — `vstack()`, `hstack()`
 
-[Unreleased]: https://github.com/flyingrobots/bijou/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/flyingrobots/bijou/compare/v7.0.0...HEAD
+[7.0.0]: https://github.com/flyingrobots/bijou/compare/v5.0.0...v7.0.0
 [5.0.0]: https://github.com/flyingrobots/bijou/compare/v4.4.1...v5.0.0
 [4.4.1]: https://github.com/flyingrobots/bijou/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/flyingrobots/bijou/compare/v4.3.0...v4.4.0

--- a/docs/release.md
+++ b/docs/release.md
@@ -558,8 +558,10 @@ npm view @flyingrobots/bijou-mcp version dist-tags --json
 
 Abort immediately if any of these are true:
 
-- release prep starts from a dirty worktree
-- release prep starts from a branch other than `main`
+- Phase 1 preflight starts from a dirty worktree
+- Phase 1 preflight starts with the operator checked out to a branch other than
+  `main`; after Phase 1 passes, Phase 2 step 2 creates the `release/vX.Y.Z`
+  branch where prep work continues
 - final tag prep is not on `main`
 - final tag prep is not exactly synced to `origin/main`
 - version bump not reflected cleanly across the workspace

--- a/docs/release.md
+++ b/docs/release.md
@@ -216,8 +216,10 @@ Long-form release docs live under `docs/releases/<version>/`.
 
 No next public release version is selected in this file.
 
-`v6.0.0` and `v7.0.0` are both issue-complete GitHub milestone lanes. The next
-release target should be selected from the live tracker and reflected in
+The latest shipped package release is `7.0.0`. The older `v6.0.0` milestone
+and the `v7.0.0` milestone are both issue-complete tracker lanes retained as
+release lineage, not as the next target. The next release target should be
+selected from the live tracker and reflected in
 [`docs/ROADMAP.md`](./ROADMAP.md), [`docs/BEARING.md`](./BEARING.md), and the
 versioned release packet before release prep begins.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -121,7 +121,7 @@ still relies on operator verification:
 | `REL-GH-PRIOR-RELEASE-ZERO` | Lower `v*` milestones have zero open issues or PRs. | operator |
 | `REL-META-VERSION-LOCKSTEP` | Every workspace package version and internal Bijou dependency version matches `X.Y.Z`. | `release:preflight` |
 | `REL-GIT-CLEAN` | The worktree is clean before release prep starts, before the release PR is opened, and before final tagging. | operator |
-| `REL-GIT-ORIGIN-MAIN` | The final tag commit is exactly `origin/main`. | operator, workflows |
+| `REL-GIT-ORIGIN-MAIN` | The final tag commit is exactly `origin/main`. | operator |
 | `REL-DOC-CHANGELOG-DATED` | `docs/CHANGELOG.md` has a dated `[X.Y.Z] - YYYY-MM-DD` entry. | operator |
 | `REL-DOC-EVIDENCE` | `docs/releases/X.Y.Z/README.md` records release evidence, review disposition, replay commands, and residual risk. | operator |
 | `REL-DOC-DOGFOOD-I18N` | DOGFOOD markdown and visible strings satisfy supported-locale checks and the i18n debt ratchet. | `release:readiness` |
@@ -136,7 +136,7 @@ The stage model is:
 | `operator-preflight` | maintainer before release prep | Clean local `main` exactly matches `origin/main`. | Optional visibility check. |
 | `prep-pr` | release-prep branch | Branch-local validation after version/docs changes; does not require `HEAD == origin/main`. | Report target milestone state in the PR. |
 | `final-local` | maintainer after merge | Local `main` exactly matches `origin/main`; final tag target is fixed. | Enforced live. |
-| `tag-workflow` | tag push workflow | Tag commit must be the release commit on `origin/main`. | Enforced when workflow has GitHub access. |
+| `tag-workflow` | tag push workflow | Tag commit must be the release commit on `origin/main`. | Policy target; current workflows do not enforce ancestry. |
 | `rerun-workflow` | manual workflow dispatch for an existing tag | Existing tag must remain reachable from `origin/main`. | Skipped for registry recovery; do not move the tag. |
 
 ### Human Review Gates
@@ -583,8 +583,9 @@ Abort immediately if any of these are true:
 - clean-worktree is an operator preflight check, not a `release:readiness`
   concern, because Phase 2 intentionally dirties the worktree
 - branch-sync, latest-tag, tag-collision, live GitHub issue gates, changelog
-  dating, release evidence shape, and human review disposition are documented
-  here, but they do not yet have a single dedicated repo-native guard
+  dating, release tag ancestry, release evidence shape, and human review
+  disposition are documented here, but they do not yet have a single dedicated
+  repo-native guard
 - `docs:inventory` and runtime `npm audit` are release policy gates but are not
   currently part of `release:readiness`
 - JSR publishing is not currently part of Bijou's release surface

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,6 +17,8 @@ Bijou is currently:
 - tag-driven for release automation
 - GitHub Actions driven for publish, release notes, and GitHub Release
   creation
+- npm-only for registry publishing; JSR is not part of the current release
+  surface
 
 ## Operator Flow
 
@@ -43,9 +45,10 @@ That is why `release:readiness` is the validation gauntlet, not the
 2. Abort on the first hard failure.
 3. Never claim a release succeeded unless the tag, workflows, and npm
    registry state were directly verified.
-4. Never release from a dirty worktree.
-5. Never release from a branch other than `main`.
-6. Never release from a `main` that is ahead of or behind `origin/main`.
+4. Never create a release tag from a dirty worktree.
+5. Never create a release tag from a branch other than `main`.
+6. Never create a release tag from a `main` that is ahead of or behind
+   `origin/main`.
 7. Use repo-native tooling:
    - version bump: `npm run version X.Y.Z`
    - metadata check: `npm run release:preflight`
@@ -53,21 +56,150 @@ That is why `release:readiness` is the validation gauntlet, not the
    - CI dry-run: `.github/workflows/release-dry-run.yml`
    - tag publish: `.github/workflows/publish.yml`
 8. Respect lock-step versioning across the workspace.
+9. Prepare releases on a branch, merge through a PR, and tag only the exact
+   merged `origin/main` commit.
+
+## Registry Setup
+
+Bijou publishes public packages to npm through GitHub Actions and npm trusted
+publishing. Do not store npm automation tokens in GitHub secrets.
+
+For a new public workspace package, first publish one version manually from the
+package directory so npm has a package record:
+
+```bash
+npm login
+npm publish --access public
+```
+
+Then configure the npm package trusted publisher:
+
+- Organization/user: `flyingrobots`
+- Repository: `bijou`
+- Workflow filename: `publish.yml`
+- GitHub environment: `npm`
+
+The GitHub `npm` environment does not need registry secrets for trusted
+publishing. Keep the package manifest `publishConfig.provenance` setting aligned
+with the publish workflow so npm records provenance for automated releases.
+
+JSR setup from other projects does not apply to Bijou today. If Bijou later
+adds `jsr.json`, JSR package records, and a JSR publish workflow, update this
+runbook and the automation in the same PR.
+
+## Release Law
+
+No public release tag may be created unless all automated and human evidence
+gates below are satisfied. A failed automated gate blocks the release. A human
+review gate blocks the release until the release evidence packet records either
+the required update or an explicit "reviewed, no change" disposition.
+
+### Automated Evidence Gates
+
+The current executable gates are `npm run release:preflight`,
+`npm run release:readiness`, `.github/workflows/release-dry-run.yml`,
+`.github/workflows/tag-guard.yml`, and `.github/workflows/publish.yml`.
+
+The release policy requires these checks, even where the current implementation
+still relies on operator verification:
+
+| Gate | Rule | Current enforcement |
+| --- | --- | --- |
+| `REL-TOOL-NODE` | Node.js is available for metadata and validation commands. | `release:readiness` |
+| `REL-TOOL-NPM` | npm is available for workspace, pack, audit, and registry checks. | `release:readiness`, workflows |
+| `REL-TOOL-GIT` | Git is available for tag, ancestry, and clean-tree checks. | operator, workflows |
+| `REL-TOOL-GH` | GitHub CLI can read the repository before live issue gates run. | operator |
+| `REL-TAG-FORMAT` | Release tags use leading-`v` SemVer with optional `alpha`, `beta`, or `rc` prerelease suffix. | `tag-guard.yml`, `release:preflight` |
+| `REL-GH-ACCESS` | `gh` can read `flyingrobots/bijou` before final issue gates run. | operator |
+| `REL-GH-PRIORITY-HIGH-ZERO` | There are zero open release-blocking issues labeled `priority:high`, unless the evidence packet names the accepted risk and owner. | operator |
+| `REL-GH-TARGET-MILESTONE-ZERO` | The target GitHub milestone exists and has zero open issues or PRs. | operator |
+| `REL-GH-PRIOR-RELEASE-ZERO` | Lower `v*` milestones have zero open issues or PRs. | operator |
+| `REL-META-VERSION-LOCKSTEP` | Every workspace package version and internal Bijou dependency version matches `X.Y.Z`. | `release:preflight` |
+| `REL-GIT-CLEAN` | The worktree is clean before release prep starts, before the release PR is opened, and before final tagging. | operator |
+| `REL-GIT-ORIGIN-MAIN` | The final tag commit is exactly `origin/main`. | operator, workflows |
+| `REL-DOC-CHANGELOG-DATED` | `docs/CHANGELOG.md` has a dated `[X.Y.Z] - YYYY-MM-DD` entry. | operator |
+| `REL-DOC-EVIDENCE` | `docs/releases/X.Y.Z/README.md` records release evidence, review disposition, replay commands, and residual risk. | operator |
+| `REL-DOC-DOGFOOD-I18N` | DOGFOOD markdown and visible strings satisfy supported-locale checks and the i18n debt ratchet. | `release:readiness` |
+| `REL-DOC-INVENTORY` | Documentation inventory is valid after release docs are moved from `next/` to `X.Y.Z/`. | operator |
+| `REL-PACK-DRY-RUN` | Release dry-run workflow verifies packed files and npm publish dry-runs for the automated publish matrix. | `release-dry-run.yml` |
+| `REL-NPM-AUDIT` | Runtime npm dependencies have no high or critical vulnerabilities. | operator |
+
+The stage model is:
+
+| Stage | Caller | Git posture | Issue gates |
+| --- | --- | --- | --- |
+| `operator-preflight` | maintainer before release prep | Clean local `main` exactly matches `origin/main`. | Optional visibility check. |
+| `prep-pr` | release-prep branch | Branch-local validation after version/docs changes; does not require `HEAD == origin/main`. | Report target milestone state in the PR. |
+| `final-local` | maintainer after merge | Local `main` exactly matches `origin/main`; final tag target is fixed. | Enforced live. |
+| `tag-workflow` | tag push workflow | Tag commit must be the release commit on `origin/main`. | Enforced when workflow has GitHub access. |
+| `rerun-workflow` | manual workflow dispatch for an existing tag | Existing tag must remain reachable from `origin/main`. | Skipped for registry recovery; do not move the tag. |
+
+### Human Review Gates
+
+Automation proves structure and repeatability. It does not prove release prose
+is truthful. The release evidence packet must record human review for:
+
+- `docs/CHANGELOG.md` accurately reflects the diff since the previous public
+  tag.
+- `README.md` changed if front-door positioning, install commands, examples, or
+  current release status changed.
+- `ARCHITECTURE.md` changed if ports, adapters, package boundaries, storage,
+  rendering contracts, or runtime posture changed.
+- `docs/VISION.md`, `docs/METHOD.md`, `docs/ROADMAP.md`, and
+  `docs/BEARING.md` match the release posture.
+- `docs/DOGFOOD.md` and DOGFOOD-facing markdown changed if the docs app,
+  release title, navigation model, localization posture, or proof surface
+  changed.
+- Package READMEs, API references, migration docs, design-system docs, and MCP
+  docs changed when their public surfaces changed.
+- Every landed release goalpost contributing to this version is named with its
+  issue, design doc, landed PRs, completed slice count, deterministic proof,
+  canonical fixtures or immutable inputs, witnesses, replay commands, and
+  residual-risk disposition.
+- Any accepted residual risk is named with rationale, owner, and a follow-up
+  issue. Hidden accepted failures are not allowed.
+
+### Deterministic Reproducibility
+
+Evidence is complete only when another operator can replay it from the tag
+commit, committed release packet, and named immutable inputs.
+
+Every release evidence packet must record:
+
+- the exact command, script, workflow, or DOGFOOD route that produced each
+  witness
+- the canonical fixture or immutable input used by that command, when the
+  claim depends on more than repository state at the tag commit
+- the expected stable result, normalized output, digest, or screenshot
+  assertion that replay must reproduce
+- any normalization applied for host-specific noise such as temp paths, clocks,
+  terminal size, color mode, process IDs, registry timestamps, ordering, or
+  environment-specific absolute paths
+
+Place release-specific fixtures under `docs/releases/X.Y.Z/fixtures/` unless an
+existing committed fixture is already canonical. DOGFOOD terminal witnesses
+should record the route, command, terminal dimensions, shell theme or renderer
+mode, and stable assertion. A screenshot or recording is useful, but it is not a
+substitute for the command and immutable input that produced it.
 
 ## Current Release And Publish Surface
 
 ### Latest Shipped Release
 
-The latest shipped release is **`5.0.0`**.
+The latest shipped release is **`7.0.0`**.
 
+- `7.0.0` - DOGFOOD release identity, BlockLab naming, release-facing proof,
+  theme/token work, image-to-glyph tooling, and V7 title-screen polish
 - `5.0.0` - frame-owned hosted runner, Node-host theme selection,
   crash-mode auto-exit, scoped Node I/O symlink hardening, deterministic
   scripted-example smoke, markdown pipe tables, and browsable-list marquee
-- `4.4.1` — framed-shell background-fill fixes, stock shell theme cycling, uppercase quit-confirm input
-- `4.4.0` — data-viz toolkit, zero-alloc framed app render, new bench scenarios
-- `4.3.0` — RE-008 byte-packed surface, RE-015 braille fix, `setRGB` API
-- `4.2.0` — RE-007 framed shell, `@flyingrobots/bijou-mcp`, METHOD migration
-- `4.1.0` — runtime engine through RE-006, DOGFOOD maturation (DF-021
+- `4.4.1` - framed-shell background-fill fixes, stock shell theme cycling,
+  uppercase quit-confirm input
+- `4.4.0` - data-viz toolkit, zero-alloc framed app render, new bench
+  scenarios
+- `4.3.0` - RE-008 byte-packed surface, RE-015 braille fix, `setRGB` API
+- `4.2.0` - RE-007 framed shell, `@flyingrobots/bijou-mcp`, METHOD migration
+- `4.1.0` - runtime engine through RE-006, DOGFOOD maturation (DF-021
   through DF-026, including DF-023, DF-024, WF-003), i18n packages
 
 The release smoke contract is DOGFOOD-centered through
@@ -77,12 +209,12 @@ Long-form release docs live under `docs/releases/<version>/`.
 
 ### Next Release Posture
 
-The next release being prepared is **`6.0.0`**.
+No next public release version is selected in this file.
 
-It is shaped around layout truth and standard blocks: mandatory layout
-envelopes, viewport and chrome formalization, first-party block composition,
-and tooling that can inspect variants and mode lowerings. The active shaping
-lane is [`docs/method/backlog/v6.0.0/`](./method/backlog/v6.0.0/README.md).
+`v6.0.0` and `v7.0.0` are both issue-complete GitHub milestone lanes. The next
+release target should be selected from the live tracker and reflected in
+[`docs/ROADMAP.md`](./ROADMAP.md), [`docs/BEARING.md`](./BEARING.md), and the
+versioned release packet before release prep begins.
 
 ### Lock-step Versioned Units
 
@@ -190,7 +322,21 @@ Allowed tag formats are:
 Stable releases should be the default unless there is a clear reason for
 a prerelease.
 
-### 2. Bump all workspace manifests
+### 2. Create the release-prep branch
+
+Create the branch after the target version is known and before mutating files:
+
+```bash
+git switch -c release/vX.Y.Z
+```
+
+For prereleases:
+
+```bash
+git switch -c release/vX.Y.Z-rc.N
+```
+
+### 3. Bump all workspace manifests
 
 ```bash
 npm run version X.Y.Z
@@ -199,23 +345,24 @@ npm run version X.Y.Z
 This updates all workspace package versions and pins internal dependency
 references to the exact same version.
 
-### 3. Update `CHANGELOG.md`
+### 4. Update `CHANGELOG.md`
 
 - move `[Unreleased]` into a real version header
 - use UTC date format `YYYY-MM-DD`
 - keep the existing changelog style intact
 - do not release with an empty `[Unreleased]` section
 
-### 4. Update `README.md`
+### 5. Update `README.md`
 
 - add or replace `## What's New in vX.Y.Z`
 - keep it concise and user-facing
 - keep a visible link to [`CHANGELOG.md`](./CHANGELOG.md)
 
-### 5. Draft long-form release docs
+### 6. Draft long-form release docs
 
 Before the version is chosen, draft these in `docs/releases/next/`:
 
+- `README.md`
 - `whats-new.md`
 - `migration-guide.md`
 
@@ -223,8 +370,18 @@ When the version is chosen, move that directory to
 `docs/releases/X.Y.Z/` and update any version placeholders inside the
 docs.
 
-For `v6.0.0`, release shaping currently lives under
-`docs/method/backlog/v6.0.0/` until long-form release docs are drafted.
+The versioned `README.md` is the release evidence packet. It must include:
+
+- release summary
+- tracker and goalpost map
+- automated evidence matrix
+- human review matrix
+- deterministic reproducibility record
+- package and registry verification plan
+- residual-risk disposition
+
+Historical releases before this policy may only have `whats-new.md` and
+`migration-guide.md`. Future releases must carry the evidence packet.
 
 ## Phase 3: Local Validation
 
@@ -233,6 +390,8 @@ Run:
 ```bash
 npm run release:preflight
 npm run release:readiness
+npm run docs:inventory
+npm audit --omit=dev --audit-level=high
 ```
 
 `release:readiness` is the repo-native local gauntlet. It currently runs
@@ -243,12 +402,15 @@ these gates in order:
 3. `typecheck:test`
 4. `docs:design-system:preflight`
 5. `dogfood:coverage:gate`
-6. `workflow:shell:preflight`
-7. `release:preflight`
-8. `test:frames`
-9. `smoke:canaries -- --skip-build`
-10. `smoke:dogfood -- --skip-build`
-11. `npm test`
+6. `dogfood:i18n:check`
+7. `dogfood:i18n:debt`
+8. `workflow:shell:preflight`
+9. `release:preflight`
+10. `test:frames`
+11. `verify:interactive-examples`
+12. `smoke:canaries -- --skip-build`
+13. `smoke:dogfood -- --skip-build`
+14. `npm test`
 
 Abort on any failure.
 
@@ -259,8 +421,8 @@ moved the release smoke gate onto the DOGFOOD contract used for
 
 ## Phase 4: CI Dry Run
 
-Before tagging a real release, run the **Release Dry Run** workflow in
-GitHub Actions.
+Before tagging a real release, run the **Release Dry Run** workflow in GitHub
+Actions against the release-prep branch or PR commit.
 
 This is currently the authoritative place where Bijou checks:
 
@@ -271,34 +433,68 @@ This is currently the authoritative place where Bijou checks:
 Until equivalent local tooling exists, treat the dry-run workflow as a
 required release gate for real releases.
 
-## Phase 5: Commit And Tag
+## Phase 5: Commit, Push, And Open The Release PR
 
 After docs and validation are green:
 
 ```bash
 git add -A
 git commit -m "chore(release): vX.Y.Z"
-git tag -a vX.Y.Z -m "release: vX.Y.Z"
+git push -u origin release/vX.Y.Z
 ```
 
 For prereleases:
 
 ```bash
 git commit -m "chore(release): vX.Y.Z-rc.N"
+git push -u origin release/vX.Y.Z-rc.N
+```
+
+Open a normal PR to `main`. Do not open a draft PR. The PR body must link the
+release evidence packet, target milestone, changelog entry, release dry-run,
+and validation commands.
+
+Merge the release PR only after review and green CI. Do not tag the branch
+commit before it is merged.
+
+## Phase 6: Final Main Preflight And Tag
+
+After the release PR is merged, fast-forward local `main` to the exact release
+commit:
+
+```bash
+git fetch origin main --tags --prune
+git switch main
+git merge --ff-only origin/main
+git status --porcelain=v1
+npm run release:preflight
+npm run docs:inventory
+```
+
+Abort if the worktree is dirty or local `main` does not exactly match
+`origin/main`.
+
+Create the tag from that exact commit:
+
+```bash
+git tag -a vX.Y.Z -m "release: vX.Y.Z"
+```
+
+For prereleases:
+
+```bash
 git tag -a vX.Y.Z-rc.N -m "release: vX.Y.Z-rc.N"
 ```
 
 Bijou currently enforces tag **format** through
-[tag-guard.yml](../.github/workflows/tag-guard.yml), not signed tags.
-Do not pretend signed-tag policy exists unless the automation is updated
-to require it.
+[tag-guard.yml](../.github/workflows/tag-guard.yml), not signed tags. Do not
+pretend signed-tag policy exists unless the automation is updated to require it.
 
-## Phase 6: Push And Let Automation Publish
+## Phase 7: Push The Tag And Let Automation Publish
 
-Push in two steps:
+Push only the tag:
 
 ```bash
-git push origin main
 git push origin vX.Y.Z
 ```
 
@@ -318,7 +514,7 @@ just to recover from workflow drift.
 Do not manually create a GitHub Release unless the automation fails and
 the process is being explicitly repaired.
 
-## Phase 7: Verify The Result
+## Phase 8: Verify The Result
 
 Do not stop at "workflow started."
 
@@ -354,13 +550,21 @@ npm view @flyingrobots/bijou-mcp version dist-tags --json
 
 Abort immediately if any of these are true:
 
-- dirty worktree
-- not on `main`
-- `main` not exactly synced to `origin/main`
+- release prep starts from a dirty worktree
+- release prep starts from a branch other than `main`
+- final tag prep is not on `main`
+- final tag prep is not exactly synced to `origin/main`
 - version bump not reflected cleanly across the workspace
 - `CHANGELOG.md` still has no real release section
+- `docs/releases/X.Y.Z/README.md` release evidence packet is missing
+- target GitHub milestone does not exist
+- target GitHub milestone has open issues or PRs
+- lower `v*` GitHub milestones have open issues or PRs
+- open `priority:high` issues lack an explicit release-risk disposition
 - `release:preflight` fails
 - `release:readiness` fails
+- `docs:inventory` fails
+- `npm audit --omit=dev --audit-level=high` fails
 - release dry-run fails
 - tag push fails
 - publish workflow fails
@@ -368,11 +572,17 @@ Abort immediately if any of these are true:
 
 ## Known Current Gaps
 
-- clean-worktree is an operator preflight check, not a
-  `release:readiness` concern, because Phase 2 intentionally dirties the
-  worktree
-- branch-sync, latest-tag, and tag-collision checks are documented
-  here, but they do not yet have a dedicated repo-native script
+- Bijou does not yet have a stage-aware `release:prep` or `release:guard`
+  script. The policy names those gates, but `release:preflight` and
+  `release:readiness` are the current repo-native commands.
+- clean-worktree is an operator preflight check, not a `release:readiness`
+  concern, because Phase 2 intentionally dirties the worktree
+- branch-sync, latest-tag, tag-collision, live GitHub issue gates, changelog
+  dating, release evidence shape, and human review disposition are documented
+  here, but they do not yet have a single dedicated repo-native guard
+- `docs:inventory` and runtime `npm audit` are release policy gates but are not
+  currently part of `release:readiness`
+- JSR publishing is not currently part of Bijou's release surface
 - signed tags are not currently a repo policy
 
 If any of those policies change, update this doc and the automation

--- a/docs/release.md
+++ b/docs/release.md
@@ -472,12 +472,15 @@ git fetch origin main --tags --prune
 git switch main
 git merge --ff-only origin/main
 git status --porcelain=v1
+git rev-parse HEAD origin/main
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
 npm run release:preflight
 npm run docs:inventory
 ```
 
-Abort if the worktree is dirty or local `main` does not exactly match
-`origin/main`.
+Abort if the worktree is dirty, if the two printed SHAs differ, or if the
+`test` command fails. Local `main` must exactly match `origin/main`; being ahead
+of `origin/main` is also release-blocking.
 
 Create the tag from that exact commit:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -69,8 +69,13 @@ package directory so npm has a package record:
 
 ```bash
 npm login
-npm publish --access public
+NPM_CONFIG_PROVENANCE=false npm publish --access public
 ```
+
+The seed publish is deliberately non-provenance because it runs outside the
+trusted GitHub Actions OIDC environment. After the trusted publisher is
+configured, automated releases should publish with provenance through
+`publish.yml`.
 
 Then configure the npm package trusted publisher:
 


### PR DESCRIPTION
## Summary

- Adapt Bijou's release guide to the stricter release-runbook pattern while keeping it npm-only and aligned to existing repo tooling.
- Add trusted npm publishing setup, release law, automated evidence gates, human review gates, deterministic reproducibility rules, and explicit known automation gaps.
- Change the release flow to branch-first release prep, normal PR review, final preflight from exact `origin/main`, then tag-only publish.
- Update release posture from stale `5.0.0` / `6.0.0` text to the current `7.0.0` package/tag state and repair changelog compare links.

## Linked Work

Refs #270

## Validation

- `npm run docs:inventory`
- `git diff --check`
- `npm run release:preflight`
- `npm run lint`
- pre-push hook:
  - `npm run dogfood:i18n:complete`
  - `npm run dogfood:i18n:check`
  - `npm run dogfood:i18n:debt`
  - `npm run typecheck:test`
  - `npm test`
  - `npm run verify:interactive-examples -- --skip-build --mode=interactive-scripted`

## Self-Review

- Worktree was clean before review and `git fetch origin --prune` completed.
- Reviewed `git diff origin/main...HEAD` for copied foreign assumptions, stale release posture, branch/tag flow contradictions, and Markdown hygiene.
- Fixed one discovered issue before opening: `docs/CHANGELOG.md` had a stale `[Unreleased]` compare link pointing at `v5.0.0`; it now points at `v7.0.0` and includes a `7.0.0` compare link.
- No remaining self-review findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded release runbook into a repo-native source of truth: clearer phased workflow, preflight/readiness gates, evidence-packet requirements, and post-publish verification.
  * Clarified npm-only publishing scope and updated publish/operator rules.
  * Updated "Latest Shipped Release" to 7.0.0 and refreshed changelog compare links.
  * Added abort conditions, known gaps, and enhanced CI/PR checklist guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->