### PR TITLE
Start DX-044 GraphQL IR interop

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧭 Planning
 
+- **GraphQL-authored Bijou block IR proof** —
+  `docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md` now defines the
+  first implementation slice after the portable `ui-scene-ir/1` runtime seed:
+  constrained GraphQL SDL authoring into a `bijou-block/1` artifact, lowering
+  into `ui-scene-ir/1`, terminal `Surface` proof, deterministic receipts, and
+  source-map facts. This advances issue #302.
 - **Fluid triangle title-screen direction** —
   `docs/design/DF-074-fluid-triangle-title-screen.md` now records a future
   DOGFOOD title-screen concept inspired by ASCII fluid rendering: a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   rendered full-cell surface hashes back to `ui-scene-receipt/1`, lower modes
   for node, i18n, and token inspection, and fail-loud target requirement
   checks. This starts issue #302.
+- **GraphQL-authored Bijou block artifact proof** — `@flyingrobots/bijou` now
+  exports `compileGraphqlBijouBlock()` and `lowerBijouBlockToUiScene()` for the
+  first constrained GraphQL SDL authoring slice. The compiler emits a stable
+  `bijou-block/1` artifact with semantic source anchors, i18n fallbacks, token
+  refs, action commands, target-profile facts, and a whitespace-stable source
+  hash, then lowers the artifact into `ui-scene-ir/1` for terminal proof and
+  receipt generation. This advances issue #302.
 - **Theme token builder API slices** — `@flyingrobots/bijou` now exports the
   first runtime slices for the DL-013 design token builder: `defineTheme()`
   creates immutable theme definitions with required dark/light token maps,

--- a/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
+++ b/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
@@ -156,7 +156,7 @@ not the same thing as a final `Surface`.
 - token references
 - action ids, commands, keybindings, and targets
 - binding facts when present
-- source-map facts from SDL lines to IR nodes
+- source-map facts from SDL field anchors to IR nodes
 - target profile facts
 
 If the source asks for unsupported target facts, the compiler must fail before
@@ -164,10 +164,12 @@ lowering.
 
 ## Source Map Posture
 
-Source strings should be stable and local to the input:
+Source strings should be stable and local to the input. The first slice uses
+semantic anchors instead of line and column positions so formatting-only SDL
+edits do not change the artifact or scene hash:
 
 ```text
-release-title.graphql:7:3
+release-title.graphql#type.ReleaseTitle.field.heading
 ```
 
 Absolute paths are not allowed in emitted artifacts. The caller may provide a

--- a/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
+++ b/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
@@ -1,0 +1,245 @@
+---
+title: DX-044 GraphQL Authored Bijou Block IR Proof
+legend: DX
+lane: cool-ideas
+priority: medium
+github_issue: 302
+status: active
+keywords:
+  - developer-experience
+  - graphql
+  - blocks
+  - ir
+  - geordi
+  - dogfood
+  - render-everywhere
+---
+
+# DX-044 GraphQL Authored Bijou Block IR Proof
+
+Legend: [DX - Developer Experience](../legends/DX-developer-experience.md)
+
+## Linked Work
+
+- GitHub issue: [#302](https://github.com/flyingrobots/bijou/issues/302)
+- Runtime seed: [DX-042 Shared UI Scene IR And Bijou Render Target](./DX-042-shared-ui-scene-ir-and-bijou-render-target.md)
+- Portable endpoint direction: [DX-043 Portable Bijou Blocks And Multi-Endpoint IR](./DX-043-portable-bijou-blocks-and-multi-endpoint-ir.md)
+- Prior block contract: [DX-031 Standard Bijou Blocks](./DX-031-standard-bijou-blocks.md)
+
+This cycle is the first implementation proof after the `ui-scene-ir/1`
+runtime seed. It should not try to make every Bijou block GraphQL-authored.
+It should prove one boring, deterministic vertical slice that future Wesley and
+Geordi work can replace or extend without changing the proof contract.
+
+## Decision Summary
+
+Bijou should treat GraphQL SDL as an authoring surface for portable block
+semantics, not as a runtime data store and not as a visual scene graph.
+
+The first flow is:
+
+```text
+GraphQL SDL fixture
+  -> bijou-block/1 artifact
+    -> ui-scene-ir/1
+      -> Bijou terminal Surface proof
+        -> ui-scene-receipt/1
+```
+
+The first slice stays inside Bijou. Geordi remains a named endpoint target, but
+this cycle does not require Geordi repository changes unless the Bijou proof
+needs a companion endpoint fixture.
+
+## Sponsored Human
+
+A Bijou author wants to define a small UI block in a declarative source format
+and get a deterministic block artifact, scene IR, terminal output, source map,
+and receipt without hand-maintaining parallel JSON fixtures.
+
+## Sponsored Agent
+
+An agent wants to inspect the GraphQL source, generated block artifact,
+`ui-scene-ir/1`, terminal cell source map, and receipt hashes to understand
+exactly which source field produced each visible terminal fact.
+
+## Hill
+
+Given a constrained GraphQL SDL file for one text-first Bijou block, Bijou can
+produce a stable `bijou-block/1` artifact, lower it into `ui-scene-ir/1`, render
+it to a terminal `Surface`, and emit a receipt whose source maps, tokens, i18n
+keys, actions, bindings, and hashes are deterministic.
+
+## Scope
+
+- A constrained SDL reader for one block type.
+- Directive-like metadata for block identity, target profile, slots, commands,
+  bindings, theme tokens, localization keys, and source positions.
+- A public `bijou-block/1` artifact type.
+- A compiler function from SDL source to block artifact.
+- A lowering function from block artifact to `ui-scene-ir/1`.
+- Tests proving whitespace-stable source hashing, artifact stability, IR
+  validation, terminal lowering, source maps, and receipts.
+
+## Non-Goals
+
+- No full GraphQL parser dependency in the first slice.
+- No Wesley code generation in the first slice.
+- No Geordi endpoint implementation in the first slice.
+- No arbitrary GraphQL schema execution.
+- No nested field resolver runtime.
+- No visual layout engine beyond explicit first-slice layout facts.
+- No DOGFOOD-wide migration.
+
+## First SDL Shape
+
+The first SDL subset is intentionally explicit:
+
+```graphql
+type ReleaseTitle
+  @bijouBlock(id: "release.title", component: "ReleaseTitleBlock")
+  @bijouTarget(kind: "bijou-terminal", cols: 40, rows: 5) {
+  heading: String!
+    @bijouText(id: "heading", x: 2, y: 1)
+    @bijouI18n(key: "release.title.heading", fallback: "Bijou")
+    @bijouToken(fg: "semantic.title.fg")
+
+  openNotes: String
+    @bijouAction(id: "release.openNotes", command: "release.openNotes", key: "Enter")
+    @bijouText(id: "open-notes", x: 2, y: 3)
+    @bijouI18n(key: "release.title.openNotes", fallback: "Open release notes")
+    @bijouToken(fg: "semantic.action.fg", bg: "semantic.action.bg")
+}
+```
+
+The subset allows only:
+
+- one `type`
+- type directives on the same type declaration
+- scalar fields
+- field directives on following indented lines
+- string and integer directive arguments
+
+That is small enough to parse deterministically without pretending to be a
+general GraphQL compiler.
+
+## Artifact Contract
+
+The first generated artifact is:
+
+```text
+bijou-block/1
+  id
+  component
+  sourceHash
+  fields[]
+    fieldName
+    nodeId
+    text
+    action
+    binding
+    token refs
+    source
+  targetProfiles[]
+```
+
+`bijou-block/1` is semantic. It is not the same thing as Geordi IR and it is
+not the same thing as a final `Surface`.
+
+## Lowering Contract
+
+`bijou-block/1 -> ui-scene-ir/1` must preserve:
+
+- source hash
+- node ids
+- component ids
+- i18n keys and fallbacks
+- token references
+- action ids, commands, keybindings, and targets
+- binding facts when present
+- source-map facts from SDL lines to IR nodes
+- target profile facts
+
+If the source asks for unsupported target facts, the compiler must fail before
+lowering.
+
+## Source Map Posture
+
+Source strings should be stable and local to the input:
+
+```text
+release-title.graphql:7:3
+```
+
+Absolute paths are not allowed in emitted artifacts. The caller may provide a
+`sourceName` option, but the default should be a neutral `inline.graphql`.
+
+## Agent Inspectability
+
+The useful debug path should be:
+
+```text
+SDL field -> bijou-block/1 field -> ui-scene-ir/1 node -> Surface cell -> receipt
+```
+
+An agent should not need a screenshot to answer:
+
+- Which SDL field produced this node?
+- Which node produced this terminal cell?
+- Which i18n key and token refs were used?
+- Which action or binding belongs to the rendered text?
+- Which hash proves the scene and terminal output?
+
+## Accessibility And Localization Posture
+
+This first slice preserves localization keys and fallbacks but does not add new
+runtime translation behavior. The source author must provide fallback text for
+renderable text nodes. Directionality is deferred until multiline text and
+localized layout constraints exist in the IR.
+
+## Geordi Posture
+
+Geordi is the likely next endpoint after this Bijou-only proof. The first
+Geordi-facing shape should be a receipt-compatible endpoint facet, not a
+semantic replacement for `bijou-block/1`.
+
+Expected later flow:
+
+```text
+bijou-block/1
+  -> ui-scene-ir/1
+    -> Geordi endpoint profile
+      -> browser/image/packed-cell witness
+```
+
+## Implementation Outline
+
+1. Add this design doc and issue update.
+2. Add `bijou-block/1` artifact types.
+3. Add a deterministic constrained SDL compiler.
+4. Add block-artifact to `ui-scene-ir/1` lowering.
+5. Add public exports.
+6. Add a focused fixture test that renders one GraphQL-authored block into a
+   terminal proof.
+7. Update changelog and issue/PR proof.
+
+## Tests To Write First
+
+- RED: a whitespace-variant SDL input should produce the same block hash and
+  scene hash.
+- RED: missing `@bijouBlock` should fail with a deterministic error.
+- RED: a text field with i18n/token/action directives should become one IR
+  text node with matching source-map facts.
+- GREEN: terminal proof should render fallback text and include SHA-256 scene,
+  layout, and surface hashes.
+
+## Closeout
+
+The cycle is landed when:
+
+- the design doc exists and links #302
+- #302 has a cycle comment pointing at the branch and PR
+- `@flyingrobots/bijou` exports the first block authoring APIs
+- the focused GraphQL-authored block proof is green
+- `npm run lint`, `npm run typecheck:test`, `npm run docs:inventory`, and the
+  relevant focused tests are green
+- the PR names #302 and explains what remains for Wesley and Geordi

--- a/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
+++ b/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
@@ -69,6 +69,35 @@ produce a stable `bijou-block/1` artifact, lower it into `ui-scene-ir/1`, render
 it to a terminal `Surface`, and emit a receipt whose source maps, tokens, i18n
 keys, actions, bindings, and hashes are deterministic.
 
+## Playback Questions
+
+This design is successful only if the committed proof lets a maintainer or
+agent answer the following questions from repository facts:
+
+- Can a reader trace one SDL field through `bijou-block/1`, `ui-scene-ir/1`,
+  terminal cells, and receipt dependencies?
+- Can whitespace-only SDL edits preserve the block artifact hash and scene
+  hash?
+- Can unsupported or duplicate identities fail before terminal lowering
+  produces a misleading witness?
+- Can an agent inspect source-map, token, i18n, action, and binding facts
+  without scraping a screenshot?
+
+## Linked Invariants
+
+- [Schemas Live At Boundaries](../invariants/schemas-live-at-boundaries.md):
+  the SDL reader rejects unsupported or malformed authoring input before the
+  runtime treats the block artifact as trusted.
+- [Graceful Lowering Preserves Meaning](../invariants/graceful-lowering-preserves-meaning.md):
+  `bijou-block/1` preserves semantic text, token, i18n, action, binding, and
+  source-map meaning when it lowers to terminal cells.
+- [The Buffer Holds Facts](../invariants/buffer-holds-facts.md): generated
+  artifacts, receipts, and source maps remain inspectable fact records instead
+  of executable behavior.
+- [Tests Are the Spec](../invariants/tests-are-the-spec.md): the first slice is
+  complete only when focused tests prove the hash, validation, lowering, and
+  receipt contract.
+
 ## Scope
 
 - A constrained SDL reader for one block type.
@@ -114,13 +143,37 @@ type ReleaseTitle
 The subset allows only:
 
 - one `type`
-- type directives on the same type declaration
+- type directives on the type declaration or following indented lines before
+  `{`
 - scalar fields
 - field directives on following indented lines
 - string and integer directive arguments
 
 That is small enough to parse deterministically without pretending to be a
 general GraphQL compiler.
+
+## Binding Directive Shape
+
+Bindings use field directives because they attach authoring source to one
+renderable field:
+
+```graphql
+status: String
+  @bijouText(id: "status", x: 2, y: 3)
+  @bijouBind(
+    id: "release.status.value",
+    kind: "state",
+    path: "release.status",
+    targetProperty: "text",
+    when: "release.visible"
+  )
+```
+
+The first slice treats binding directives as fact records, not live dataflow.
+`kind` is intentionally constrained to source categories such as `state`,
+`query`, and `computed`. `path` identifies the external source fact.
+`targetProperty` defaults to `text` when omitted. `when` is optional and records
+the gating condition that a later runtime or endpoint may evaluate.
 
 ## Artifact Contract
 

--- a/packages/bijou/src/core/graphql-bijou-block.test.ts
+++ b/packages/bijou/src/core/graphql-bijou-block.test.ts
@@ -166,6 +166,51 @@ describe('GraphQL-authored Bijou block artifacts', () => {
       }
     `)).toThrow('GraphQL Bijou block source must include @bijouBlock(id:, component:).');
   });
+
+  it('rejects duplicate scene identities before lowering', () => {
+    expect(() => compileGraphqlBijouBlock(`
+      type DuplicateNode
+        @bijouBlock(id: "duplicate.node", component: "DuplicateNodeBlock")
+        @bijouTarget(kind: "bijou-terminal", cols: 20, rows: 4) {
+        one: String
+          @bijouText(id: "same-node", x: 0, y: 0)
+          @bijouI18n(key: "one", fallback: "One")
+        two: String
+          @bijouText(id: "same-node", x: 0, y: 1)
+          @bijouI18n(key: "two", fallback: "Two")
+      }
+    `)).toThrow('Duplicate GraphQL Bijou block node id: same-node');
+
+    expect(() => compileGraphqlBijouBlock(`
+      type DuplicateAction
+        @bijouBlock(id: "duplicate.action", component: "DuplicateActionBlock")
+        @bijouTarget(kind: "bijou-terminal", cols: 20, rows: 4) {
+        one: String
+          @bijouText(id: "one", x: 0, y: 0)
+          @bijouI18n(key: "one", fallback: "One")
+          @bijouAction(id: "same.action", command: "one")
+        two: String
+          @bijouText(id: "two", x: 0, y: 1)
+          @bijouI18n(key: "two", fallback: "Two")
+          @bijouAction(id: "same.action", command: "two")
+      }
+    `)).toThrow('Duplicate GraphQL Bijou block action id: same.action');
+
+    expect(() => compileGraphqlBijouBlock(`
+      type DuplicateBinding
+        @bijouBlock(id: "duplicate.binding", component: "DuplicateBindingBlock")
+        @bijouTarget(kind: "bijou-terminal", cols: 20, rows: 4) {
+        one: String
+          @bijouText(id: "one", x: 0, y: 0)
+          @bijouI18n(key: "one", fallback: "One")
+          @bijouBind(id: "same.binding", kind: "state", path: "one")
+        two: String
+          @bijouText(id: "two", x: 0, y: 1)
+          @bijouI18n(key: "two", fallback: "Two")
+          @bijouBind(id: "same.binding", kind: "state", path: "two")
+      }
+    `)).toThrow('Duplicate GraphQL Bijou block binding id: same.binding');
+  });
 });
 
 function rowText(surface: { get(x: number, y: number): { char: string; empty?: boolean }; width: number }, y: number): string {

--- a/packages/bijou/src/core/graphql-bijou-block.test.ts
+++ b/packages/bijou/src/core/graphql-bijou-block.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compileGraphqlBijouBlock,
+  lowerBijouBlockToUiScene,
+} from './graphql-bijou-block.js';
+import {
+  hashUiSceneValue,
+  lowerUiSceneToTerminalProof,
+  validateUiSceneIr,
+  type UiSceneIr,
+} from './ui-scene-ir.js';
+
+const releaseTitleSdl = `
+type ReleaseTitle
+  @bijouBlock(id: "release.title", component: "ReleaseTitleBlock")
+  @bijouTarget(kind: "bijou-terminal", cols: 40, rows: 5) {
+  heading: String!
+    @bijouText(id: "heading", x: 2, y: 1)
+    @bijouI18n(key: "release.title.heading", fallback: "Bijou")
+    @bijouToken(fg: "semantic.title.fg")
+
+  openNotes: String
+    @bijouAction(id: "release.openNotes", command: "release.openNotes", key: "Enter")
+    @bijouText(id: "open-notes", x: 2, y: 3)
+    @bijouI18n(key: "release.title.openNotes", fallback: "Open release notes")
+    @bijouToken(fg: "semantic.action.fg", bg: "semantic.action.bg")
+}
+`;
+
+const releaseTitleSdlWithDifferentWhitespace = `
+type   ReleaseTitle
+  @bijouBlock( id: "release.title", component: "ReleaseTitleBlock" )
+  @bijouTarget( kind: "bijou-terminal", cols: 40, rows: 5 ) {
+  heading:    String!
+    @bijouText( id: "heading", x: 2, y: 1 )
+    @bijouI18n( key: "release.title.heading", fallback: "Bijou" )
+    @bijouToken( fg: "semantic.title.fg" )
+
+  openNotes: String
+    @bijouAction( id: "release.openNotes", command: "release.openNotes", key: "Enter" )
+    @bijouText( id: "open-notes", x: 2, y: 3 )
+    @bijouI18n( key: "release.title.openNotes", fallback: "Open release notes" )
+    @bijouToken( fg: "semantic.action.fg", bg: "semantic.action.bg" )
+}
+`;
+
+describe('GraphQL-authored Bijou block artifacts', () => {
+  it('compiles constrained GraphQL SDL into a terminal scene proof', () => {
+    const artifact = compileGraphqlBijouBlock(releaseTitleSdl, {
+      sourceName: 'release-title.graphql',
+    });
+
+    expect(artifact).toMatchObject({
+      artifactVersion: 'bijou-block/1',
+      id: 'release.title',
+      component: 'ReleaseTitleBlock',
+      rootNodeId: 'release.title.root',
+      sourceHash: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      fields: [
+        {
+          fieldName: 'heading',
+          nodeId: 'heading',
+          source: 'release-title.graphql#type.ReleaseTitle.field.heading',
+          text: { kind: 'i18n', key: 'release.title.heading', fallback: 'Bijou' },
+          style: { fg: { token: 'semantic.title.fg' } },
+        },
+        {
+          fieldName: 'openNotes',
+          nodeId: 'open-notes',
+          action: {
+            id: 'release.openNotes',
+            command: 'release.openNotes',
+            keybindings: ['Enter'],
+          },
+          source: 'release-title.graphql#type.ReleaseTitle.field.openNotes',
+          text: {
+            kind: 'i18n',
+            key: 'release.title.openNotes',
+            fallback: 'Open release notes',
+          },
+          style: {
+            fg: { token: 'semantic.action.fg' },
+            bg: { token: 'semantic.action.bg' },
+          },
+        },
+      ],
+      targetProfiles: [{ kind: 'bijou-terminal', cols: 40, rows: 5 }],
+    });
+
+    const scene = lowerBijouBlockToUiScene(artifact);
+    expect(validateUiSceneIr(scene)).toEqual({ ok: true, issues: [] });
+    expect(scene).toMatchObject<Partial<UiSceneIr>>({
+      irVersion: 'ui-scene-ir/1',
+      id: 'release.title',
+      sourceHash: artifact.sourceHash,
+      rootNodeId: 'release.title.root',
+      portability: { level: 'portable' },
+    });
+    expect(scene.nodes.map((node) => node.id)).toEqual([
+      'release.title.root',
+      'heading',
+      'open-notes',
+    ]);
+    expect(scene.actions).toEqual([
+      {
+        id: 'release.openNotes',
+        command: 'release.openNotes',
+        keybindings: ['Enter'],
+        label: {
+          kind: 'i18n',
+          key: 'release.title.openNotes',
+          fallback: 'Open release notes',
+        },
+        targetNodeId: 'open-notes',
+      },
+    ]);
+
+    const proof = lowerUiSceneToTerminalProof(scene, {
+      tokenColors: {
+        'semantic.action.bg': '#1f2937',
+        'semantic.action.fg': '#f9fafb',
+        'semantic.title.fg': '#f7d774',
+      },
+    });
+
+    expect(rowText(proof.lowering.surface, 1)).toContain('Bijou');
+    expect(rowText(proof.lowering.surface, 3)).toContain('Open release notes');
+    expect(proof.lowering.cellSourceMap.find((entry) => entry.nodeId === 'open-notes')).toMatchObject({
+      nodeId: 'open-notes',
+      source: 'release-title.graphql#type.ReleaseTitle.field.openNotes',
+      textKey: 'release.title.openNotes',
+      fgToken: 'semantic.action.fg',
+      bgToken: 'semantic.action.bg',
+    });
+    expect(proof.receipt.sceneHash).toBe(hashUiSceneValue(scene));
+    expect(proof.receipt.i18nKeys).toEqual([
+      'release.title.heading',
+      'release.title.openNotes',
+    ]);
+    expect(proof.receipt.tokenRefs).toEqual([
+      'semantic.action.bg',
+      'semantic.action.fg',
+      'semantic.title.fg',
+    ]);
+  });
+
+  it('keeps semantic artifact and scene hashes stable across whitespace-only SDL variants', () => {
+    const one = compileGraphqlBijouBlock(releaseTitleSdl, {
+      sourceName: 'release-title.graphql',
+    });
+    const two = compileGraphqlBijouBlock(releaseTitleSdlWithDifferentWhitespace, {
+      sourceName: 'release-title.graphql',
+    });
+
+    expect(one.sourceHash).toBe(two.sourceHash);
+    expect(hashUiSceneValue(one)).toBe(hashUiSceneValue(two));
+    expect(hashUiSceneValue(lowerBijouBlockToUiScene(one))).toBe(hashUiSceneValue(lowerBijouBlockToUiScene(two)));
+  });
+
+  it('fails loudly when the SDL omits the block directive', () => {
+    expect(() => compileGraphqlBijouBlock(`
+      type MissingBlock {
+        heading: String
+          @bijouText(id: "heading", x: 0, y: 0)
+          @bijouI18n(key: "heading", fallback: "Heading")
+      }
+    `)).toThrow('GraphQL Bijou block source must include @bijouBlock(id:, component:).');
+  });
+});
+
+function rowText(surface: { get(x: number, y: number): { char: string; empty?: boolean }; width: number }, y: number): string {
+  let text = '';
+  for (let x = 0; x < surface.width; x++) {
+    const cell = surface.get(x, y);
+    text += cell.empty ? ' ' : cell.char;
+  }
+  return text.trimEnd();
+}

--- a/packages/bijou/src/core/graphql-bijou-block.test.ts
+++ b/packages/bijou/src/core/graphql-bijou-block.test.ts
@@ -188,10 +188,11 @@ describe('GraphQL-authored Bijou block artifacts', () => {
   });
 
   it('rejects absolute and UNC source names', () => {
+    const backslash = String.fromCharCode(92);
     for (const sourceName of [
       '/tmp/release-title.graphql',
-      'C:\\tmp\\release-title.graphql',
-      '\\\\server\\share\\release-title.graphql',
+      `C:${backslash}tmp${backslash}release-title.graphql`,
+      `${backslash}${backslash}server${backslash}share${backslash}release-title.graphql`,
       '//server/share/release-title.graphql',
     ]) {
       expect(() => compileGraphqlBijouBlock(releaseTitleSdl, { sourceName }))

--- a/packages/bijou/src/core/graphql-bijou-block.test.ts
+++ b/packages/bijou/src/core/graphql-bijou-block.test.ts
@@ -157,6 +157,26 @@ describe('GraphQL-authored Bijou block artifacts', () => {
     expect(hashUiSceneValue(lowerBijouBlockToUiScene(one))).toBe(hashUiSceneValue(lowerBijouBlockToUiScene(two)));
   });
 
+  it('parses quoted directive arguments containing closing parentheses', () => {
+    const artifact = compileGraphqlBijouBlock(`
+      type ParenText
+        @bijouBlock(id: "paren.text", component: "ParenTextBlock")
+        @bijouTarget(kind: "bijou-terminal", cols: 30, rows: 3) {
+        heading: String
+          @bijouText(id: "heading", x: 0, y: 0)
+          @bijouI18n(key: "heading", fallback: "Open (beta)")
+      }
+    `);
+
+    expect(artifact.fields[0]?.text).toEqual({
+      kind: 'i18n',
+      key: 'heading',
+      fallback: 'Open (beta)',
+    });
+    expect(rowText(lowerUiSceneToTerminalProof(lowerBijouBlockToUiScene(artifact)).lowering.surface, 0))
+      .toContain('Open (beta)');
+  });
+
   it('fails loudly when the SDL omits the block directive', () => {
     expect(() => compileGraphqlBijouBlock(`
       type MissingBlock {
@@ -165,6 +185,18 @@ describe('GraphQL-authored Bijou block artifacts', () => {
           @bijouI18n(key: "heading", fallback: "Heading")
       }
     `)).toThrow('GraphQL Bijou block source must include @bijouBlock(id:, component:).');
+  });
+
+  it('rejects absolute and UNC source names', () => {
+    for (const sourceName of [
+      '/tmp/release-title.graphql',
+      'C:\\tmp\\release-title.graphql',
+      '\\\\server\\share\\release-title.graphql',
+      '//server/share/release-title.graphql',
+    ]) {
+      expect(() => compileGraphqlBijouBlock(releaseTitleSdl, { sourceName }))
+        .toThrow('GraphQL Bijou block sourceName must be a relative or logical name.');
+    }
   });
 
   it('rejects duplicate scene identities before lowering', () => {
@@ -210,6 +242,22 @@ describe('GraphQL-authored Bijou block artifacts', () => {
           @bijouBind(id: "same.binding", kind: "state", path: "two")
       }
     `)).toThrow('Duplicate GraphQL Bijou block binding id: same.binding');
+
+    const validArtifact = compileGraphqlBijouBlock(releaseTitleSdl, {
+      sourceName: 'release-title.graphql',
+    });
+    const invalidArtifact = {
+      ...validArtifact,
+      fields: [
+        ...validArtifact.fields,
+        {
+          ...validArtifact.fields[0]!,
+          fieldName: 'duplicateHeading',
+        },
+      ],
+    };
+    expect(() => lowerBijouBlockToUiScene(invalidArtifact))
+      .toThrow('Duplicate GraphQL Bijou block node id: heading');
   });
 });
 

--- a/packages/bijou/src/core/graphql-bijou-block.ts
+++ b/packages/bijou/src/core/graphql-bijou-block.ts
@@ -108,13 +108,15 @@ export function compileGraphqlBijouBlock(
 
   const targetProfiles = targetProfilesFor(parsed.typeDirectives);
   const fields = parsed.fields.map((field) => bijouBlockFieldFor(field, parsed.typeName, sourceName));
+  const rootNodeId = `${blockId}.root`;
+  assertUniqueBlockIdentities(fields, rootNodeId);
   const artifactBody = {
     artifactVersion: BIJOU_BLOCK_ARTIFACT_VERSION,
     id: blockId,
     component,
     sourceTypeName: parsed.typeName,
     sourceName,
-    rootNodeId: `${blockId}.root`,
+    rootNodeId,
     fields,
     targetProfiles,
   } satisfies Omit<BijouBlockArtifact, 'sourceHash'>;
@@ -495,6 +497,35 @@ function appendI18nUse(i18nUses: UiI18nUse[], id: string, text: UiTextRef, kind:
   i18nUses.push(kind === 'node'
     ? { nodeId: id, key: text.key }
     : { actionId: id, key: text.key });
+}
+
+function assertUniqueBlockIdentities(fields: readonly BijouBlockField[], rootNodeId: string): void {
+  assertUniqueValues(
+    fields.map((field) => field.fieldName),
+    'field name',
+  );
+  assertUniqueValues(
+    [rootNodeId, ...fields.map((field) => field.nodeId)],
+    'node id',
+  );
+  assertUniqueValues(
+    fields.flatMap((field) => field.action == null ? [] : [field.action.id]),
+    'action id',
+  );
+  assertUniqueValues(
+    fields.flatMap((field) => field.binding == null ? [] : [field.binding.id]),
+    'binding id',
+  );
+}
+
+function assertUniqueValues(values: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new Error(`Duplicate GraphQL Bijou block ${label}: ${value}`);
+    }
+    seen.add(value);
+  }
 }
 
 function normalizeSourceName(sourceName: string): string {

--- a/packages/bijou/src/core/graphql-bijou-block.ts
+++ b/packages/bijou/src/core/graphql-bijou-block.ts
@@ -1,0 +1,533 @@
+import {
+  UI_SCENE_IR_VERSION,
+  hashUiSceneValue,
+  type UiAction,
+  type UiBinding,
+  type UiI18nUse,
+  type UiLayoutIntent,
+  type UiNode,
+  type UiSceneIr,
+  type UiSourceMapEntry,
+  type UiStyleRef,
+  type UiTargetProfile,
+  type UiTextRef,
+  type UiTokenUse,
+} from './ui-scene-ir.js';
+
+export const BIJOU_BLOCK_ARTIFACT_VERSION = 'bijou-block/1' as const;
+export type BijouBlockArtifactVersion = typeof BIJOU_BLOCK_ARTIFACT_VERSION;
+
+export interface CompileGraphqlBijouBlockOptions {
+  readonly sourceName?: string;
+}
+
+export interface BijouBlockFieldAction {
+  readonly id: string;
+  readonly command: string;
+  readonly keybindings: readonly string[];
+}
+
+export interface BijouBlockFieldBinding {
+  readonly id: string;
+  readonly targetProperty: string;
+  readonly source: {
+    readonly kind: 'state' | 'query' | 'computed';
+    readonly path: string;
+  };
+  readonly when?: string;
+}
+
+export interface BijouBlockField {
+  readonly fieldName: string;
+  readonly nodeId: string;
+  readonly graphqlType: string;
+  readonly source: string;
+  readonly layout: UiLayoutIntent;
+  readonly text: UiTextRef;
+  readonly style?: UiStyleRef;
+  readonly action?: BijouBlockFieldAction;
+  readonly binding?: BijouBlockFieldBinding;
+}
+
+export interface BijouBlockArtifact {
+  readonly artifactVersion: BijouBlockArtifactVersion;
+  readonly id: string;
+  readonly component: string;
+  readonly sourceTypeName: string;
+  readonly sourceName: string;
+  readonly sourceHash: string;
+  readonly rootNodeId: string;
+  readonly fields: readonly BijouBlockField[];
+  readonly targetProfiles: readonly UiTargetProfile[];
+}
+
+interface ParsedGraphqlBijouBlock {
+  readonly typeName: string;
+  readonly typeDirectives: readonly ParsedDirective[];
+  readonly fields: readonly ParsedField[];
+}
+
+interface ParsedField {
+  readonly fieldName: string;
+  readonly graphqlType: string;
+  readonly directives: readonly ParsedDirective[];
+}
+
+interface FieldDraft {
+  readonly fieldName: string;
+  readonly graphqlType: string;
+  readonly directiveTexts: string[];
+}
+
+interface ParsedDirective {
+  readonly name: string;
+  readonly args: Readonly<Record<string, DirectiveArgValue>>;
+}
+
+type DirectiveArgValue = string | number;
+
+const DEFAULT_SOURCE_NAME = 'inline.graphql';
+const IDENTIFIER_PATTERN = '[A-Za-z_][A-Za-z0-9_]*';
+const FIELD_PATTERN = new RegExp(`^(${IDENTIFIER_PATTERN})\\s*:\\s*([A-Za-z0-9_!\\[\\]]+)(.*)$`);
+const TYPE_PATTERN = new RegExp(`^type\\s+(${IDENTIFIER_PATTERN})\\b(.*)$`);
+const DIRECTIVE_PATTERN = new RegExp(`@(${IDENTIFIER_PATTERN})\\s*\\(([^)]*)\\)`, 'g');
+const ARG_PATTERN = new RegExp(`(${IDENTIFIER_PATTERN})\\s*:\\s*("(?:[^"\\\\]|\\\\.)*"|-?\\d+)`, 'g');
+
+export function compileGraphqlBijouBlock(
+  source: string,
+  options: CompileGraphqlBijouBlockOptions = {},
+): BijouBlockArtifact {
+  const sourceName = normalizeSourceName(options.sourceName ?? DEFAULT_SOURCE_NAME);
+  const parsed = parseConstrainedGraphqlBijouBlock(source);
+  const blockDirective = directiveByName(parsed.typeDirectives, 'bijouBlock');
+  const blockId = blockDirective == null ? undefined : optionalStringArg(blockDirective, 'id');
+  const component = blockDirective == null ? undefined : optionalStringArg(blockDirective, 'component');
+  if (blockId == null || component == null) {
+    throw new Error('GraphQL Bijou block source must include @bijouBlock(id:, component:).');
+  }
+
+  const targetProfiles = targetProfilesFor(parsed.typeDirectives);
+  const fields = parsed.fields.map((field) => bijouBlockFieldFor(field, parsed.typeName, sourceName));
+  const artifactBody = {
+    artifactVersion: BIJOU_BLOCK_ARTIFACT_VERSION,
+    id: blockId,
+    component,
+    sourceTypeName: parsed.typeName,
+    sourceName,
+    rootNodeId: `${blockId}.root`,
+    fields,
+    targetProfiles,
+  } satisfies Omit<BijouBlockArtifact, 'sourceHash'>;
+
+  return {
+    ...artifactBody,
+    sourceHash: hashUiSceneValue(artifactBody),
+  };
+}
+
+export function lowerBijouBlockToUiScene(artifact: BijouBlockArtifact): UiSceneIr {
+  const nodes: UiNode[] = [
+    {
+      id: artifact.rootNodeId,
+      kind: 'group',
+      component: artifact.component,
+      children: artifact.fields.map((field) => field.nodeId),
+      metadata: {
+        artifactVersion: artifact.artifactVersion,
+        sourceTypeName: artifact.sourceTypeName,
+      },
+    },
+  ];
+  const actions: UiAction[] = [];
+  const bindings: UiBinding[] = [];
+  const tokenUses: UiTokenUse[] = [];
+  const i18nUses: UiI18nUse[] = [];
+  const sourceMap: UiSourceMapEntry[] = [];
+
+  for (const field of artifact.fields) {
+    nodes.push(nodeForField(artifact, field));
+    sourceMap.push({ nodeId: field.nodeId, source: field.source });
+    appendTokenUses(tokenUses, field);
+    appendI18nUse(i18nUses, field.nodeId, field.text);
+
+    if (field.action != null) {
+      actions.push({
+        id: field.action.id,
+        command: field.action.command,
+        keybindings: field.action.keybindings,
+        label: field.text,
+        targetNodeId: field.nodeId,
+      });
+      appendI18nUse(i18nUses, field.action.id, field.text, 'action');
+    }
+
+    if (field.binding != null) {
+      bindings.push({
+        id: field.binding.id,
+        targetNodeId: field.nodeId,
+        targetProperty: field.binding.targetProperty,
+        source: field.binding.source,
+        when: field.binding.when,
+      });
+    }
+  }
+
+  return {
+    irVersion: UI_SCENE_IR_VERSION,
+    id: artifact.id,
+    sourceHash: artifact.sourceHash,
+    rootNodeId: artifact.rootNodeId,
+    nodes,
+    bindings,
+    actions,
+    tokenUses,
+    i18nUses,
+    sourceMap,
+    targetProfiles: artifact.targetProfiles,
+    portability: { level: 'portable' },
+  };
+}
+
+function parseConstrainedGraphqlBijouBlock(source: string): ParsedGraphqlBijouBlock {
+  const typeDirectiveTexts: string[] = [];
+  const fields: ParsedField[] = [];
+  let typeName: string | undefined;
+  let insideType = false;
+  let currentField: FieldDraft | undefined;
+
+  for (const rawLine of source.replace(/\r\n?/g, '\n').split('\n')) {
+    const trimmed = stripGraphqlLineComment(rawLine).trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    if (typeName == null) {
+      const match = TYPE_PATTERN.exec(trimmed);
+      if (match == null) {
+        continue;
+      }
+      typeName = match[1]!;
+      const rest = match[2] ?? '';
+      typeDirectiveTexts.push(rest);
+      insideType = rest.includes('{');
+      continue;
+    }
+
+    if (!insideType) {
+      typeDirectiveTexts.push(trimmed);
+      insideType = trimmed.includes('{');
+      continue;
+    }
+
+    if (trimmed.startsWith('}')) {
+      if (currentField != null) {
+        fields.push(fieldFromDraft(currentField));
+        currentField = undefined;
+      }
+      break;
+    }
+
+    const fieldMatch = FIELD_PATTERN.exec(trimmed);
+    if (fieldMatch != null) {
+      if (currentField != null) {
+        fields.push(fieldFromDraft(currentField));
+      }
+      currentField = {
+        fieldName: fieldMatch[1]!,
+        graphqlType: fieldMatch[2]!,
+        directiveTexts: [fieldMatch[3] ?? ''],
+      };
+      continue;
+    }
+
+    if (trimmed.startsWith('@') && currentField != null) {
+      currentField.directiveTexts.push(trimmed);
+    }
+  }
+
+  if (typeName == null) {
+    throw new Error('GraphQL Bijou block source must include a type definition.');
+  }
+  if (currentField != null) {
+    fields.push(fieldFromDraft(currentField));
+  }
+
+  return {
+    typeName,
+    typeDirectives: parseDirectives(typeDirectiveTexts.join('\n')),
+    fields,
+  };
+}
+
+function fieldFromDraft(draft: FieldDraft): ParsedField {
+  return {
+    fieldName: draft.fieldName,
+    graphqlType: draft.graphqlType,
+    directives: parseDirectives(draft.directiveTexts.join('\n')),
+  };
+}
+
+function parseDirectives(source: string): readonly ParsedDirective[] {
+  const directives: ParsedDirective[] = [];
+  for (const match of source.matchAll(DIRECTIVE_PATTERN)) {
+    directives.push({
+      name: match[1]!,
+      args: parseDirectiveArgs(match[2] ?? ''),
+    });
+  }
+  return directives;
+}
+
+function parseDirectiveArgs(source: string): Readonly<Record<string, DirectiveArgValue>> {
+  const args: Record<string, DirectiveArgValue> = {};
+  for (const match of source.matchAll(ARG_PATTERN)) {
+    const key = match[1]!;
+    const rawValue = match[2]!;
+    args[key] = rawValue.startsWith('"') ? parseQuotedArg(rawValue) : Number(rawValue);
+  }
+  return args;
+}
+
+function parseQuotedArg(rawValue: string): string {
+  try {
+    return JSON.parse(rawValue) as string;
+  } catch {
+    throw new Error(`Invalid GraphQL Bijou block string argument: ${rawValue}`);
+  }
+}
+
+function bijouBlockFieldFor(field: ParsedField, typeName: string, sourceName: string): BijouBlockField {
+  const textDirective = requireDirective(field, 'bijouText');
+  const i18nDirective = requireDirective(field, 'bijouI18n');
+  const tokenDirective = directiveByName(field.directives, 'bijouToken');
+  const actionDirective = directiveByName(field.directives, 'bijouAction');
+  const bindingDirective = directiveByName(field.directives, 'bijouBind');
+  const nodeId = requiredStringArg(textDirective, 'id', `@bijouText on ${field.fieldName} must include id:.`);
+  return {
+    fieldName: field.fieldName,
+    nodeId,
+    graphqlType: field.graphqlType,
+    source: `${sourceName}#type.${typeName}.field.${field.fieldName}`,
+    layout: layoutFor(textDirective),
+    text: {
+      kind: 'i18n',
+      key: requiredStringArg(i18nDirective, 'key', `@bijouI18n on ${field.fieldName} must include key:.`),
+      fallback: requiredStringArg(i18nDirective, 'fallback', `@bijouI18n on ${field.fieldName} must include fallback:.`),
+    },
+    style: tokenDirective == null ? undefined : styleFor(tokenDirective),
+    action: actionDirective == null ? undefined : actionFor(actionDirective),
+    binding: bindingDirective == null ? undefined : bindingFor(bindingDirective),
+  };
+}
+
+function nodeForField(artifact: BijouBlockArtifact, field: BijouBlockField): UiNode {
+  const node: UiNode = {
+    id: field.nodeId,
+    kind: 'text',
+    component: artifact.component,
+    parentId: artifact.rootNodeId,
+    layout: field.layout,
+    text: field.text,
+    style: field.style,
+    actions: field.action == null ? undefined : [field.action.id],
+    metadata: {
+      graphqlField: field.fieldName,
+      graphqlType: field.graphqlType,
+    },
+  };
+  return node;
+}
+
+function targetProfilesFor(directives: readonly ParsedDirective[]): readonly UiTargetProfile[] {
+  const targetDirective = requireDirective(
+    { fieldName: 'type', directives },
+    'bijouTarget',
+    'GraphQL Bijou block source must include @bijouTarget(kind:, cols:, rows:).',
+  );
+  const kind = requiredStringArg(targetDirective, 'kind', '@bijouTarget must include kind:.');
+  if (kind !== 'bijou-terminal') {
+    throw new Error(`Unsupported GraphQL Bijou block target kind: ${kind}`);
+  }
+  return [
+    {
+      kind,
+      cols: requiredPositiveIntegerArg(targetDirective, 'cols', '@bijouTarget bijou-terminal must include positive cols:.'),
+      rows: requiredPositiveIntegerArg(targetDirective, 'rows', '@bijouTarget bijou-terminal must include positive rows:.'),
+    },
+  ];
+}
+
+function layoutFor(directive: ParsedDirective): UiLayoutIntent {
+  const layout: {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+  } = {};
+  copyOptionalIntegerArg(directive, layout, 'x');
+  copyOptionalIntegerArg(directive, layout, 'y');
+  copyOptionalIntegerArg(directive, layout, 'width');
+  copyOptionalIntegerArg(directive, layout, 'height');
+  return layout;
+}
+
+function styleFor(directive: ParsedDirective): UiStyleRef {
+  const style: {
+    fg?: { readonly token: string };
+    bg?: { readonly token: string };
+    border?: { readonly token: string };
+  } = {};
+  const fg = optionalStringArg(directive, 'fg');
+  const bg = optionalStringArg(directive, 'bg');
+  const border = optionalStringArg(directive, 'border');
+  if (fg != null) {
+    style.fg = { token: fg };
+  }
+  if (bg != null) {
+    style.bg = { token: bg };
+  }
+  if (border != null) {
+    style.border = { token: border };
+  }
+  return style;
+}
+
+function actionFor(directive: ParsedDirective): BijouBlockFieldAction {
+  const id = requiredStringArg(directive, 'id', '@bijouAction must include id:.');
+  const command = requiredStringArg(directive, 'command', '@bijouAction must include command:.');
+  const key = optionalStringArg(directive, 'key');
+  return {
+    id,
+    command,
+    keybindings: key == null ? [] : [key],
+  };
+}
+
+function bindingFor(directive: ParsedDirective): BijouBlockFieldBinding {
+  const kind = requiredStringArg(directive, 'kind', '@bijouBind must include kind:.');
+  if (kind !== 'state' && kind !== 'query' && kind !== 'computed') {
+    throw new Error(`Unsupported @bijouBind kind: ${kind}`);
+  }
+  return {
+    id: requiredStringArg(directive, 'id', '@bijouBind must include id:.'),
+    targetProperty: optionalStringArg(directive, 'targetProperty') ?? 'text',
+    source: {
+      kind,
+      path: requiredStringArg(directive, 'path', '@bijouBind must include path:.'),
+    },
+    when: optionalStringArg(directive, 'when'),
+  };
+}
+
+function requireDirective(
+  owner: { readonly fieldName: string; readonly directives: readonly ParsedDirective[] },
+  name: string,
+  message?: string,
+): ParsedDirective {
+  const directive = directiveByName(owner.directives, name);
+  if (directive == null) {
+    throw new Error(message ?? `GraphQL Bijou block field ${owner.fieldName} must include @${name}(...).`);
+  }
+  return directive;
+}
+
+function directiveByName(directives: readonly ParsedDirective[], name: string): ParsedDirective | undefined {
+  const matches = directives.filter((directive) => directive.name === name);
+  if (matches.length > 1) {
+    throw new Error(`GraphQL Bijou block source has duplicate @${name} directives.`);
+  }
+  return matches[0];
+}
+
+function requiredStringArg(directive: ParsedDirective, name: string, message: string): string {
+  const value = optionalStringArg(directive, name);
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function optionalStringArg(directive: ParsedDirective, name: string): string | undefined {
+  const value = directive.args[name];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function requiredPositiveIntegerArg(directive: ParsedDirective, name: string, message: string): number {
+  const value = optionalIntegerArg(directive, name);
+  if (value == null || value <= 0) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function optionalIntegerArg(directive: ParsedDirective, name: string): number | undefined {
+  const value = directive.args[name];
+  return typeof value === 'number' && Number.isInteger(value) ? value : undefined;
+}
+
+function copyOptionalIntegerArg(
+  directive: ParsedDirective,
+  layout: { x?: number; y?: number; width?: number; height?: number },
+  name: 'x' | 'y' | 'width' | 'height',
+): void {
+  const value = optionalIntegerArg(directive, name);
+  if (value != null) {
+    layout[name] = value;
+  }
+}
+
+function appendTokenUses(tokenUses: UiTokenUse[], field: BijouBlockField): void {
+  if (field.style?.fg?.token != null) {
+    tokenUses.push({ nodeId: field.nodeId, slot: 'fg', token: field.style.fg.token });
+  }
+  if (field.style?.bg?.token != null) {
+    tokenUses.push({ nodeId: field.nodeId, slot: 'bg', token: field.style.bg.token });
+  }
+  if (field.style?.border?.token != null) {
+    tokenUses.push({ nodeId: field.nodeId, slot: 'border', token: field.style.border.token });
+  }
+}
+
+function appendI18nUse(i18nUses: UiI18nUse[], id: string, text: UiTextRef, kind: 'node' | 'action' = 'node'): void {
+  if (text.kind !== 'i18n') {
+    return;
+  }
+  i18nUses.push(kind === 'node'
+    ? { nodeId: id, key: text.key }
+    : { actionId: id, key: text.key });
+}
+
+function normalizeSourceName(sourceName: string): string {
+  const trimmed = sourceName.trim();
+  if (trimmed.length === 0) {
+    throw new Error('GraphQL Bijou block sourceName cannot be empty.');
+  }
+  if (trimmed.startsWith('/') || /^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.includes('\0')) {
+    throw new Error('GraphQL Bijou block sourceName must be a relative or logical name.');
+  }
+  return trimmed;
+}
+
+function stripGraphqlLineComment(line: string): string {
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && char === '#') {
+      return line.slice(0, index);
+    }
+  }
+  return line;
+}

--- a/packages/bijou/src/core/graphql-bijou-block.ts
+++ b/packages/bijou/src/core/graphql-bijou-block.ts
@@ -90,7 +90,7 @@ const DEFAULT_SOURCE_NAME = 'inline.graphql';
 const IDENTIFIER_PATTERN = '[A-Za-z_][A-Za-z0-9_]*';
 const FIELD_PATTERN = new RegExp(`^(${IDENTIFIER_PATTERN})\\s*:\\s*([A-Za-z0-9_!\\[\\]]+)(.*)$`);
 const TYPE_PATTERN = new RegExp(`^type\\s+(${IDENTIFIER_PATTERN})\\b(.*)$`);
-const DIRECTIVE_PATTERN = new RegExp(`@(${IDENTIFIER_PATTERN})\\s*\\(([^)]*)\\)`, 'g');
+const DIRECTIVE_PATTERN = new RegExp(`@(${IDENTIFIER_PATTERN})\\s*\\(((?:[^()"\\\\]|"(?:[^"\\\\]|\\\\.)*")*)\\)`, 'g');
 const ARG_PATTERN = new RegExp(`(${IDENTIFIER_PATTERN})\\s*:\\s*("(?:[^"\\\\]|\\\\.)*"|-?\\d+)`, 'g');
 
 export function compileGraphqlBijouBlock(
@@ -128,6 +128,7 @@ export function compileGraphqlBijouBlock(
 }
 
 export function lowerBijouBlockToUiScene(artifact: BijouBlockArtifact): UiSceneIr {
+  assertUniqueBlockIdentities(artifact.fields, artifact.rootNodeId);
   const nodes: UiNode[] = [
     {
       id: artifact.rootNodeId,
@@ -533,7 +534,13 @@ function normalizeSourceName(sourceName: string): string {
   if (trimmed.length === 0) {
     throw new Error('GraphQL Bijou block sourceName cannot be empty.');
   }
-  if (trimmed.startsWith('/') || /^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.includes('\0')) {
+  if (
+    trimmed.startsWith('/')
+    || trimmed.startsWith('\\\\')
+    || trimmed.startsWith('//')
+    || /^[A-Za-z]:[\\/]/.test(trimmed)
+    || trimmed.includes('\0')
+  ) {
     throw new Error('GraphQL Bijou block sourceName must be a relative or logical name.');
   }
   return trimmed;

--- a/packages/bijou/src/index.ts
+++ b/packages/bijou/src/index.ts
@@ -141,6 +141,17 @@ export {
   type ModeMap,
 } from './core/mode-render.js';
 export {
+  BIJOU_BLOCK_ARTIFACT_VERSION,
+  compileGraphqlBijouBlock,
+  lowerBijouBlockToUiScene,
+  type BijouBlockArtifact,
+  type BijouBlockArtifactVersion,
+  type BijouBlockField,
+  type BijouBlockFieldAction,
+  type BijouBlockFieldBinding,
+  type CompileGraphqlBijouBlockOptions,
+} from './core/graphql-bijou-block.js';
+export {
   UI_SCENE_IR_VERSION,
   UI_SCENE_RECEIPT_VERSION,
   createUiSceneTerminalReceipt,

--- a/tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts
+++ b/tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { BIJOU_LIGHT } from '@flyingrobots/bijou';
 import { _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
+import type { KeyMsg } from '@flyingrobots/bijou-tui';
 import {
   createScriptTestContext as createTestContext,
   runScriptDeterministic as runScript,
@@ -46,9 +47,9 @@ describe('RE-017 framed shell theme demo', () => {
     const app = createDocsApp(ctx, { initialRoute: 'docs' });
 
     let [model] = app.init();
-    [model] = app.update(keyMsg('f2') as never, model);
-    [model] = app.update(keyMsg('down') as never, model);
-    [model] = app.update(keyMsg('enter') as never, model);
+    [model] = app.update(keyMsg('f2'), model);
+    [model] = app.update(keyMsg('down'), model);
+    [model] = app.update(keyMsg('enter'), model);
 
     const resultModel = model as {
       landingThemeIndex: number;
@@ -70,7 +71,7 @@ describe('RE-017 framed shell theme demo', () => {
   });
 });
 
-function keyMsg(key: string) {
+function keyMsg(key: string): KeyMsg {
   return {
     type: 'key' as const,
     key,

--- a/tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts
+++ b/tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts
@@ -6,9 +6,8 @@ import {
   runScriptDeterministic as runScript,
 } from '../../helpers/scripted.js';
 import { createDocsApp } from '../../../examples/docs/app.js';
+import { normalizeViewOutput } from '../../../packages/bijou-tui/src/view-output.js';
 
-const KEY_F2 = '\x1bOQ';
-const KEY_DOWN = '\x1b[B';
 const KEY_ENTER = '\r';
 
 describe('RE-017 framed shell theme demo', () => {
@@ -41,30 +40,42 @@ describe('RE-017 framed shell theme demo', () => {
     expect(frame.get(frame.width - 2, 2).bg).toBe('#043015');
   });
 
-  it('cycles the stock frame shell-theme row through DogFood shell themes before landing palettes', async () => {
+  it('cycles the stock frame shell-theme row through DogFood shell themes before landing palettes', () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 36 } });
     const originalBg = ctx.surface('primary').bg;
     const app = createDocsApp(ctx, { initialRoute: 'docs' });
 
-    const result = await runScript(app, [
-      { key: KEY_F2 },
-      { key: KEY_DOWN },
-      { key: KEY_ENTER },
-    ], { ctx });
+    let [model] = app.init();
+    [model] = app.update(keyMsg('f2') as never, model);
+    [model] = app.update(keyMsg('down') as never, model);
+    [model] = app.update(keyMsg('enter') as never, model);
 
-    const model = result.model as {
+    const resultModel = model as {
       landingThemeIndex: number;
       docsModel: {
         activeShellThemeId?: string;
         pageModels: Record<string, { landingThemeIndex: number; activeShellThemeId?: string }>;
       };
     };
-    const frame = result.frames.at(-1)!;
-    expect(model.landingThemeIndex).toBe(0);
-    expect(model.docsModel.activeShellThemeId).toBe('dogfood:light');
-    expect(Object.values(model.docsModel.pageModels).every((pageModel) => pageModel.landingThemeIndex === 0)).toBe(true);
-    expect(Object.values(model.docsModel.pageModels).every((pageModel) => pageModel.activeShellThemeId === 'dogfood:light')).toBe(true);
+    const frame = normalizeViewOutput(app.view(model), {
+      width: ctx.runtime.columns,
+      height: ctx.runtime.rows,
+    }).surface;
+    expect(resultModel.landingThemeIndex).toBe(0);
+    expect(resultModel.docsModel.activeShellThemeId).toBe('dogfood:light');
+    expect(Object.values(resultModel.docsModel.pageModels).every((pageModel) => pageModel.landingThemeIndex === 0)).toBe(true);
+    expect(Object.values(resultModel.docsModel.pageModels).every((pageModel) => pageModel.activeShellThemeId === 'dogfood:light')).toBe(true);
     expect(ctx.surface('primary').bg).toBe(originalBg);
     expect(frame.get(frame.width - 2, 2).bg).toBe(BIJOU_LIGHT.surface.primary.bg);
   });
 });
+
+function keyMsg(key: string) {
+  return {
+    type: 'key' as const,
+    key,
+    ctrl: false,
+    alt: false,
+    shift: false,
+  };
+}


### PR DESCRIPTION
## Summary

- adds the first constrained GraphQL SDL compiler for `bijou-block/1` artifacts
- lowers compiled block artifacts into the existing `ui-scene-ir/1` runtime contract
- proves terminal rendering, cell source-map facts, i18n/token/action receipts, whitespace-stable semantic hashes, duplicate identity rejection before lowering, quoted-paren parsing, and source-name hygiene
- bounds an existing DOGFOOD shell-theme demo test so the full Linux Node 22 CI suite does not depend on scripted app timing for a settings-row assertion

## Linked Work

- Advances #302
- Design doc: `docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md`

## Validation

- RED: `npx vitest run packages/bijou/src/core/graphql-bijou-block.test.ts` failed before `graphql-bijou-block` existed
- RED: focused duplicate-identity regression failed before compiler validation rejected duplicate node ids
- CI RED: `test (22)` timed out in `tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts`
- pre-push RED: `scripts/no-local-paths.test.ts` rejected a Windows absolute path literal in the source-name test fixture
- GREEN: `npx vitest run packages/bijou/src/core/graphql-bijou-block.test.ts`
- GREEN: `npx vitest run tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts packages/bijou/src/core/graphql-bijou-block.test.ts`
- GREEN: `npx vitest run packages/bijou/src/core/graphql-bijou-block.test.ts scripts/no-local-paths.test.ts`
- `npm run typecheck:test`
- `npm run docs:inventory`
- `npm run lint`
- pre-push: DOGFOOD i18n completeness/check/debt, `typecheck:test`, full `npm test` (`345` files / `3821` tests), and scripted interactive smokes

## Notes

This stays Bijou-only for the first proof. Geordi, Wesley, and Bunny worktrees are available for later slices, but this PR does not need external repo changes.
