### PR TITLE
Make DOGFOOD light theme demo-ready

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -105,8 +105,8 @@ Current direction and active tensions. Historical ship data is in
 - The first `v7.2.0` demo-integrity pull was RE-041: fix framework mouse
   fallthrough (#344), expose page-scoped frame helpers (#345), and add scripted
   mouse builders (#353).
-- The current urgent `v7.2.0` pull is LX-020: make DOGFOOD non-English locale
-  demo paths honest and marker-free for #340.
+- The current urgent `v7.2.0` pull is DL-017: make DOGFOOD light-theme chrome
+  painted, readable, and diagnostically covered for #341.
 - The next feature horizon remains `v8.0.0`: the Runtime Graph and Scene IR
   product contract built from the proof chain that v7.1.0 shipped.
 - The detailed release-horizon index lives in [ROADMAP.md](./ROADMAP.md), and
@@ -124,8 +124,8 @@ Current direction and active tensions. Historical ship data is in
 
 ### 3. Stabilize V7.2, Then Shape V8 And V9 From Beyond
 
-- The `v7.2.0` milestone is the current active stabilization lane: 7 open and
-  6 closed milestone items as of the latest roadmap sync.
+- The `v7.2.0` milestone is the current active stabilization lane: 5 open and
+  8 closed milestone items as of the latest roadmap sync.
 - The `Beyond` milestone is the current post-v7 backlog: 31 open and 6 closed
   milestone items as of the latest roadmap sync.
 - `v7.2.0` should stay bounded to the framework input and DOGFOOD demo-integrity
@@ -191,8 +191,8 @@ GraphQL SDL fixture
 
 Recommended pull order:
 
-1. Land LX-020 for #340 so non-English DOGFOOD demo paths are marker-free and
-   English-source documentation is labeled.
+1. Land DL-017 for #341 so DOGFOOD light-theme chrome is painted, readable,
+   and covered by deterministic theme diagnostics.
 2. Move through the remaining selected `v7.2.0` DOGFOOD demo-integrity items
    from #354.
 3. Run the normal `v7.2.0` release-prep checklist before any tag is created.

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -124,7 +124,7 @@ Current direction and active tensions. Historical ship data is in
 
 ### 3. Stabilize V7.2, Then Shape V8 And V9 From Beyond
 
-- The `v7.2.0` milestone is the current active stabilization lane: 5 open and
+- The `v7.2.0` milestone is the current active stabilization lane: 6 open and
   8 closed milestone items as of the latest roadmap sync.
 - The `Beyond` milestone is the current post-v7 backlog: 31 open and 6 closed
   milestone items as of the latest roadmap sync.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **AppShell theme-mode shortcut** — apps that opt into mode-aware stock shell
   themes now inherit `Ctrl+T` from the shared frame shell to toggle the active
   theme family between dark and light modes without opening Settings.
+- **Theme Lab light-mode readability** — DOGFOOD Theme Lab and Theme Inspector
+  token swatches now render diagnostic label/value text with the active shell
+  theme's readable foreground tokens while preserving the inspected token
+  colors in the swatch bars.
 - **DOGFOOD light theme readiness** — modal and drawer chrome now paint
   explicit panel backgrounds behind border cells instead of inheriting
   terminal-default background. The Bijou light theme has darker muted border

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   `docs/design/LX-020-dogfood-locale-demo-readiness.md` scopes a bounded #340
   repair for keeping non-English DOGFOOD release-demo paths free of missing
   localization markers while labeling English-source docs honestly.
+- **DOGFOOD light-theme readiness shaping** —
+  `docs/design/DL-017-dogfood-light-theme-readiness.md` scopes a bounded #341
+  repair for light-theme settings/menu/modal background ownership, chrome
+  contrast, and DOGFOOD theme diagnostics.
 
 ## [7.1.0] - 2026-06-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Fixed
 
+- **DOGFOOD light theme readiness** — modal and drawer chrome now paint
+  explicit panel backgrounds behind border cells instead of inheriting
+  terminal-default background. The Bijou light theme has darker muted border
+  and scroll-track tokens, the dark theme's subtle chrome now clears the same
+  cross-mode diagnostic floor, and DOGFOOD's theme safe-pair diagnostics cover
+  chrome tokens used by borders, scrollbars, focus gutters, and modal surfaces.
 - **Dependency security patch** — the lockfile now resolves `esbuild@0.28.1`,
   clearing the GitHub/npm audit advisories reported against the development
   tooling path for `esbuild@0.28.0`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Fixed
 
+- **AppShell theme-mode shortcut** — apps that opt into mode-aware stock shell
+  themes now inherit `Ctrl+T` from the shared frame shell to toggle the active
+  theme family between dark and light modes without opening Settings.
 - **DOGFOOD light theme readiness** — modal and drawer chrome now paint
   explicit panel backgrounds behind border cells instead of inheriting
   terminal-default background. The Bijou light theme has darker muted border

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ V7 story harder to use, test, or demonstrate.
 
 | Horizon | Milestone | Open Items | Closed Items | Current Posture |
 | :--- | :--- | ---: | ---: | :--- |
-| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 5 | 8 | Active stabilization lane for demo integrity, framework input correctness, and narrow security repairs. |
+| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 6 | 8 | Active stabilization lane for demo integrity, framework input correctness, and narrow security repairs. |
 | `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 | Latest shipped release lineage after the release PR merges. Complete; do not reopen for new feature work. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Shipped release lineage. Complete; do not reopen for new feature work. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 31 | 6 | Active forward backlog. Promote shaped work from here into a versioned release. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ V7 story harder to use, test, or demonstrate.
 
 | Horizon | Milestone | Open Items | Closed Items | Current Posture |
 | :--- | :--- | ---: | ---: | :--- |
-| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 7 | 6 | Active stabilization lane for demo integrity, framework input correctness, and narrow security repairs. |
+| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 5 | 8 | Active stabilization lane for demo integrity, framework input correctness, and narrow security repairs. |
 | `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 | Latest shipped release lineage after the release PR merges. Complete; do not reopen for new feature work. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Shipped release lineage. Complete; do not reopen for new feature work. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 31 | 6 | Active forward backlog. Promote shaped work from here into a versioned release. |
@@ -200,13 +200,14 @@ that a cross-repository release is the next smallest honest boundary.
 
 ## Next Pull
 
-The immediate implementation pull should land the **DOGFOOD localization demo
-readiness** repair from #340 through PR #359.
+The immediate implementation pull should land the **DOGFOOD light theme
+readiness** repair from #341 through DL-017.
 
-That pull should keep non-English DOGFOOD demo paths free of visible missing
-localization markers, label intentionally English-source documentation when a
-non-English locale is selected, and preserve the maintainer-facing i18n debt
-ratchets before `v7.2.0` moves to the remaining selected demo-integrity items.
+That pull should add deterministic light-theme witnesses for settings, menu,
+or modal chrome; fix any unpainted background path those witnesses reveal; tune
+low-contrast light-theme token pairs used by borders, panels, muted text, and
+selection rows; and expand theme diagnostics so DOGFOOD chrome contrast does
+not regress silently.
 
 ## Forward Goalposts
 

--- a/docs/design/DL-017-dogfood-light-theme-readiness.md
+++ b/docs/design/DL-017-dogfood-light-theme-readiness.md
@@ -1,0 +1,170 @@
+---
+id: DL-017
+title: DOGFOOD Light Theme Readiness
+status: active
+lane: asap
+priority: medium
+github_issue: 341
+legend: DL
+---
+
+# DL-017 - DOGFOOD Light Theme Readiness
+
+Legend: [DL - Design Language](../legends/DL-design-language.md)
+
+## Decision Summary
+
+DOGFOOD's `dogfood:light` shell theme should be safe to demonstrate in a real
+terminal without relying on the terminal profile's default background or lucky
+contrast. For `v7.2.0`, the bounded repair is:
+
+- framed settings, menu, and modal chrome paints explicit light-theme
+  backgrounds
+- borders, panel fills, muted copy, selection rows, and action labels remain
+  visually distinct in the Bijou light palette
+- the theme doctor covers the chrome-safe pairs that failed the release-video
+  rehearsal by sight
+- deterministic tests prove both token-level contrast and rendered shell
+  background ownership
+
+## Sponsored Human
+
+A release-video user needs to switch DOGFOOD into light mode and have the app
+look deliberate on camera. Settings and quit chrome should not show dark
+terminal patches, washed-out borders, or action labels that are hard to find.
+
+## Sponsored Agent
+
+An agent needs a deterministic witness for light-theme chrome. It should be
+able to render the DOGFOOD shell in `dogfood:light`, inspect actual `Surface`
+cell metadata, and fail if settings or modal chrome leaves meaningful cells
+without a theme-owned background.
+
+## Hill
+
+After this cycle, `dogfood:light` is release-demo-ready for the current V7
+surface: the theme paints its shell chrome, passes explicit chrome contrast
+diagnostics, and has enough focused proof to keep terminal-default background
+leaks from silently returning.
+
+## Problem
+
+Issue #341 came from the `v7.1.0` release-video rehearsal. The light theme
+looked unfinished around settings and modal chrome: some border/background
+regions appeared to inherit the terminal's unstyled background, and several
+low-contrast token pairs made panels, muted text, and selected rows difficult
+to read.
+
+The dark DOGFOOD theme mostly hides this class of problem because terminal
+profiles are commonly dark. The light theme needs explicit proof because a
+terminal-default background leak can look acceptable on one profile and broken
+on another.
+
+## Scope
+
+- Add a focused rendered witness for DOGFOOD light-theme settings/menu/modal
+  chrome.
+- Fix any shell-rendering path that fails to paint theme-owned backgrounds for
+  the witness.
+- Retune the Bijou light palette only where the current tokens make borders,
+  panels, muted text, selection rows, or modal actions unclear.
+- Expand DOGFOOD theme safe-pair diagnostics so light-theme chrome tokens are
+  checked by `doctorTheme()`.
+- Update release-facing docs/changelog so `v7.2.0` records the light-theme
+  demo-readiness repair honestly.
+
+## Non-Goals
+
+- Do not solve #343's full first-party dark/light variant coverage.
+- Do not redesign Theme Lab or Theme Inspector.
+- Do not add a global dark/light hotkey in this cycle.
+- Do not redesign DOGFOOD's layout, typography, or theme family model.
+- Do not turn `v7.2.0` into a broad design-system feature train.
+
+## User Experience Contract
+
+The light theme may be calmer than the dark theme, but it cannot be ambiguous.
+The user should be able to distinguish the app background, panels, borders,
+muted text, selected rows, scrollbars, and modal actions without changing their
+terminal profile.
+
+Settings and modal surfaces must paint their own backgrounds. Empty frame
+chrome inside those surfaces should not be transparent unless the transparency
+is a deliberate tokenized overlay with a deterministic fallback.
+
+## Lower Modes
+
+### Static Mode
+
+Static rendered proof should expose actual `Surface` cells and token-derived
+foreground/background choices so tests can inspect theme ownership without
+parsing screenshots.
+
+### Pipe Mode
+
+Pipe output remains text-first and does not need to encode color proof. The
+color-specific proof belongs in rendered `Surface` tests and theme diagnostics.
+
+### Accessible Mode
+
+No new accessibility contract is introduced. Any action labels or status text
+made easier to see through color should remain textual, not color-only.
+
+## Theme Diagnostics
+
+The existing DOGFOOD safe-pair matrix should grow beyond primary text/status
+pairs to cover the light chrome pairs that matter for this bug:
+
+- border tokens against primary, secondary, elevated, overlay, and muted
+  surfaces
+- muted text against the same surfaces used by settings and modal panels
+- selection/focus gutter foregrounds and backgrounds
+- scroll thumb and scroll track visibility
+- modal action/status foregrounds against overlay and elevated surfaces
+
+The diagnostic is intentionally token-level. Rendered tests prove that chrome
+uses those tokens; the doctor proves that the token pairs remain readable.
+
+## Linked Invariants
+
+- DOGFOOD light mode should not depend on terminal-profile background color.
+- Theme diagnostics should cover app chrome, not just body copy.
+- Light-theme repairs must stay compatible with existing dark theme behavior.
+- `v7.2.0` remains a narrow stabilization release.
+
+## Implementation Plan
+
+1. Add a focused failing test that renders DOGFOOD `dogfood:light` settings or
+   modal chrome and finds unpainted cells in the chrome rectangle.
+2. Add a focused failing diagnostic test for missing DOGFOOD chrome safe pairs.
+3. Fix the shell/component path that leaves backgrounds unset, or retune tokens
+   if the renderer already paints but the selected color pair is too weak.
+4. Expand the DOGFOOD safe-pair matrix to cover chrome-relevant light-theme
+   pairs.
+5. Run focused rendered tests, theme doctor tests, `npm run typecheck:test`,
+   `npm run lint`, `npm run docs:inventory`, `git diff --check`, and the
+   relevant broader suite before review.
+
+## Tests To Write First
+
+- A DOGFOOD light-theme settings/menu/modal render fails when visible chrome
+  cells inside the overlay rectangle have no background metadata.
+- `doctorTheme(DOGFOOD_LIGHT_THEME, { contrastPairs:
+  DOGFOOD_THEME_SAFE_PAIRS })` fails if chrome pairs are omitted or fall below
+  the selected contrast floor.
+- Existing dark-theme DOGFOOD shell tests continue to pass.
+
+## Acceptance Criteria
+
+- Deterministic light-theme chrome witness exists for settings, menu, or modal
+  rendering.
+- Any unpainted background path found by the witness is fixed.
+- Bijou light theme border, panel, muted text, selection, and modal action
+  tokens are readable enough for the DOGFOOD release-video path.
+- DOGFOOD theme diagnostics cover the relevant chrome safe pairs.
+- `docs/CHANGELOG.md` records the demo-readiness fix.
+- Issue #341 is closed by the implementation PR.
+
+## Retrospective
+
+To be completed when the PR lands.

--- a/docs/design/DL-017-dogfood-light-theme-readiness.md
+++ b/docs/design/DL-017-dogfood-light-theme-readiness.md
@@ -88,9 +88,10 @@ The user should be able to distinguish the app background, panels, borders,
 muted text, selected rows, scrollbars, and modal actions without changing their
 terminal profile.
 
-Settings and modal surfaces must paint their own backgrounds. Empty frame
-chrome inside those surfaces should not be transparent unless the transparency
-is a deliberate tokenized overlay with a deterministic fallback.
+Settings, command-palette menu, and modal surfaces must paint their own
+backgrounds. Empty frame chrome inside those surfaces should not be transparent
+unless the transparency is a deliberate tokenized overlay with a deterministic
+fallback.
 
 ## Lower Modes
 
@@ -109,6 +110,35 @@ color-specific proof belongs in rendered `Surface` tests and theme diagnostics.
 
 No new accessibility contract is introduced. Any action labels or status text
 made easier to see through color should remain textual, not color-only.
+
+## Localization / Directionality Posture
+
+This cycle does not add new localization or bidirectional-layout behavior. The
+theme repair must preserve the selected-locale text path, existing
+English-source documentation notices, and current left-to-right DOGFOOD chrome
+geometry.
+
+The rendered witnesses should avoid making assertions about translated copy
+beyond stable shell titles such as settings, command palette, and quit chrome.
+If a future right-to-left shell layout changes modal or drawer geometry, it
+should still inherit the same token-owned background contract.
+
+## Agent Inspectability / Explainability Posture
+
+Agents should be able to inspect the repair without screenshots. The important
+facts are:
+
+- which concrete DOGFOOD shell theme is active
+- which shell surface is open: settings drawer, command-palette menu, or quit
+  modal
+- whether visible chrome border cells have explicit foreground and background
+  metadata
+- which safe-pair token declarations cover the chrome colors
+- whether `doctorTheme()` reports any low-contrast chrome pairs for DOGFOOD
+  dark or light modes
+
+The proof should stay in `Surface` metadata and theme-doctor reports so future
+agents can reason about background ownership deterministically.
 
 ## Theme Diagnostics
 
@@ -134,21 +164,24 @@ uses those tokens; the doctor proves that the token pairs remain readable.
 
 ## Implementation Plan
 
-1. Add a focused failing test that renders DOGFOOD `dogfood:light` settings or
-   modal chrome and finds unpainted cells in the chrome rectangle.
+1. Add focused failing tests that render DOGFOOD `dogfood:light` settings
+   drawer, command-palette menu, and quit modal chrome and find unpainted cells
+   in each chrome rectangle.
 2. Add a focused failing diagnostic test for missing DOGFOOD chrome safe pairs.
 3. Fix the shell/component path that leaves backgrounds unset, or retune tokens
    if the renderer already paints but the selected color pair is too weak.
 4. Expand the DOGFOOD safe-pair matrix to cover chrome-relevant light-theme
    pairs.
-5. Run focused rendered tests, theme doctor tests, `npm run typecheck:test`,
-   `npm run lint`, `npm run docs:inventory`, `git diff --check`, and the
-   relevant broader suite before review.
+5. Run focused rendered tests, theme doctor tests, the DOGFOOD terminal capture
+   smoke path, `npm run typecheck:test`, `npm run lint`,
+   `npm run docs:inventory`, `git diff --check`, and the relevant broader
+   suite before review.
 
 ## Tests To Write First
 
-- A DOGFOOD light-theme settings/menu/modal render fails when visible chrome
-  cells inside the overlay rectangle have no background metadata.
+- DOGFOOD light-theme settings drawer, command-palette menu, and quit modal
+  renders fail when visible chrome cells inside their overlay rectangles have
+  no background metadata.
 - `doctorTheme(DOGFOOD_LIGHT_THEME, { contrastPairs:
   DOGFOOD_THEME_SAFE_PAIRS })` fails if chrome pairs are omitted or fall below
   the selected contrast floor.
@@ -156,12 +189,14 @@ uses those tokens; the doctor proves that the token pairs remain readable.
 
 ## Acceptance Criteria
 
-- Deterministic light-theme chrome witness exists for settings, menu, or modal
-  rendering.
+- Deterministic light-theme chrome witnesses exist for settings drawer,
+  command-palette menu, and quit modal rendering.
 - Any unpainted background path found by the witness is fixed.
 - Bijou light theme border, panel, muted text, selection, and modal action
   tokens are readable enough for the DOGFOOD release-video path.
 - DOGFOOD theme diagnostics cover the relevant chrome safe pairs.
+- The DOGFOOD terminal capture smoke path is run as release-video-path
+  evidence.
 - `docs/CHANGELOG.md` records the demo-readiness fix.
 - Issue #341 is closed by the implementation PR.
 

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -3877,13 +3877,36 @@ function describeThemeToken(entry: ThemeTokenEntry, localization: LocalizationPo
   return (entry.stops ?? []).join(' -> ');
 }
 
+function foregroundOnlyToken(token: TokenValue): TokenValue {
+  return {
+    hex: token.hex,
+    modifiers: token.modifiers,
+  };
+}
+
+function themePaletteChromeTokens(theme: Theme): {
+  readonly group: TokenValue;
+  readonly label: TokenValue;
+  readonly value: TokenValue;
+} {
+  return {
+    group: foregroundOnlyToken(theme.ui.sectionHeader),
+    label: foregroundOnlyToken(theme.surface.primary),
+    value: foregroundOnlyToken(theme.surface.muted),
+  };
+}
+
 function renderThemeTokenPalette(
   theme: Theme,
   width: number,
   localization: LocalizationPort | undefined,
-  options: { readonly maxRows?: number } = {},
+  options: {
+    readonly maxRows?: number;
+    readonly chromeTheme?: Theme;
+  } = {},
 ): Surface {
   const safeWidth = Math.max(24, width);
+  const chrome = themePaletteChromeTokens(options.chromeTheme ?? theme);
   const rows = themePaletteRows(theme);
   const visibleRows = options.maxRows === undefined
     ? rows
@@ -3895,17 +3918,17 @@ function renderThemeTokenPalette(
 
   visibleRows.forEach((row, y) => {
     if (row.kind === 'group') {
-      writeSurfaceText(surface, 0, y, row.label.toUpperCase(), { hex: '#f2c45d', modifiers: ['bold'] });
+      writeSurfaceText(surface, 0, y, row.label.toUpperCase(), chrome.group);
       return;
     }
     renderSwatch(surface, row.entry, 0, y, swatchWidth);
-    writeSurfaceText(surface, labelX, y, row.entry.path, { hex: '#f4e8bf' });
+    writeSurfaceText(surface, labelX, y, row.entry.path, chrome.label);
     writeSurfaceText(
       surface,
       Math.min(safeWidth - 1, labelX + 26),
       y,
       describeThemeToken(row.entry, localization),
-      { hex: '#a8b1c7', modifiers: ['dim'] },
+      chrome.value,
     );
   });
 
@@ -3917,7 +3940,7 @@ function renderThemeTokenPalette(
       dogfoodText(localization, 'themePalette.moreTokens', '... {count} more tokens', {
         count: truncatedCount,
       }),
-      { hex: '#a8b1c7', modifiers: ['dim'] },
+      chrome.value,
     );
   }
 
@@ -4013,7 +4036,10 @@ function renderThemeLabPane(
       ctx,
     }),
     spacer(1, 1),
-    boxSurface(renderThemeTokenPalette(BIJOU_DARK, bodyWidth, localization, { maxRows: 28 }), {
+    boxSurface(renderThemeTokenPalette(BIJOU_DARK, bodyWidth, localization, {
+      maxRows: 28,
+      chromeTheme: ctx.theme.theme,
+    }), {
       title: dogfoodText(localization, 'themeLab.darkSwatchesTitle', 'bijou-dark token swatches'),
       width: Math.max(28, paneWidth),
       borderToken: docsThemeMutedBorderToken(landingTheme),
@@ -4022,7 +4048,10 @@ function renderThemeLabPane(
       ctx,
     }),
     spacer(1, 1),
-    boxSurface(renderThemeTokenPalette(BIJOU_LIGHT, bodyWidth, localization, { maxRows: 28 }), {
+    boxSurface(renderThemeTokenPalette(BIJOU_LIGHT, bodyWidth, localization, {
+      maxRows: 28,
+      chromeTheme: ctx.theme.theme,
+    }), {
       title: dogfoodText(localization, 'themeLab.lightSwatchesTitle', 'bijou-light token swatches'),
       width: Math.max(28, paneWidth),
       borderToken: docsThemeMutedBorderToken(landingTheme),
@@ -4052,7 +4081,9 @@ function renderThemeInspectorDrawer(
     })),
     line(dogfoodSafePairSummary(activeTheme.theme, localization)),
     spacer(1, 1),
-    renderThemeTokenPalette(activeTheme.theme, bodyWidth, localization),
+    renderThemeTokenPalette(activeTheme.theme, bodyWidth, localization, {
+      chromeTheme: activeTheme.theme,
+    }),
     spacer(1, 1),
     line(dogfoodText(localization, 'themeInspector.close', 'F10/Esc close • ↑/↓ scroll • q quit')),
   ]);

--- a/examples/docs/dogfood-shell-themes.ts
+++ b/examples/docs/dogfood-shell-themes.ts
@@ -44,8 +44,8 @@ function cloneThemeWithName(theme: Theme, name: string): Theme {
   };
 }
 
-const DOGFOOD_DARK_THEME = cloneThemeWithName(BIJOU_DARK, 'dogfood-dark');
-const DOGFOOD_LIGHT_THEME = cloneThemeWithName(BIJOU_LIGHT, 'dogfood-light');
+export const DOGFOOD_DARK_THEME = cloneThemeWithName(BIJOU_DARK, 'dogfood-dark');
+export const DOGFOOD_LIGHT_THEME = cloneThemeWithName(BIJOU_LIGHT, 'dogfood-light');
 
 const DOGFOOD_READABLE_FOREGROUNDS = [
   'semantic.primary',
@@ -86,7 +86,14 @@ for (const foreground of DOGFOOD_STATUS_FOREGROUNDS) {
 
 for (const background of DOGFOOD_SURFACE_BACKGROUNDS) {
   dogfoodPairs.chrome('ui.cursor', background);
+  dogfoodPairs.chrome('border.primary', background);
+  dogfoodPairs.chrome('border.secondary', background);
+  dogfoodPairs.chrome('ui.scrollThumb', background);
+  dogfoodPairs.chrome('border.muted', background, { minRatio: 3 });
+  dogfoodPairs.chrome('ui.scrollTrack', background, { minRatio: 3 });
 }
+
+dogfoodPairs.chrome('ui.focusGutter', 'ui.focusGutter.bg');
 
 export const DOGFOOD_THEME_SAFE_PAIRS = dogfoodPairs.build();
 

--- a/packages/bijou-tui/src/app-frame-actions.ts
+++ b/packages/bijou-tui/src/app-frame-actions.ts
@@ -114,6 +114,8 @@ export function applyFrameAction<PageModel, Msg>(
         commandPaletteKind: opening ? undefined : model.commandPaletteKind,
       }, []];
     }
+    case 'toggle-shell-theme-mode':
+      return [model, []];
     case 'toggle-notifications': {
       if (!hasNotificationCenter(model, options, pagesById)) {
         return [model, []];

--- a/packages/bijou-tui/src/app-frame-i18n.ts
+++ b/packages/bijou-tui/src/app-frame-i18n.ts
@@ -23,6 +23,7 @@ export const FRAME_I18N_CATALOG: I18nCatalog = {
     message('key.prevPane', 'Previous pane'),
     message('key.search', 'Search'),
     message('key.openPalette', 'Open command palette'),
+    message('key.toggleThemeMode', 'Toggle theme mode'),
     message('key.toggleMinimize', 'Fold/unfold pane'),
     message('key.toggleMaximize', 'Full-screen pane'),
     message('key.dockUp', 'Move pane up'),

--- a/packages/bijou-tui/src/app-frame-overlays.ts
+++ b/packages/bijou-tui/src/app-frame-overlays.ts
@@ -268,6 +268,32 @@ export function resolveNextShellTheme(
   return shellThemes[(currentIndex + 1) % shellThemes.length];
 }
 
+export function resolveShellThemeModeToggle(
+  shellThemes: readonly ResolvedFrameShellTheme[],
+  activeShellThemeId: string | undefined,
+): ResolvedFrameShellTheme | undefined {
+  const current = resolveCurrentShellTheme(shellThemes, activeShellThemeId);
+  if (current?.modeId == null) return undefined;
+
+  const siblings = shellThemes.filter((theme) =>
+    theme.shellThemeId === current.shellThemeId && theme.modeId != null,
+  );
+  if (siblings.length < 2) return undefined;
+
+  const oppositeModeId = current.modeId === 'dark'
+    ? 'light'
+    : current.modeId === 'light'
+      ? 'dark'
+      : undefined;
+  const opposite = oppositeModeId == null
+    ? undefined
+    : siblings.find((theme) => theme.modeId === oppositeModeId);
+  if (opposite != null) return opposite;
+
+  const currentIndex = Math.max(0, siblings.findIndex((theme) => theme.id === current.id));
+  return siblings[(currentIndex + 1) % siblings.length];
+}
+
 export function resolveShellThemeForContext(
   shellThemes: readonly ResolvedFrameShellTheme[],
   ctx: BijouContext | undefined,

--- a/packages/bijou-tui/src/app-frame-palette.ts
+++ b/packages/bijou-tui/src/app-frame-palette.ts
@@ -37,6 +37,10 @@ export function handlePaletteKey<PageModel, Msg>(
   paletteKeys: KeyMap<PaletteAction>,
   options: CreateFramedAppOptions<PageModel, Msg>,
   pagesById: Map<string, FramePage<PageModel, Msg>>,
+  applyFrameActionOverride?: (
+    action: FrameAction,
+    model: InternalFrameModel<PageModel, Msg>,
+  ) => [InternalFrameModel<PageModel, Msg>, Cmd<FramedAppMsg<Msg>>[]] | undefined,
 ): [InternalFrameModel<PageModel, Msg>, Cmd<FramedAppMsg<Msg>>[]] {
   const cp = model.commandPalette!;
   const action = paletteKeys.handle(msg);
@@ -67,6 +71,8 @@ export function handlePaletteKey<PageModel, Msg>(
             commandPaletteTitle: undefined,
             commandPaletteKind: undefined,
           };
+          const overridden = applyFrameActionOverride?.(entry.frameAction, closed);
+          if (overridden !== undefined) return overridden;
           return applyFrameAction(entry.frameAction, closed, options, pagesById);
         }
         if (entry?.msgAction !== undefined) {

--- a/packages/bijou-tui/src/app-frame-types.ts
+++ b/packages/bijou-tui/src/app-frame-types.ts
@@ -223,6 +223,7 @@ export type FrameAction =
   | { type: 'toggle-perf-hud' }
   | { type: 'toggle-footer' }
   | { type: 'toggle-settings' }
+  | { type: 'toggle-shell-theme-mode' }
   | { type: 'toggle-notifications' }
   | { type: 'push-notification'; notification: FrameNotificationSpec }
   | { type: 'prev-tab' }
@@ -288,6 +289,7 @@ export type FrameShellCommand<Msg> =
   | { readonly type: 'settings-scroll'; readonly delta: number }
   | { readonly type: 'settings-scroll-to'; readonly position: 'top' | 'bottom' }
   | { readonly type: 'activate-settings-row'; readonly rowIndex: number }
+  | { readonly type: 'toggle-shell-theme-mode' }
   // --- notification center ---
   | { readonly type: 'notification-center-scroll'; readonly delta: number }
   | { readonly type: 'notification-center-scroll-to'; readonly position: 'top' | 'bottom' }

--- a/packages/bijou-tui/src/app-frame-utils.ts
+++ b/packages/bijou-tui/src/app-frame-utils.ts
@@ -137,7 +137,12 @@ export function mergeBindingSources(...sources: Array<BindingSource | undefined>
 
 /** Build the default key map for frame-level actions (tabs, panes, scroll, help '?', command palette 'ctrl+p'/':'). */
 export function createFrameKeyMap(
-  options: { readonly enableSettings?: boolean; readonly enableNotifications?: boolean; readonly i18n?: I18nRuntime } = {},
+  options: {
+    readonly enableSettings?: boolean;
+    readonly enableShellThemeModeToggle?: boolean;
+    readonly enableNotifications?: boolean;
+    readonly i18n?: I18nRuntime;
+  } = {},
 ): KeyMap<FrameAction> {
   const t = (id: string, fallback: string) => frameMessage(options.i18n, id, fallback);
   const group = (id: string, fallback: string) => frameMessage(options.i18n, id, fallback);
@@ -176,6 +181,11 @@ export function createFrameKeyMap(
     keyMap.group(group('key.group.shell', 'Shell'), (g) => g
       .bind('ctrl+,', t('key.settings', 'Settings'), { type: 'toggle-settings' })
       .bind('f2', t('key.settings', 'Settings'), { type: 'toggle-settings' }));
+  }
+
+  if (options.enableShellThemeModeToggle) {
+    keyMap.group(group('key.group.shell', 'Shell'), (g) => g
+      .bind('ctrl+t', t('key.toggleThemeMode', 'Toggle theme mode'), { type: 'toggle-shell-theme-mode' }));
   }
 
   if (options.enableNotifications) {

--- a/packages/bijou-tui/src/app-frame.test.ts
+++ b/packages/bijou-tui/src/app-frame.test.ts
@@ -41,6 +41,7 @@ import {
   type FrameOverlayContext,
   type PageTransition,
   underlyingFrameLayer,
+  wrapFrameMsg,
 } from './app-frame.js';
 import { activeRuntimeView } from './runtime-engine.js';
 import { QUIT, isCmdCleanup, type Cmd, type MouseMsg } from './types.js';
@@ -2577,6 +2578,94 @@ describe('createFramedApp', () => {
     }
   });
 
+  it('toggles the active shell theme family mode with ctrl+t', () => {
+    const explicitCtx = createTestContext({ mode: 'interactive' });
+    const alternateTheme = createAlternateShellTheme(explicitCtx);
+    const emitted: Array<{
+      readonly id: string;
+      readonly shellThemeId: string | undefined;
+      readonly modeId: string | undefined;
+    }> = [];
+
+    _resetDefaultContextForTesting();
+    try {
+      const app = createFramedApp({
+        ctx: explicitCtx,
+        pages: [makePage('home', 'Home', 'main')],
+        shellThemes: [
+          {
+            id: 'dogfood',
+            label: 'DOGFOOD',
+            modes: [
+              { id: 'dark', label: 'Dark', theme: explicitCtx.theme.theme },
+              { id: 'light', label: 'Light', theme: alternateTheme },
+            ],
+          },
+          { id: 'single', label: 'Single', theme: explicitCtx.theme.theme },
+        ],
+        onShellThemeChange(change) {
+          emitted.push({
+            id: change.shellTheme.id,
+            shellThemeId: change.shellThemeId,
+            modeId: change.modeId,
+          });
+        },
+      });
+
+      let [model] = app.init();
+      expect(model.activeShellThemeId).toBe('dogfood:dark');
+
+      [model] = app.update(ctrlKey('t'), model);
+      expect(model.activeShellThemeId).toBe('dogfood:light');
+      expect(model.settingsOpen).toBe(false);
+      expect(emitted).toEqual([
+        { id: 'dogfood:dark', shellThemeId: 'dogfood', modeId: 'dark' },
+        { id: 'dogfood:light', shellThemeId: 'dogfood', modeId: 'light' },
+      ]);
+      expect(model.runtimeNotifications.items[0]?.message).toBe('Shell theme set to DOGFOOD / Light.');
+
+      [model] = app.update(ctrlKey('t'), model);
+      expect(model.activeShellThemeId).toBe('dogfood:dark');
+      expect(emitted.at(-1)).toEqual({
+        id: 'dogfood:dark',
+        shellThemeId: 'dogfood',
+        modeId: 'dark',
+      });
+      expect(model.activeShellThemeId).not.toBe('single');
+    } finally {
+      setDefaultContext(testCtx);
+    }
+  });
+
+  it('toggles shell theme mode through the frame action wrapper', () => {
+    const explicitCtx = createTestContext({ mode: 'interactive' });
+    const alternateTheme = createAlternateShellTheme(explicitCtx);
+
+    _resetDefaultContextForTesting();
+    try {
+      const app = createFramedApp({
+        ctx: explicitCtx,
+        pages: [makePage('home', 'Home', 'main')],
+        shellThemes: [{
+          id: 'dogfood',
+          label: 'DOGFOOD',
+          modes: [
+            { id: 'dark', label: 'Dark', theme: explicitCtx.theme.theme },
+            { id: 'light', label: 'Light', theme: alternateTheme },
+          ],
+        }],
+      });
+
+      let [model] = app.init();
+      [model] = app.update(wrapFrameMsg({ type: 'toggle-shell-theme-mode' }), model);
+
+      expect(model.activeShellThemeId).toBe('dogfood:light');
+      expect(model.runtimeNotifications.items[0]?.message).toBe('Shell theme set to DOGFOOD / Light.');
+    } finally {
+      setDefaultContext(testCtx);
+    }
+  });
+
   it('uses the run-time ctx as the shell rendering context when shellThemes are configured without an ambient default', async () => {
     const clock = mockClock();
     const explicitCtx = createTestContext({
@@ -2981,6 +3070,43 @@ describe('createFramedApp', () => {
 
     expect((result.model as any).settingsOpen).toBe(true);
     expect(result.model.commandPalette).toBeUndefined();
+  });
+
+  it('toggles shell theme mode from the standard command palette entry', async () => {
+    const explicitCtx = createTestContext({ mode: 'interactive' });
+    const alternateTheme = createAlternateShellTheme(explicitCtx);
+
+    _resetDefaultContextForTesting();
+    try {
+      const app = createFramedApp({
+        ctx: explicitCtx,
+        pages: [makePage('home', 'Home', 'main')],
+        enableCommandPalette: true,
+        shellThemes: [{
+          id: 'dogfood',
+          label: 'DOGFOOD',
+          modes: [
+            { id: 'dark', label: 'Dark', theme: explicitCtx.theme.theme },
+            { id: 'light', label: 'Light', theme: alternateTheme },
+          ],
+        }],
+      });
+
+      const result = await runScript(app, [
+        { key: KEY_CTRL_P },
+        { key: 't' },
+        { key: 'h' },
+        { key: 'e' },
+        { key: 'm' },
+        { key: 'e' },
+        { key: KEY_ENTER },
+      ], { ctx: explicitCtx });
+
+      expect(result.model.activeShellThemeId).toBe('dogfood:light');
+      expect(result.model.commandPalette).toBeUndefined();
+    } finally {
+      setDefaultContext(testCtx);
+    }
   });
 
   it('opens the shell notification center with Shift+N and closes it with the same binding', () => {

--- a/packages/bijou-tui/src/app-frame.ts
+++ b/packages/bijou-tui/src/app-frame.ts
@@ -106,6 +106,7 @@ import {
   resolveFrameShellThemeChoices,
   resolveCurrentShellTheme,
   resolveNextShellTheme,
+  resolveShellThemeModeToggle,
   resolveShellThemeForContext,
   resolveFrameSettings,
   resolveFrameNotificationCenter,
@@ -904,6 +905,7 @@ export function createFramedApp<PageModel, Msg>(
 
   const frameKeys = createFrameKeyMap({
     enableSettings: options.settings != null || enableShellThemeSettings,
+    enableShellThemeModeToggle: shellThemeSpecs.some((theme) => (theme.modes?.length ?? 0) > 1),
     enableNotifications: options.notificationCenter != null || options.runtimeNotifications !== false,
     i18n: options.i18n,
   });
@@ -1098,6 +1100,11 @@ export function createFramedApp<PageModel, Msg>(
       teaCmds.push(...cmds);
       return nextModel;
     },
+    'toggle-shell-theme-mode': (model, _cmd, teaCmds) => {
+      const [nextModel, cmds] = toggleShellThemeMode(model);
+      teaCmds.push(...cmds);
+      return nextModel;
+    },
 
     // --- notification center ---
     'notification-center-scroll': (model, cmd) => {
@@ -1184,7 +1191,16 @@ export function createFramedApp<PageModel, Msg>(
     },
     'palette-key': (model, cmd, teaCmds) => {
       const c = cmd as Extract<FrameShellCommand<Msg>, { type: 'palette-key' }>;
-      const [nextModel, cmds] = handlePaletteKey(c.msg, model, paletteKeys, options, pagesById);
+      const [nextModel, cmds] = handlePaletteKey(
+        c.msg,
+        model,
+        paletteKeys,
+        options,
+        pagesById,
+        (action, closedModel) => action.type === 'toggle-shell-theme-mode'
+          ? toggleShellThemeMode(closedModel)
+          : undefined,
+      );
       teaCmds.push(...cmds);
       return nextModel;
     },
@@ -1291,6 +1307,9 @@ export function createFramedApp<PageModel, Msg>(
     if (action.type === 'open-palette' && options.enableCommandPalette) {
       return [{ type: 'observed-key', msg, route }, { type: 'open-command-palette' }];
     }
+    if (action.type === 'toggle-shell-theme-mode') {
+      return [{ type: 'observed-key', msg, route }, { type: 'toggle-shell-theme-mode' }];
+    }
     return [{ type: 'observed-key', msg, route }, { type: 'apply-frame-action', action }];
   }
 
@@ -1316,6 +1335,9 @@ export function createFramedApp<PageModel, Msg>(
         ? [obs, { type: 'close-palette' }]
         : [obs, { type: 'open-command-palette' }];
     }
+    if (frameAction?.type === 'toggle-shell-theme-mode') {
+      return [obs, { type: 'toggle-shell-theme-mode' }];
+    }
     if (frameAction?.type === 'toggle-notifications') {
       return [obs, { type: 'close-palette' }, { type: 'apply-frame-action', action: frameAction }];
     }
@@ -1336,6 +1358,9 @@ export function createFramedApp<PageModel, Msg>(
       return quitRequestCommands(msg, 'help');
     }
     const helpAction = frameKeys.handle(msg);
+    if (helpAction?.type === 'toggle-shell-theme-mode') {
+      return [obs, { type: 'toggle-shell-theme-mode' }];
+    }
     if (helpAction?.type === 'toggle-perf-hud') {
       return [obs, { type: 'apply-frame-action', action: helpAction }];
     }
@@ -1377,6 +1402,9 @@ export function createFramedApp<PageModel, Msg>(
       return [obs, { type: 'open-command-palette' }];
     }
     const settingsFrameAction = frameKeys.handle(msg);
+    if (settingsFrameAction?.type === 'toggle-shell-theme-mode') {
+      return [obs, { type: 'toggle-shell-theme-mode' }];
+    }
     if (settingsFrameAction?.type === 'toggle-notifications') {
       return [obs, { type: 'apply-frame-action', action: settingsFrameAction }];
     }
@@ -1442,6 +1470,9 @@ export function createFramedApp<PageModel, Msg>(
       return quitRequestCommands(msg, 'frame');
     }
     const centerFrameAction = frameKeys.handle(msg);
+    if (centerFrameAction?.type === 'toggle-shell-theme-mode') {
+      return [obs, { type: 'toggle-shell-theme-mode' }];
+    }
     if (centerFrameAction?.type === 'toggle-notifications') {
       return [obs, { type: 'apply-frame-action', action: centerFrameAction }];
     }
@@ -2228,6 +2259,47 @@ export function createFramedApp<PageModel, Msg>(
     return [nextModel, notificationCmds];
   }
 
+  function pushShellThemeModeFeedback(
+    model: InternalFrameModel<PageModel, Msg>,
+    nextTheme: ResolvedFrameShellTheme,
+  ): [InternalFrameModel<PageModel, Msg>, Cmd<FramedAppMsg<Msg>>[]] {
+    if (!frameNotificationOptions.enabled) {
+      return [model, []];
+    }
+    const nowMs = resolveClock(resolveFrameCtx()).now();
+    const notifications = pushNotification(model.runtimeNotifications, {
+      title: frameMessage(options.i18n, 'settings.title', 'Settings'),
+      message: frameMessage(
+        options.i18n,
+        'settings.shellTheme.feedback',
+        'Shell theme set to {theme}.',
+        { theme: nextTheme.label },
+      ),
+      variant: 'TOAST',
+      tone: 'INFO',
+      width: SETTINGS_FEEDBACK_TOAST_WIDTH,
+      placement: frameNotificationOptions.placement,
+      durationMs: 2_500,
+      overflow: frameNotificationOptions.overflow,
+    }, nowMs);
+    return applyFrameNotificationState(model, notifications, nowMs);
+  }
+
+  function toggleShellThemeMode(
+    model: InternalFrameModel<PageModel, Msg>,
+  ): [InternalFrameModel<PageModel, Msg>, Cmd<FramedAppMsg<Msg>>[]] {
+    ensureResolvedShellThemes(resolveFrameCtx());
+    const nextTheme = resolveShellThemeModeToggle(resolvedShellThemes, model.activeShellThemeId);
+    if (nextTheme == null) {
+      return [model, []];
+    }
+    publishShellThemeContext(nextTheme);
+    return pushShellThemeModeFeedback({
+      ...model,
+      activeShellThemeId: nextTheme.id,
+    }, nextTheme);
+  }
+
   const app: App<InternalFrameModel<PageModel, Msg>, FramedAppMsg<Msg>> = {
     init() {
       const pageModels: Record<string, PageModel> = {};
@@ -2345,6 +2417,9 @@ export function createFramedApp<PageModel, Msg>(
         if (action.type === 'notification-tick') {
           const notifications = tickNotifications(model.runtimeNotifications, action.atMs);
           return applyFrameNotificationState(model, notifications, action.atMs, true);
+        }
+        if (action.type === 'toggle-shell-theme-mode') {
+          return toggleShellThemeMode(model);
         }
         if (action.type === 'transition') {
           // Ignore stale transition ticks from a previous generation

--- a/packages/bijou-tui/src/overlay.ts
+++ b/packages/bijou-tui/src/overlay.ts
@@ -326,6 +326,16 @@ function mergeStyles(base: CellStyle, extra: CellStyle): CellStyle {
   };
 }
 
+function withFallbackBackground(style: CellStyle, background: Pick<CellStyle, 'bg' | 'bgRGB'>): CellStyle {
+  if (style.bg != null || style.bgRGB != null) return style;
+  if (background.bg == null && background.bgRGB == null) return style;
+  return {
+    ...style,
+    bg: background.bg,
+    bgRGB: background.bgRGB,
+  };
+}
+
 function plainSurfaceToString(surface: Surface): string {
   const lines: string[] = [];
   for (let y = 0; y < surface.height; y++) {
@@ -456,24 +466,25 @@ function renderBoxSurface(
   fillStyle: CellStyle,
   innerWidthOverride?: number,
 ): Surface {
+  const paintedBorderStyle = withFallbackBackground(borderStyle, fillStyle);
   const innerWidth = innerWidthOverride ?? lines.reduce((max, line) => Math.max(max, line.width), 0);
   const width = innerWidth + 4;
   const height = lines.length + 2;
   const surface = createSurface(width, height);
 
-  setStyledCell(surface, 0, 0, BORDER.tl, borderStyle);
-  for (let x = 1; x < width - 1; x++) setStyledCell(surface, x, 0, BORDER.h, borderStyle);
-  setStyledCell(surface, width - 1, 0, BORDER.tr, borderStyle);
+  setStyledCell(surface, 0, 0, BORDER.tl, paintedBorderStyle);
+  for (let x = 1; x < width - 1; x++) setStyledCell(surface, x, 0, BORDER.h, paintedBorderStyle);
+  setStyledCell(surface, width - 1, 0, BORDER.tr, paintedBorderStyle);
 
-  setStyledCell(surface, 0, height - 1, BORDER.bl, borderStyle);
-  for (let x = 1; x < width - 1; x++) setStyledCell(surface, x, height - 1, BORDER.h, borderStyle);
-  setStyledCell(surface, width - 1, height - 1, BORDER.br, borderStyle);
+  setStyledCell(surface, 0, height - 1, BORDER.bl, paintedBorderStyle);
+  for (let x = 1; x < width - 1; x++) setStyledCell(surface, x, height - 1, BORDER.h, paintedBorderStyle);
+  setStyledCell(surface, width - 1, height - 1, BORDER.br, paintedBorderStyle);
 
   for (let i = 0; i < lines.length; i++) {
     const y = i + 1;
-    setStyledCell(surface, 0, y, BORDER.v, borderStyle);
+    setStyledCell(surface, 0, y, BORDER.v, paintedBorderStyle);
     for (let x = 1; x < width - 1; x++) setStyledCell(surface, x, y, ' ', fillStyle);
-    setStyledCell(surface, width - 1, y, BORDER.v, borderStyle);
+    setStyledCell(surface, width - 1, y, BORDER.v, paintedBorderStyle);
 
     const line = lineWithInheritedBackground(lines[i]!, fillStyle);
     if (line.width > 0 && innerWidth > 0) {
@@ -696,8 +707,8 @@ export function drawer(options: DrawerOptions): Overlay {
   const { width, height, row, col } = dims;
   const innerWidth = Math.max(0, width - 4); // border + padding on each side
 
-  const borderStyle = styleFromToken(options.borderToken, ctx);
   const fillStyle = backgroundStyleFromToken(options.bgToken, ctx);
+  const borderStyle = withFallbackBackground(styleFromToken(options.borderToken, ctx), fillStyle);
   const titleStyle = ctx ? { modifiers: ['bold'] as string[] } : {};
   const surface = createSurface(width, height);
 

--- a/packages/bijou/src/core/theme/presets.ts
+++ b/packages/bijou/src/core/theme/presets.ts
@@ -171,14 +171,14 @@ export const BIJOU_DARK: Theme<BaseStatusKey> = {
     success:   tv('#8bd67d'),
     warning:   tv('#f2c45d'),
     error:     tv('#ff8a80'),
-    muted:     tv('#5f6b86'),
+    muted:     tv('#77809d'),
   },
 
   ui: {
     cursor:        tv('#f2c45d'),
     focusGutter:   { hex: '#f2c45d', bg: '#171827', modifiers: ['bold'] },
     scrollThumb:   tv('#7aa7e8'),
-    scrollTrack:   tv('#5f6b86'),
+    scrollTrack:   tv('#77809d'),
     sectionHeader: tv('#f2c45d', ['bold']),
     logo:          tv('#f2c45d'),
     tableHeader:   tv('#f4e8bf', ['bold']),
@@ -235,14 +235,14 @@ export const BIJOU_LIGHT: Theme<BaseStatusKey> = {
     success:   tv('#246a3d'),
     warning:   tv('#7a5200'),
     error:     tv('#a33a3a'),
-    muted:     tv('#8a93a2'),
+    muted:     tv('#6f7888'),
   },
 
   ui: {
     cursor:        tv('#7a5200'),
     focusGutter:   { hex: '#7a5200', bg: '#fbf7ea', modifiers: ['bold'] },
     scrollThumb:   tv('#285c9e'),
-    scrollTrack:   tv('#cdd5e2'),
+    scrollTrack:   tv('#718399'),
     sectionHeader: tv('#7a5200', ['bold']),
     logo:          tv('#7a5200'),
     tableHeader:   tv('#1e2433', ['bold']),

--- a/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
+++ b/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
@@ -19,6 +19,7 @@ const KEY_ENTER = { key: '\r' };
 const KEY_ESCAPE = { key: '\x1b' };
 const KEY_CTRL_P = { key: '\x10' };
 const KEY_Q = { key: 'q' };
+const MSG_CTRL_T = { type: 'key', key: 't', ctrl: true, alt: false, shift: false } as const;
 const MSG_F10 = { type: 'key', key: 'f10', ctrl: false, alt: false, shift: false } as const;
 
 describe('DL-017 DOGFOOD light theme readiness', () => {
@@ -136,13 +137,9 @@ describe('DL-017 DOGFOOD light theme readiness', () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 180, rows: 56 } });
     const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'themes' });
 
-    const labResult = await runScript(app, [
-      KEY_F2,
-      KEY_DOWN,
-      KEY_ENTER,
-      KEY_ESCAPE,
-    ], { ctx });
-    const labFrame = normalizeViewOutput(app.view(labResult.model), {
+    const [initialModel] = app.init();
+    const [lightModel] = app.update(MSG_CTRL_T, initialModel);
+    const labFrame = normalizeViewOutput(app.view(lightModel), {
       width: ctx.runtime.columns,
       height: ctx.runtime.rows,
     }).surface;
@@ -154,7 +151,7 @@ describe('DL-017 DOGFOOD light theme readiness', () => {
       'Theme Lab',
     );
 
-    const [inspectorModel] = app.update(MSG_F10, labResult.model);
+    const [inspectorModel] = app.update(MSG_F10, lightModel);
     const inspectorFrame = normalizeViewOutput(app.view(inspectorModel), {
       width: ctx.runtime.columns,
       height: ctx.runtime.rows,

--- a/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
+++ b/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
@@ -19,6 +19,7 @@ const KEY_ENTER = { key: '\r' };
 const KEY_ESCAPE = { key: '\x1b' };
 const KEY_CTRL_P = { key: '\x10' };
 const KEY_Q = { key: 'q' };
+const MSG_F10 = { type: 'key', key: 'f10', ctrl: false, alt: false, shift: false } as const;
 
 describe('DL-017 DOGFOOD light theme readiness', () => {
   afterEach(() => _resetDefaultContextForTesting());
@@ -128,6 +129,44 @@ describe('DL-017 DOGFOOD light theme readiness', () => {
     const report = doctorTheme(lightTheme!, { contrastPairs: DOGFOOD_THEME_SAFE_PAIRS });
     expect(report.issues.filter((issue) => issue.kind === 'low-contrast')).toEqual([]);
   });
+
+  it('renders Theme Lab and Theme Inspector swatch text with readable light theme tokens', async () => {
+    const lightTheme = DOGFOOD_SHELL_THEMES[0]?.modes?.find((mode) => mode.id === 'light')?.theme;
+    expect(lightTheme?.name).toBe('dogfood-light');
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 180, rows: 56 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'themes' });
+
+    const labResult = await runScript(app, [
+      KEY_F2,
+      KEY_DOWN,
+      KEY_ENTER,
+      KEY_ESCAPE,
+    ], { ctx });
+    const labFrame = normalizeViewOutput(app.view(labResult.model), {
+      width: ctx.runtime.columns,
+      height: ctx.runtime.rows,
+    }).surface;
+    assertTokenTextColors(
+      labFrame,
+      'semantic.success',
+      lightTheme!.surface.primary.hex,
+      lightTheme!.surface.muted.hex,
+      'Theme Lab',
+    );
+
+    const [inspectorModel] = app.update(MSG_F10, labResult.model);
+    const inspectorFrame = normalizeViewOutput(app.view(inspectorModel), {
+      width: ctx.runtime.columns,
+      height: ctx.runtime.rows,
+    }).surface;
+    assertTokenTextColors(
+      inspectorFrame,
+      'semantic.success',
+      lightTheme!.surface.primary.hex,
+      lightTheme!.surface.muted.hex,
+      'Theme Inspector',
+    );
+  });
 });
 
 function rightAnchoredDrawerBorderCells(surface: Surface): readonly [number, number][] {
@@ -174,6 +213,48 @@ function assertBorderCellsPaintBackground(
   });
 
   expect(unpainted, `${label} border cells without background`).toEqual([]);
+}
+
+function assertTokenTextColors(
+  surface: Surface,
+  tokenLabel: string,
+  expectedLabelFg: string,
+  expectedValueFg: string,
+  surfaceLabel: string,
+): void {
+  const labelCell = firstTextCell(surface, tokenLabel);
+  expect(labelCell.cell.fg, `${surfaceLabel} ${tokenLabel} label foreground`).toBe(expectedLabelFg);
+
+  const tokenValue = firstHexTokenCellAfter(surface, labelCell.y, labelCell.x + tokenLabel.length);
+  expect(tokenValue.cell.fg, `${surfaceLabel} ${tokenLabel} value foreground`).toBe(expectedValueFg);
+}
+
+function firstTextCell(
+  surface: Surface,
+  text: string,
+): { readonly x: number; readonly y: number; readonly cell: ReturnType<Surface['get']> } {
+  for (let y = 0; y < surface.height; y += 1) {
+    const line = Array.from({ length: surface.width }, (_, x) => surface.get(x, y).char).join('');
+    const x = line.indexOf(text);
+    if (x !== -1) {
+      return { x, y, cell: surface.get(x, y) };
+    }
+  }
+  throw new Error(`No row containing "${text}".`);
+}
+
+function firstHexTokenCellAfter(
+  surface: Surface,
+  y: number,
+  startX: number,
+): { readonly x: number; readonly y: number; readonly cell: ReturnType<Surface['get']> } {
+  for (let x = Math.max(0, startX); x < surface.width; x += 1) {
+    const cell = surface.get(x, y);
+    if (cell.char === '#') {
+      return { x, y, cell };
+    }
+  }
+  throw new Error(`No hex token cell found on row ${y} after column ${startX}.`);
 }
 
 function firstTopBorderCol(surface: Surface, start: number, row = 0): number {

--- a/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
+++ b/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { doctorTheme, type Surface } from '@flyingrobots/bijou';
+import { _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
+import { normalizeViewOutput } from '../../../packages/bijou-tui/src/view-output.js';
+import {
+  createScriptTestContext as createTestContext,
+  runScriptDeterministic as runScript,
+} from '../../helpers/scripted.js';
+import {
+  DOGFOOD_SHELL_THEMES,
+  DOGFOOD_THEME_SAFE_PAIRS,
+} from '../../../examples/docs/dogfood-shell-themes.js';
+import { createDocsApp } from '../../../examples/docs/app.js';
+
+const DRAWER_BORDER_CHARS = new Set(['┌', '┐', '└', '┘', '│', '─']);
+const KEY_F2 = { key: '\x1bOQ' };
+const KEY_DOWN = { key: '\x1b[B' };
+const KEY_ENTER = { key: '\r' };
+const KEY_Q = { key: 'q' };
+
+describe('DL-017 DOGFOOD light theme readiness', () => {
+  afterEach(() => _resetDefaultContextForTesting());
+
+  it('paints DOGFOOD light settings drawer chrome with explicit backgrounds', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 36 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs' });
+
+    const result = await runScript(app, [
+      KEY_F2,
+      KEY_DOWN,
+      KEY_ENTER,
+    ], { ctx });
+    const model = result.model as {
+      docsModel: { activeShellThemeId?: string };
+    };
+    const frame = normalizeViewOutput(app.view(result.model), {
+      width: ctx.runtime.columns,
+      height: ctx.runtime.rows,
+    }).surface;
+
+    expect(model.docsModel.activeShellThemeId).toBe('dogfood:light');
+    assertBorderCellsPaintBackground(
+      frame,
+      rightAnchoredDrawerBorderCells(frame),
+      'settings drawer',
+    );
+  });
+
+  it('paints DOGFOOD light quit modal chrome with explicit backgrounds', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 36 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs' });
+
+    const result = await runScript(app, [
+      KEY_F2,
+      KEY_DOWN,
+      KEY_ENTER,
+      KEY_Q,
+    ], { ctx });
+    const model = result.model as {
+      docsModel: { activeShellThemeId?: string };
+    };
+    const frame = normalizeViewOutput(app.view(result.model), {
+      width: ctx.runtime.columns,
+      height: ctx.runtime.rows,
+    }).surface;
+
+    expect(model.docsModel.activeShellThemeId).toBe('dogfood:light');
+    assertBorderCellsPaintBackground(
+      frame,
+      centeredModalBorderCells(frame),
+      'quit modal',
+    );
+  });
+
+  it('covers DOGFOOD light chrome tokens in safe-pair diagnostics', () => {
+    const lightTheme = DOGFOOD_SHELL_THEMES[0]?.modes?.find((mode) => mode.id === 'light')?.theme;
+    expect(lightTheme?.name).toBe('dogfood-light');
+
+    const requiredChromePairs = [
+      'border.primary -> surface.elevated.bg',
+      'border.primary -> surface.overlay.bg',
+      'border.muted -> surface.primary.bg',
+      'border.muted -> surface.elevated.bg',
+      'ui.scrollThumb -> surface.elevated.bg',
+      'ui.scrollTrack -> surface.elevated.bg',
+      'ui.focusGutter -> ui.focusGutter.bg',
+    ];
+    const chromePairs = new Set(
+      DOGFOOD_THEME_SAFE_PAIRS
+        .filter((pair) => pair.kind === 'chrome')
+        .map((pair) => `${pair.foreground} -> ${pair.background}`),
+    );
+
+    for (const pair of requiredChromePairs) {
+      expect(chromePairs).toContain(pair);
+    }
+
+    const report = doctorTheme(lightTheme!, { contrastPairs: DOGFOOD_THEME_SAFE_PAIRS });
+    expect(report.issues.filter((issue) => issue.kind === 'low-contrast')).toEqual([]);
+  });
+});
+
+function rightAnchoredDrawerBorderCells(surface: Surface): readonly [number, number][] {
+  const startCol = Math.floor(surface.width * 0.55);
+  const cells: [number, number][] = [];
+  for (let y = 0; y < surface.height; y += 1) {
+    for (let x = startCol; x < surface.width; x += 1) {
+      if (DRAWER_BORDER_CHARS.has(surface.get(x, y).char)) {
+        cells.push([x, y]);
+      }
+    }
+  }
+  expect(cells.length).toBeGreaterThan(0);
+  return cells;
+}
+
+function centeredModalBorderCells(surface: Surface): readonly [number, number][] {
+  const modalTitleRow = firstBorderRowContaining(surface, 'Quit?');
+  const topRow = findNearestBorderRow(surface, modalTitleRow, -1);
+  const bottomRow = findNearestBorderRow(surface, modalTitleRow, 1);
+  const startCol = firstTopBorderCol(surface, 0, topRow);
+  const endCol = lastTopBorderCol(surface, topRow);
+
+  const cells: [number, number][] = [];
+  for (let y = topRow; y <= bottomRow; y += 1) {
+    for (let x = startCol; x <= endCol; x += 1) {
+      if (DRAWER_BORDER_CHARS.has(surface.get(x, y).char)) {
+        cells.push([x, y]);
+      }
+    }
+  }
+  expect(cells.length).toBeGreaterThan(0);
+  return cells;
+}
+
+function assertBorderCellsPaintBackground(
+  surface: Surface,
+  cells: readonly [number, number][],
+  label: string,
+): void {
+  const unpainted = cells.filter(([x, y]) => {
+    const cell = surface.get(x, y);
+    return cell.bg == null && cell.bgRGB == null;
+  });
+
+  expect(unpainted, `${label} border cells without background`).toEqual([]);
+}
+
+function firstTopBorderCol(surface: Surface, start: number, row = 0): number {
+  for (let x = start; x < surface.width; x += 1) {
+    if (surface.get(x, row).char === '┌') return x;
+  }
+  throw new Error(`No top-left border found from column ${start} on row ${row}.`);
+}
+
+function lastTopBorderCol(surface: Surface, row: number): number {
+  for (let x = surface.width - 1; x >= 0; x -= 1) {
+    if (surface.get(x, row).char === '┐') return x;
+  }
+  throw new Error(`No top-right border found on row ${row}.`);
+}
+
+function firstBorderRowContaining(surface: Surface, text: string): number {
+  for (let y = 0; y < surface.height; y += 1) {
+    const line = Array.from({ length: surface.width }, (_, x) => surface.get(x, y).char).join('');
+    if (line.includes(text)) return y;
+  }
+  throw new Error(`No row containing "${text}".`);
+}
+
+function findNearestBorderRow(surface: Surface, startRow: number, step: -1 | 1): number {
+  for (let y = startRow; y >= 0 && y < surface.height; y += step) {
+    const expected = step === -1 ? '┌' : '└';
+    if (Array.from({ length: surface.width }, (_, x) => surface.get(x, y).char).includes(expected)) {
+      return y;
+    }
+  }
+  throw new Error(`No modal border row found from ${startRow}.`);
+}

--- a/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
+++ b/tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts
@@ -16,6 +16,8 @@ const DRAWER_BORDER_CHARS = new Set(['┌', '┐', '└', '┘', '│', '─']);
 const KEY_F2 = { key: '\x1bOQ' };
 const KEY_DOWN = { key: '\x1b[B' };
 const KEY_ENTER = { key: '\r' };
+const KEY_ESCAPE = { key: '\x1b' };
+const KEY_CTRL_P = { key: '\x10' };
 const KEY_Q = { key: 'q' };
 
 describe('DL-017 DOGFOOD light theme readiness', () => {
@@ -54,6 +56,7 @@ describe('DL-017 DOGFOOD light theme readiness', () => {
       KEY_F2,
       KEY_DOWN,
       KEY_ENTER,
+      KEY_ESCAPE,
       KEY_Q,
     ], { ctx });
     const model = result.model as {
@@ -67,8 +70,35 @@ describe('DL-017 DOGFOOD light theme readiness', () => {
     expect(model.docsModel.activeShellThemeId).toBe('dogfood:light');
     assertBorderCellsPaintBackground(
       frame,
-      centeredModalBorderCells(frame),
+      centeredModalBorderCells(frame, 'Quit?'),
       'quit modal',
+    );
+  });
+
+  it('paints DOGFOOD light command palette menu chrome with explicit backgrounds', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 36 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs' });
+
+    const result = await runScript(app, [
+      KEY_F2,
+      KEY_DOWN,
+      KEY_ENTER,
+      KEY_ESCAPE,
+      KEY_CTRL_P,
+    ], { ctx });
+    const model = result.model as {
+      docsModel: { activeShellThemeId?: string };
+    };
+    const frame = normalizeViewOutput(app.view(result.model), {
+      width: ctx.runtime.columns,
+      height: ctx.runtime.rows,
+    }).surface;
+
+    expect(model.docsModel.activeShellThemeId).toBe('dogfood:light');
+    assertBorderCellsPaintBackground(
+      frame,
+      centeredModalBorderCells(frame, 'Command Palette'),
+      'command palette',
     );
   });
 
@@ -114,8 +144,8 @@ function rightAnchoredDrawerBorderCells(surface: Surface): readonly [number, num
   return cells;
 }
 
-function centeredModalBorderCells(surface: Surface): readonly [number, number][] {
-  const modalTitleRow = firstBorderRowContaining(surface, 'Quit?');
+function centeredModalBorderCells(surface: Surface, title: string): readonly [number, number][] {
+  const modalTitleRow = firstBorderRowContaining(surface, title);
   const topRow = findNearestBorderRow(surface, modalTitleRow, -1);
   const bottomRow = findNearestBorderRow(surface, modalTitleRow, 1);
   const startCol = firstTopBorderCol(surface, 0, topRow);

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -60,7 +60,7 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`v9.0.0`: Product Workbench And Operator Surfaces');
     expect(roadmap).toContain('`v10.0.0+`: Ecosystem Integration');
     expect(roadmap).toContain('v6.0.0` was never published as a public package release');
-    expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 5 | 8 |');
+    expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 6 | 8 |');
     expect(roadmap).toContain('| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 |');
     expect(roadmap).toContain('Latest shipped release lineage after the release PR merges.');
     expect(roadmap).toContain('#270 release-readiness guardrails, #312 DOGFOOD i18n debt coverage');
@@ -118,7 +118,7 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(bearing).toContain('The next feature horizon remains `v8.0.0`');
     expect(bearing).toContain('the immediate focus is');
     expect(bearing).toContain('`v7.2.0` is now selected as a narrow stabilization and demo-integrity release');
-    expect(bearing).toContain('`v7.2.0` milestone is the current active stabilization lane: 5 open and 8 closed milestone items');
+    expect(bearing).toContain('`v7.2.0` milestone is the current active stabilization lane: 6 open and 8 closed milestone items');
     expect(bearing).toContain('Stabilize V7.2, Then Shape V8 And V9 From Beyond');
     expect(bearing).not.toContain('The next release-facing action is release-readiness validation');
 

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -60,7 +60,7 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`v9.0.0`: Product Workbench And Operator Surfaces');
     expect(roadmap).toContain('`v10.0.0+`: Ecosystem Integration');
     expect(roadmap).toContain('v6.0.0` was never published as a public package release');
-    expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 7 | 6 |');
+    expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 5 | 8 |');
     expect(roadmap).toContain('| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 |');
     expect(roadmap).toContain('Latest shipped release lineage after the release PR merges.');
     expect(roadmap).toContain('#270 release-readiness guardrails, #312 DOGFOOD i18n debt coverage');
@@ -73,8 +73,9 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`Beyond`');
     expect(roadmap).toContain('31 | 6');
     expect(roadmap).toContain('Next Pull');
-    expect(roadmap).toContain('DOGFOOD localization demo readiness');
-    expect(roadmap).toContain('preserve the maintainer-facing i18n debt ratchets');
+    expect(roadmap).toContain('DOGFOOD light theme readiness');
+    expect(roadmap).toContain('unpainted background path');
+    expect(roadmap).toContain('DOGFOOD chrome contrast');
     expect(roadmap).toContain('versioned artifact semantics');
     expect(roadmap).toContain('DOGFOOD fixtures that round-trip');
     expect(roadmap).toContain('https://github.com/flyingrobots/bijou/issues/270');
@@ -117,7 +118,7 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(bearing).toContain('The next feature horizon remains `v8.0.0`');
     expect(bearing).toContain('the immediate focus is');
     expect(bearing).toContain('`v7.2.0` is now selected as a narrow stabilization and demo-integrity release');
-    expect(bearing).toContain('`v7.2.0` milestone is the current active stabilization lane: 7 open and 6 closed milestone items');
+    expect(bearing).toContain('`v7.2.0` milestone is the current active stabilization lane: 5 open and 8 closed milestone items');
     expect(bearing).toContain('Stabilize V7.2, Then Shape V8 And V9 From Beyond');
     expect(bearing).not.toContain('The next release-facing action is release-readiness validation');
 


### PR DESCRIPTION
## Summary

- Adds DL-017 as the cycle design for #341 DOGFOOD light theme readiness.
- Fixes modal/drawer overlay chrome so border cells inherit the panel background when the border token is foreground-only.
- Retunes Bijou light and dark subtle chrome tokens so DOGFOOD chrome clears the same cross-mode diagnostic floor.
- Expands DOGFOOD theme safe-pair diagnostics to cover borders, scrollbars, focus gutters, and modal surfaces.
- Adds deterministic DL-017 rendered witnesses for `dogfood:light` settings drawer and quit modal chrome.

Closes #341.

## Validation

- `npm test -- tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
- `npm run docs:inventory`
- `git diff --check`
- `npm test -- tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts`
- `npm test -- tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts packages/bijou-tui/src/app-frame-overlays.test.ts packages/bijou-tui/src/app-frame.test.ts packages/bijou/src/core/theme/presets.test.ts packages/bijou/src/core/theme/doctor.test.ts`
- `npm test -- packages/bijou-tui/src/overlay.test.ts packages/bijou-tui/src/app-frame-render.test.ts packages/bijou/src/core/theme/extend.test.ts packages/bijou/src/core/theme/dtcg.test.ts packages/bijou/src/core/theme/resolve.test.ts`
- `npm test -- scripts/docs-preview.test.ts tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts packages/bijou/src/core/theme/presets.test.ts`
- `npm run typecheck:test`
- `npm run lint`
- full `npm test`
- pre-push DOGFOOD i18n completeness/check/debt gates
- pre-push `npm run typecheck:test`
- pre-push full `npm test`
- pre-push `npm run verify:interactive-examples -- --skip-build --mode=interactive-scripted`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+T keyboard shortcut to toggle between dark and light theme modes.
  * Enhanced light-theme readiness for preview quality.

* **Bug Fixes**
  * Improved theme color values for visual consistency.
  * Fixed border rendering to properly inherit background colors.

* **Documentation**
  * Added design documentation for light-theme readiness initiative.
  * Updated release notes and v7.2.0 roadmap.

* **Tests**
  * Added tests verifying theme mode toggle functionality.
  * Added light-theme readiness validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->