### PR TITLE
Polish DOGFOOD shell and Blocks defaults

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Fixed
+
+- **DOGFOOD shell polish** — repeated `Tab` presses no longer trigger a hidden
+  footer hide/show gesture, the quit confirmation now renders as a compact
+  themed modal with readable action keys, and the Blocks section now opens the
+  interactive `CounterDemoBlock` preview first.
+
 ### 🧭 Planning
 
 - **DOGFOOD post-release polish shaping** —

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,9 +6,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
-### Notes
+### 🧭 Planning
 
-- _Nothing yet._
+- **DOGFOOD post-release polish shaping** —
+  `docs/design/DF-075-dogfood-post-release-polish.md` scopes a bounded #334
+  follow-up for disabling the hidden double-`Tab` footer toggle, restyling the
+  quit confirmation, and making Blocks lead with `CounterDemoBlock`.
 
 ## [7.1.0] - 2026-06-14
 

--- a/docs/design/DF-075-dogfood-post-release-polish.md
+++ b/docs/design/DF-075-dogfood-post-release-polish.md
@@ -1,0 +1,133 @@
+---
+title: DF-075 DOGFOOD Post-Release Polish
+legend: DF
+lane: inbox
+priority: medium
+status: proposed
+github_issue: 334
+keywords:
+  - dogfood
+  - app-shell
+  - quit-confirm
+  - blocks
+  - polish
+---
+
+# DF-075 DOGFOOD Post-Release Polish
+
+Legend: [DF - DOGFOOD](../legends/DF-dogfood.md)
+
+## Linked Work
+
+- GitHub Issue: #334
+- Related future release-story work: #335
+- Related future affordance work: #336
+
+This document scopes a bounded post-release polish cycle. It does not reopen
+the `v7.1.0` feature train and it does not claim the broader V8 Runtime Graph
+and Scene IR product surface.
+
+## Decision Summary
+
+DOGFOOD should absorb the three most visible post-release polish findings from
+the `v7.1.0` sanity pass without expanding into a broad shell redesign:
+
+1. Disable the hidden double-`Tab` footer toggle until the AppShell has a
+   visible command, animation, and restore affordance.
+2. Restyle the quit confirmation so it is compact, themed, aligned, and easy
+   to answer in the default theme.
+3. Make the Blocks section lead with `CounterDemoBlock`, because that is the
+   most alive interactive proof of what Blocks are.
+
+## Sponsored Human
+
+A DOGFOOD user wants the docs app to feel deliberate after `v7.1.0`: no hidden
+state that leaves terminal background behind, no awkward quit prompt, and a
+Blocks page that immediately demonstrates an interactive block instead of
+starting on descriptive prose.
+
+## Sponsored Agent
+
+An agent wants deterministic behavior to assert: footer visibility should not
+change through undocumented key timing, the quit dialog should have stable
+themed geometry, and the Blocks default route should identify the same guide id
+that renders the interactive counter proof.
+
+## Hill
+
+DOGFOOD can start the post-`v7.1.0` era with a cleaner shell and a stronger
+Blocks first impression while keeping the patch small, testable, and isolated
+from V8 product-contract work.
+
+## Scope
+
+### Disable Hidden Footer Toggle
+
+The current hidden double-`Tab` footer toggle is not discoverable. When hidden,
+it can expose uncolored terminal background and does not explain how to recover
+the footer. This cycle should remove that key path from normal DOGFOOD/AppShell
+input handling. `Tab` should remain the normal focus traversal key.
+
+This does not forbid a future footer command. A future version can reintroduce
+footer visibility as an explicit command with visible state, animation, help
+text, and theme-safe repaint behavior.
+
+### Restyle Quit Confirmation
+
+The quit confirmation should render as a compact modal rather than a tall,
+skinny prompt. Its background, border, title, body, and actions should use the
+selected frame theme instead of leaving unthemed terminal patches.
+
+The action labels must be readable in the default DOGFOOD theme. The dialog
+should keep the existing command contract: confirm quits, reject closes the
+dialog, and normal app state remains underneath.
+
+### Counter-First Blocks
+
+The Blocks section should open directly on `CounterDemoBlock`. Selecting the
+`Block Preview` parent row should also route to `CounterDemoBlock`, making the
+preview group demonstrate an interactive block first.
+
+Static and descriptive block previews remain available below it. The prior
+navigation fix that lets focus move from the first preview child back to the
+`Block Preview` parent row must not regress.
+
+## Out Of Scope
+
+- #335 release-story surfaces: What's New, GraphQL proof, and CHANGELOG viewer.
+- #336 future affordances: theme hotkey, tab badges, tutorial, and achievements.
+- A full AppShell animation or layout redesign.
+- A new `v7.2.0` feature train.
+- Broad V8 Runtime Graph and Scene IR product-contract work.
+
+## Playback Questions
+
+1. Does pressing `Tab` repeatedly leave the footer visible and themed?
+2. Does the quit confirmation render with compact themed geometry and readable
+   `Yes` / `No` actions?
+3. Does opening Blocks, or activating `Block Preview`, show
+   `CounterDemoBlock` first?
+4. Does arrow navigation still allow the `Block Preview` parent row to receive
+   focus from the first standard block preview child?
+
+## Test Plan
+
+- Add or update DOGFOOD Blocks tests in
+  `tests/cycles/DX-031/dogfood-blocks-section.test.ts` for initial Blocks
+  selection and `Block Preview` activation.
+- Add AppShell regression coverage proving `Tab` no longer emits a hidden
+  footer toggle path.
+- Extend quit confirmation tests in `packages/bijou-tui/src/` so the modal's
+  compact geometry and action styling are observable.
+- Run the focused test files, `npm run typecheck:test`, `npm run lint`,
+  `npm run docs:inventory`, `git diff --check`, and the relevant broader suite
+  before review.
+
+## Acceptance Criteria
+
+- Double-`Tab` no longer hides the DOGFOOD footer.
+- The quit confirmation is compact, filled, aligned, and theme-readable.
+- Blocks starts on `CounterDemoBlock`, and the `Block Preview` parent opens the
+  same interactive demo.
+- Existing Blocks guide focus behavior remains intact.
+- The change is linked from #334 and carried by a non-draft PR to `main`.

--- a/docs/design/DF-075-dogfood-post-release-polish.md
+++ b/docs/design/DF-075-dogfood-post-release-polish.md
@@ -15,7 +15,7 @@ keywords:
 
 # DF-075 DOGFOOD Post-Release Polish
 
-Legend: [DF - DOGFOOD](../legends/DF-dogfood.md)
+Legend: [DF - DOGFOOD](../legends/DF-dogfood-field-guide.md)
 
 ## Linked Work
 
@@ -104,7 +104,7 @@ navigation fix that lets focus move from the first preview child back to the
 
 1. Does pressing `Tab` repeatedly leave the footer visible and themed?
 2. Does the quit confirmation render with compact themed geometry and readable
-   `Yes` / `No` actions?
+   `Y Quit` / `N Stay` actions?
 3. Does opening Blocks, or activating `Block Preview`, show
    `CounterDemoBlock` first?
 4. Does arrow navigation still allow the `Block Preview` parent row to receive

--- a/docs/design/DF-075-dogfood-post-release-polish.md
+++ b/docs/design/DF-075-dogfood-post-release-polish.md
@@ -1,7 +1,7 @@
 ---
 title: DF-075 DOGFOOD Post-Release Polish
 legend: DF
-lane: inbox
+lane: asap
 priority: medium
 status: proposed
 github_issue: 334

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -2101,7 +2101,7 @@ function createInitialExplorerModel(
 ): DocsExplorerModel {
   const expandedFamilies = Object.fromEntries(STORY_FAMILIES.map((family) => [family.id, false]));
   const guideItems = guideItemsForPage(pageId);
-  return {
+  const model: DocsExplorerModel = {
     layoutVariant: resolveDocsLayoutVariant(ctx.runtime.columns, ctx.runtime.rows),
     familyState: createBrowsableListState({
       items: buildFamilyItems(expandedFamilies),
@@ -2124,6 +2124,9 @@ function createInitialExplorerModel(
     landingQualityMode: 'auto',
     counterBlockDemo: createCounterDemoModel(5),
   };
+  return pageId === BLOCKS_PAGE_ID
+    ? selectGuide(pageId, model, COUNTER_DEMO_BLOCK_GUIDE_ID)
+    : model;
 }
 
 function createInitialComponentsExplorerModel(
@@ -2388,8 +2391,7 @@ function selectedGuide(pageId: DocsPageId, model: DocsExplorerModel): GuideDoc |
 
 function resolveSelectableGuideId(pageId: DocsPageId, guideId: string): string {
   if (pageId === BLOCKS_PAGE_ID && guideId === BLOCK_PREVIEW_GUIDE_ID) {
-    const firstBlock = standardBlocks[0];
-    return firstBlock == null ? guideId : blockPreviewGuideId(firstBlock);
+    return COUNTER_DEMO_BLOCK_GUIDE_ID;
   }
 
   return guideId;
@@ -2426,12 +2428,7 @@ function selectFocusedBlockPreviewGuide(pageId: DocsPageId, model: DocsExplorerM
   const doc = focusedGuideDoc(pageId, model);
   if (doc == null) return model;
   if (doc.id === BLOCK_PREVIEW_GUIDE_ID) {
-    const firstBlock = standardBlocks[0];
-    if (firstBlock == null) return model;
-    return {
-      ...model,
-      selectedGuideId: blockPreviewGuideId(firstBlock),
-    };
+    return model;
   }
   if (
     doc.id !== COUNTER_DEMO_BLOCK_GUIDE_ID

--- a/packages/bijou-tui/ADVANCED_GUIDE.md
+++ b/packages/bijou-tui/ADVANCED_GUIDE.md
@@ -233,10 +233,10 @@ import {
 } from '@flyingrobots/bijou-tui';
 
 const recognizer = createInputGestureRecognizer({ doubleTapMs: 300 });
-const actions = createInputActionMap<{ type: 'toggle-footer' }>()
-  .bind('footer.doubleTab', 'Toggle footer', [
-    { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
-  ], { type: 'toggle-footer' });
+const actions = createInputActionMap<{ type: 'open-jump-list' }>()
+  .bind('nav.doubleG', 'Open jump list', [
+    { deviceId: 'keyboard', featureId: 'key.g', type: 'double-tap' },
+  ], { type: 'open-jump-list' });
 
 const inputEvent = recognizer.observeKey(keyMsg, ctx.runtime.clock.now());
 const action = actions.handle(inputEvent);
@@ -245,10 +245,10 @@ const action = actions.handle(inputEvent);
 Feature-event patterns are arrays so compound inputs can stay declarative:
 
 ```typescript
-actions.bind('ctrlDoubleTab', 'Ctrl double-tap Tab', [
+actions.bind('ctrlDoubleG', 'Ctrl double-tap G', [
   { deviceId: 'keyboard', featureId: 'modifier.ctrl', type: 'held' },
-  { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
-], { type: 'toggle-footer' });
+  { deviceId: 'keyboard', featureId: 'key.g', type: 'double-tap' },
+], { type: 'open-jump-list' });
 ```
 
 The recognizer uses caller-provided timestamps instead of owning a timer. That

--- a/packages/bijou-tui/README.md
+++ b/packages/bijou-tui/README.md
@@ -303,10 +303,10 @@ import {
 } from '@flyingrobots/bijou-tui';
 
 const recognizer = createInputGestureRecognizer({ doubleTapMs: 300 });
-const actions = createInputActionMap<{ type: 'toggle-footer' }>()
-  .bind('footer.doubleTab', 'Toggle footer', [
-    { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
-  ], { type: 'toggle-footer' });
+const actions = createInputActionMap<{ type: 'open-jump-list' }>()
+  .bind('nav.doubleG', 'Open jump list', [
+    { deviceId: 'keyboard', featureId: 'key.g', type: 'double-tap' },
+  ], { type: 'open-jump-list' });
 
 const action = actions.handle(recognizer.observeKey(keyMsg, ctx.runtime.clock.now()));
 ```

--- a/packages/bijou-tui/src/app-frame-i18n.ts
+++ b/packages/bijou-tui/src/app-frame-i18n.ts
@@ -82,7 +82,7 @@ export const FRAME_I18N_CATALOG: I18nCatalog = {
     message('help.key.stay', 'Stay'),
     message('quit.title', 'Quit?'),
     message('quit.body', 'Quit this app?'),
-    message('quit.footer', 'Y quit • N stay'),
+    message('quit.footer', 'Y Quit • N Stay'),
     message('mode.normal', 'NORMAL'),
     message('mode.palette', 'PALETTE'),
     message('mode.help', 'HELP'),

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -533,7 +533,7 @@ describe('createFramedApp', () => {
     expect(result.model.focusedPaneByPage.home).toBe('right');
   });
 
-  it('toggles the footer with a double Tab gesture while preserving single Tab pane focus', async () => {
+  it('keeps the footer visible while repeated Tab gestures traverse panes', async () => {
     const page: FramePage<PageModel, Msg> = {
       id: 'home',
       title: 'Home',
@@ -553,7 +553,7 @@ describe('createFramedApp', () => {
     });
     const tab = { type: 'key' as const, key: 'tab', ctrl: false, alt: false, shift: false };
 
-    let [model] = app.init();
+    const [model] = app.init();
     const [afterSingleTab, singleTabCmds] = app.update(tab, model);
 
     expect(afterSingleTab.focusedPaneByPage.home).toBe('right');
@@ -561,38 +561,17 @@ describe('createFramedApp', () => {
     expect(afterSingleTab.footerTranslateY).toBe(0);
     expect(singleTabCmds).toHaveLength(0);
 
-    let footerCmds: Cmd<FramedAppMsg<Msg>>[];
-    [model, footerCmds] = app.update(tab, afterSingleTab);
+    const [afterRepeatedTab, repeatedTabCmds] = app.update(tab, afterSingleTab);
 
-    expect(model.focusedPaneByPage.home).toBe('right');
-    expect(model.footerVisible).toBe(false);
-    expect(footerCmds).toHaveLength(1);
-
-    const hideMessages = await collectCommandMessages(footerCmds[0]!, [0.1, 0.1]);
-    for (const message of hideMessages) {
-      [model] = app.update(message, model);
-    }
-
-    expect(model.footerVisible).toBe(false);
-    expect(model.footerTranslateY).toBe(1);
+    expect(afterRepeatedTab.focusedPaneByPage.home).toBe('left');
+    expect(afterRepeatedTab.footerVisible).toBe(true);
+    expect(afterRepeatedTab.footerTranslateY).toBe(0);
+    expect(repeatedTabCmds).toHaveLength(0);
     expect(surfaceToString(
-      normalizeViewOutput(app.view(model), { width: model.columns, height: model.rows }).surface,
-      testCtx.style,
-    )).not.toContain('[NORMAL]');
-
-    [model] = app.update(tab, model);
-    [model, footerCmds] = app.update(tab, model);
-    expect(model.footerVisible).toBe(true);
-
-    const showMessages = await collectCommandMessages(footerCmds[0]!, [0.1, 0.1]);
-    for (const message of showMessages) {
-      [model] = app.update(message, model);
-    }
-
-    expect(model.footerVisible).toBe(true);
-    expect(model.footerTranslateY).toBe(0);
-    expect(surfaceToString(
-      normalizeViewOutput(app.view(model), { width: model.columns, height: model.rows }).surface,
+      normalizeViewOutput(
+        app.view(afterRepeatedTab),
+        { width: afterRepeatedTab.columns, height: afterRepeatedTab.rows },
+      ).surface,
       testCtx.style,
     )).toContain('[NORMAL]');
   });

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -167,10 +167,6 @@ import {
   openCommandPalette,
   openSearchPalette,
 } from './app-frame-palette.js';
-import {
-  createInputActionMap,
-  createInputGestureRecognizer,
-} from './input-map.js';
 import type { RenderStageTiming } from './pipeline/pipeline.js';
 
 // ---------------------------------------------------------------------------
@@ -553,7 +549,6 @@ export {
 const FRAME_NOTIFICATION_TICK_MS = 40;
 const DEFAULT_FRAME_NOTIFICATION_DURATION_MS = 6_000;
 const SETTINGS_FEEDBACK_TOAST_WIDTH = 40;
-const FRAME_FOOTER_DOUBLE_TAB_MS = 300;
 const EMPTY_RUNTIME_LAYOUTS = createRuntimeRetainedLayouts();
 
 interface ResolvedFrameNotificationOptions {
@@ -903,13 +898,6 @@ export function createFramedApp<PageModel, Msg>(
     enableNotifications: options.notificationCenter != null || options.runtimeNotifications !== false,
     i18n: options.i18n,
   });
-  const frameInputRecognizer = createInputGestureRecognizer({
-    doubleTapMs: FRAME_FOOTER_DOUBLE_TAB_MS,
-  });
-  const frameInputActions = createInputActionMap<FrameAction>()
-    .bind('frame.footer.doubleTab', 'Toggle footer', [
-      { deviceId: 'keyboard', featureId: 'key.tab', type: 'double-tap' },
-    ], { type: 'toggle-footer' });
   const quitHelpKeys = createQuitHelpKeys(options.i18n);
   const helpLayerHelpKeys = createHelpLayerHelpKeys(options.i18n);
   const settingsHelpKeys = createSettingsHelpKeys(options.i18n);
@@ -1283,25 +1271,6 @@ export function createFramedApp<PageModel, Msg>(
     return [{ type: 'observed-key', msg, route }, { type: 'open-quit-confirm' }];
   }
 
-  function resolveFrameInputActionCommands(
-    msg: KeyMsg,
-    route: ObservedKeyRoute,
-  ): FrameShellCommand<Msg>[] | undefined {
-    const inputEvent = frameInputRecognizer.observeKey(msg, resolveClock(resolveFrameCtx()).now());
-    const inputAction = frameInputActions.handle(inputEvent);
-    if (inputAction == null || msg.ctrl || msg.alt || msg.shift) {
-      return undefined;
-    }
-    return [{ type: 'observed-key', msg, route }, { type: 'apply-frame-action', action: inputAction }];
-  }
-
-  function routeForFrameInputAction(layerKind: FrameLayerKind): ObservedKeyRoute {
-    if (layerKind === 'search' || layerKind === 'command-palette') return 'palette';
-    if (layerKind === 'help') return 'help';
-    if (layerKind === 'page-modal') return 'page';
-    return 'frame';
-  }
-
   function resolveFrameActionCommands(
     msg: KeyMsg,
     action: FrameAction,
@@ -1573,14 +1542,6 @@ export function createFramedApp<PageModel, Msg>(
       ({ layer }) => {
         const frameLayer = layer.model;
         if (frameLayer == null) return undefined;
-        const inputActionCommands = resolveFrameInputActionCommands(
-          msg,
-          routeForFrameInputAction(frameLayer.kind),
-        );
-        if (inputActionCommands != null) {
-          return { handled: true, commands: inputActionCommands };
-        }
-
         if (frameLayer.kind === 'search' || frameLayer.kind === 'command-palette') {
           return { handled: true, commands: handlePaletteLayerKeyCommands(msg, frameLayer.kind) };
         }
@@ -2060,7 +2021,7 @@ export function createFramedApp<PageModel, Msg>(
     const helpHint = frameMessage(options.i18n, 'help.hint', 'j/k scroll • d/u page • g/G top/bottom • mouse wheel • ?/Esc close');
     const settingsHint = frameMessage(options.i18n, 'settings.footer', 'F2/Esc close • ↑/↓ rows • Enter toggle • / search • q quit');
     const notificationsHint = frameMessage(options.i18n, 'notifications.footer', 'Shift+N close • f filter • j/k scroll • q quit');
-    const quitHint = frameMessage(options.i18n, 'quit.footer', 'Y quit • N stay');
+    const quitHint = frameMessage(options.i18n, 'quit.footer', 'Y Quit • N Stay');
     const paletteTitle = model.commandPaletteTitle
       ?? frameMessage(options.i18n, 'palette.title', 'Command Palette');
     const activePageTitle = resolveFramePageText(activePage.title, activePageModel) ?? '';

--- a/packages/bijou-tui/src/shell-quit.test.ts
+++ b/packages/bijou-tui/src/shell-quit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
 import { stripAnsi } from '@flyingrobots/bijou';
 import { renderShellQuitOverlay } from './shell-quit.js';
 
@@ -12,6 +13,38 @@ describe('shell quit confirmation', () => {
     const text = stripAnsi(overlay.content);
 
     expect(text).toContain('Quit this app?');
-    expect(occurrences(text, 'Y quit • N stay')).toBe(1);
+    expect(occurrences(text, 'Y Quit')).toBe(1);
+    expect(occurrences(text, 'N Stay')).toBe(1);
+  });
+
+  it('uses compact themed geometry for the confirmation modal', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const overlay = renderShellQuitOverlay(80, 24, undefined, ctx);
+
+    expect(overlay.surface).toBeDefined();
+    expect(overlay.surface!.width).toBeGreaterThanOrEqual(36);
+    expect(overlay.surface!.width).toBeLessThanOrEqual(44);
+    expect(overlay.surface!.height).toBeLessThanOrEqual(7);
+    expect(overlay.surface!.get(2, 3).bg).toBe(ctx.surface('elevated').bg);
+  });
+
+  it('styles quit action keys so they are not muted into the body copy', () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const overlay = renderShellQuitOverlay(80, 24, undefined, ctx);
+    const surface = overlay.surface!;
+
+    const actionCells: { char: string; modifiers?: readonly string[]; fg?: unknown; fgRGB?: unknown }[] = [];
+    for (let y = 0; y < surface.height; y++) {
+      for (let x = 0; x < surface.width; x++) {
+        const cell = surface.get(x, y);
+        if (cell.char === 'Y' || cell.char === 'N') actionCells.push(cell);
+      }
+    }
+
+    expect(actionCells).toHaveLength(2);
+    for (const cell of actionCells) {
+      expect(cell.modifiers).toContain('bold');
+      expect(cell.fg ?? cell.fgRGB).toBeDefined();
+    }
   });
 });

--- a/packages/bijou-tui/src/shell-quit.ts
+++ b/packages/bijou-tui/src/shell-quit.ts
@@ -1,4 +1,13 @@
-import { resolveSafeCtx, stringToSurface, type BijouContext } from '@flyingrobots/bijou';
+import {
+  createSurface,
+  graphemeClusterWidth,
+  resolveSafeCtx,
+  segmentGraphemes,
+  stringToSurface,
+  type BijouContext,
+  type Cell,
+  type Surface,
+} from '@flyingrobots/bijou';
 import { modal, type Overlay } from './overlay.js';
 import type { KeyMsg } from './types.js';
 import type { I18nRuntime } from '@flyingrobots/bijou-i18n';
@@ -32,6 +41,55 @@ export function isShellQuitConfirmDismiss(msg: KeyMsg): boolean {
   return !msg.shift && (msg.key === 'escape' || msg.key === 'q');
 }
 
+function textWidth(text: string): number {
+  return segmentGraphemes(text).reduce(
+    (width, grapheme) => width + Math.max(1, graphemeClusterWidth(grapheme)),
+    0,
+  );
+}
+
+function writeHintText(surface: Surface, x: number, text: string, style: Partial<Cell>): number {
+  let cursor = x;
+  for (const grapheme of segmentGraphemes(text)) {
+    const width = Math.max(1, graphemeClusterWidth(grapheme));
+    surface.set(cursor, 0, { char: grapheme, ...style, empty: false });
+    for (let offset = 1; offset < width; offset++) {
+      surface.set(cursor + offset, 0, { char: '', ...style, empty: false });
+    }
+    cursor += width;
+  }
+  return cursor;
+}
+
+function renderQuitHintSurface(i18n?: I18nRuntime, ctx?: BijouContext) {
+  const quitLabel = frameMessage(i18n, 'help.key.quit', 'Quit');
+  const stayLabel = frameMessage(i18n, 'help.key.stay', 'Stay');
+  const text = `Y ${quitLabel} • N ${stayLabel}`;
+  const surface = createSurface(textWidth(text), 1);
+  const keyStyle: Partial<Cell> = {
+    fg: ctx?.semantic('accent').hex,
+    fgRGB: ctx?.semantic('accent').fgRGB,
+    modifiers: ['bold'],
+  };
+  const actionStyle: Partial<Cell> = {
+    fg: ctx?.semantic('primary').hex,
+    fgRGB: ctx?.semantic('primary').fgRGB,
+    modifiers: ['bold'],
+  };
+  const mutedStyle: Partial<Cell> = {
+    fg: ctx?.semantic('muted').hex,
+    fgRGB: ctx?.semantic('muted').fgRGB,
+  };
+
+  let x = 0;
+  x = writeHintText(surface, x, 'Y', keyStyle);
+  x = writeHintText(surface, x, ` ${quitLabel}`, actionStyle);
+  x = writeHintText(surface, x, ' • ', mutedStyle);
+  x = writeHintText(surface, x, 'N', keyStyle);
+  writeHintText(surface, x, ` ${stayLabel}`, actionStyle);
+  return surface;
+}
+
 export function renderShellQuitOverlay(
   screenWidth: number,
   screenHeight: number,
@@ -40,15 +98,16 @@ export function renderShellQuitOverlay(
 ): Overlay {
   const title = frameMessage(i18n, 'quit.title', 'Quit?');
   const bodyText = frameMessage(i18n, 'quit.body', 'Quit this app?');
-  const hint = frameMessage(i18n, 'quit.footer', 'Y quit • N stay');
+  const modalWidth = Math.min(40, Math.max(8, screenWidth - 4));
+  const bodyWidth = Math.max(0, modalWidth - 4);
   return modal({
     title,
-    body: stringToSurface(bodyText, 20, 3),
-    hint,
+    body: stringToSurface(bodyText, bodyWidth, 1),
+    hint: renderQuitHintSurface(i18n, ctx),
     borderToken: ctx?.border('primary'),
     bgToken: ctx?.surface('elevated'),
     ctx,
-    width: 24,
+    width: modalWidth,
     screenWidth,
     screenHeight,
   });

--- a/tests/cycles/DX-031/dogfood-blocks-section.test.ts
+++ b/tests/cycles/DX-031/dogfood-blocks-section.test.ts
@@ -109,6 +109,7 @@ describe('DX-031D DOGFOOD Blocks section', () => {
     const model = result.model as any;
     const blocksModel = docsPageModel(model, 'blocks');
     const guideLabels = blocksModel.guideState.items.map((item: { label: string }) => item.label);
+    const text = frameText(result.frames.at(-1)!);
 
     expect(model.docsModel.activePageId).toBe('blocks');
     expect(guideLabels).toEqual([
@@ -121,10 +122,12 @@ describe('DX-031D DOGFOOD Blocks section', () => {
       '  CounterDemoBlock',
       'How Blocks Lower',
     ]);
-    expect(blocksModel.selectedGuideId).toBe('blocks-what-are-blocks');
+    expect(blocksModel.selectedGuideId).toBe('blocks-preview-counterdemoblock');
+    expect(text).toContain('CounterDemoBlock fixture');
+    expect(text).toContain('Counter: 5');
   });
 
-  it('opens the Block Preview group on the first standard block preview', async () => {
+  it('opens the Block Preview group on the interactive CounterDemoBlock preview', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 220, rows: 260 } });
     const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
 
@@ -135,13 +138,14 @@ describe('DX-031D DOGFOOD Blocks section', () => {
       },
     }], { ctx });
     const text = frameText(result.frames.at(-1)!);
-    const firstBlockName = standardBlocks[0]!.metadata.blockName;
 
-    expect(docsPageModel(result.model as any, 'blocks').selectedGuideId).toBe(blockPreviewGuideId(firstBlockName));
-    expect(text).toContain(`${firstBlockName}`);
+    expect(docsPageModel(result.model as any, 'blocks').selectedGuideId).toBe('blocks-preview-counterdemoblock');
+    expect(text).toContain('CounterDemoBlock fixture');
+    expect(text).toContain('Counter: 5');
+    expect(text).toContain('[-] decrease');
+    expect(text).toContain('[+] increase');
     expect(text).toContain('lowering summary');
     expect(text).toContain('documentation');
-    expect(text).not.toContain('Live example');
     expect(text).not.toContain('Available Blocks');
   });
 
@@ -152,6 +156,8 @@ describe('DX-031D DOGFOOD Blocks section', () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 150, rows: 43 } });
     const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
     const result = await runScript(app, [
+      { msg: { type: 'docs', msg: { type: 'select-guide', guideId: 'blocks-what-are-blocks' } } },
+      { msg: { type: 'docs', msg: { type: 'guide-next' } } },
       { msg: { type: 'docs', msg: { type: 'guide-next' } } },
       { msg: { type: 'docs', msg: { type: 'guide-next' } } },
       { msg: { type: 'docs', msg: { type: 'guide-next' } } },


### PR DESCRIPTION
## Summary

This PR implements the bounded #334 DOGFOOD post-release polish cycle.

- removes the hidden double-`Tab` footer hide/show gesture from AppShell input so repeated `Tab` stays normal pane traversal
- restyles the quit confirmation as a compact themed modal with a one-line body and readable styled `Y Quit` / `N Stay` actions
- makes the Blocks section open on `CounterDemoBlock` first, and makes activating `Block Preview` route to the same interactive counter proof
- preserves the prior Blocks navigation fix: arrowing from the first standard block child back to the `Block Preview` parent row keeps focus on the parent without unexpectedly changing the selected document

## Linked Work

- Closes #334
- Design: `docs/design/DF-075-dogfood-post-release-polish.md`

## Validation

- RED: focused tests failed against the old hidden footer toggle, old quit modal geometry/action styling, and old Blocks default selection
- GREEN: `npm test -- --run packages/bijou-tui/src/app-frame.test.ts packages/bijou-tui/src/shell-quit.test.ts tests/cycles/DX-031/dogfood-blocks-section.test.ts`
- `npm test -- --run tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts`
- `npm test -- --run packages/bijou-tui/src/app-frame.test.ts packages/bijou-tui/src/shell-quit.test.ts tests/cycles/DX-031/dogfood-blocks-section.test.ts tests/cycles/DF-068/dogfood-block-preview-regressions.test.ts`
- `npm run typecheck:test`
- `npm run lint`
- `npm run docs:inventory`
- `git diff --check`
- pre-commit lint / lockfile consistency
- pre-push DOGFOOD i18n completeness/check/debt
- pre-push `npm run typecheck:test`
- pre-push full `npm test` (346 files, 3846 tests)
- pre-push scripted interactive example smoke
