### PR TITLE
Fix BlockLab navigation ownership

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Fixed
 
+- **BlockLab navigation ownership** — `npm run blocklab` now lets the
+  workbench's `up` / `down` and `j` / `k` story navigation bindings win over
+  generic framed-shell scroll bindings, so the release-demo workbench moves the
+  selected story instead of surfacing key-shadowing behavior.
 - **DOGFOOD shell polish** — repeated `Tab` presses no longer trigger a hidden
   footer hide/show gesture, the quit confirmation now renders as a compact
   themed modal with readable action keys, and the Blocks section now opens the

--- a/docs/design/DF-076-blocklab-demo-readiness.md
+++ b/docs/design/DF-076-blocklab-demo-readiness.md
@@ -1,0 +1,43 @@
+---
+id: DF-076
+title: BlockLab Demo Readiness Navigation
+status: active
+lane: asap
+github_issue: 338
+legend: DF
+---
+
+# DF-076 - BlockLab Demo Readiness Navigation
+
+## Decision Summary
+
+BlockLab is a focused app/workbench surface. Its story navigation keys must win
+over generic framed-shell scroll bindings.
+
+## Problem
+
+`npm run blocklab` runs through `createFramedApp()`. The frame shell defaults to
+`keyPriority: "frame-first"`, so story-navigation keys such as `up`, `down`,
+`j`, and `k` are consumed by generic frame scroll bindings before BlockLab sees
+them.
+
+That makes BlockLab unusable in the release-video path and contradicts the
+workbench contract: when the app advertises story navigation keys, those keys
+must move the selected story.
+
+## Scope
+
+- Configure the BlockLab framed app to prefer page-owned keys.
+- Add a regression that sends navigation keys through the framed-app runner
+  path and asserts selected-story movement.
+
+## Non-Goals
+
+- Change the default key priority for all framed apps.
+- Redesign BlockLab.
+- Add Theme Lab, localization, or GraphQL demo surfaces.
+
+## Playback
+
+Run `npm run blocklab`, press `down` or `j`, and verify the selected story moves
+from `alert()` to `badge()` without a frame key-shadowing warning.

--- a/examples/docs/storybook-app.ts
+++ b/examples/docs/storybook-app.ts
@@ -111,6 +111,7 @@ export function createStorybookFrameApp(
     title,
     initialColumns: ctx.runtime.columns,
     initialRows: ctx.runtime.rows,
+    keyPriority: 'page-first',
     helpLineSource: () => FOOTER_HINT,
     pages: [createStorybookPage(ctx, stories, title, options.initialStoryId)],
   });

--- a/tests/cycles/DF-027/storybook-workstation.test.ts
+++ b/tests/cycles/DF-027/storybook-workstation.test.ts
@@ -138,18 +138,30 @@ describe('DF-027 BlockLab DOGFOOD workstation', () => {
 
     for (const key of [KEY_DOWN, 'j']) {
       const app = createStorybookFrameApp(ctx);
+      const [initialModel] = app.init();
+      const initialPageModel = (initialModel as any).pageModels.storybook;
+      const before = selectedStorybookStory(initialPageModel).id;
       const result = await runScript(app, [{ key }], { ctx, pulseFps: false });
       const pageModel = (result.model as any).pageModels.storybook;
+      const after = selectedStorybookStory(pageModel).id;
 
-      expect(selectedStorybookStory(pageModel).id).toBe('badge');
+      expect(before).toBe('alert');
+      expect(after).not.toBe(before);
+      expect(after).toBe('badge');
     }
 
     for (const key of [KEY_UP, 'k']) {
       const app = createStorybookFrameApp(ctx, { initialStoryId: 'badge' });
+      const [initialModel] = app.init();
+      const initialPageModel = (initialModel as any).pageModels.storybook;
+      const before = selectedStorybookStory(initialPageModel).id;
       const result = await runScript(app, [{ key }], { ctx, pulseFps: false });
       const pageModel = (result.model as any).pageModels.storybook;
+      const after = selectedStorybookStory(pageModel).id;
 
-      expect(selectedStorybookStory(pageModel).id).toBe('alert');
+      expect(before).toBe('badge');
+      expect(after).not.toBe(before);
+      expect(after).toBe('alert');
     }
   });
 });

--- a/tests/cycles/DF-027/storybook-workstation.test.ts
+++ b/tests/cycles/DF-027/storybook-workstation.test.ts
@@ -14,8 +14,12 @@ import {
   renderDogfoodStorybookIndex,
 } from '../../../examples/docs/storybook-workstation.js';
 import { COMPONENT_STORIES } from '../../../examples/docs/stories.js';
+import { runScript } from '../../../packages/bijou-tui/src/driver.js';
 import { normalizeViewOutput } from '../../../packages/bijou-tui/src/view-output.js';
 import { readRepoFile } from '../repo.js';
+
+const KEY_UP = '\x1b[A';
+const KEY_DOWN = '\x1b[B';
 
 describe('DF-027 BlockLab DOGFOOD workstation', () => {
   it('keeps the active cycle doc tied to the playback contract', () => {
@@ -127,5 +131,25 @@ describe('DF-027 BlockLab DOGFOOD workstation', () => {
     expect(text).toContain('Bijou BlockLab');
     expect(text).toContain('BlockLab');
     expect(text).toContain('notification-system');
+  });
+
+  it('lets framed BlockLab navigation keys move the selected story', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
+
+    for (const key of [KEY_DOWN, 'j']) {
+      const app = createStorybookFrameApp(ctx);
+      const result = await runScript(app, [{ key }], { ctx, pulseFps: false });
+      const pageModel = (result.model as any).pageModels.storybook;
+
+      expect(selectedStorybookStory(pageModel).id).toBe('badge');
+    }
+
+    for (const key of [KEY_UP, 'k']) {
+      const app = createStorybookFrameApp(ctx, { initialStoryId: 'badge' });
+      const result = await runScript(app, [{ key }], { ctx, pulseFps: false });
+      const pageModel = (result.model as any).pageModels.storybook;
+
+      expect(selectedStorybookStory(pageModel).id).toBe('alert');
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes BlockLab story navigation inside the framed app shell.

The BlockLab workbench has page-owned navigation bindings for `up`, `down`, `j`, and `k`, but the surrounding frame shell defaulted to `frame-first` key ownership. That let generic frame scroll bindings consume those keys before the storybook page could move the selected story.

## Changes

- Configures the BlockLab framed app with `keyPriority: 'page-first'`.
- Adds a framed-app regression that sends arrow and vim-style navigation through `runScript()` and asserts selected-story movement.
- Adds DF-076 design documentation for the focused demo-readiness slice.
- Records the fix in the changelog.

Closes #338.

## Validation

- `git diff --check`
- `npm test -- --run tests/cycles/DF-027/storybook-workstation.test.ts`
- `npm run docs:inventory`
- `npm run lint`
- pre-push gate:
  - `npm run dogfood:i18n:complete`
  - `npm run dogfood:i18n:check`
  - `npm run dogfood:i18n:debt`
  - `npm run typecheck:test`
  - `npm test`
  - `npm run verify:interactive-examples -- --skip-build --mode=interactive-scripted`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BlockLab story navigation keys (up, down, j, k) to properly prioritize workbench navigation over frame scroll bindings.

* **Documentation**
  * Added design documentation for BlockLab demo readiness and navigation key priority handling.

* **Tests**
  * Added regression test for story navigation key behavior in the BlockLab workbench.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->