### PR TITLE
Start DX-046 DOGFOOD GraphQL fixture

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -74,10 +74,11 @@ Current direction and active tensions. Historical ship data is in
 - `DX-043`, `DX-044`, and `DX-045` landed the portable `ui-scene-ir/1` seed,
   the first GraphQL-authored `bijou-block/1` proof, grouped block authoring,
   and deterministic debug facts for #302.
-- The next active pull is `DX-046`: one real DOGFOOD block or panel authored as
-  GraphQL SDL, compiled to `bijou-block/1`, lowered to `ui-scene-ir/1`, and
-  proven through terminal output plus debug facts. This keeps the work inside
-  Bijou one more slice before Wesley or Geordi integration.
+- The next active pull is `DX-046` / #329: one real DOGFOOD block or panel
+  authored as GraphQL SDL, compiled to `bijou-block/1`, lowered to
+  `ui-scene-ir/1`, and proven through terminal output plus debug facts. This
+  keeps the work inside Bijou one more slice before Wesley or Geordi
+  integration while #302 remains the broad V8/Beyond tracker.
 - The useful proof path is now:
 
   ```text
@@ -153,8 +154,8 @@ Current direction and active tensions. Historical ship data is in
 ## Next Target
 
 The immediate feature focus is `DX-046`: a GraphQL-authored DOGFOOD block
-fixture for #302. This is a post-v7 proof slice, not a `v6.0.0` or `v7.0.0`
-release-readiness task.
+fixture for #329, the release-scoped child of #302. This is a post-v7 proof
+slice, not a `v6.0.0` or `v7.0.0` release-readiness task.
 
 DX-046 is also the final planned implementation pull for `v7.1.0`. After it
 lands, the repo should move into release prep unless the open dependency PR is
@@ -173,7 +174,7 @@ The `DX-046` validation pass must prove:
 Recommended pull order:
 
 1. Land this release-train roadmap decision.
-2. Take `DX-046` GraphQL-authored DOGFOOD block fixture for #302.
+2. Take `DX-046` GraphQL-authored DOGFOOD block fixture for #329.
 3. Include dependency PR #326 only if it is green, low-risk, and still useful
    before release prep.
 4. Create or update the `v7.1.0` release packet, move only selected tracker

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -134,6 +134,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧭 Planning
 
+- **DX-046 DOGFOOD GraphQL fixture shaping** —
+  `docs/design/DX-046-graphql-authored-dogfood-block-fixture.md` now scopes
+  the `v7.1.0` implementation item to issue #329, a child of the broad #302
+  tracker, and selects `NavigationListBlock` as the first real DOGFOOD surface
+  to prove GraphQL SDL -> `bijou-block/1` -> `ui-scene-ir/1` -> terminal proof
+  -> `graphql-bijou-block-debug/1` facts.
 - **GraphQL block groups and debug facts** —
   `docs/design/DX-045-graphql-block-groups-and-debug-facts.md` recorded the
   grouped #302 slice after the GraphQL-authored block proof: explicit

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,14 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### ✨ Features
 
+- **DOGFOOD GraphQL navigation fixture** —
+  `examples/docs/fixtures/graphql/navigation-list.graphql` now checks in the
+  first real DOGFOOD GraphQL SDL fixture for `NavigationListBlock`. Focused
+  DX-046 tests compile it into `bijou-block/1`, lower it into `ui-scene-ir/1`,
+  prove terminal output, assert `graphql-bijou-block-debug/1` facts for groups,
+  fields, source maps, i18n keys, token refs, actions, bindings, lower modes,
+  and hashes, and reject malformed fixture facts before terminal proof. This
+  advances issue #329 and keeps parent issue #302 as the broad V8 tracker.
 - **Portable UI scene IR seed** — `@flyingrobots/bijou` now exports the first
   `ui-scene-ir/1` runtime contract for portable Bijou block and component
   proof: deterministic SHA-256 scene hashing, structural receipts, validation of node,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,10 +23,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   selection, and the project markdownlint config disables the Markdown
   line-length rule so links and tables are not wrapped by policy.
 - **Post-DX-045 roadmap signposts** — `docs/BEARING.md` and `docs/ROADMAP.md`
-  now mark DX-045 as landed, set DX-046 as the next #302 pull for a real
-  GraphQL-authored DOGFOOD block fixture, refresh the Beyond milestone counts
-  from GitHub, and move the closed legacy-theme cleanup issue into closed
-  Beyond lineage.
+  now mark DX-045 as landed, set DX-046 as the next #302-derived pull for a
+  real GraphQL-authored DOGFOOD block fixture, refresh the Beyond milestone
+  counts from GitHub, and move the closed legacy-theme cleanup issue into
+  closed Beyond lineage.
 - **Release policy evidence gates** — `docs/release.md` now adapts the
   release-runbook pattern to Bijou's npm-only workspace publishing model,
   requires branch-first release prep, release evidence packets, human review
@@ -42,7 +42,7 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   prove terminal output, assert `graphql-bijou-block-debug/1` facts for groups,
   fields, source maps, i18n keys, token refs, actions, bindings, lower modes,
   and hashes, and reject malformed fixture facts before terminal proof. This
-  advances issue #329 and keeps parent issue #302 as the broad V8 tracker.
+  closes issue #329 and keeps parent issue #302 as the broad V8 tracker.
 - **Portable UI scene IR seed** — `@flyingrobots/bijou` now exports the first
   `ui-scene-ir/1` runtime contract for portable Bijou block and component
   proof: deterministic SHA-256 scene hashing, structural receipts, validation of node,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -175,6 +175,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🐛 Fixes
 
+- **Surface ANSI reset handling** — `parseAnsiToSurface()` now honors scoped
+  SGR foreground/background resets (`39`/`49`) so styled list markers no longer
+  leak muted or accent colors into following DOGFOOD navigation labels.
 - **Shell quit confirmation copy** — The shell quit confirmation modal now
   renders `Y quit • N stay` only once by keeping the question in the modal body
   and the controls in the modal hint/footer instead of duplicating the same

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,6 +37,7 @@ release-process reason justifies a narrow `v7.1.x` patch or emergency
 
 | Horizon | Milestone | Open Items | Closed Items | Current Posture |
 | :--- | :--- | ---: | ---: | :--- |
+| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 1 | 0 | Selected next release packet. DX-046 is the active implementation item. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Latest shipped release lineage. Complete; do not reopen for new feature work. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 33 | 4 | Active forward backlog. Promote shaped work from here into a versioned release. |
 | `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 30 | Skipped public release lane. Complete lineage retained for issue history. |
@@ -54,9 +55,10 @@ Scope:
   grouped block authoring, `graphql-bijou-block-debug/1` facts, theme-token and
   mode-aware shell-theme foundations, raster/image glyph work, release-policy
   hardening, and roadmap truth updates
-- DX-046: one real DOGFOOD block or panel authored as GraphQL SDL, compiled to
-  `bijou-block/1`, lowered to `ui-scene-ir/1`, proven in terminal output, and
-  summarized through debug facts
+- DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329): one real
+  DOGFOOD block or panel authored as GraphQL SDL, compiled to `bijou-block/1`,
+  lowered to `ui-scene-ir/1`, proven in terminal output, and summarized through
+  debug facts
 - dependency PR [#326](https://github.com/flyingrobots/bijou/pull/326) is a
   candidate only; it is not selected for `v7.1.0` until it is green, low-risk,
   still open before release prep, and moved into the `v7.1.0` milestone or
@@ -70,8 +72,9 @@ Non-scope:
   surface
 - no new major API churn beyond what is already represented in `Unreleased`
 
-Before release prep starts, create a `v7.1.0` GitHub milestone or release packet
-and move only the selected issues and pull requests into it.
+The `v7.1.0` GitHub milestone is the selected release packet. Keep #329 there,
+leave parent #302 in `Beyond`, and move only selected pull requests or
+dependency items into `v7.1.0`.
 
 ### After `v7.1.0`: Skip Feature `v7.2.0`
 
@@ -167,7 +170,8 @@ that a cross-repository release is the next smallest honest boundary.
 ## Next Pull
 
 The immediate implementation pull is **DX-046: GraphQL-authored DOGFOOD block
-fixture for #302**.
+fixture [#329](https://github.com/flyingrobots/bijou/issues/329)**, a
+release-scoped child of the broad #302 tracker.
 
 The useful proof path is:
 
@@ -193,7 +197,7 @@ before those scopes become tracker-enforced release packets.
 
 | Target | Goalpost | Tracker | Why It Belongs There | Release Gate |
 | :--- | :--- | :--- | :--- | :--- |
-| `v7.1.0` | Post-V7 Minor | DX-046 implementation PR or release-packet item, candidate-only [#326](https://github.com/flyingrobots/bijou/pull/326), and `Unreleased` changelog work | The repo already has a meaningful post-V7 batch. One more Bijou-side DOGFOOD fixture makes the GraphQL/IR story release-worthy without turning this into a major; the broad #302 tracker stays in `Beyond` for `v8.0.0`. | DX-046 green, release evidence packet written, selected tracker items moved to a `v7.1.0` milestone or release packet without moving #302 out of `Beyond`, and no broad scope creep. |
+| `v7.1.0` | Post-V7 Minor | DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329), candidate-only [#326](https://github.com/flyingrobots/bijou/pull/326), and `Unreleased` changelog work | The repo already has a meaningful post-V7 batch. One more Bijou-side DOGFOOD fixture makes the GraphQL/IR story release-worthy without turning this into a major; the broad #302 tracker stays in `Beyond` for `v8.0.0`. | DX-046 green, release evidence packet written, #329 kept in `v7.1.0` without moving #302 out of `Beyond`, and no broad scope creep. |
 | `v8.0.0` | Runtime Graph And Scene IR Product Contract | Beyond: [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#301](https://github.com/flyingrobots/bijou/issues/301), [#302](https://github.com/flyingrobots/bijou/issues/302). Triage: [#306](https://github.com/flyingrobots/bijou/issues/306), [#321](https://github.com/flyingrobots/bijou/issues/321). | This is the current product direction after DX-043 through DX-046: portable scenes, GraphQL blocks, deterministic debug facts, and product fixtures need to become a stable contract. | Stable artifact semantics, DOGFOOD round-trip fixtures, terminal/frame-capture proof, lower-mode and source-map receipts, and failure tests. |
 | `v9.0.0` | Product Workbench And Operator Surfaces | Beyond: [#204](https://github.com/flyingrobots/bijou/issues/204), [#205](https://github.com/flyingrobots/bijou/issues/205), [#206](https://github.com/flyingrobots/bijou/issues/206), [#207](https://github.com/flyingrobots/bijou/issues/207), [#208](https://github.com/flyingrobots/bijou/issues/208), [#214](https://github.com/flyingrobots/bijou/issues/214), [#215](https://github.com/flyingrobots/bijou/issues/215), [#217](https://github.com/flyingrobots/bijou/issues/217), [#218](https://github.com/flyingrobots/bijou/issues/218), [#248](https://github.com/flyingrobots/bijou/issues/248), [#272](https://github.com/flyingrobots/bijou/issues/272), [#311](https://github.com/flyingrobots/bijou/issues/311), [#312](https://github.com/flyingrobots/bijou/issues/312), [#315](https://github.com/flyingrobots/bijou/issues/315), [#318](https://github.com/flyingrobots/bijou/issues/318). Triage: [#317](https://github.com/flyingrobots/bijou/issues/317), [#316](https://github.com/flyingrobots/bijou/issues/316). | Once V8 stabilizes the artifact contract, the next value is authoring and inspecting real product surfaces: BlockLab, Theme Lab, localization operations, artifact matrices, and host controls. | Storybook-grade BlockLab workflows, Theme Inspector/Lab provenance, localization workbench proof, artifact matrices, and playback-backed terminal input where applicable. |
 | `v10.0.0+` | Ecosystem Integration | Wesley, Geordi, and host integration follow-on work after V8/V9 shape the contracts | Cross-repository integration should consume proven Bijou contracts rather than define them under release pressure. | A cross-repo release packet with explicit dependency ordering, proof artifacts, and rollback boundaries. |
@@ -202,8 +206,8 @@ before those scopes become tracker-enforced release packets.
 
 - **Next version**: `v7.1.0`. It is a small post-V7 minor release whose final
   planned implementation pull is DX-046. The broad #302 tracker stays in
-  `Beyond` for `v8.0.0`; `v7.1.0` owns only the DX-046 implementation PR or
-  release-packet item.
+  `Beyond` for `v8.0.0`; `v7.1.0` owns #329 as the release-scoped DX-046
+  implementation item.
 - **No feature `v7.2.0`**: after `v7.1.0`, go directly to `v8.0.0` for new
   feature development unless maintenance pressure forces a narrow patch or
   stabilization release.
@@ -296,6 +300,8 @@ Use GitHub as the source of truth:
 
 ```sh
 gh api repos/flyingrobots/bijou/milestones --method GET -f state=all --paginate
+gh issue list --state all --milestone v7.1.0
+gh pr list --state all --search 'milestone:"v7.1.0"'
 gh issue list --state all --milestone v7.0.0
 gh pr list --state all --search 'milestone:"v7.0.0"'
 gh issue list --state all --milestone Beyond

--- a/docs/design/DX-046-graphql-authored-dogfood-block-fixture.md
+++ b/docs/design/DX-046-graphql-authored-dogfood-block-fixture.md
@@ -5,7 +5,7 @@ lane: asap
 priority: high
 github_issue: 329
 parent_issue: 302
-status: proposed
+status: landed
 keywords:
   - developer-experience
   - dogfood
@@ -132,7 +132,7 @@ Expected SDL shape:
 ```graphql
 type DogfoodNavigationList
   @bijouBlock(id: "dogfood.navigation", component: "NavigationListBlock")
-  @bijouTarget(kind: "bijou-terminal", cols: 48, rows: 8)
+  @bijouTarget(kind: "bijou-terminal", cols: 80, rows: 8)
   @bijouGroup(id: "dogfood.navigation.header", label: "Header", x: 1, y: 0, width: 46, height: 2)
   @bijouGroup(id: "dogfood.navigation.items", label: "Items", x: 1, y: 2, width: 46, height: 5) {
   title: String!
@@ -254,3 +254,12 @@ The cycle is landed when:
   tests, and the relevant full validation are green
 - `docs/CHANGELOG.md` records the real DOGFOOD GraphQL fixture under
   `Unreleased`
+
+## Implementation Notes
+
+This cycle adds `examples/docs/fixtures/graphql/navigation-list.graphql` as the
+first checked-in DOGFOOD GraphQL SDL fixture. Focused tests compile it into the
+`dogfood.navigation` `bijou-block/1` artifact, prove that it matches the
+existing `docs.navigation` registry entry and `NavigationListBlock`, lower it
+to `ui-scene-ir/1`, render terminal proof, assert debug facts, and reject
+malformed fixture variants before terminal proof.

--- a/docs/design/DX-046-graphql-authored-dogfood-block-fixture.md
+++ b/docs/design/DX-046-graphql-authored-dogfood-block-fixture.md
@@ -1,0 +1,256 @@
+---
+title: DX-046 GraphQL Authored DOGFOOD Block Fixture
+legend: DX
+lane: asap
+priority: high
+github_issue: 329
+parent_issue: 302
+status: proposed
+keywords:
+  - developer-experience
+  - dogfood
+  - graphql
+  - blocks
+  - ir
+  - debug-facts
+  - v7.1.0
+---
+
+# DX-046 GraphQL Authored DOGFOOD Block Fixture
+
+Legend: [DX - Developer Experience](../legends/DX-developer-experience.md)
+
+## Linked Work
+
+- User story: [#329](https://github.com/flyingrobots/bijou/issues/329)
+- Parent tracker: [#302](https://github.com/flyingrobots/bijou/issues/302)
+- Prior slice:
+  [DX-045 GraphQL Block Groups And Debug Facts](./DX-045-graphql-block-groups-and-debug-facts.md)
+- Runtime seed:
+  [DX-042 Shared UI Scene IR And Bijou Render Target](./DX-042-shared-ui-scene-ir-and-bijou-render-target.md)
+- Portable endpoint direction:
+  [DX-043 Portable Bijou Blocks And Multi-Endpoint IR](./DX-043-portable-bijou-blocks-and-multi-endpoint-ir.md)
+- DOGFOOD surface block lineage:
+  [DF-030 Dogfood Docs Surface Block](./DF-030-dogfood-docs-surface-block.md)
+
+This cycle is the narrow `v7.1.0` implementation item. It must not move the
+broad #302 tracker out of `Beyond`; #329 carries the release-scoped DX-046
+proof.
+
+## Decision Summary
+
+DX-044 and DX-045 proved that constrained GraphQL SDL can produce
+`bijou-block/1`, lower into `ui-scene-ir/1`, render terminal proof, and emit
+`graphql-bijou-block-debug/1` facts. DX-046 turns that compiler proof into a
+real DOGFOOD product fixture.
+
+The first DOGFOOD target is `NavigationListBlock` from
+`examples/docs/dogfood-blocks.ts`. It is small enough for a release-boundary
+slice but real enough to carry product semantics: navigation items, selection
+state, command intents, i18n text, token styling, group structure, terminal
+proof, and debug facts.
+
+The useful flow is:
+
+```text
+NavigationListBlock GraphQL SDL fixture
+  -> bijou-block/1 grouped artifact
+    -> ui-scene-ir/1
+      -> terminal Surface proof
+        -> graphql-bijou-block-debug/1 facts
+          -> DOGFOOD product facts
+```
+
+## Sponsored Human
+
+A maintainer wants the post-V7 GraphQL block compiler to prove it can describe
+an actual DOGFOOD surface, not only synthetic release-card examples.
+
+A DOGFOOD reader benefits because the docs navigation surface becomes
+inspectable from one source contract instead of only from runtime rendering
+code.
+
+## Sponsored Agent
+
+An agent wants to trace one DOGFOOD navigation field from SDL through
+`bijou-block/1`, `ui-scene-ir/1`, terminal cells, lower modes, debug summary
+facts, and receipt hashes without scraping screenshots or reconstructing
+product intent from rendered text.
+
+## Hill
+
+Given a checked-in GraphQL SDL fixture for `NavigationListBlock`, Bijou can
+compile it into a deterministic grouped `bijou-block/1` artifact, lower it into
+a valid `ui-scene-ir/1` scene, render terminal proof, and emit
+`graphql-bijou-block-debug/1` facts that preserve source maps, token refs,
+i18n keys, actions, bindings, groups, lower-mode witnesses, and hashes.
+
+## Playback Questions
+
+- Which DOGFOOD product surface is now authored as GraphQL SDL?
+- Can a maintainer prove that the fixture is tied to the existing
+  `docs.navigation` registry entry and `NavigationListBlock` component name?
+- Can one SDL field be traced through artifact field, scene node, terminal
+  cell source map, lower-mode row, debug fact, and receipt dependency?
+- Can debug facts list the DOGFOOD groups, fields, i18n keys, token refs,
+  action ids, binding ids, lower-mode hashes, artifact hash, and scene hash?
+- Can failure tests reject missing or broken product facts before terminal
+  proof is generated?
+
+## Scope
+
+- Add a checked-in GraphQL SDL fixture for `NavigationListBlock`.
+- Keep the fixture inside the Bijou repository and inside the existing
+  constrained compiler path.
+- Compile the fixture with `compileGraphqlBijouBlock()`.
+- Lower the artifact with `lowerBijouBlockToUiScene()`.
+- Render deterministic terminal proof with `lowerUiSceneToTerminalProof()`.
+- Assert `createGraphqlBijouBlockDebugSummary()` facts for the real DOGFOOD
+  surface.
+- Add tests that bind the fixture to `defaultDogfoodBlockRegistry` and the
+  existing `docs.navigation` surface.
+- Update changelog and issue/PR evidence.
+
+## Non-Goals
+
+- Do not require Wesley or Geordi repository changes.
+- Do not migrate all DOGFOOD blocks to GraphQL.
+- Do not rewrite the DOGFOOD navigation runtime or docs app.
+- Do not introduce a general GraphQL parser or resolver runtime.
+- Do not create BlockLab, Theme Lab, localization workbench, or a browser
+  endpoint.
+- Do not move parent issue #302 out of the `Beyond` milestone.
+
+## Fixture Contract
+
+The fixture should live at
+`examples/docs/fixtures/graphql/navigation-list.graphql` unless implementation
+finds a stronger local convention.
+
+Expected SDL shape:
+
+```graphql
+type DogfoodNavigationList
+  @bijouBlock(id: "dogfood.navigation", component: "NavigationListBlock")
+  @bijouTarget(kind: "bijou-terminal", cols: 48, rows: 8)
+  @bijouGroup(id: "dogfood.navigation.header", label: "Header", x: 1, y: 0, width: 46, height: 2)
+  @bijouGroup(id: "dogfood.navigation.items", label: "Items", x: 1, y: 2, width: 46, height: 5) {
+  title: String!
+    @bijouText(id: "dogfood.navigation.title", group: "dogfood.navigation.header", x: 2, y: 0)
+    @bijouI18n(key: "dogfood.navigation.title", fallback: "Documentation")
+    @bijouToken(fg: "semantic.nav.title.fg")
+
+  activeItem: String!
+    @bijouText(id: "dogfood.navigation.active", group: "dogfood.navigation.items", x: 2, y: 2)
+    @bijouAction(id: "navigation.selectItem", command: "navigation.selectItem", key: "Enter")
+    @bijouBind(id: "navigation.selection.activeLabel", kind: "state", path: "navigation.selection.activeLabel")
+    @bijouI18n(key: "dogfood.navigation.active", fallback: "Active: Blocks")
+    @bijouToken(fg: "semantic.nav.item.active.fg", bg: "semantic.nav.item.active.bg")
+
+  itemCount: String!
+    @bijouText(id: "dogfood.navigation.itemCount", group: "dogfood.navigation.items", x: 2, y: 3)
+    @bijouBind(id: "navigation.items.count", kind: "computed", path: "navigation.items.count")
+    @bijouI18n(key: "dogfood.navigation.itemCount", fallback: "Items: 7")
+    @bijouToken(fg: "semantic.nav.item.fg")
+
+  expandHint: String
+    @bijouText(id: "dogfood.navigation.expandHint", group: "dogfood.navigation.items", x: 2, y: 4)
+    @bijouAction(id: "navigation.expandGroup", command: "navigation.expandGroup", key: "ArrowRight")
+    @bijouI18n(key: "dogfood.navigation.expandHint", fallback: "Expand group")
+    @bijouToken(fg: "semantic.nav.hint.fg")
+}
+```
+
+The implementation may adjust coordinates, labels, or token names if existing
+terminal proof requires it, but the fixture must still preserve:
+
+- `NavigationListBlock` as the component
+- `dogfood.navigation` as the artifact id
+- `docs.navigation` as the registry surface connected by tests
+- `navigation.selectItem`, `navigation.expandGroup`, and selection/item-count
+  binding facts
+
+## Accessibility And Assistive Posture
+
+Meaning must survive without color or borders. The `node-ids`, `i18n-keys`, and
+`token-refs` lower modes must expose the same DOGFOOD navigation nodes as the
+normal terminal proof, and the active selection must be identifiable through
+source maps and binding facts.
+
+## Localization And Directionality Posture
+
+Renderable fields must use `@bijouI18n` with fallback text. This slice does not
+add runtime translation behavior or directionality rules; it preserves i18n keys
+and fallbacks so later locale-aware fixtures can replace the fallback text
+without changing the artifact contract.
+
+## Agent Inspectability And Explainability Posture
+
+The committed facts should let an agent inspect:
+
+- fixture source path and semantic source anchors
+- artifact id, component, source hash, and group hierarchy
+- scene id, root node, action ids, binding ids, i18n keys, and token refs
+- terminal cell source-map entries for visible navigation text
+- lower-mode rows and hashes
+- debug summary hash, artifact hash, and scene hash
+
+No emitted artifact may include absolute local paths, timestamps, process ids,
+or screenshots.
+
+## Linked Invariants
+
+- [Schemas Live At Boundaries](../invariants/schemas-live-at-boundaries.md):
+  the DOGFOOD SDL fixture must fail before lowering when required source facts
+  are malformed or missing.
+- [Graceful Lowering Preserves Meaning](../invariants/graceful-lowering-preserves-meaning.md):
+  the fixture must preserve DOGFOOD navigation meaning across `bijou-block/1`,
+  `ui-scene-ir/1`, terminal cells, and lower modes.
+- [The Buffer Holds Facts](../invariants/buffer-holds-facts.md): debug output
+  must stay inspectable as serializable facts.
+- [Tests Are the Spec](../invariants/tests-are-the-spec.md): DX-046 is not
+  complete until focused tests prove the real DOGFOOD fixture contract.
+
+## Implementation Outline
+
+1. Add this design doc and issue/roadmap updates.
+2. Add failing tests for the checked-in DOGFOOD GraphQL fixture.
+3. Add the `NavigationListBlock` SDL fixture.
+4. Add any small fixture loader or export needed by tests.
+5. Compile the fixture into `bijou-block/1` and assert DOGFOOD registry
+   alignment.
+6. Lower the artifact into `ui-scene-ir/1` and assert terminal proof facts.
+7. Assert `graphql-bijou-block-debug/1` fields, groups, lower modes, and hashes.
+8. Add failure coverage for missing DOGFOOD product facts.
+9. Update changelog and issue/PR evidence.
+
+## Tests To Write First
+
+- RED: loading the checked-in DOGFOOD navigation SDL fixture should fail before
+  the fixture exists.
+- RED: compiling the fixture should produce `dogfood.navigation`,
+  `NavigationListBlock`, two groups, DOGFOOD fields, token refs, i18n keys,
+  action ids, binding ids, and a neutral source name.
+- RED: registry alignment should prove `defaultDogfoodBlockRegistry` maps
+  `docs.navigation` to `NavigationListBlock`.
+- RED: lowering and terminal proof should expose visible navigation text and
+  source-map entries for the active item.
+- RED: debug summary should include artifact hash, scene hash, summary hash,
+  groups, fields, i18n keys, token refs, actions, bindings, and normal /
+  `node-ids` / `i18n-keys` / `token-refs` lower modes.
+- RED: malformed DOGFOOD fixture variants should fail before terminal proof
+  when they omit required i18n, action, binding, group, or token facts.
+
+## Closeout
+
+The cycle is landed when:
+
+- #329 links this design doc and the PR
+- #302 remains the broad Beyond tracker
+- `v7.1.0` keeps #329 as the release-scoped tracker item
+- the branch PR links #329, #302, and this design
+- focused DX-046 tests are green
+- `npm run docs:inventory`, `npm run typecheck:test`, `npm run lint`, focused
+  tests, and the relevant full validation are green
+- `docs/CHANGELOG.md` records the real DOGFOOD GraphQL fixture under
+  `Unreleased`

--- a/docs/release.md
+++ b/docs/release.md
@@ -219,14 +219,15 @@ The next selected public release target is **`7.1.0`**.
 The latest shipped package release is `7.0.0`. The older `v6.0.0` milestone
 and the `v7.0.0` milestone are both zero-open tracker lanes retained as release
 lineage, not as the next target. `7.1.0` should stay a small post-V7 minor:
-ship the accumulated `Unreleased` work, include DX-046 if it lands cleanly, and
-then move into release prep.
+ship the accumulated `Unreleased` work, include DX-046 issue #329 if it lands
+cleanly, and then move into release prep.
 
 There is no planned feature `7.2.0` train. After `7.1.0`, new feature work
 should shape toward `8.0.0` unless a bug, security, dependency, or
 release-process reason justifies a narrow maintenance release.
 
-Before release prep begins, reflect the selected scope in
+The `v7.1.0` GitHub milestone is the selected release packet. Before release
+prep begins, keep the selected scope reflected in
 [`docs/ROADMAP.md`](./ROADMAP.md), [`docs/BEARING.md`](./BEARING.md), the live
 tracker, and the versioned release packet.
 

--- a/examples/docs/fixtures/graphql/navigation-list.graphql
+++ b/examples/docs/fixtures/graphql/navigation-list.graphql
@@ -1,0 +1,29 @@
+type DogfoodNavigationList
+  @bijouBlock(id: "dogfood.navigation", component: "NavigationListBlock")
+  @bijouTarget(kind: "bijou-terminal", cols: 80, rows: 8)
+  @bijouGroup(id: "dogfood.navigation.header", label: "Header", x: 1, y: 0, width: 46, height: 2)
+  @bijouGroup(id: "dogfood.navigation.items", label: "Items", x: 1, y: 2, width: 46, height: 5) {
+  title: String!
+    @bijouText(id: "dogfood.navigation.title", group: "dogfood.navigation.header", x: 2, y: 0)
+    @bijouI18n(key: "dogfood.navigation.title", fallback: "Documentation")
+    @bijouToken(fg: "semantic.nav.title.fg")
+
+  activeItem: String!
+    @bijouText(id: "dogfood.navigation.active", group: "dogfood.navigation.items", x: 2, y: 2)
+    @bijouAction(id: "navigation.selectItem", command: "navigation.selectItem", key: "Enter")
+    @bijouBind(id: "navigation.selection.activeLabel", kind: "state", path: "navigation.selection.activeLabel")
+    @bijouI18n(key: "dogfood.navigation.active", fallback: "Active: Blocks")
+    @bijouToken(fg: "semantic.nav.item.active.fg", bg: "semantic.nav.item.active.bg")
+
+  itemCount: String!
+    @bijouText(id: "dogfood.navigation.itemCount", group: "dogfood.navigation.items", x: 2, y: 3)
+    @bijouBind(id: "navigation.items.count", kind: "computed", path: "navigation.items.count")
+    @bijouI18n(key: "dogfood.navigation.itemCount", fallback: "Items: 7")
+    @bijouToken(fg: "semantic.nav.item.fg")
+
+  expandHint: String
+    @bijouText(id: "dogfood.navigation.expandHint", group: "dogfood.navigation.items", x: 2, y: 4)
+    @bijouAction(id: "navigation.expandGroup", command: "navigation.expandGroup", key: "ArrowRight")
+    @bijouI18n(key: "dogfood.navigation.expandHint", fallback: "Expand group")
+    @bijouToken(fg: "semantic.nav.hint.fg")
+}

--- a/packages/bijou/src/core/render/differ.test.ts
+++ b/packages/bijou/src/core/render/differ.test.ts
@@ -169,4 +169,24 @@ describe('surface text bridges', () => {
     expect(surface.get(1, 0).char).toBe('B');
     expect(surface.get(1, 0).fg).toBeUndefined();
   });
+
+  it('parseAnsiToSurface respects scoped SGR foreground and background resets', () => {
+    const surface = parseAnsiToSurface(
+      '\x1b[38;2;255;0;0m•\x1b[39m label\n\x1b[48;2;0;0;255mX\x1b[49mY',
+      8,
+      2,
+    );
+
+    expect(surface.get(0, 0).char).toBe('•');
+    expect(surface.get(0, 0).fg).toBe('#ff0000');
+    expect(surface.get(1, 0).char).toBe(' ');
+    expect(surface.get(1, 0).fg).toBeUndefined();
+    expect(surface.get(2, 0).char).toBe('l');
+    expect(surface.get(2, 0).fg).toBeUndefined();
+
+    expect(surface.get(0, 1).char).toBe('X');
+    expect(surface.get(0, 1).bg).toBe('#0000ff');
+    expect(surface.get(1, 1).char).toBe('Y');
+    expect(surface.get(1, 1).bg).toBeUndefined();
+  });
 });

--- a/packages/bijou/src/core/render/differ.ts
+++ b/packages/bijou/src/core/render/differ.ts
@@ -93,7 +93,12 @@ export function parseAnsiToSurface(text: string, width: number, height: number):
         let i = 0;
         while (i < parts.length) {
           const code = parts[i]!;
-          if (code === '1') currentMods.add('bold');
+          if (code === '0') {
+            currentFg = undefined;
+            currentBg = undefined;
+            currentMods.clear();
+          }
+          else if (code === '1') currentMods.add('bold');
           else if (code === '2') currentMods.add('dim');
           else if (code === '3') currentMods.add('italic');
           else if (code === '4') currentMods.add('underline');
@@ -104,6 +109,8 @@ export function parseAnsiToSurface(text: string, width: number, height: number):
           else if (code === '24') currentMods.delete('underline');
           else if (code === '27') currentMods.delete('inverse');
           else if (code === '29') currentMods.delete('strike');
+          else if (code === '39') currentFg = undefined;
+          else if (code === '49') currentBg = undefined;
           else if (code === '38' && parts[i+1] === '2') {
             // Truecolor FG: 38;2;R;G;B
             const r = parseInt(parts[i+2]!, 10).toString(16).padStart(2, '0');

--- a/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
+++ b/tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts
@@ -4,6 +4,7 @@ import {
   stripAnsi,
   surfaceToString,
 } from '@flyingrobots/bijou';
+import { chalkStyle } from '@flyingrobots/bijou-node';
 import {
   _resetDefaultContextForTesting,
 } from '@flyingrobots/bijou/adapters/test';
@@ -32,7 +33,19 @@ function blockPreviewGuideId(blockName: string): string {
   return `blocks-preview-${slug || 'family'}`;
 }
 
-function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
+type FrameCell = {
+  readonly char?: string;
+  readonly fg?: string | { readonly hex?: string };
+  readonly modifiers?: readonly string[];
+};
+
+type FrameLike = {
+  readonly width: number;
+  readonly height: number;
+  get(x: number, y: number): FrameCell;
+};
+
+function frameText(frame: FrameLike) {
   let text = '';
   for (let y = 0; y < frame.height; y++) {
     for (let x = 0; x < frame.width; x++) {
@@ -63,6 +76,58 @@ async function renderBlocksGuide(guideId: string, columns = 150, rows = 43) {
     result,
     text: frameText(result.frames.at(-1)!),
   };
+}
+
+async function renderBlocksGuideWithRealAnsi(guideId: string, columns = 150, rows = 43) {
+  const ctx = createTestContext({
+    mode: 'interactive',
+    runtime: { columns, rows },
+    style: chalkStyle({ level: 3 }),
+  });
+  const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
+  const result = await runScript(app, [{
+    msg: {
+      type: 'docs',
+      msg: { type: 'select-guide', guideId },
+    },
+  }], { ctx });
+  expect(result.frames.length).toBeGreaterThan(0);
+
+  return {
+    ctx,
+    result,
+    frame: result.frames.at(-1)!,
+    text: frameText(result.frames.at(-1)!),
+  };
+}
+
+function colorHex(value: FrameCell['fg']): string | undefined {
+  if (typeof value === 'string') return value;
+  return value?.hex;
+}
+
+function findTextStart(frame: FrameLike, text: string): { readonly x: number; readonly y: number } {
+  for (let y = 0; y < frame.height; y++) {
+    let row = '';
+    for (let x = 0; x < frame.width; x++) {
+      row += frame.get(x, y).char || ' ';
+    }
+    const x = row.indexOf(text);
+    if (x >= 0) return { x, y };
+  }
+  throw new Error(`text not found in frame: ${text}`);
+}
+
+function findCharBefore(
+  frame: FrameLike,
+  y: number,
+  beforeX: number,
+  char: string,
+): { readonly x: number; readonly y: number } {
+  for (let x = beforeX - 1; x >= 0; x--) {
+    if (frame.get(x, y).char === char) return { x, y };
+  }
+  throw new Error(`character ${char} not found before column ${beforeX}`);
 }
 
 function textBefore(text: string, marker: string): string {
@@ -163,6 +228,18 @@ describe('DF-068 DOGFOOD block preview regressions', () => {
     expect(loweringRegion).not.toContain('surface output:');
     expect(loweringRegion).not.toContain('┌─ ReaderSurface');
     expect(loweringRegion).not.toContain('┌─ Navigation');
+  });
+
+  it('keeps unselected Blocks navigation titles readable when marker styling uses real ANSI', async () => {
+    const { ctx, frame } = await renderBlocksGuideWithRealAnsi(blockPreviewGuideId('ReaderSurface'), 150, 43);
+    const title = findTextStart(frame, 'ReaderSurface');
+    const marker = findCharBefore(frame, title.y, title.x, '•');
+    const titleCell = frame.get(title.x, title.y);
+    const markerCell = frame.get(marker.x, marker.y);
+
+    expect(colorHex(markerCell.fg)).not.toBe(colorHex(titleCell.fg));
+    expect(colorHex(titleCell.fg)).toBe(ctx.surface('primary').hex);
+    expect(titleCell.modifiers ?? []).not.toContain('dim');
   });
 
   it('keeps the CounterDemoBlock fixture box bounded when style output contains ANSI codes', () => {

--- a/tests/cycles/DX-046/graphql-dogfood-navigation-fixture.test.ts
+++ b/tests/cycles/DX-046/graphql-dogfood-navigation-fixture.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compileGraphqlBijouBlock,
+  createGraphqlBijouBlockDebugSummary,
+  hashUiSceneValue,
+  lowerBijouBlockToUiScene,
+  lowerUiSceneToTerminalProof,
+  validateUiSceneIr,
+} from '@flyingrobots/bijou';
+import {
+  defaultDogfoodBlockRegistry,
+  navigationListBlock,
+} from '../../../examples/docs/dogfood-blocks.js';
+import { existsRepoPath, readRepoFile } from '../repo.js';
+
+const FIXTURE_PATH = 'examples/docs/fixtures/graphql/navigation-list.graphql';
+
+const NAV_TOKEN_COLORS = {
+  'semantic.nav.hint.fg': '#8aa4ff',
+  'semantic.nav.item.active.bg': '#1f2937',
+  'semantic.nav.item.active.fg': '#f9fafb',
+  'semantic.nav.item.fg': '#d1d5db',
+  'semantic.nav.title.fg': '#f7d774',
+};
+
+describe('DX-046 GraphQL-authored DOGFOOD navigation fixture', () => {
+  it('checks in a real NavigationListBlock GraphQL fixture', () => {
+    expect(existsRepoPath(FIXTURE_PATH)).toBe(true);
+
+    const source = readRepoFile(FIXTURE_PATH);
+    const artifact = compileGraphqlBijouBlock(source, { sourceName: FIXTURE_PATH });
+    const registryEntry = defaultDogfoodBlockRegistry.forSurface('docs.navigation');
+
+    expect(registryEntry?.block).toBe(navigationListBlock);
+    expect(registryEntry?.block.metadata.blockName).toBe('NavigationListBlock');
+    expect(artifact).toMatchObject({
+      artifactVersion: 'bijou-block/1',
+      id: 'dogfood.navigation',
+      component: 'NavigationListBlock',
+      sourceTypeName: 'DogfoodNavigationList',
+      sourceName: FIXTURE_PATH,
+      rootNodeId: 'dogfood.navigation.root',
+      groups: [
+        {
+          id: 'dogfood.navigation.header',
+          label: 'Header',
+          source: `${FIXTURE_PATH}#type.DogfoodNavigationList.group.dogfood.navigation.header`,
+        },
+        {
+          id: 'dogfood.navigation.items',
+          label: 'Items',
+          source: `${FIXTURE_PATH}#type.DogfoodNavigationList.group.dogfood.navigation.items`,
+        },
+      ],
+      targetProfiles: [{ kind: 'bijou-terminal', cols: 80, rows: 8 }],
+    });
+    expect(artifact.fields.map((field) => field.nodeId)).toEqual([
+      'dogfood.navigation.title',
+      'dogfood.navigation.active',
+      'dogfood.navigation.itemCount',
+      'dogfood.navigation.expandHint',
+    ]);
+    expect(artifact.fields.map((field) => field.text.kind === 'i18n' ? field.text.key : 'literal')).toEqual([
+      'dogfood.navigation.title',
+      'dogfood.navigation.active',
+      'dogfood.navigation.itemCount',
+      'dogfood.navigation.expandHint',
+    ]);
+    expect(artifact.fields.flatMap((field) => field.action == null ? [] : [field.action.id])).toEqual([
+      'navigation.selectItem',
+      'navigation.expandGroup',
+    ]);
+    expect(artifact.fields.flatMap((field) => field.binding == null ? [] : [field.binding.id])).toEqual([
+      'navigation.selection.activeLabel',
+      'navigation.items.count',
+    ]);
+  });
+
+  it('lowers the DOGFOOD navigation fixture to terminal proof and debug facts', () => {
+    const source = readRepoFile(FIXTURE_PATH);
+    const artifact = compileGraphqlBijouBlock(source, { sourceName: FIXTURE_PATH });
+    const scene = lowerBijouBlockToUiScene(artifact);
+
+    expect(validateUiSceneIr(scene)).toEqual({ ok: true, issues: [] });
+    expect(scene.nodes.map((node) => node.id)).toEqual([
+      'dogfood.navigation.root',
+      'dogfood.navigation.header',
+      'dogfood.navigation.items',
+      'dogfood.navigation.title',
+      'dogfood.navigation.active',
+      'dogfood.navigation.itemCount',
+      'dogfood.navigation.expandHint',
+    ]);
+
+    const proof = lowerUiSceneToTerminalProof(scene, { tokenColors: NAV_TOKEN_COLORS });
+    expect(rowText(proof.lowering.surface, 0)).toContain('Documentation');
+    expect(rowText(proof.lowering.surface, 2)).toContain('Active: Blocks');
+    expect(rowText(proof.lowering.surface, 3)).toContain('Items: 7');
+    expect(rowText(proof.lowering.surface, 4)).toContain('Expand group');
+    expect(proof.lowering.cellSourceMap.find((entry) => entry.nodeId === 'dogfood.navigation.active'))
+      .toMatchObject({
+        nodeId: 'dogfood.navigation.active',
+        source: `${FIXTURE_PATH}#type.DogfoodNavigationList.field.activeItem`,
+        textKey: 'dogfood.navigation.active',
+        fgToken: 'semantic.nav.item.active.fg',
+        bgToken: 'semantic.nav.item.active.bg',
+      });
+    expect(proof.receipt.sceneHash).toBe(hashUiSceneValue(scene));
+    expect(proof.receipt.actionIds).toEqual(['navigation.expandGroup', 'navigation.selectItem']);
+    expect(proof.receipt.bindingIds).toEqual([
+      'navigation.items.count',
+      'navigation.selection.activeLabel',
+    ]);
+
+    const summary = createGraphqlBijouBlockDebugSummary(artifact, { tokenColors: NAV_TOKEN_COLORS });
+    expect(summary).toMatchObject({
+      summaryVersion: 'graphql-bijou-block-debug/1',
+      artifactId: 'dogfood.navigation',
+      artifactHash: hashUiSceneValue(artifact),
+      sceneHash: hashUiSceneValue(scene),
+      rootNodeId: 'dogfood.navigation.root',
+      actionIds: ['navigation.expandGroup', 'navigation.selectItem'],
+      bindingIds: ['navigation.items.count', 'navigation.selection.activeLabel'],
+      i18nKeys: [
+        'dogfood.navigation.active',
+        'dogfood.navigation.expandHint',
+        'dogfood.navigation.itemCount',
+        'dogfood.navigation.title',
+      ],
+      tokenRefs: [
+        'semantic.nav.hint.fg',
+        'semantic.nav.item.active.bg',
+        'semantic.nav.item.active.fg',
+        'semantic.nav.item.fg',
+        'semantic.nav.title.fg',
+      ],
+    });
+    expect(summary.summaryHash).toBe(hashUiSceneValue({ ...summary, summaryHash: undefined }));
+    expect(summary.groups.map((group) => [group.id, group.childNodeIds])).toEqual([
+      ['dogfood.navigation.header', ['dogfood.navigation.title']],
+      [
+        'dogfood.navigation.items',
+        [
+          'dogfood.navigation.active',
+          'dogfood.navigation.itemCount',
+          'dogfood.navigation.expandHint',
+        ],
+      ],
+    ]);
+    expect(summary.lowerModes.map((mode) => mode.mode)).toEqual([
+      'normal',
+      'node-ids',
+      'i18n-keys',
+      'token-refs',
+    ]);
+    expect(summary.lowerModes.find((mode) => mode.mode === 'node-ids')?.rows.join('\n'))
+      .toContain('dogfood.navigation.active');
+    expect(summary.lowerModes.find((mode) => mode.mode === 'i18n-keys')?.rows.join('\n'))
+      .toContain('dogfood.navigation.active');
+    expect(summary.lowerModes.find((mode) => mode.mode === 'token-refs')?.rows.join('\n'))
+      .toContain('semantic.nav.item.active.fg semantic.nav.item.active.bg');
+  });
+
+  it('rejects malformed DOGFOOD navigation fixture facts before terminal proof', () => {
+    const source = readRepoFile(FIXTURE_PATH);
+
+    expect(() => compileGraphqlBijouBlock(
+      source.replace(
+        '\n    @bijouI18n(key: "dogfood.navigation.itemCount", fallback: "Items: 7")',
+        '',
+      ),
+      { sourceName: FIXTURE_PATH },
+    )).toThrow('GraphQL Bijou block field itemCount must include @bijouI18n(...).');
+
+    expect(() => compileGraphqlBijouBlock(
+      source.replace(
+        '@bijouText(id: "dogfood.navigation.active", group: "dogfood.navigation.items", x: 2, y: 2)',
+        '@bijouText(id: "dogfood.navigation.active", group: "dogfood.navigation.missing", x: 2, y: 2)',
+      ),
+      { sourceName: FIXTURE_PATH },
+    )).toThrow('GraphQL Bijou block field activeItem references missing group: dogfood.navigation.missing');
+  });
+});
+
+function rowText(surface: { get(x: number, y: number): { char: string; empty?: boolean }; width: number }, y: number): string {
+  let text = '';
+  for (let x = 0; x < surface.width; x++) {
+    const cell = surface.get(x, y);
+    text += cell.empty ? ' ' : cell.char;
+  }
+  return text.trimEnd();
+}

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -44,6 +44,7 @@ describe('WF-130 roadmap goalpost policy', () => {
     const roadmap = normalizeWhitespace(read('docs/ROADMAP.md'));
     const bearing = normalizeWhitespace(read('docs/BEARING.md'));
     const releaseRunbook = normalizeWhitespace(read('docs/release.md'));
+    const dx046Design = normalizeWhitespace(read('docs/design/DX-046-graphql-authored-dogfood-block-fixture.md'));
 
     expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-06-13.');
     expect(roadmap).toContain('The latest shipped public release is');
@@ -57,6 +58,8 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`v9.0.0`: Product Workbench And Operator Surfaces');
     expect(roadmap).toContain('`v10.0.0+`: Ecosystem Integration');
     expect(roadmap).toContain('v6.0.0` was never published as a public package release');
+    expect(roadmap).toContain('| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 1 | 0 |');
+    expect(roadmap).toContain('Selected next release packet.');
     expect(roadmap).toContain('`v6.0.0`');
     expect(roadmap).toContain('0 | 30');
     expect(roadmap).toContain('Skipped public release lane.');
@@ -66,7 +69,8 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`Beyond`');
     expect(roadmap).toContain('33 | 4');
     expect(roadmap).toContain('Next Pull');
-    expect(roadmap).toContain('DX-046: GraphQL-authored DOGFOOD block fixture for #302');
+    expect(roadmap).toContain('DX-046: GraphQL-authored DOGFOOD block fixture');
+    expect(roadmap).toContain('https://github.com/flyingrobots/bijou/issues/329');
     expect(roadmap).toContain('Forward Goalposts');
     expect(roadmap).toContain('Decision Points');
     expect(roadmap).toContain('Runtime Graph And Scene IR Product Contract');
@@ -84,6 +88,7 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('[#326]');
     expect(roadmap).toContain('candidate-only [#326]');
     expect(roadmap).toContain('it is not selected for `v7.1.0` until');
+    expect(roadmap).toContain('The `v7.1.0` GitHub milestone is the selected release packet.');
     expect(roadmap).toContain('Closed Lineage');
     expect(roadmap).toContain('Skipped public release; complete lineage');
 
@@ -95,13 +100,20 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).not.toContain('Workflow, Capture, And CI Determinism');
     expect(bearing).toContain('The latest shipped public release is `v7.0.0`');
     expect(bearing).toContain('The next selected public release target is `v7.1.0`');
+    expect(bearing).toContain('The next active pull is `DX-046` / #329');
     expect(bearing).toContain('There is no planned `v7.2.0` feature train.');
     expect(bearing).toContain('Shape V8 And V9 From Beyond');
     expect(bearing).not.toContain('The next release-facing action is release-readiness validation');
 
     expect(releaseRunbook).toContain('The next selected public release target is **`7.1.0`**');
+    expect(releaseRunbook).toContain('include DX-046 issue #329');
     expect(releaseRunbook).toContain('There is no planned feature `7.2.0` train.');
     expect(releaseRunbook).not.toContain('No next public release version is selected');
+
+    expect(dx046Design).toContain('User story: [#329](https://github.com/flyingrobots/bijou/issues/329)');
+    expect(dx046Design).toContain('Parent tracker: [#302](https://github.com/flyingrobots/bijou/issues/302)');
+    expect(dx046Design).toContain('NavigationListBlock');
+    expect(dx046Design).toContain('Tests To Write First');
   });
 
   it('disables Markdown line-length linting for project docs', () => {
@@ -126,11 +138,11 @@ describe('WF-130 roadmap goalpost policy', () => {
     const v71Row = goalposts.split('\n').find(line => line.startsWith('| `v7.1.0` |')) ?? '';
     const v8Row = goalposts.split('\n').find(line => line.startsWith('| `v8.0.0` |')) ?? '';
 
-    expect(v71Row).toContain('DX-046 implementation PR or release-packet item');
+    expect(v71Row).toContain('https://github.com/flyingrobots/bijou/issues/329');
     expect(v71Row).not.toContain('https://github.com/flyingrobots/bijou/issues/302');
     expect(v8Row).toContain('https://github.com/flyingrobots/bijou/issues/302');
     expect(normalizedRoadmap).toContain(
-      'The broad #302 tracker stays in `Beyond` for `v8.0.0`; `v7.1.0` owns only the DX-046 implementation PR or release-packet item.',
+      'The broad #302 tracker stays in `Beyond` for `v8.0.0`; `v7.1.0` owns #329 as the release-scoped DX-046 implementation item.',
     );
   });
 


### PR DESCRIPTION
## Summary

Implement the DX-046 `v7.1.0` GraphQL-authored DOGFOOD block fixture.

This PR:

- creates issue #329 as the release-scoped DX-046 child of broad parent #302
- creates the `v7.1.0` milestone and assigns #329 there while #302 remains in `Beyond`
- adds `docs/design/DX-046-graphql-authored-dogfood-block-fixture.md`
- adds `examples/docs/fixtures/graphql/navigation-list.graphql`, the first real DOGFOOD GraphQL SDL fixture for `NavigationListBlock`
- adds focused DX-046 tests that compile the fixture to `bijou-block/1`, lower it to `ui-scene-ir/1`, prove terminal output, assert `graphql-bijou-block-debug/1` facts, and reject malformed fixture facts before terminal proof
- updates ROADMAP, BEARING, release posture, changelog, and WF-130 guardrails so #329 is the v7.1 item and #302 remains the V8/Beyond parent tracker

## Linked Work

Closes #329
Refs #302
Design: `docs/design/DX-046-graphql-authored-dogfood-block-fixture.md`

## Validation

- `npm test -- --run tests/cycles/DX-046/graphql-dogfood-navigation-fixture.test.ts`
- `npm test -- --run tests/cycles/DX-046/graphql-dogfood-navigation-fixture.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
- `npm run docs:inventory`
- `npm run typecheck:test`
- `npm run lint`
- `git diff --check`
- `npm test` - 346 files / 3832 tests
- pre-push hook: DOGFOOD i18n completeness/check/debt, `npm run typecheck:test`, full `npm test`, and scripted interactive examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced GraphQL-authored navigation fixture with i18n support, styling tokens, and interactive features for the DOGFOOD preview.

* **Bug Fixes**
  * Fixed ANSI SGR reset handling to properly respect scoped foreground and background resets, preventing color leakage into subsequent display elements.

* **Documentation**
  * Added comprehensive design specification and updated roadmap documentation to reflect implementation scope and planning updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->