### PR TITLE
Gate release readiness and DOGFOOD i18n debt

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -71,15 +71,15 @@ Current direction and active tensions. Historical ship data is in
 
 ### 0. Advance Runtime Graph And Scene IR From Proof To Product Fixture
 
-- `DX-043`, `DX-044`, and `DX-045` landed the portable `ui-scene-ir/1` seed,
+- `DX-043`, `DX-044`, `DX-045`, and `DX-046` landed the portable
+  `ui-scene-ir/1` seed,
   the first GraphQL-authored `bijou-block/1` proof, grouped block authoring,
-  and deterministic debug facts for #302.
-- The next active pull is `DX-046` / #329: one real DOGFOOD block or panel
-  authored as GraphQL SDL, compiled to `bijou-block/1`, lowered to
-  `ui-scene-ir/1`, and proven through terminal output plus debug facts. This
-  keeps the work inside Bijou one more slice before Wesley or Geordi
-  integration while #302 remains the broad V8/Beyond tracker.
-- The useful proof path is now:
+  deterministic debug facts, and the first real GraphQL-authored DOGFOOD
+  NavigationListBlock fixture for #302.
+- The broad #302 tracker remains in `Beyond` for V8. The v7.1 feature proof is
+  complete; the active v7.1 pull is now release-prep guardrail work for #270
+  and #312.
+- The proof path that v7.1 now carries is:
 
   ```text
   GraphQL SDL fixture
@@ -96,8 +96,8 @@ Current direction and active tensions. Historical ship data is in
 - The `v6.0.0` and `v7.0.0` GitHub milestone lanes are complete release
   lineage with zero open items, not the next implementation target.
 - The next selected public release target is `v7.1.0`: a small post-V7 minor
-  release for accumulated `Unreleased` work plus DX-046 as the final planned
-  implementation pull.
+  release for accumulated `Unreleased` work plus DX-046 as closed feature
+  proof and #270/#312 as release-prep guardrails.
 - There is no planned `v7.2.0` feature train. After `v7.1.0`, new feature work
   should shape toward `v8.0.0` unless maintenance pressure requires a narrow
   patch or stabilization release.
@@ -116,7 +116,7 @@ Current direction and active tensions. Historical ship data is in
 
 ### 3. Shape V8 And V9 From Beyond
 
-- The `Beyond` milestone is the current post-v7 backlog: 33 open and 4 closed
+- The `Beyond` milestone is the current post-v7 backlog: 30 open and 5 closed
   milestone items as of the latest roadmap sync.
 - `v8.0.0` should organize Runtime Graph And Scene IR into a product contract:
   versioned `bijou-block/1`, `ui-scene-ir/1`, receipts, source maps, lower
@@ -153,34 +153,28 @@ Current direction and active tensions. Historical ship data is in
 
 ## Next Target
 
-The immediate feature focus is `DX-046`: a GraphQL-authored DOGFOOD block
-fixture for #329, the release-scoped child of #302. This is a post-v7 proof
-slice, not a `v6.0.0` or `v7.0.0` release-readiness task.
+The immediate release-prep focus is #270 and #312 for `v7.1.0`.
 
-DX-046 is also the final planned implementation pull for `v7.1.0`. After it
-lands, the repo should move into release prep unless the open dependency PR is
-green and low-risk enough to include.
+#270 must make release readiness issue-complete rather than vibe-complete:
+`npm run release:readiness -- --milestone vX.Y.Z` should print a concise
+milestone report, reject open tracker issues or lingering `work-in-progress`
+labels, confirm obvious roadmap/bearing/changelog posture, require the
+versioned release evidence packet, and preserve package-smoke coverage.
 
-The `DX-046` validation pass must prove:
-
-- one existing DOGFOOD block or panel has a checked-in GraphQL SDL source
-- that SDL compiles into a deterministic grouped `bijou-block/1` artifact
-- the artifact lowers into valid `ui-scene-ir/1`
-- terminal proof preserves source maps, tokens, i18n keys, actions, bindings,
-  lower modes, receipt hashes, and `graphql-bijou-block-debug/1` facts
-- failure tests catch missing product facts such as invalid token refs,
-  missing localization posture, duplicate ids, or broken group references
+#312 must make DOGFOOD i18n debt coverage source-complete rather than
+list-complete: new `examples/docs/**/*.ts` modules should participate in the
+debt ratchet by default unless explicitly excluded as tooling-only, and the
+ratchet should keep reporting counts by source surface.
 
 Recommended pull order:
 
-1. Land this release-train roadmap decision.
-2. Take `DX-046` GraphQL-authored DOGFOOD block fixture for #329.
-3. Include dependency PR #326 only if it is green, low-risk, and still useful
+1. Land the #270/#312 release-prep guardrail pull.
+2. Include dependency PR #326 only if it is green, low-risk, and still useful
    before release prep.
-4. Create or update the `v7.1.0` release packet, move only selected tracker
+3. Create or update the `v7.1.0` release packet, move only selected tracker
    items into it, and cut `v7.1.0` from a clean release branch.
-5. Shape `v8.0.0` around the Runtime Graph And Scene IR product contract.
-6. Keep `v9.0.0` for Product Workbench and operator surfaces after V8 stabilizes
+4. Shape `v8.0.0` around the Runtime Graph And Scene IR product contract.
+5. Keep `v9.0.0` for Product Workbench and operator surfaces after V8 stabilizes
    the source/artifact/IR contract.
 
 Non-goals for the next cycle:
@@ -188,7 +182,8 @@ Non-goals for the next cycle:
 - no feature-train `v7.2.0`
 - no broad DOGFOOD runtime rewrite
 - no full remaining component-family audit sweep from `v7.0.0`
-- no full visual redesign of DOGFOOD while DX-046 is still the active proof
+- no full visual redesign of DOGFOOD during the v7.1 release-prep guardrail
+  pull
 - no conversion of every leaf component into a Block
 - no hidden global block registry
 - no localization runtime rewrite

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -199,6 +199,17 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🛠 Maintenance
 
+- **Milestone-aware release readiness report** — `npm run release:readiness`
+  now accepts `-- --milestone vX.Y.Z`, prints a release-readiness report before
+  the local gauntlet, and blocks when the target milestone still has open
+  tracker issues, lingering `work-in-progress` labels, stale release docs, a
+  missing versioned release evidence packet, or missing package-smoke
+  coverage. This addresses issue #270.
+- **DOGFOOD i18n debt source discovery** — `npm run dogfood:i18n:debt` now
+  discovers DOGFOOD TypeScript modules under `examples/docs/**/*.ts` by
+  default, keeps tooling-only exclusions explicit, and updates the raw-string
+  baseline to cover newly scanned DOGFOOD block, shell-theme, guard, and helper
+  modules. This addresses issue #312.
 - **Design token and theme builder planning** —
   `docs/design/DL-013-design-token-theme-builder-api.md` now specifies the
   first official fluent-builder shape for semantic color tokens, dark/light

--- a/docs/DOGFOOD.md
+++ b/docs/DOGFOOD.md
@@ -139,7 +139,8 @@ reconstructing product truth from adjacent rendering code.
 - **Locale Preference**: The Settings drawer can switch DOGFOOD's preferred
   language after startup, while startup itself uses the host locale adapter.
 - **Localization Debt Ratchet**: `npm run dogfood:i18n:debt` counts remaining
-  localizable source strings by DOGFOOD surface plus missing Markdown
+  localizable source strings by DOGFOOD surface across `examples/docs/**/*.ts`
+  modules, keeps tooling-only exclusions documented, counts missing Markdown
   localizations by locale, and fails when either baseline increases.
 - **Localization Completeness Gate**: `npm run dogfood:i18n:complete` requires
   every newly added or source-changed DOGFOOD string to carry current values for

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,8 +27,9 @@ is complete tracker lineage whose work was absorbed before Bijou shipped
 
 The next selected public release target is **`v7.1.0`**. It is a small post-V7
 minor release, not a new product epoch: ship the accumulated `Unreleased` work
-since `v7.0.0`, take DX-046 as the final planned implementation pull if it lands
-cleanly, and then move into release prep.
+since `v7.0.0`, carry the landed DX-046 DOGFOOD GraphQL fixture as the final
+planned feature pull, and finish #270/#312 as release-prep guardrails before
+the release packet is cut.
 
 There is no planned `v7.2.0` feature train. After `v7.1.0`, new feature work
 should shape directly toward `v8.0.0` unless a bug, security, dependency, or
@@ -37,9 +38,9 @@ release-process reason justifies a narrow `v7.1.x` patch or emergency
 
 | Horizon | Milestone | Open Items | Closed Items | Current Posture |
 | :--- | :--- | ---: | ---: | :--- |
-| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 1 | 0 | Selected next release packet. DX-046 is the active implementation item. |
+| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 2 | 1 | Selected next release packet. DX-046 has landed; #270 and #312 are the release-prep guardrail items. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Latest shipped release lineage. Complete; do not reopen for new feature work. |
-| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 33 | 4 | Active forward backlog. Promote shaped work from here into a versioned release. |
+| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 30 | 5 | Active forward backlog. Promote shaped work from here into a versioned release. |
 | `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 30 | Skipped public release lane. Complete lineage retained for issue history. |
 
 ## Release Train Decision
@@ -55,10 +56,15 @@ Scope:
   grouped block authoring, `graphql-bijou-block-debug/1` facts, theme-token and
   mode-aware shell-theme foundations, raster/image glyph work, release-policy
   hardening, and roadmap truth updates
-- DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329): one real
+- landed DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329): one real
   DOGFOOD block or panel authored as GraphQL SDL, compiled to `bijou-block/1`,
   lowered to `ui-scene-ir/1`, proven in terminal output, and summarized through
   debug facts
+- release-readiness and DOGFOOD guardrails:
+  [#270](https://github.com/flyingrobots/bijou/issues/270) for a
+  milestone-aware readiness report, and
+  [#312](https://github.com/flyingrobots/bijou/issues/312) for default
+  DOGFOOD i18n debt coverage across new docs modules
 - dependency PR [#326](https://github.com/flyingrobots/bijou/pull/326) is a
   candidate only; it is not selected for `v7.1.0` until it is green, low-risk,
   still open before release prep, and moved into the `v7.1.0` milestone or
@@ -146,8 +152,7 @@ Primary tracker:
 - localization and docs operations:
   [#206](https://github.com/flyingrobots/bijou/issues/206),
   [#207](https://github.com/flyingrobots/bijou/issues/207),
-  [#208](https://github.com/flyingrobots/bijou/issues/208), and
-  [#312](https://github.com/flyingrobots/bijou/issues/312)
+  [#208](https://github.com/flyingrobots/bijou/issues/208)
 - terminal input and host controls:
   [#316](https://github.com/flyingrobots/bijou/issues/316), if the transport
   contract becomes a product-control requirement rather than a standalone
@@ -169,24 +174,17 @@ that a cross-repository release is the next smallest honest boundary.
 
 ## Next Pull
 
-The immediate implementation pull is **DX-046: GraphQL-authored DOGFOOD block
-fixture [#329](https://github.com/flyingrobots/bijou/issues/329)**, a
-release-scoped child of the broad #302 tracker.
+The immediate implementation pull is the **#270/#312 release-prep guardrail
+cycle** for `v7.1.0`.
 
-The useful proof path is:
+#270 adds milestone-aware release readiness reporting so
+`npm run release:readiness -- --milestone vX.Y.Z` can prove tracker closure,
+WIP-label cleanup, obvious release-doc posture, release-packet presence, and
+package-smoke coverage before tagging.
 
-```text
-GraphQL SDL fixture
-  -> bijou-block/1 grouped artifact
-    -> ui-scene-ir/1
-      -> terminal Surface proof
-        -> graphql-bijou-block-debug/1 facts
-          -> DOGFOOD product facts
-```
-
-DX-046 should stay inside Bijou. Do not pull Wesley or Geordi into the critical
-path until one real DOGFOOD block or panel proves the source, artifact, IR,
-terminal, and debug contracts.
+#312 makes the DOGFOOD i18n debt scanner discover `examples/docs/**/*.ts`
+modules by default so new DOGFOOD docs modules cannot bypass the raw-string
+ratchet unless they are explicitly excluded as tooling-only.
 
 ## Forward Goalposts
 
@@ -197,17 +195,17 @@ before those scopes become tracker-enforced release packets.
 
 | Target | Goalpost | Tracker | Why It Belongs There | Release Gate |
 | :--- | :--- | :--- | :--- | :--- |
-| `v7.1.0` | Post-V7 Minor | DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329), candidate-only [#326](https://github.com/flyingrobots/bijou/pull/326), and `Unreleased` changelog work | The repo already has a meaningful post-V7 batch. One more Bijou-side DOGFOOD fixture makes the GraphQL/IR story release-worthy without turning this into a major; the broad #302 tracker stays in `Beyond` for `v8.0.0`. | DX-046 green, release evidence packet written, #329 kept in `v7.1.0` without moving #302 out of `Beyond`, and no broad scope creep. |
+| `v7.1.0` | Post-V7 Minor | Landed DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329), release-prep guardrails [#270](https://github.com/flyingrobots/bijou/issues/270) and [#312](https://github.com/flyingrobots/bijou/issues/312), candidate-only [#326](https://github.com/flyingrobots/bijou/pull/326), and `Unreleased` changelog work | The repo already has a meaningful post-V7 batch. The Bijou-side DOGFOOD GraphQL fixture landed; the remaining v7.1 work is release-readiness evidence and DOGFOOD i18n scanner coverage, not a new feature train. | DX-046 green, #270/#312 green, release evidence packet written, #329 kept in `v7.1.0` without moving #302 out of `Beyond`, and no broad scope creep. |
 | `v8.0.0` | Runtime Graph And Scene IR Product Contract | Beyond: [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#301](https://github.com/flyingrobots/bijou/issues/301), [#302](https://github.com/flyingrobots/bijou/issues/302). Triage: [#306](https://github.com/flyingrobots/bijou/issues/306), [#321](https://github.com/flyingrobots/bijou/issues/321). | This is the current product direction after DX-043 through DX-046: portable scenes, GraphQL blocks, deterministic debug facts, and product fixtures need to become a stable contract. | Stable artifact semantics, DOGFOOD round-trip fixtures, terminal/frame-capture proof, lower-mode and source-map receipts, and failure tests. |
-| `v9.0.0` | Product Workbench And Operator Surfaces | Beyond: [#204](https://github.com/flyingrobots/bijou/issues/204), [#205](https://github.com/flyingrobots/bijou/issues/205), [#206](https://github.com/flyingrobots/bijou/issues/206), [#207](https://github.com/flyingrobots/bijou/issues/207), [#208](https://github.com/flyingrobots/bijou/issues/208), [#214](https://github.com/flyingrobots/bijou/issues/214), [#215](https://github.com/flyingrobots/bijou/issues/215), [#217](https://github.com/flyingrobots/bijou/issues/217), [#218](https://github.com/flyingrobots/bijou/issues/218), [#248](https://github.com/flyingrobots/bijou/issues/248), [#272](https://github.com/flyingrobots/bijou/issues/272), [#311](https://github.com/flyingrobots/bijou/issues/311), [#312](https://github.com/flyingrobots/bijou/issues/312), [#315](https://github.com/flyingrobots/bijou/issues/315), [#318](https://github.com/flyingrobots/bijou/issues/318). Triage: [#317](https://github.com/flyingrobots/bijou/issues/317), [#316](https://github.com/flyingrobots/bijou/issues/316). | Once V8 stabilizes the artifact contract, the next value is authoring and inspecting real product surfaces: BlockLab, Theme Lab, localization operations, artifact matrices, and host controls. | Storybook-grade BlockLab workflows, Theme Inspector/Lab provenance, localization workbench proof, artifact matrices, and playback-backed terminal input where applicable. |
+| `v9.0.0` | Product Workbench And Operator Surfaces | Beyond: [#204](https://github.com/flyingrobots/bijou/issues/204), [#205](https://github.com/flyingrobots/bijou/issues/205), [#206](https://github.com/flyingrobots/bijou/issues/206), [#207](https://github.com/flyingrobots/bijou/issues/207), [#208](https://github.com/flyingrobots/bijou/issues/208), [#214](https://github.com/flyingrobots/bijou/issues/214), [#215](https://github.com/flyingrobots/bijou/issues/215), [#217](https://github.com/flyingrobots/bijou/issues/217), [#218](https://github.com/flyingrobots/bijou/issues/218), [#248](https://github.com/flyingrobots/bijou/issues/248), [#272](https://github.com/flyingrobots/bijou/issues/272), [#311](https://github.com/flyingrobots/bijou/issues/311), [#315](https://github.com/flyingrobots/bijou/issues/315), [#318](https://github.com/flyingrobots/bijou/issues/318). Triage: [#317](https://github.com/flyingrobots/bijou/issues/317), [#316](https://github.com/flyingrobots/bijou/issues/316). | Once V8 stabilizes the artifact contract, the next value is authoring and inspecting real product surfaces: BlockLab, Theme Lab, localization operations, artifact matrices, and host controls. | Storybook-grade BlockLab workflows, Theme Inspector/Lab provenance, localization workbench proof, artifact matrices, and playback-backed terminal input where applicable. |
 | `v10.0.0+` | Ecosystem Integration | Wesley, Geordi, and host integration follow-on work after V8/V9 shape the contracts | Cross-repository integration should consume proven Bijou contracts rather than define them under release pressure. | A cross-repo release packet with explicit dependency ordering, proof artifacts, and rollback boundaries. |
 
 ## Decision Points
 
 - **Next version**: `v7.1.0`. It is a small post-V7 minor release whose final
-  planned implementation pull is DX-046. The broad #302 tracker stays in
-  `Beyond` for `v8.0.0`; `v7.1.0` owns #329 as the release-scoped DX-046
-  implementation item.
+  planned feature pull, DX-046, has landed. The broad #302 tracker stays in
+  `Beyond` for `v8.0.0`; `v7.1.0` now owns #329 as closed DX-046 lineage plus
+  #270 and #312 as release-prep guardrails.
 - **No feature `v7.2.0`**: after `v7.1.0`, go directly to `v8.0.0` for new
   feature development unless maintenance pressure forces a narrow patch or
   stabilization release.
@@ -250,8 +248,6 @@ before those scopes become tracker-enforced release packets.
 | [#219](https://github.com/flyingrobots/bijou/issues/219) | `lane:inbox` | `type:enhancement` | RE-027 generalize crash-mode auto-exit beyond TTY detection |
 | [#248](https://github.com/flyingrobots/bijou/issues/248) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | Capture artifacts as first-class docs artifact matrix |
 | [#268](https://github.com/flyingrobots/bijou/issues/268) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | Method tracker-sync sentinel for GitHub milestones |
-| [#269](https://github.com/flyingrobots/bijou/issues/269) | `lane:bad-code` | `type:maintenance` | Review-cooldown merge sentinel |
-| [#270](https://github.com/flyingrobots/bijou/issues/270) | `lane:bad-code` / `lane:release` | `type:docs` / `type:maintenance` | Release-readiness gate for issue-complete milestones |
 | [#272](https://github.com/flyingrobots/bijou/issues/272) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | BlockLab toward Storybook-grade product workflows |
 | [#290](https://github.com/flyingrobots/bijou/issues/290) | `lane:cool-ideas` | `type:enhancement` / `type:docs` / `type:maintenance` | Method cycle artifact manifest |
 | [#298](https://github.com/flyingrobots/bijou/issues/298) | `lane:bad-code` | `type:maintenance` | Fixture-backed DOGFOOD view harness |
@@ -260,7 +256,6 @@ before those scopes become tracker-enforced release packets.
 | [#301](https://github.com/flyingrobots/bijou/issues/301) | `lane:cool-ideas` | `type:enhancement` / `type:maintenance` | Native Bijou frame-capture format |
 | [#302](https://github.com/flyingrobots/bijou/issues/302) | `lane:cool-ideas` | `type:enhancement` / `type:spike` | Compile GraphQL-authored UI scenes into Bijou Blocks |
 | [#311](https://github.com/flyingrobots/bijou/issues/311) | `lane:cool-ideas` | `type:enhancement` | DL-014 theme inspector drawer |
-| [#312](https://github.com/flyingrobots/bijou/issues/312) | `lane:bad-code` | `type:maintenance` | DOGFOOD i18n debt scanner misses new docs modules |
 | [#315](https://github.com/flyingrobots/bijou/issues/315) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | DOGFOOD theme lab and preset gallery |
 | [#318](https://github.com/flyingrobots/bijou/issues/318) | `lane:cool-ideas` | `type:enhancement` / `type:spike` | Rampensau-inspired Bijou theme generator |
 
@@ -292,7 +287,7 @@ horizon until GitHub metadata says so.
 | :--- | :--- | :--- |
 | `v7.0.0` | Shipped public release | DOGFOOD truth, BlockLab naming, release-facing proof, scoped Node I/O documentation, release title proof, and component-family Block contracts. Full lineage lives in the [v7.0.0 milestone](https://github.com/flyingrobots/bijou/milestone/2). |
 | `v6.0.0` | Skipped public release; complete lineage | Layout truth, standard Blocks, data binding, selection/copy, and status/feedback Blocks. Full lineage lives in the [v6.0.0 milestone](https://github.com/flyingrobots/bijou/milestone/1). |
-| `Beyond closed items` | Closed backlog lineage | [#289](https://github.com/flyingrobots/bijou/issues/289), [#308](https://github.com/flyingrobots/bijou/issues/308), [#313](https://github.com/flyingrobots/bijou/issues/313), and [#314](https://github.com/flyingrobots/bijou/issues/314) are closed milestone items whose work has already landed or been resolved. |
+| `Beyond closed items` | Closed backlog lineage | [#269](https://github.com/flyingrobots/bijou/issues/269), [#289](https://github.com/flyingrobots/bijou/issues/289), [#308](https://github.com/flyingrobots/bijou/issues/308), [#313](https://github.com/flyingrobots/bijou/issues/313), and [#314](https://github.com/flyingrobots/bijou/issues/314) are closed milestone items whose work has already landed or been resolved as not planned. |
 
 ## Maintenance Rule
 

--- a/docs/design/WF-132-release-readiness-and-dogfood-i18n-gates.md
+++ b/docs/design/WF-132-release-readiness-and-dogfood-i18n-gates.md
@@ -1,0 +1,64 @@
+# WF-132 - Release Readiness And DOGFOOD I18n Gates
+
+## Status
+
+In progress for issues
+[#270](https://github.com/flyingrobots/bijou/issues/270) and
+[#312](https://github.com/flyingrobots/bijou/issues/312).
+
+## Problem
+
+The repo already has `npm run release:readiness`, but the command is mostly a
+validation gauntlet. It does not produce a milestone-aware readiness report
+that proves tracker closure, WIP-label cleanup, release-document posture, and
+package smoke coverage before a release tag.
+
+The DOGFOOD i18n debt ratchet also depends on a hand-maintained source list.
+New `examples/docs/**/*.ts` modules can introduce visible strings without
+participating in the debt baseline.
+
+## Scope
+
+- Keep `release:readiness` as the single release readiness command.
+- Add an optional milestone report mode that can be run before tagging, for
+  example `npm run release:readiness -- --milestone v7.1.0`.
+- Classify tracker, docs, release-packet, and package-smoke readiness using
+  deterministic fixture-testable data.
+- Discover DOGFOOD TypeScript debt sources from `examples/docs/**/*.ts` by
+  default, with documented exclusions for tooling-only files.
+- Preserve per-surface i18n debt counts so ratchet output stays actionable.
+
+## Non-Goals
+
+- Do not move broad V8/V9 product work into `v7.1.0`.
+- Do not require GitHub access for the default no-argument local gauntlet.
+- Do not replace the GitHub release dry-run workflow; the local report should
+  point to the existing workflow boundary.
+- Do not burn down the current DOGFOOD raw-string debt in this cycle.
+
+## Implementation Plan
+
+1. Extend `scripts/release-readiness.ts` with a milestone-aware readiness
+   report model and CLI parsing for `--milestone`.
+2. Keep the existing command plan intact, but add package-smoke proof by
+   recognizing the existing `smoke:canaries` package-pack canary step and the
+   release dry-run workflow boundary.
+3. Add fixture tests for ready, open-issue, lingering-WIP, stale-docs, and
+   missing-release-packet report classification.
+4. Replace the hand-maintained `DOGFOOD_I18N_DEBT_SOURCES` list with
+   deterministic source discovery under `examples/docs/`.
+5. Add tests proving newly added docs modules are discovered and can fail the
+   ratchet when they add raw visible strings.
+6. Update release/DOGFOOD docs, roadmap posture, and changelog entries.
+
+## Acceptance
+
+- `npm run release:readiness` keeps running the current gauntlet.
+- `npm run release:readiness -- --milestone v7.1.0` prints a concise readiness
+  report before running the gauntlet and blocks if milestone readiness is not
+  satisfied.
+- Report classification is covered by unit tests with fixture tracker data.
+- `dogfood:i18n:debt` covers new `examples/docs/**/*.ts` modules unless the
+  module is explicitly excluded as tooling-only.
+- The current DOGFOOD i18n baseline reflects the newly covered sources and
+  still reports counts by source surface.

--- a/docs/design/WF-132-release-readiness-and-dogfood-i18n-gates.md
+++ b/docs/design/WF-132-release-readiness-and-dogfood-i18n-gates.md
@@ -6,6 +6,23 @@ In progress for issues
 [#270](https://github.com/flyingrobots/bijou/issues/270) and
 [#312](https://github.com/flyingrobots/bijou/issues/312).
 
+## Linked Legend
+
+- `legend:wf` for release workflow readiness.
+- `legend:df` for DOGFOOD docs-surface coverage.
+- `legend:lx` for localization debt and scanner behavior.
+
+## Sponsors
+
+- Human sponsor: James Ross.
+- Agent sponsor: Codex.
+
+## Hill
+
+Before `v7.1.0` is cut, release readiness should be inspectable as a
+milestone-specific report and DOGFOOD i18n debt should cover newly added docs
+modules by default.
+
 ## Problem
 
 The repo already has `npm run release:readiness`, but the command is mostly a
@@ -36,6 +53,40 @@ participating in the debt baseline.
   point to the existing workflow boundary.
 - Do not burn down the current DOGFOOD raw-string debt in this cycle.
 
+## Playback Questions
+
+- Does `release:readiness -- --milestone v7.1.0` explain why a release is or is
+  not ready before running expensive local gates?
+- Can a new `examples/docs/**/*.ts` module introduce visible copy without
+  increasing the DOGFOOD i18n debt ratchet?
+- Are remaining release-process gaps documented instead of silently implied?
+
+## Accessibility / Assistive Posture
+
+No runtime UI accessibility behavior changes. The new readiness report is plain
+text plus a Markdown table so it can be copied into release PRs and read by
+terminal or screen-reader workflows.
+
+## Localization / Directionality Posture
+
+#312 directly strengthens localization guardrails. It does not localize
+existing raw DOGFOOD copy; it makes the current raw-string debt baseline honest
+across newly discovered DOGFOOD modules.
+
+## Agent Inspectability / Explainability Posture
+
+The release-readiness report classifies each gate as pass/fail with a concise
+summary. The i18n debt scanner continues to report counts by source surface so
+agents can identify which DOGFOOD module moved the ratchet.
+
+## Linked Invariants
+
+- Release tags require issue-complete tracker posture and release evidence.
+- DOGFOOD visible strings must either be cataloged, counted as known debt, or
+  explicitly excluded as non-product tooling.
+- The no-argument local `release:readiness` gauntlet must keep working without
+  GitHub access.
+
 ## Implementation Plan
 
 1. Extend `scripts/release-readiness.ts` with a milestone-aware readiness
@@ -51,6 +102,16 @@ participating in the debt baseline.
    ratchet when they add raw visible strings.
 6. Update release/DOGFOOD docs, roadmap posture, and changelog entries.
 
+## Tests To Write First
+
+- Release-readiness report classification for ready milestone fixture data.
+- Release-readiness report failures for open tracker issues, WIP labels, stale
+  release docs, and missing release packet evidence.
+- CLI parsing for `--milestone`.
+- DOGFOOD i18n source discovery for new docs modules and documented exclusions.
+- DOGFOOD i18n ratchet failure when a newly discovered module adds raw visible
+  text above a supplied zero baseline.
+
 ## Acceptance
 
 - `npm run release:readiness` keeps running the current gauntlet.
@@ -62,3 +123,7 @@ participating in the debt baseline.
   module is explicitly excluded as tooling-only.
 - The current DOGFOOD i18n baseline reflects the newly covered sources and
   still reports counts by source surface.
+
+## Retrospective
+
+To be completed when the PR lands.

--- a/docs/release.md
+++ b/docs/release.md
@@ -219,15 +219,18 @@ The next selected public release target is **`7.1.0`**.
 The latest shipped package release is `7.0.0`. The older `v6.0.0` milestone
 and the `v7.0.0` milestone are both zero-open tracker lanes retained as release
 lineage, not as the next target. `7.1.0` should stay a small post-V7 minor:
-ship the accumulated `Unreleased` work, include DX-046 issue #329 if it lands
-cleanly, and then move into release prep.
+ship the accumulated `Unreleased` work, carry landed DX-046 issue #329 as the
+final planned feature proof, and finish #270/#312 as release-prep guardrails
+before the release packet is cut.
 
 There is no planned feature `7.2.0` train. After `7.1.0`, new feature work
 should shape toward `8.0.0` unless a bug, security, dependency, or
 release-process reason justifies a narrow maintenance release.
 
-The `v7.1.0` GitHub milestone is the selected release packet. Before release
-prep begins, keep the selected scope reflected in
+The `v7.1.0` GitHub milestone is the selected release packet. DX-046 issue #329
+has landed; #270 and #312 are the selected release-prep guardrails before the
+release packet is cut. Before release prep begins, keep the selected scope
+reflected in
 [`docs/ROADMAP.md`](./ROADMAP.md), [`docs/BEARING.md`](./BEARING.md), the live
 tracker, and the versioned release packet.
 
@@ -404,13 +407,24 @@ Run:
 
 ```bash
 npm run release:preflight
-npm run release:readiness
+npm run release:readiness -- --milestone vX.Y.Z
 npm run docs:inventory
 npm audit --omit=dev --audit-level=high
 ```
 
-`release:readiness` is the repo-native local gauntlet. It currently runs
-these gates in order:
+`release:readiness` is the repo-native local gauntlet. With `--milestone`, it
+first prints a release-readiness report and blocks before the gauntlet if:
+
+- the target GitHub milestone has open tracker issues
+- any milestone tracker issue still has `work-in-progress`
+- `ROADMAP.md` and `BEARING.md` do not mention the target milestone
+- `CHANGELOG.md` does not have an `Unreleased` or versioned release boundary
+- `docs/releases/X.Y.Z/README.md` release evidence packet is missing
+- the command plan no longer includes package smoke or the release guide no
+  longer documents the release dry-run package boundary
+
+Without `--milestone`, the command runs only the local gauntlet and does not
+require GitHub access. The gauntlet currently runs these gates in order:
 
 1. `build`
 2. `lint`
@@ -597,10 +611,10 @@ Abort immediately if any of these are true:
   `release:readiness` are the current repo-native commands.
 - clean-worktree is an operator preflight check, not a `release:readiness`
   concern, because Phase 2 intentionally dirties the worktree
-- branch-sync, latest-tag, tag-collision, live GitHub issue gates, changelog
-  dating, release tag ancestry, release evidence shape, and human review
-  disposition are documented here, but they do not yet have a single dedicated
-  repo-native guard
+- branch-sync, latest-tag, tag-collision, live GitHub pull-request milestone
+  gates, changelog dating, release tag ancestry, release evidence shape, and
+  human review disposition are documented here, but they do not yet have a
+  single dedicated repo-native guard
 - `docs:inventory` and runtime `npm audit` are release policy gates but are not
   currently part of `release:readiness`
 - JSR publishing is not currently part of Bijou's release surface

--- a/examples/docs/i18n-debt.ts
+++ b/examples/docs/i18n-debt.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { posix as posixPath } from 'node:path';
 import ts from 'typescript';
 import { parse as parseYaml } from 'yaml';
@@ -21,6 +21,11 @@ export interface DogfoodI18nDebtEntry {
 export interface DogfoodI18nDebtSurfaceCount {
   readonly surface: string;
   readonly count: number;
+}
+
+export interface DogfoodI18nDebtSourceExclusion {
+  readonly path: string;
+  readonly reason: string;
 }
 
 export interface DogfoodI18nDebtInventory {
@@ -90,23 +95,67 @@ interface DogfoodMarkdownLocalizationSpec {
 
 type DogfoodMarkdownFileReader = (path: string) => string;
 
-export const DOGFOOD_I18N_DEBT_SOURCES: readonly DogfoodI18nDebtSource[] = Object.freeze([
-  { surface: 'docs-app', path: 'examples/docs/app.ts' },
-  { surface: 'dogfood-locale', path: 'examples/docs/locale.ts' },
-  { surface: 'component-stories', path: 'examples/docs/stories.ts' },
-  { surface: 'storybook-app', path: 'examples/docs/storybook-app.ts' },
-  { surface: 'storybook-workstation', path: 'examples/docs/storybook-workstation.ts' },
-  { surface: 'storybook-entrypoint', path: 'examples/docs/storybook.ts' },
+const DOGFOOD_I18N_DEBT_ROOT = 'examples/docs';
+
+export const DOGFOOD_I18N_DEBT_SOURCE_EXCLUSIONS: readonly DogfoodI18nDebtSourceExclusion[] = Object.freeze([
+  {
+    path: 'examples/docs/i18n-debt.ts',
+    reason: 'localization debt scanner implementation, not a DOGFOOD product surface',
+  },
 ]);
 
+const DOGFOOD_I18N_DEBT_SURFACE_NAMES: Readonly<Record<string, string>> = Object.freeze({
+  'examples/docs/app.ts': 'docs-app',
+  'examples/docs/locale.ts': 'dogfood-locale',
+  'examples/docs/stories.ts': 'component-stories',
+  'examples/docs/storybook-app.ts': 'storybook-app',
+  'examples/docs/storybook-workstation.ts': 'storybook-workstation',
+  'examples/docs/storybook.ts': 'storybook-entrypoint',
+});
+
+export function discoverDogfoodI18nDebtSources(
+  options: {
+    readonly rootPath?: string;
+    readonly paths?: readonly string[];
+  } = {},
+): readonly DogfoodI18nDebtSource[] {
+  const rootPath = options.rootPath ?? DOGFOOD_I18N_DEBT_ROOT;
+  const excludedPaths = new Set(DOGFOOD_I18N_DEBT_SOURCE_EXCLUSIONS.map((entry) => entry.path));
+  const paths = options.paths ?? listRepoTypescriptFiles(rootPath);
+  return Object.freeze(paths
+    .filter((path) => path.startsWith(`${rootPath}/`))
+    .filter((path) => /\.tsx?$/.test(path) && !/\.d\.ts$/.test(path))
+    .filter((path) => !excludedPaths.has(path))
+    .sort()
+    .map((path) => Object.freeze({
+      surface: dogfoodI18nDebtSurface(path, rootPath),
+      path,
+    })));
+}
+
+export const DOGFOOD_I18N_DEBT_SOURCES: readonly DogfoodI18nDebtSource[] = discoverDogfoodI18nDebtSources();
+
 export const DOGFOOD_I18N_DEBT_BASELINE: DogfoodI18nDebtBaseline = Object.freeze({
-  total: 1993,
+  total: 2772,
   bySurface: Object.freeze({
-    'component-stories': 1638,
-    'docs-app': 299,
+    'capture-main': 17,
+    'component-stories': 1631,
+    'counter-block-demo': 56,
+    coverage: 1,
+    'docs-app': 258,
+    'dogfood-blocks': 681,
     'dogfood-locale': 12,
+    'dogfood-shell-themes': 6,
+    'i18n-dogfood-authoring': 1,
+    'i18n-dogfood-catalog': 3,
+    'i18n-missing-localization': 3,
+    localization: 1,
+    'node-locale': 7,
+    'release-title': 44,
     'storybook-app': 37,
     'storybook-workstation': 7,
+    'svg-raster': 2,
+    'terminal-guard': 5,
   }),
 });
 
@@ -225,7 +274,7 @@ export function collectDogfoodMarkdownLocalizationDebt(
     readonly templateValues?: Readonly<Record<string, string>>;
   } = {},
 ): DogfoodMarkdownLocalizationInventory {
-  const sources = options.sources ?? [{ surface: 'docs-app', path: 'examples/docs/app.ts' }];
+  const sources = options.sources ?? DOGFOOD_I18N_DEBT_SOURCES;
   const locales = options.locales ?? DOGFOOD_LOCALE_OPTIONS.map((option) => option.id);
   const defaultLocale = options.defaultLocale ?? DEFAULT_LOCALE.id;
   const targetLocales = locales.filter((locale) => locale !== defaultLocale);
@@ -269,6 +318,35 @@ export function collectDogfoodMarkdownLocalizationDebt(
     byLocale,
     total: entries.length,
   });
+}
+
+function listRepoTypescriptFiles(rootPath: string): readonly string[] {
+  const files: string[] = [];
+
+  function visit(repoPath: string): void {
+    for (const entry of readdirSync(repoUrl(repoPath), { withFileTypes: true })) {
+      const entryPath = posixPath.join(repoPath, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+        continue;
+      }
+      if (entry.isFile() && /\.tsx?$/.test(entry.name) && !/\.d\.ts$/.test(entry.name)) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  visit(rootPath);
+  return Object.freeze(files.sort());
+}
+
+function dogfoodI18nDebtSurface(path: string, rootPath: string): string {
+  const explicit = DOGFOOD_I18N_DEBT_SURFACE_NAMES[path];
+  if (explicit != null) return explicit;
+  return path
+    .slice(rootPath.length + 1)
+    .replace(/\.tsx?$/, '')
+    .replaceAll('/', '-');
 }
 
 export function evaluateDogfoodMarkdownLocalizationRatchet(
@@ -713,11 +791,15 @@ function isImportOrExportDeclaration(node: ts.Node): boolean {
 }
 
 function readRepoFile(path: string): string {
-  return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+  return readFileSync(repoUrl(path), 'utf8');
 }
 
 function repoFileExists(path: string): boolean {
-  return existsSync(new URL(`../../${path}`, import.meta.url));
+  return existsSync(repoUrl(path));
+}
+
+function repoUrl(path: string): URL {
+  return new URL(`../../${path}`, import.meta.url);
 }
 
 function defaultMarkdownTemplateValues(): Readonly<Record<string, string>> {

--- a/scripts/dogfood-i18n-debt.test.ts
+++ b/scripts/dogfood-i18n-debt.test.ts
@@ -1,13 +1,56 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DOGFOOD_I18N_DEBT_SOURCE_EXCLUSIONS,
   collectDogfoodI18nDebt,
   collectDogfoodMarkdownLocalizationDebt,
+  discoverDogfoodI18nDebtSources,
   evaluateDogfoodI18nDebtRatchet,
   evaluateDogfoodMarkdownLocalizationRatchet,
 } from '../examples/docs/i18n-debt.js';
 import { runDogfoodI18nDebtInventory } from './dogfood-i18n-debt.js';
 
 describe('DOGFOOD i18n debt inventory', () => {
+  it('discovers new DOGFOOD docs modules while keeping tooling exclusions explicit', () => {
+    const sources = discoverDogfoodI18nDebtSources({
+      paths: [
+        'examples/docs/app.ts',
+        'examples/docs/dogfood-shell-themes.ts',
+        'examples/docs/i18n/new-docs-module.ts',
+        'examples/docs/i18n-debt.ts',
+        'examples/docs/content/guide.md',
+        'examples/hello/hello.ts',
+      ],
+    });
+
+    expect(sources).toEqual([
+      { surface: 'docs-app', path: 'examples/docs/app.ts' },
+      { surface: 'dogfood-shell-themes', path: 'examples/docs/dogfood-shell-themes.ts' },
+      { surface: 'i18n-new-docs-module', path: 'examples/docs/i18n/new-docs-module.ts' },
+    ]);
+    expect(DOGFOOD_I18N_DEBT_SOURCE_EXCLUSIONS).toContainEqual({
+      path: 'examples/docs/i18n-debt.ts',
+      reason: 'localization debt scanner implementation, not a DOGFOOD product surface',
+    });
+  });
+
+  it('fails the ratchet when a newly discovered DOGFOOD module adds raw visible text', () => {
+    const sources = discoverDogfoodI18nDebtSources({
+      paths: ['examples/docs/new-docs-module.ts'],
+    }).map((source) => ({
+      ...source,
+      text: "export const label = 'Fresh DOGFOOD Label';",
+    }));
+    const inventory = collectDogfoodI18nDebt({ sources });
+    const result = evaluateDogfoodI18nDebtRatchet(inventory, {
+      total: 0,
+      bySurface: {},
+    });
+
+    expect(inventory.bySurface).toEqual([{ surface: 'new-docs-module', count: 1 }]);
+    expect(result.ok).toBe(false);
+    expect(result.violations).toContain('new-docs-module 1 exceeds baseline 0');
+  });
+
   it('counts uncataloged visible strings while ignoring ids, paths, and catalog fallbacks', () => {
     const inventory = collectDogfoodI18nDebt({
       sources: [{

--- a/scripts/release-readiness.test.ts
+++ b/scripts/release-readiness.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import { buildReleaseReadinessPlan, runReleaseReadiness } from './release-readiness.js';
+import {
+  buildReleaseReadinessPlan,
+  buildReleaseReadinessReport,
+  parseReleaseReadinessArgs,
+  runReleaseReadiness,
+  type ReleaseReadinessDocsSnapshot,
+} from './release-readiness.js';
+
+function releaseDocsSnapshot(
+  milestone: string,
+  options: { readonly releasePacketExists?: boolean; readonly staleDocs?: boolean } = {},
+): ReleaseReadinessDocsSnapshot {
+  const version = milestone.replace(/^v/, '');
+  const milestoneText = options.staleDocs === true ? 'v0.0.0' : milestone;
+  return {
+    roadmap: `ROADMAP ${milestoneText}`,
+    bearing: `BEARING ${milestoneText}`,
+    changelog: `## [Unreleased]\n\n## [${version}]`,
+    releaseGuide: `release:readiness ${milestoneText} release-dry-run`,
+    releasePacketExists: options.releasePacketExists ?? true,
+  };
+}
 
 describe('release-readiness', () => {
   it('runs the expected release gate commands in order', () => {
@@ -83,5 +104,101 @@ describe('release-readiness', () => {
 
     expect(code).toBe(0);
     expect(stdout.at(-1)).toBe('release-readiness: ok\n');
+  });
+
+  it('classifies a milestone report as ready when tracker, docs, packet, and package smoke are ready', () => {
+    const report = buildReleaseReadinessReport({
+      milestone: 'v7.1.0',
+      trackerItems: [{
+        number: 329,
+        title: 'DX-046',
+        state: 'CLOSED',
+        labels: [{ name: 'legend:dx' }],
+      }],
+      docs: releaseDocsSnapshot('v7.1.0'),
+    });
+
+    expect(report.status).toBe('ready');
+    expect(report.checks.map((check) => `${check.label}:${check.status}`)).toEqual([
+      'tracker-open-items:pass',
+      'tracker-wip-labels:pass',
+      'docs-roadmap-bearing:pass',
+      'docs-changelog:pass',
+      'release-packet:pass',
+      'package-smoke:pass',
+    ]);
+  });
+
+  it('blocks a milestone report when tracker issues are open or still marked work-in-progress', () => {
+    const report = buildReleaseReadinessReport({
+      milestone: 'v7.1.0',
+      trackerItems: [
+        {
+          number: 270,
+          title: 'Release readiness',
+          state: 'OPEN',
+          labels: [{ name: 'lane:bad-code' }],
+        },
+        {
+          number: 312,
+          title: 'DOGFOOD i18n scanner',
+          state: 'CLOSED',
+          labels: [{ name: 'work-in-progress' }],
+        },
+      ],
+      docs: releaseDocsSnapshot('v7.1.0'),
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.openTrackerItems.map((item) => item.number)).toEqual([270]);
+    expect(report.wipTrackerItems.map((item) => item.number)).toEqual([312]);
+    expect(report.checks.find((check) => check.label === 'tracker-open-items')?.summary).toContain('#270');
+    expect(report.checks.find((check) => check.label === 'tracker-wip-labels')?.summary).toContain('#312');
+  });
+
+  it('blocks a milestone report when release docs or release packet evidence are stale', () => {
+    const report = buildReleaseReadinessReport({
+      milestone: 'v7.1.0',
+      trackerItems: [],
+      docs: releaseDocsSnapshot('v7.1.0', {
+        releasePacketExists: false,
+        staleDocs: true,
+      }),
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.checks.find((check) => check.label === 'docs-roadmap-bearing')?.status).toBe('fail');
+    expect(report.checks.find((check) => check.label === 'release-packet')?.status).toBe('fail');
+  });
+
+  it('prints and enforces a milestone report before running the local gauntlet', () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const executed: string[] = [];
+
+    const code = runReleaseReadiness({
+      milestone: 'v7.1.0',
+      trackerItems: [{ number: 270, title: 'Release readiness', state: 'OPEN' }],
+      docs: releaseDocsSnapshot('v7.1.0'),
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+      runCommand(step) {
+        executed.push(step.label);
+        return { status: 0 };
+      },
+    });
+
+    expect(code).toBe(1);
+    expect(stdout.join('')).toContain('Release readiness: BLOCKED (v7.1.0)');
+    expect(stderr.join('')).toContain('release-readiness: v7.1.0 report is blocked');
+    expect(executed).toEqual([]);
+  });
+
+  it('parses milestone CLI arguments', () => {
+    expect(parseReleaseReadinessArgs([])).toEqual({});
+    expect(parseReleaseReadinessArgs(['--milestone', 'v7.1.0'])).toEqual({ milestone: 'v7.1.0' });
+    expect(parseReleaseReadinessArgs(['--milestone=v7.1.0'])).toEqual({ milestone: 'v7.1.0' });
+    expect(() => parseReleaseReadinessArgs(['--milestone'])).toThrow('--milestone requires a value');
+    expect(() => parseReleaseReadinessArgs(['--wat'])).toThrow('unknown release:readiness option: --wat');
   });
 });

--- a/scripts/release-readiness.ts
+++ b/scripts/release-readiness.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 
 import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,8 +11,47 @@ export interface ReleaseReadinessStep {
   readonly args: readonly string[];
 }
 
+export interface ReleaseReadinessTrackerLabel {
+  readonly name: string;
+}
+
+export interface ReleaseReadinessTrackerItem {
+  readonly number: number;
+  readonly title: string;
+  readonly state: string;
+  readonly labels?: readonly (string | ReleaseReadinessTrackerLabel)[];
+  readonly url?: string;
+}
+
+export interface ReleaseReadinessDocsSnapshot {
+  readonly roadmap: string;
+  readonly bearing: string;
+  readonly changelog: string;
+  readonly releaseGuide: string;
+  readonly releasePacketExists: boolean;
+}
+
+export type ReleaseReadinessCheckStatus = 'pass' | 'fail';
+
+export interface ReleaseReadinessReportCheck {
+  readonly label: string;
+  readonly status: ReleaseReadinessCheckStatus;
+  readonly summary: string;
+}
+
+export interface ReleaseReadinessReport {
+  readonly milestone: string;
+  readonly status: 'ready' | 'blocked';
+  readonly checks: readonly ReleaseReadinessReportCheck[];
+  readonly openTrackerItems: readonly ReleaseReadinessTrackerItem[];
+  readonly wipTrackerItems: readonly ReleaseReadinessTrackerItem[];
+}
+
 export interface ReleaseReadinessIO {
   readonly cwd?: string;
+  readonly milestone?: string;
+  readonly trackerItems?: readonly ReleaseReadinessTrackerItem[];
+  readonly docs?: ReleaseReadinessDocsSnapshot;
   readonly stdout?: (text: string) => void;
   readonly stderr?: (text: string) => void;
   readonly runCommand?: (step: ReleaseReadinessStep, cwd: string) => {
@@ -44,6 +84,91 @@ export function buildReleaseReadinessPlan(): readonly ReleaseReadinessStep[] {
   ];
 }
 
+export function buildReleaseReadinessReport(options: {
+  readonly milestone: string;
+  readonly trackerItems: readonly ReleaseReadinessTrackerItem[];
+  readonly docs: ReleaseReadinessDocsSnapshot;
+  readonly plan?: readonly ReleaseReadinessStep[];
+}): ReleaseReadinessReport {
+  const milestone = options.milestone;
+  const version = milestone.replace(/^v/, '');
+  const plan = options.plan ?? buildReleaseReadinessPlan();
+  const openTrackerItems = options.trackerItems.filter((item) => item.state.toUpperCase() !== 'CLOSED');
+  const wipTrackerItems = options.trackerItems.filter((item) => (
+    trackerItemLabelNames(item).includes('work-in-progress')
+  ));
+  const hasChangelogBoundary = options.docs.changelog.includes(`## [${version}]`)
+    || options.docs.changelog.includes(`## [${milestone}]`)
+    || options.docs.changelog.includes('## [Unreleased]');
+  const hasPackageSmoke = plan.some((step) => step.label === 'smoke:canaries');
+  const hasReleaseDryRunBoundary = options.docs.releaseGuide.includes('release-dry-run')
+    || options.docs.releaseGuide.includes('Release Dry Run');
+  const checks: ReleaseReadinessReportCheck[] = [
+    {
+      label: 'tracker-open-items',
+      status: openTrackerItems.length === 0 ? 'pass' : 'fail',
+      summary: openTrackerItems.length === 0
+        ? `${milestone} has zero open tracker issues`
+        : `${milestone} has ${openTrackerItems.length} open tracker issue(s): ${formatTrackerItems(openTrackerItems)}`,
+    },
+    {
+      label: 'tracker-wip-labels',
+      status: wipTrackerItems.length === 0 ? 'pass' : 'fail',
+      summary: wipTrackerItems.length === 0
+        ? `${milestone} has no lingering work-in-progress labels`
+        : `${milestone} has work-in-progress labels on ${formatTrackerItems(wipTrackerItems)}`,
+    },
+    {
+      label: 'docs-roadmap-bearing',
+      status: options.docs.roadmap.includes(milestone) && options.docs.bearing.includes(milestone) ? 'pass' : 'fail',
+      summary: options.docs.roadmap.includes(milestone) && options.docs.bearing.includes(milestone)
+        ? `ROADMAP.md and BEARING.md mention ${milestone}`
+        : `ROADMAP.md and BEARING.md must both mention ${milestone}`,
+    },
+    {
+      label: 'docs-changelog',
+      status: hasChangelogBoundary ? 'pass' : 'fail',
+      summary: hasChangelogBoundary
+        ? `CHANGELOG.md has an Unreleased or ${milestone} release boundary`
+        : `CHANGELOG.md must contain an Unreleased or ${milestone} release boundary`,
+    },
+    {
+      label: 'release-packet',
+      status: options.docs.releasePacketExists ? 'pass' : 'fail',
+      summary: options.docs.releasePacketExists
+        ? `docs/releases/${version}/README.md exists`
+        : `docs/releases/${version}/README.md release evidence packet is missing`,
+    },
+    {
+      label: 'package-smoke',
+      status: hasPackageSmoke && hasReleaseDryRunBoundary ? 'pass' : 'fail',
+      summary: hasPackageSmoke && hasReleaseDryRunBoundary
+        ? 'release:readiness includes smoke:canaries and release.md documents the release dry-run package boundary'
+        : 'release:readiness must include smoke:canaries and release.md must document the release dry-run package boundary',
+    },
+  ];
+
+  return Object.freeze({
+    milestone,
+    status: checks.some((check) => check.status === 'fail') ? 'blocked' : 'ready',
+    checks: Object.freeze(checks.map((check) => Object.freeze({ ...check }))),
+    openTrackerItems: Object.freeze(openTrackerItems.map((item) => Object.freeze({ ...item }))),
+    wipTrackerItems: Object.freeze(wipTrackerItems.map((item) => Object.freeze({ ...item }))),
+  });
+}
+
+export function formatReleaseReadinessReport(report: ReleaseReadinessReport): string {
+  return [
+    `Release readiness: ${report.status.toUpperCase()} (${report.milestone})`,
+    '| Check | Status | Summary |',
+    '| :--- | :--- | :--- |',
+    ...report.checks.map((check) => (
+      `| ${check.label} | ${check.status.toUpperCase()} | ${escapeMarkdownTableCell(check.summary)} |`
+    )),
+    '',
+  ].join('\n');
+}
+
 function defaultRunCommand(step: ReleaseReadinessStep, cwd: string): { readonly status: number | null; readonly error?: Error } {
   const result = spawnSync(step.command, step.args, {
     cwd,
@@ -60,8 +185,23 @@ export function runReleaseReadiness(io: ReleaseReadinessIO = {}): number {
   const stdout = io.stdout ?? ((text: string) => process.stdout.write(text));
   const stderr = io.stderr ?? ((text: string) => process.stderr.write(text));
   const runCommand = io.runCommand ?? defaultRunCommand;
+  const plan = buildReleaseReadinessPlan();
 
-  for (const step of buildReleaseReadinessPlan()) {
+  if (io.milestone != null) {
+    const report = buildReleaseReadinessReport({
+      milestone: io.milestone,
+      trackerItems: io.trackerItems ?? readMilestoneTrackerItems(io.milestone, cwd),
+      docs: io.docs ?? readReleaseReadinessDocs(cwd, io.milestone),
+      plan,
+    });
+    stdout(formatReleaseReadinessReport(report));
+    if (report.status === 'blocked') {
+      stderr(`release-readiness: ${io.milestone} report is blocked\n`);
+      return 1;
+    }
+  }
+
+  for (const step of plan) {
     stdout(`==> ${step.label}\n`);
     const result = runCommand(step, cwd);
     if (result.error) {
@@ -78,8 +218,94 @@ export function runReleaseReadiness(io: ReleaseReadinessIO = {}): number {
   return 0;
 }
 
+export function parseReleaseReadinessArgs(args: readonly string[]): { readonly milestone?: string } {
+  let milestone: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--milestone') {
+      const value = args[index + 1];
+      if (value == null || value.startsWith('--')) {
+        throw new Error('--milestone requires a value');
+      }
+      milestone = value;
+      index += 1;
+      continue;
+    }
+    if (arg?.startsWith('--milestone=')) {
+      milestone = arg.slice('--milestone='.length);
+      if (milestone === '') throw new Error('--milestone requires a value');
+      continue;
+    }
+    throw new Error(`unknown release:readiness option: ${arg}`);
+  }
+  return milestone == null ? {} : { milestone };
+}
+
+function readMilestoneTrackerItems(milestone: string, cwd: string): readonly ReleaseReadinessTrackerItem[] {
+  const result = spawnSync('gh', [
+    'issue',
+    'list',
+    '--state',
+    'all',
+    '--milestone',
+    milestone,
+    '--limit',
+    '1000',
+    '--json',
+    'number,title,state,labels,url',
+  ], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`gh issue list exited with status ${result.status ?? 'null'}: ${result.stderr.trim()}`);
+  }
+
+  const parsed = JSON.parse(result.stdout) as ReleaseReadinessTrackerItem[];
+  return Object.freeze(parsed.map((item) => Object.freeze({
+    number: item.number,
+    title: item.title,
+    state: item.state,
+    labels: Object.freeze([...(item.labels ?? [])]),
+    url: item.url,
+  })));
+}
+
+function readReleaseReadinessDocs(cwd: string, milestone: string): ReleaseReadinessDocsSnapshot {
+  const version = milestone.replace(/^v/, '');
+  return Object.freeze({
+    roadmap: readFileSync(resolve(cwd, 'docs/ROADMAP.md'), 'utf8'),
+    bearing: readFileSync(resolve(cwd, 'docs/BEARING.md'), 'utf8'),
+    changelog: readFileSync(resolve(cwd, 'docs/CHANGELOG.md'), 'utf8'),
+    releaseGuide: readFileSync(resolve(cwd, 'docs/release.md'), 'utf8'),
+    releasePacketExists: existsSync(resolve(cwd, 'docs/releases', version, 'README.md')),
+  });
+}
+
+function trackerItemLabelNames(item: ReleaseReadinessTrackerItem): readonly string[] {
+  return Object.freeze((item.labels ?? []).map((label) => (
+    typeof label === 'string' ? label : label.name
+  )));
+}
+
+function formatTrackerItems(items: readonly ReleaseReadinessTrackerItem[]): string {
+  return items.map((item) => `#${item.number}`).join(', ');
+}
+
+function escapeMarkdownTableCell(text: string): string {
+  return text.replaceAll('|', '\\|');
+}
+
 function main(): void {
-  process.exitCode = runReleaseReadiness();
+  try {
+    process.exitCode = runReleaseReadiness(parseReleaseReadinessArgs(process.argv.slice(2)));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`release-readiness: ${message}\n`);
+    process.exitCode = 1;
+  }
 }
 
 if (process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -58,8 +58,9 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`v9.0.0`: Product Workbench And Operator Surfaces');
     expect(roadmap).toContain('`v10.0.0+`: Ecosystem Integration');
     expect(roadmap).toContain('v6.0.0` was never published as a public package release');
-    expect(roadmap).toContain('| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 1 | 0 |');
+    expect(roadmap).toContain('| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 2 | 1 |');
     expect(roadmap).toContain('Selected next release packet.');
+    expect(roadmap).toContain('#270 and #312 are the release-prep guardrail items.');
     expect(roadmap).toContain('`v6.0.0`');
     expect(roadmap).toContain('0 | 30');
     expect(roadmap).toContain('Skipped public release lane.');
@@ -67,9 +68,13 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('0 | 27');
     expect(roadmap).toContain('Latest shipped release lineage.');
     expect(roadmap).toContain('`Beyond`');
-    expect(roadmap).toContain('33 | 4');
+    expect(roadmap).toContain('30 | 5');
     expect(roadmap).toContain('Next Pull');
-    expect(roadmap).toContain('DX-046: GraphQL-authored DOGFOOD block fixture');
+    expect(roadmap).toContain('#270/#312 release-prep guardrail cycle');
+    expect(roadmap).toContain('milestone-aware release readiness reporting');
+    expect(roadmap).toContain('DOGFOOD i18n debt scanner');
+    expect(roadmap).toContain('https://github.com/flyingrobots/bijou/issues/270');
+    expect(roadmap).toContain('https://github.com/flyingrobots/bijou/issues/312');
     expect(roadmap).toContain('https://github.com/flyingrobots/bijou/issues/329');
     expect(roadmap).toContain('Forward Goalposts');
     expect(roadmap).toContain('Decision Points');
@@ -100,13 +105,13 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).not.toContain('Workflow, Capture, And CI Determinism');
     expect(bearing).toContain('The latest shipped public release is `v7.0.0`');
     expect(bearing).toContain('The next selected public release target is `v7.1.0`');
-    expect(bearing).toContain('The next active pull is `DX-046` / #329');
+    expect(bearing).toContain('The immediate release-prep focus is #270 and #312 for `v7.1.0`');
     expect(bearing).toContain('There is no planned `v7.2.0` feature train.');
     expect(bearing).toContain('Shape V8 And V9 From Beyond');
     expect(bearing).not.toContain('The next release-facing action is release-readiness validation');
 
     expect(releaseRunbook).toContain('The next selected public release target is **`7.1.0`**');
-    expect(releaseRunbook).toContain('include DX-046 issue #329');
+    expect(releaseRunbook).toContain('finish #270/#312 as release-prep guardrails');
     expect(releaseRunbook).toContain('There is no planned feature `7.2.0` train.');
     expect(releaseRunbook).not.toContain('No next public release version is selected');
 
@@ -139,10 +144,12 @@ describe('WF-130 roadmap goalpost policy', () => {
     const v8Row = goalposts.split('\n').find(line => line.startsWith('| `v8.0.0` |')) ?? '';
 
     expect(v71Row).toContain('https://github.com/flyingrobots/bijou/issues/329');
+    expect(v71Row).toContain('https://github.com/flyingrobots/bijou/issues/270');
+    expect(v71Row).toContain('https://github.com/flyingrobots/bijou/issues/312');
     expect(v71Row).not.toContain('https://github.com/flyingrobots/bijou/issues/302');
     expect(v8Row).toContain('https://github.com/flyingrobots/bijou/issues/302');
     expect(normalizedRoadmap).toContain(
-      'The broad #302 tracker stays in `Beyond` for `v8.0.0`; `v7.1.0` owns #329 as the release-scoped DX-046 implementation item.',
+      'The broad #302 tracker stays in `Beyond` for `v8.0.0`; `v7.1.0` now owns #329 as closed DX-046 lineage plus #270 and #312 as release-prep guardrails.',
     );
   });
 
@@ -189,7 +196,7 @@ describe('WF-130 roadmap goalpost policy', () => {
   it('keeps the Beyond open snapshot count aligned with the Open Beyond Issues table', () => {
     const roadmap = read('docs/ROADMAP.md');
     const beyondRow = roadmap.match(/\| `Beyond` \| \[Beyond\]\([^)]+\) \| (?<open>\d+) \| (?<closed>\d+) \|/);
-    expect(beyondRow?.groups?.closed).toBe('4');
+    expect(beyondRow?.groups?.closed).toBe('5');
 
     const openBeyondIssues = sectionBetween(
       roadmap,


### PR DESCRIPTION
## Summary

- Adds milestone-aware `npm run release:readiness -- --milestone vX.Y.Z` reporting before the existing local release gauntlet.
- Blocks release readiness on open milestone tracker issues, lingering `work-in-progress` labels, stale roadmap/bearing/changelog posture, missing versioned release packet evidence, or missing package-smoke coverage.
- Switches DOGFOOD i18n debt from a hand-maintained source list to deterministic `examples/docs/**/*.ts` source discovery with explicit tooling-only exclusions.
- Updates v7.1.0 roadmap/bearing/release docs for the #270/#312 release-prep guardrail scope.

Closes #270.
Closes #312.

## Notes

`npm run release:readiness -- --milestone v7.1.0` currently blocks as expected because #270/#312 are still open on this PR and `docs/releases/7.1.0/README.md` has not been written yet. The stale `work-in-progress` label on closed #329 was removed after the new report caught it.

## Validation

- `npm test -- scripts/release-readiness.test.ts scripts/dogfood-i18n-debt.test.ts`
- `npm test -- tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
- `npm run dogfood:i18n:debt`
- `npm run release:readiness -- --milestone v7.1.0` exits 1 with expected blockers: open #270/#312 and missing `docs/releases/7.1.0/README.md`
- `npm run docs:inventory`
- `npm run typecheck:test`
- `npm run lint`
- `npm run release:readiness`
- `git diff --check HEAD`
- pre-push hook: DOGFOOD i18n complete/check/debt, `typecheck:test`, full `npm test`, scripted interactive examples
