### PR TITLE
Refresh post-DX-045 roadmap signposts

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -56,6 +56,10 @@ Current direction and active tensions. Historical ship data is in
   six-pack landed as standard Block contracts for brand emphasis, mode-aware
   primitives, dense comparisons, hierarchies, exploration lists, and
   temporal/dependency views.
+- `DX-043` through `DX-045` — the Runtime Graph and Scene IR lane now has a
+  portable `ui-scene-ir/1` seed, a constrained GraphQL-authored
+  `bijou-block/1` proof, grouped block authoring, and deterministic
+  `graphql-bijou-block-debug/1` facts for #302.
 - `4.4.1` — framed-shell polish and background-fill recovery after `4.4.0`.
 - `4.2.0` — [RE-007](./design/RE-007-migrate-framed-shell-onto-runtime-engine-seams.md)
   lands the framed shell on the runtime-engine seams and ships
@@ -65,21 +69,24 @@ Current direction and active tensions. Historical ship data is in
 
 ## Active Gravity
 
-### 0. Advance Runtime Graph And Scene IR From Proof To Pipeline
+### 0. Advance Runtime Graph And Scene IR From Proof To Product Fixture
 
-- `DX-043` and `DX-044` landed the portable `ui-scene-ir/1` seed and the first
-  GraphQL-authored `bijou-block/1` proof for #302.
-- The next active pull is `DX-045`: grouped GraphQL block authoring and
-  deterministic debug facts. This keeps the work inside Bijou before crossing
-  into Geordi endpoint implementation.
+- `DX-043`, `DX-044`, and `DX-045` landed the portable `ui-scene-ir/1` seed,
+  the first GraphQL-authored `bijou-block/1` proof, grouped block authoring,
+  and deterministic debug facts for #302.
+- The next active pull is `DX-046`: one real DOGFOOD block or panel authored as
+  GraphQL SDL, compiled to `bijou-block/1`, lowered to `ui-scene-ir/1`, and
+  proven through terminal output plus debug facts. This keeps the work inside
+  Bijou one more slice before Wesley or Geordi integration.
 - The useful proof path is now:
 
   ```text
-  GraphQL SDL
+  GraphQL SDL fixture
     -> bijou-block/1 grouped artifact
       -> ui-scene-ir/1
         -> terminal Surface proof
-          -> debug summary facts
+          -> graphql-bijou-block-debug/1 facts
+            -> DOGFOOD product facts
   ```
 
 ### 1. Keep The `v6.0.0` Release Boundary Closed
@@ -140,19 +147,20 @@ Current direction and active tensions. Historical ship data is in
 
 ## Next Target
 
-The immediate feature focus is the `DX-045` grouped GraphQL block pipeline for
-#302. Release-readiness validation remains the release-boundary focus for the
-closed V6 and V7 lanes, but the next implementation branch should avoid
-reopening those issue-complete milestones.
+The immediate feature focus is `DX-046`: a GraphQL-authored DOGFOOD block
+fixture for #302. Release-readiness validation remains the release-boundary
+focus for the closed V6 and V7 lanes, but the next implementation branch should
+avoid reopening those issue-complete milestones.
 
-The `DX-045` validation pass must prove:
+The `DX-046` validation pass must prove:
 
-- grouped SDL compiles into deterministic `bijou-block/1` group facts
-- grouped block artifacts lower into valid `ui-scene-ir/1`
+- one existing DOGFOOD block or panel has a checked-in GraphQL SDL source
+- that SDL compiles into a deterministic grouped `bijou-block/1` artifact
+- the artifact lowers into valid `ui-scene-ir/1`
 - terminal proof preserves source maps, tokens, i18n keys, actions, bindings,
-  lower modes, and receipt hashes
-- debug summary facts are inspectable without screenshots or host-specific
-  paths
+  lower modes, receipt hashes, and `graphql-bijou-block-debug/1` facts
+- failure tests catch missing product facts such as invalid token refs,
+  missing localization posture, duplicate ids, or broken group references
 
 The release-readiness validation pass must prove:
 
@@ -163,9 +171,12 @@ The release-readiness validation pass must prove:
 
 Recommended pull order:
 
-1. Land `DX-045` grouped GraphQL block authoring and debug facts for #302.
-2. Run release-readiness validation against the now-closed V6 and V7 lanes.
-3. Cut release title treatment variants for the next release boundary only
+1. Land this post-DX-045 signpost refresh.
+2. Take `DX-046` GraphQL-authored DOGFOOD block fixture for #302.
+3. Harden the compiler boundary so Wesley can replace the bootstrap parser
+   without changing Bijou artifact semantics.
+4. Run release-readiness validation against the now-closed V6 and V7 lanes.
+5. Cut release title treatment variants for the next release boundary only
    after the tracker, docs, and CI proof are green.
 
 Non-goals for the next cycle:
@@ -176,3 +187,5 @@ Non-goals for the next cycle:
 - no conversion of every leaf component into a Block
 - no hidden global block registry
 - no localization runtime rewrite
+- no Wesley or Geordi repository changes before the DOGFOOD fixture proves the
+  Bijou-side source, artifact, IR, and debug contracts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Documentation
 
+- **Post-DX-045 roadmap signposts** — `docs/BEARING.md` and `docs/ROADMAP.md`
+  now mark DX-045 as landed, set DX-046 as the next #302 pull for a real
+  GraphQL-authored DOGFOOD block fixture, refresh the Beyond milestone counts
+  from GitHub, and move the closed legacy-theme cleanup issue into closed
+  Beyond lineage.
 - **Release policy evidence gates** — `docs/release.md` now adapts the
   release-runbook pattern to Bijou's npm-only workspace publishing model,
   requires branch-first release prep, release evidence packets, human review
@@ -116,11 +121,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 ### 🧭 Planning
 
 - **GraphQL block groups and debug facts** —
-  `docs/design/DX-045-graphql-block-groups-and-debug-facts.md` now defines the
-  next #302 slice after the GraphQL-authored block proof: explicit SDL-authored
-  group nodes, grouped `bijou-block/1` lowering into `ui-scene-ir/1`,
-  deterministic debug summary facts, lower-mode witnesses, and duplicate/missing
-  group validation.
+  `docs/design/DX-045-graphql-block-groups-and-debug-facts.md` recorded the
+  grouped #302 slice after the GraphQL-authored block proof: explicit
+  SDL-authored group nodes, grouped `bijou-block/1` lowering into
+  `ui-scene-ir/1`, deterministic debug summary facts, lower-mode witnesses, and
+  duplicate/missing group validation.
 - **GraphQL-authored Bijou block IR proof** —
   `docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md` now defines the
   first implementation slice after the portable `ui-scene-ir/1` runtime seed:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ lineage includes milestone PR rows when those PRs contribute to the totals. Do
 not compare release snapshot item totals to issue-only `gh issue list` output
 without also accounting for milestone pull requests.
 
-Last synced from GitHub milestone items: 2026-06-09.
+Last synced from GitHub milestone items: 2026-06-13.
 
 ## Release Snapshot
 
@@ -21,7 +21,7 @@ Last synced from GitHub milestone items: 2026-06-09.
 | :--- | :--- | ---: | ---: | :--- |
 | `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 30 | Issue-complete layout truth, standard blocks, and status/feedback Block lane. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Issue-complete V7 Product Truth, BlockLab naming, and release-facing proof. |
-| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 34 | 3 | Uncommitted future work, cool ideas, and raw follow-ups. |
+| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 33 | 4 | Uncommitted future work, cool ideas, and raw follow-ups. |
 
 ## v6.0.0
 
@@ -133,14 +133,14 @@ user-story issues.
 ### Candidate Goalposts From Open GitHub Issues
 
 These groupings are planning recommendations from the open tracker state as of
-2026-06-09. They are not commitments until moved into a versioned release
+2026-06-13. They are not commitments until moved into a versioned release
 packet and assigned umbrella issues.
 
 | Candidate Goalpost | Open Issues | Why It Exists | Proof Direction |
 | :--- | :--- | :--- | :--- |
-| Runtime Graph And Scene IR | [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#302](https://github.com/flyingrobots/bijou/issues/302) | Bijou keeps accumulating DAG, Mermaid, MCP, and GraphQL-authored scene ideas. These should become one runtime/IR goalpost instead of drifting as unrelated ideas. DX-042 and DX-043 shaped the shared IR boundary; DX-044 landed the first GraphQL-authored `bijou-block/1` proof; DX-045 now pulls #302 toward grouped block authoring and deterministic debug facts. | Schema fixtures, lowering tests, DOGFOOD graph examples, lower-mode rendering, debug summaries, source-map receipts, and failure-mode contracts. |
+| Runtime Graph And Scene IR | [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#302](https://github.com/flyingrobots/bijou/issues/302) | Bijou keeps accumulating DAG, Mermaid, MCP, and GraphQL-authored scene ideas. These should become one runtime/IR goalpost instead of drifting as unrelated ideas. DX-042 through DX-045 have now landed the shared IR boundary, portable `ui-scene-ir/1` seed, constrained GraphQL-authored `bijou-block/1` proof, grouped block authoring, and deterministic debug facts. The next pull should make one real DOGFOOD block or panel GraphQL-authored before Wesley or Geordi enters the critical path. | Schema fixtures, lowering tests, DOGFOOD product fixtures, lower-mode rendering, debug summaries, source-map receipts, and failure-mode contracts. |
 | DOGFOOD And BlockLab Product Surface | [#204](https://github.com/flyingrobots/bijou/issues/204), [#205](https://github.com/flyingrobots/bijou/issues/205), [#214](https://github.com/flyingrobots/bijou/issues/214), [#215](https://github.com/flyingrobots/bijou/issues/215), [#217](https://github.com/flyingrobots/bijou/issues/217), [#218](https://github.com/flyingrobots/bijou/issues/218), [#248](https://github.com/flyingrobots/bijou/issues/248), [#272](https://github.com/flyingrobots/bijou/issues/272) | DOGFOOD, BlockLab, file exploration, semantic lists, terminal shaders, and artifact matrices all point at a stronger product-facing component lab. | Scripted DOGFOOD flows, BlockLab story fixtures, image/capture witnesses, keyboard/focus proof, and localized docs. |
-| Design Tokens And Theme Modes | [#311](https://github.com/flyingrobots/bijou/issues/311), [#313](https://github.com/flyingrobots/bijou/issues/313), [#315](https://github.com/flyingrobots/bijou/issues/315), [#318](https://github.com/flyingrobots/bijou/issues/318) | Lip Gloss-like styling is valuable only if Bijou preserves its own theme truth: tokens describe semantic color slots, themes own dark/light values, and styles consume resolved colors at render time. DL-013 and DL-015 landed the first builder and safe-pair foundations; DL-016 now targets runtime theme/mode separation. | Builder API tests, theme validation fixtures, style-render resolution tests, safe-pair contrast matrices, lower-mode color proof, DOGFOOD examples, theme-inspector and theme-lab UX, theme-generator spikes, and inspectability facts. |
+| Design Tokens And Theme Modes | [#311](https://github.com/flyingrobots/bijou/issues/311), [#315](https://github.com/flyingrobots/bijou/issues/315), [#318](https://github.com/flyingrobots/bijou/issues/318) | Lip Gloss-like styling is valuable only if Bijou preserves its own theme truth: tokens describe semantic color slots, themes own dark/light values, and styles consume resolved colors at render time. DL-013, DL-015, and the legacy single-mode theme cleanup have landed the first builder, safe-pair, and runtime-mode foundations; the remaining lane is inspector, lab, and generator UX. | Builder API tests, theme validation fixtures, style-render resolution tests, safe-pair contrast matrices, lower-mode color proof, DOGFOOD examples, theme-inspector and theme-lab UX, theme-generator spikes, and inspectability facts. |
 | Workflow And CI Determinism | [#203](https://github.com/flyingrobots/bijou/issues/203), [#268](https://github.com/flyingrobots/bijou/issues/268), [#269](https://github.com/flyingrobots/bijou/issues/269), [#270](https://github.com/flyingrobots/bijou/issues/270), [#290](https://github.com/flyingrobots/bijou/issues/290), [#298](https://github.com/flyingrobots/bijou/issues/298), [#299](https://github.com/flyingrobots/bijou/issues/299), [#300](https://github.com/flyingrobots/bijou/issues/300), [#301](https://github.com/flyingrobots/bijou/issues/301) | The open bad-code and Method ideas share a dependency-injection, fake-clock, replay, and tracker-sync theme. They should become one proof and determinism goalpost. | Fake clocks, injected git/GitHub clients, fixture-backed DOGFOOD harnesses, path-gated CI proof, and merge-gate tests. |
 | Localization And Documentation Operations | [#206](https://github.com/flyingrobots/bijou/issues/206), [#207](https://github.com/flyingrobots/bijou/issues/207), [#208](https://github.com/flyingrobots/bijou/issues/208), [#312](https://github.com/flyingrobots/bijou/issues/312) | DOGFOOD Markdown localization now has a debt ratchet; the next shaped step is an operator-facing translation and preference workflow. | Localization debt tests, preference persistence fixtures, DOGFOOD dashboards, full docs-module scanner coverage, and all-supported-locale proof. |
 
@@ -179,7 +179,6 @@ packet and assigned umbrella issues.
 | [#302](https://github.com/flyingrobots/bijou/issues/302) | `lane:cool-ideas` | `type:enhancement` / `type:spike` | Compile GraphQL-authored UI scenes into Bijou Blocks |
 | [#311](https://github.com/flyingrobots/bijou/issues/311) | `lane:cool-ideas` | `type:enhancement` | DL-014 theme inspector drawer |
 | [#312](https://github.com/flyingrobots/bijou/issues/312) | `lane:bad-code` | `type:maintenance` | DOGFOOD i18n debt scanner misses new docs modules |
-| [#313](https://github.com/flyingrobots/bijou/issues/313) | `lane:bad-code` | `type:maintenance` | Legacy Theme remains single-mode beside DL-013 mode-aware themes |
 | [#315](https://github.com/flyingrobots/bijou/issues/315) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | DOGFOOD theme lab and preset gallery |
 | [#318](https://github.com/flyingrobots/bijou/issues/318) | `lane:cool-ideas` | `type:enhancement` / `type:spike` | Rampensau-inspired Bijou theme generator |
 
@@ -189,6 +188,7 @@ packet and assigned umbrella issues.
 | :--- | :--- | :--- | :--- |
 | [#289](https://github.com/flyingrobots/bijou/issues/289) | `lane:cool-ideas` / `lane:release` | `type:enhancement` / `type:docs` | Release title screens as first-class artifact gallery |
 | [#308](https://github.com/flyingrobots/bijou/issues/308) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | DL-013 design token and theme builder API |
+| [#313](https://github.com/flyingrobots/bijou/issues/313) | `lane:bad-code` | `type:maintenance` | Legacy Theme remains single-mode beside DL-013 mode-aware themes |
 | [#314](https://github.com/flyingrobots/bijou/issues/314) | `lane:cool-ideas` | `type:enhancement` | DL-015 theme safe-pair contracts and contrast matrices |
 
 ### Open Unmilestoned Triage

--- a/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
+++ b/docs/design/DX-044-graphql-authored-bijou-block-ir-proof.md
@@ -4,7 +4,7 @@ legend: DX
 lane: cool-ideas
 priority: medium
 github_issue: 302
-status: active
+status: landed
 keywords:
   - developer-experience
   - graphql

--- a/docs/design/DX-045-graphql-block-groups-and-debug-facts.md
+++ b/docs/design/DX-045-graphql-block-groups-and-debug-facts.md
@@ -4,7 +4,7 @@ legend: DX
 lane: cool-ideas
 priority: medium
 github_issue: 302
-status: active
+status: landed
 keywords:
   - developer-experience
   - graphql

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -43,13 +43,13 @@ describe('WF-130 roadmap goalpost policy', () => {
   it('makes roadmap state GitHub-backed and groups current open tracker work', () => {
     const roadmap = normalizeWhitespace(read('docs/ROADMAP.md'));
 
-    expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-06-09.');
+    expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-06-13.');
     expect(roadmap).toContain('`v6.0.0`');
     expect(roadmap).toContain('0 | 30');
     expect(roadmap).toContain('`v7.0.0`');
     expect(roadmap).toContain('0 | 27');
     expect(roadmap).toContain('`Beyond`');
-    expect(roadmap).toContain('34 | 3');
+    expect(roadmap).toContain('33 | 4');
     expect(roadmap).toContain('Candidate Goalposts From Open GitHub Issues');
     expect(roadmap).toContain('Runtime Graph And Scene IR');
     expect(roadmap).toContain('DOGFOOD And BlockLab Product Surface');
@@ -95,7 +95,7 @@ describe('WF-130 roadmap goalpost policy', () => {
   it('keeps the Beyond open snapshot count aligned with the Open Beyond Issues table', () => {
     const roadmap = read('docs/ROADMAP.md');
     const beyondRow = roadmap.match(/\| `Beyond` \| \[Beyond\]\([^)]+\) \| (?<open>\d+) \| (?<closed>\d+) \|/);
-    expect(beyondRow?.groups?.closed).toBe('3');
+    expect(beyondRow?.groups?.closed).toBe('4');
 
     const openBeyondIssues = sectionBetween(
       roadmap,


### PR DESCRIPTION
## Summary
- marks DX-044 and DX-045 design docs as landed
- updates BEARING to name DX-046 GraphQL-authored DOGFOOD block fixture as the next #302 pull
- refreshes ROADMAP live milestone snapshot to 2026-06-13 with Beyond at 33 open / 4 closed
- moves closed #313 from Open Beyond Issues into Closed Beyond Lineage
- adds a changelog planning ledger entry and updates the WF-130 roadmap policy expectation

Advances #302.

## Validation
- npm run docs:inventory
- git diff --check
- npm run lint
- npm test -- --run tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
- pre-push DOGFOOD i18n completeness/check/debt
- pre-push typecheck:test
- pre-push full Vitest suite: 345 files / 3825 tests
- pre-push scripted interactive examples
