### PR TITLE
Add Blocks app-binding snippets to DOGFOOD

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -105,8 +105,11 @@ Current direction and active tensions. Historical ship data is in
 - The first `v7.2.0` demo-integrity pull was RE-041: fix framework mouse
   fallthrough (#344), expose page-scoped frame helpers (#345), and add scripted
   mouse builders (#353).
-- The current urgent `v7.2.0` pull is DL-017: make DOGFOOD light-theme chrome
-  painted, readable, and diagnostically covered for #341.
+- The localization (#340), DOGFOOD shell polish (#334), and light-theme
+  readiness (#341) repairs have landed as v7.2.0 demo-integrity lineage.
+- The current urgent `v7.2.0` pull is DX-047: add Blocks app-binding snippets
+  for #342 so the release video can show how `CounterDemoBlock` binds to
+  application state and command routing.
 - The next feature horizon remains `v8.0.0`: the Runtime Graph and Scene IR
   product contract built from the proof chain that v7.1.0 shipped.
 - The detailed release-horizon index lives in [ROADMAP.md](./ROADMAP.md), and
@@ -124,8 +127,8 @@ Current direction and active tensions. Historical ship data is in
 
 ### 3. Stabilize V7.2, Then Shape V8 And V9 From Beyond
 
-- The `v7.2.0` milestone is the current active stabilization lane: 6 open and
-  8 closed milestone items as of the latest roadmap sync.
+- The `v7.2.0` milestone is the current active stabilization lane: 4 open and
+  10 closed milestone items as of the latest roadmap sync.
 - The `Beyond` milestone is the current post-v7 backlog: 31 open and 6 closed
   milestone items as of the latest roadmap sync.
 - `v7.2.0` should stay bounded to the framework input and DOGFOOD demo-integrity
@@ -168,13 +171,14 @@ Current direction and active tensions. Historical ship data is in
 After the `v7.1.0` tag and publish verification, the immediate focus is
 `v7.2.0` stabilization.
 
-The first pull is RE-041:
+The current pull is DX-047:
 
 ```text
-workspace mouse fallthrough
-  -> page-scoped frame helper exports
-    -> scripted mouse driver helpers
-      -> deterministic pointer regressions
+CounterDemoBlock fixture
+  -> app-owned state snippet
+    -> command-intent routing
+      -> lower-mode explanation
+        -> DOGFOOD docs proof
 ```
 
 After `v7.2.0` stabilizes the current V7 surface, V8 must turn the proof chain
@@ -191,8 +195,9 @@ GraphQL SDL fixture
 
 Recommended pull order:
 
-1. Land DL-017 for #341 so DOGFOOD light-theme chrome is painted, readable,
-   and covered by deterministic theme diagnostics.
+1. Land DX-047 for #342 so Blocks docs explain application-owned state,
+   command-intent routing, and render-time binding with real
+   `CounterDemoBlock` APIs.
 2. Move through the remaining selected `v7.2.0` DOGFOOD demo-integrity items
    from #354.
 3. Run the normal `v7.2.0` release-prep checklist before any tag is created.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Documentation
+
+- **Blocks app-binding snippets** — DOGFOOD's Blocks docs now show how
+  `CounterDemoBlock` binds to application-owned state, key-driven command
+  intents, update routing, render-time config, and pipe/accessible lower modes
+  so the release demo can explain how a reusable Block becomes app code.
+
 ### Fixed
 
 - **AppShell theme-mode shortcut** — apps that opt into mode-aware stock shell

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   `docs/design/DL-017-dogfood-light-theme-readiness.md` scopes a bounded #341
   repair for light-theme settings/menu/modal background ownership, chrome
   contrast, and DOGFOOD theme diagnostics.
+- **Blocks app-binding snippets shaping** —
+  `docs/design/DX-047-blocks-app-binding-snippets.md` scopes a bounded #342
+  repair for showing how DOGFOOD's `CounterDemoBlock` binds to application
+  state, command-intent routing, render-time config, and lower-mode output.
 
 ## [7.1.0] - 2026-06-14
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ requests assigned to each milestone. They are not issue-only totals. Do not
 compare release snapshot item totals to issue-only `gh issue list` output
 without also accounting for milestone pull requests.
 
-Last synced from GitHub milestone items: 2026-06-15.
+Last synced from GitHub milestone items: 2026-06-16.
 
 ## Current Release State
 
@@ -38,7 +38,7 @@ V7 story harder to use, test, or demonstrate.
 
 | Horizon | Milestone | Open Items | Closed Items | Current Posture |
 | :--- | :--- | ---: | ---: | :--- |
-| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 6 | 8 | Active stabilization lane for demo integrity, framework input correctness, and narrow security repairs. |
+| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 4 | 10 | Active stabilization lane for demo integrity, framework input correctness, and narrow security repairs. |
 | `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 | Latest shipped release lineage after the release PR merges. Complete; do not reopen for new feature work. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Shipped release lineage. Complete; do not reopen for new feature work. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 31 | 6 | Active forward backlog. Promote shaped work from here into a versioned release. |
@@ -200,19 +200,18 @@ that a cross-repository release is the next smallest honest boundary.
 
 ## Next Pull
 
-The immediate implementation pull should land the **DOGFOOD light theme
-readiness** repair from #341 through DL-017.
+The immediate implementation pull should land the **Blocks app-binding
+snippets** repair from #342 through DX-047.
 
-That pull should add deterministic light-theme witnesses for settings, menu,
-or modal chrome; fix any unpainted background path those witnesses reveal; tune
-low-contrast light-theme token pairs used by borders, panels, muted text, and
-selection rows; and expand theme diagnostics so DOGFOOD chrome contrast does
-not regress silently.
+That pull should add a `CounterDemoBlock` app-binding walkthrough to DOGFOOD's
+Blocks docs, show application-owned state and command-intent routing, keep the
+snippet legible in the terminal docs surface, and add deterministic proof that
+the snippet references real APIs instead of drifting into pseudo-code.
 
 ## Forward Goalposts
 
 These are planning recommendations from the open tracker state as of
-2026-06-15. `v7.1.0` is shipped lineage; `v7.2.0` is the active stabilization
+2026-06-16. `v7.1.0` is shipped lineage; `v7.2.0` is the active stabilization
 lane; `v8.0.0` and `v9.0.0` remain the intended feature horizons after the
 stabilization release.
 

--- a/docs/design/DX-047-blocks-app-binding-snippets.md
+++ b/docs/design/DX-047-blocks-app-binding-snippets.md
@@ -1,0 +1,171 @@
+---
+id: DX-047
+title: Blocks App Binding Snippets
+status: active
+lane: asap
+priority: medium
+github_issue: 342
+legend: DX
+---
+
+# DX-047 - Blocks App Binding Snippets
+
+Legend: [DX - Developer Experience](../legends/DX-developer-experience.md)
+
+## Decision Summary
+
+DOGFOOD's Blocks docs should show how a block becomes application code, not
+only how a block is described as metadata. For `v7.2.0`, the bounded repair is
+to add an app-binding walkthrough centered on the existing `CounterDemoBlock`
+fixture:
+
+- show the block contract: model, config, data requirement, and command intents
+- show the application state/update path that owns counter state
+- show how keyboard actions become command-intent emissions
+- show how the app renders the block from model-owned state
+- prove the snippet is not stale by compiling it or testing its source text
+
+## Sponsored Human
+
+A release-video viewer needs to understand why Blocks are reusable product
+assemblies rather than screenshots or one-off demos. The Blocks page should let
+the presenter say "this is how you wire one into your app" without leaving
+DOGFOOD.
+
+## Sponsored Agent
+
+An agent needs a deterministic docs witness that can inspect the Blocks section
+and verify that the app-binding example names the real API pieces: block config,
+state ownership, command intents, update routing, render invocation, and
+lower-mode expectations.
+
+## Hill
+
+After this cycle, a developer can open DOGFOOD's Blocks section and see a
+complete, real app-binding snippet for `CounterDemoBlock`, including the state
+and command routing that make the block interactive.
+
+## Problem
+
+Issue #342 came from the `v7.1.0` release-video rehearsal. The Blocks section
+now has useful catalog and preview surfaces, but it still reads like a product
+taxonomy. It does not yet answer the practical developer question:
+
+```text
+How do I bind this block to my application's state and commands?
+```
+
+The current "How to Make Your Own Blocks" page shows block authoring metadata
+and a minimal `defineBlock()` shape. It does not show the application side of
+the contract: TEA state, update routing, render-time config, and command-intent
+handling.
+
+## Scope
+
+- Add a focused app-binding section to the Blocks docs.
+- Use `CounterDemoBlock` as the first example because it already proves bounded
+  state, command intents, interaction keys, and lower-mode output in DOGFOOD.
+- Keep the code snippet small enough to read inside the terminal.
+- Back the snippet with deterministic tests so API names and command paths do
+  not drift silently.
+- Update release-facing signposts and changelog entries for #342.
+
+## Non-Goals
+
+- Do not redesign BlockLab.
+- Do not build a code editor or tutorial runner.
+- Do not pull broad #302 Runtime Graph / Scene IR product-contract work into
+  this cycle.
+- Do not add a new production counter block. `CounterDemoBlock` remains a
+  DOGFOOD fixture.
+- Do not rewrite the standard block catalog.
+
+## User Experience Contract
+
+The Blocks docs should show both sides of a block contract:
+
+- the reusable block owns metadata, data requirements, command intents, render
+  contract, and lower-mode behavior
+- the application owns model state, update decisions, host data, and when to
+  invoke the block
+
+The snippet should be readable in DOGFOOD at normal release-video dimensions.
+It should not require a browser, external docs page, or source-code search to
+explain the basic integration path.
+
+## Playback Questions
+
+- Can a viewer see where counter state lives?
+- Can a viewer see which key emits which command intent?
+- Can a viewer see that the block render input is built from app-owned state?
+- Can a viewer see how lower modes stay meaningful when interaction is absent?
+- Can a test fail if the docs remove the binding path or let the snippet drift
+  away from real APIs?
+
+## Accessibility / Assistive Posture
+
+The binding explanation must be useful as text. Code snippets and prose should
+not rely on color-only emphasis. The lower-mode note should explain what pipe
+and accessible output preserve from the interactive block.
+
+## Localization / Directionality Posture
+
+This cycle adds English-source documentation copy only. DOGFOOD already labels
+English-source Markdown under non-English locales; this cycle should preserve
+that behavior. No new right-to-left layout behavior is introduced.
+
+## Agent Inspectability / Explainability Posture
+
+Agents should be able to inspect:
+
+- the rendered Blocks docs text
+- the exact snippet source text
+- whether the snippet references real exported `CounterDemoBlock` helpers
+- whether the snippet names command-intent routing and lower-mode output
+
+The proof should not depend on screenshots.
+
+## Linked Invariants
+
+- Blocks are product-level assemblies, not leaf visual components.
+- Application state owns business data; block render functions consume
+  explicit inputs.
+- Command intents describe user intent; applications interpret and apply those
+  intents.
+- DOGFOOD release claims must be demonstrable inside DOGFOOD.
+
+## Implementation Outline
+
+1. Add a reusable app-binding snippet source for `CounterDemoBlock`.
+2. Render that snippet in `examples/docs/content/blocks-make-your-own.md` or a
+   nearby generated docs path.
+3. Add prose explaining app-owned state, command intent routing, render-time
+   config, and lower-mode output.
+4. Add focused tests that render the Blocks guide and assert the app-binding
+   section is visible and legible.
+5. Add a compile or source-integrity test so the snippet cannot drift from the
+   real helper API.
+6. Update `docs/CHANGELOG.md`, `docs/BEARING.md`, and `docs/ROADMAP.md`.
+
+## Tests To Write First
+
+- A DOGFOOD Blocks render test fails unless "How to Make Your Own Blocks"
+  includes a visible `CounterDemoBlock` app-binding section.
+- A snippet integrity test fails unless the documented code references the real
+  counter model, config, command-intent, update, and render helpers.
+- Existing CounterDemoBlock preview and intent-key tests continue to pass.
+
+## Acceptance Criteria
+
+- Blocks docs include at least one complete app-binding snippet.
+- The snippet uses real Bijou / DOGFOOD APIs and is covered by deterministic
+  test proof.
+- Interactive block docs explain state ownership and command routing.
+- DOGFOOD renders the snippet legibly in the Blocks section.
+- The release/video script can explain "how to use this in your app" from the
+  Blocks docs alone.
+- Issue #342 is closed by the implementation PR.
+
+## Retrospective
+
+To be completed when the PR lands.

--- a/examples/docs/content/blocks-make-your-own.md
+++ b/examples/docs/content/blocks-make-your-own.md
@@ -38,7 +38,7 @@ import {
   createCounterDemoModel,
   tickCounterDemoModel,
   type CounterDemoModel,
-} from './counter-block-demo.js';
+} from '../counter-block-demo.js';
 
 interface CounterAppModel {
   readonly counterBlock: CounterDemoModel;

--- a/examples/docs/content/blocks-make-your-own.md
+++ b/examples/docs/content/blocks-make-your-own.md
@@ -13,6 +13,77 @@ without relying on import-time registration.
 5. Add a schema adapter when unknown boundary data needs validation.
 6. Export the block and include it in a package manifest.
 
+## Bind CounterDemoBlock in an App
+
+App owns CounterDemoModel state. The block stays reusable: it receives
+render-time config and emits command intent facts, while the application
+decides how state changes.
+
+The binding pattern:
+
+1. App owns `CounterDemoModel` state.
+2. App keys become command intents through `counterDemoIntentForKey()`.
+3. The app applies intent facts through `applyCounterDemoIntent()`.
+4. Rendering derives `counterDemoBlockConfig()` from app state.
+5. `counterDemoBlockSurface()` turns that config into terminal output.
+6. The pipe and accessible modes still describe the value when no key loop exists.
+
+```ts
+import type { BijouContext, Surface } from '@flyingrobots/bijou';
+import {
+  applyCounterDemoIntent,
+  counterDemoBlockConfig,
+  counterDemoBlockSurface,
+  counterDemoIntentForKey,
+  createCounterDemoModel,
+  tickCounterDemoModel,
+  type CounterDemoModel,
+} from './counter-block-demo.js';
+
+interface CounterAppModel {
+  readonly counterBlock: CounterDemoModel;
+}
+
+export function initCounterApp(): CounterAppModel {
+  return {
+    counterBlock: createCounterDemoModel(5),
+  };
+}
+
+export function updateCounterApp(
+  model: CounterAppModel,
+  key: string,
+): CounterAppModel {
+  const intent = counterDemoIntentForKey(key);
+  if (intent === undefined) return model;
+
+  return {
+    ...model,
+    counterBlock: applyCounterDemoIntent(model.counterBlock, intent),
+  };
+}
+
+export function tickCounterApp(
+  model: CounterAppModel,
+  deltaMs: number,
+): CounterAppModel {
+  return {
+    ...model,
+    counterBlock: tickCounterDemoModel(model.counterBlock, deltaMs),
+  };
+}
+
+export function viewCounterApp(
+  model: CounterAppModel,
+  ctx: BijouContext,
+  width: number,
+): Surface {
+  return counterDemoBlockSurface(
+    counterDemoBlockConfig(model.counterBlock, ctx, width),
+  );
+}
+```
+
 ## Minimal Shape
 
 ```ts

--- a/tests/cycles/DX-047/blocks-app-binding-snippets.test.ts
+++ b/tests/cycles/DX-047/blocks-app-binding-snippets.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
+import {
+  createScriptTestContext as createTestContext,
+  runScriptDeterministic as runScript,
+} from '../../helpers/scripted.js';
+import { createDocsApp } from '../../../examples/docs/app.js';
+import {
+  applyCounterDemoIntent,
+  counterDemoBlockConfig,
+  counterDemoBlockSurface,
+  counterDemoIntentForKey,
+  createCounterDemoModel,
+  tickCounterDemoModel,
+} from '../../../examples/docs/counter-block-demo.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
+  let text = '';
+  for (let y = 0; y < frame.height; y++) {
+    for (let x = 0; x < frame.width; x++) {
+      text += frame.get(x, y).char || ' ';
+    }
+    text += '\n';
+  }
+  return text;
+}
+
+const REQUIRED_COUNTER_BINDING_APIS = [
+  'createCounterDemoModel',
+  'counterDemoIntentForKey',
+  'applyCounterDemoIntent',
+  'tickCounterDemoModel',
+  'counterDemoBlockConfig',
+  'counterDemoBlockSurface',
+] as const;
+
+describe('DX-047 Blocks app-binding snippets', () => {
+  afterEach(() => _resetDefaultContextForTesting());
+
+  it('renders a CounterDemoBlock app-binding walkthrough in DOGFOOD Blocks docs', async () => {
+    const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 180, rows: 84 } });
+    const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' as any });
+
+    const result = await runScript(app, [{
+      msg: {
+        type: 'docs',
+        msg: { type: 'select-guide', guideId: 'blocks-make-your-own' },
+      },
+    }], { ctx });
+    const text = frameText(result.frames.at(-1)!);
+
+    expect(text).toContain('Bind CounterDemoBlock in an App');
+    expect(text).toContain('App owns CounterDemoModel state');
+    expect(text).toContain('keys become command intents');
+    expect(text).toContain('counterDemoIntentForKey');
+    expect(text).toContain('applyCounterDemoIntent');
+    expect(text).toContain('counterDemoBlockConfig');
+    expect(text).toContain('counterDemoBlockSurface');
+    expect(text).toContain('pipe and accessible modes');
+  });
+
+  it('keeps the documented binding snippet anchored to real CounterDemoBlock helpers', () => {
+    const source = read('examples/docs/content/blocks-make-your-own.md');
+
+    for (const api of REQUIRED_COUNTER_BINDING_APIS) {
+      expect(source).toContain(api);
+    }
+
+    expect(source).toContain('type CounterDemoModel');
+    expect(source).toContain('CounterAppModel');
+    expect(source).toContain('counterBlock: createCounterDemoModel(5)');
+    expect(typeof createCounterDemoModel).toBe('function');
+    expect(typeof counterDemoIntentForKey).toBe('function');
+    expect(typeof applyCounterDemoIntent).toBe('function');
+    expect(typeof tickCounterDemoModel).toBe('function');
+    expect(typeof counterDemoBlockConfig).toBe('function');
+    expect(typeof counterDemoBlockSurface).toBe('function');
+  });
+});

--- a/tests/cycles/DX-047/blocks-app-binding-snippets.test.ts
+++ b/tests/cycles/DX-047/blocks-app-binding-snippets.test.ts
@@ -1,6 +1,7 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { afterEach, describe, expect, it } from 'vitest';
 import { _resetDefaultContextForTesting } from '@flyingrobots/bijou/adapters/test';
 import {
@@ -18,9 +19,34 @@ import {
 } from '../../../examples/docs/counter-block-demo.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const BLOCKS_MAKE_YOUR_OWN_PATH = 'examples/docs/content/blocks-make-your-own.md';
+const COUNTER_BINDING_HEADING = '## Bind CounterDemoBlock in an App';
 
 function read(relativePath: string): string {
   return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function extractFencedTsBlockAfterHeading(source: string, heading: string): string {
+  const headingIndex = source.indexOf(heading);
+  if (headingIndex === -1) {
+    throw new Error(`Missing Markdown heading: ${heading}`);
+  }
+
+  const section = source.slice(headingIndex + heading.length);
+  const match = section.match(/```ts\n([\s\S]*?)\n```/);
+  if (match === null) {
+    throw new Error(`Missing TypeScript code fence after heading: ${heading}`);
+  }
+
+  return match[1];
+}
+
+function resolveDocumentedSourceImport(markdownPath: string, importPath: string): string {
+  const markdownDirectory = dirname(resolve(ROOT, markdownPath));
+  const documentedTarget = resolve(markdownDirectory, importPath);
+  return documentedTarget.endsWith('.js')
+    ? documentedTarget.replace(/\.js$/, '.ts')
+    : documentedTarget;
 }
 
 function frameText(frame: { width: number; height: number; get(x: number, y: number): { char?: string } }) {
@@ -69,15 +95,34 @@ describe('DX-047 Blocks app-binding snippets', () => {
   });
 
   it('keeps the documented binding snippet anchored to real CounterDemoBlock helpers', () => {
-    const source = read('examples/docs/content/blocks-make-your-own.md');
+    const source = read(BLOCKS_MAKE_YOUR_OWN_PATH);
+    const snippet = extractFencedTsBlockAfterHeading(source, COUNTER_BINDING_HEADING);
 
     for (const api of REQUIRED_COUNTER_BINDING_APIS) {
-      expect(source).toContain(api);
+      expect(snippet).toContain(api);
     }
 
-    expect(source).toContain('type CounterDemoModel');
-    expect(source).toContain('CounterAppModel');
-    expect(source).toContain('counterBlock: createCounterDemoModel(5)');
+    expect(snippet).toContain('type CounterDemoModel');
+    expect(snippet).toContain('CounterAppModel');
+    expect(snippet).toContain('counterBlock: createCounterDemoModel(5)');
+
+    const transpiled = ts.transpileModule(snippet, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+      },
+      reportDiagnostics: true,
+    });
+    expect(transpiled.diagnostics ?? []).toEqual([]);
+
+    const relativeImports = [...snippet.matchAll(/from ['"](\.[^'"]+)['"]/g)]
+      .map((match) => match[1]);
+    expect(relativeImports).toEqual(['../counter-block-demo.js']);
+    for (const importPath of relativeImports) {
+      const sourcePath = resolveDocumentedSourceImport(BLOCKS_MAKE_YOUR_OWN_PATH, importPath);
+      expect(existsSync(sourcePath)).toBe(true);
+    }
+
     expect(typeof createCounterDemoModel).toBe('function');
     expect(typeof counterDemoIntentForKey).toBe('function');
     expect(typeof applyCounterDemoIntent).toBe('function');

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.test.ts
@@ -45,8 +45,9 @@ describe('WF-130 roadmap goalpost policy', () => {
     const bearing = normalizeWhitespace(read('docs/BEARING.md'));
     const releaseRunbook = normalizeWhitespace(read('docs/release.md'));
     const dx046Design = normalizeWhitespace(read('docs/design/DX-046-graphql-authored-dogfood-block-fixture.md'));
+    const dx047Design = normalizeWhitespace(read('docs/design/DX-047-blocks-app-binding-snippets.md'));
 
-    expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-06-15.');
+    expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-06-16.');
     expect(roadmap).toContain('The latest shipped public release is');
     expect(roadmap).toContain('v7.1.0');
     expect(roadmap).toContain('v7.0.0');
@@ -60,7 +61,7 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`v9.0.0`: Product Workbench And Operator Surfaces');
     expect(roadmap).toContain('`v10.0.0+`: Ecosystem Integration');
     expect(roadmap).toContain('v6.0.0` was never published as a public package release');
-    expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 6 | 8 |');
+    expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 4 | 10 |');
     expect(roadmap).toContain('| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 |');
     expect(roadmap).toContain('Latest shipped release lineage after the release PR merges.');
     expect(roadmap).toContain('#270 release-readiness guardrails, #312 DOGFOOD i18n debt coverage');
@@ -73,9 +74,10 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(roadmap).toContain('`Beyond`');
     expect(roadmap).toContain('31 | 6');
     expect(roadmap).toContain('Next Pull');
-    expect(roadmap).toContain('DOGFOOD light theme readiness');
-    expect(roadmap).toContain('unpainted background path');
-    expect(roadmap).toContain('DOGFOOD chrome contrast');
+    expect(roadmap).toContain('Blocks app-binding snippets');
+    expect(roadmap).toContain('CounterDemoBlock` app-binding walkthrough');
+    expect(roadmap).toContain('application-owned state and command-intent routing');
+    expect(roadmap).toContain('real APIs instead of drifting into pseudo-code');
     expect(roadmap).toContain('versioned artifact semantics');
     expect(roadmap).toContain('DOGFOOD fixtures that round-trip');
     expect(roadmap).toContain('https://github.com/flyingrobots/bijou/issues/270');
@@ -118,7 +120,8 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(bearing).toContain('The next feature horizon remains `v8.0.0`');
     expect(bearing).toContain('the immediate focus is');
     expect(bearing).toContain('`v7.2.0` is now selected as a narrow stabilization and demo-integrity release');
-    expect(bearing).toContain('`v7.2.0` milestone is the current active stabilization lane: 6 open and 8 closed milestone items');
+    expect(bearing).toContain('`v7.2.0` milestone is the current active stabilization lane: 4 open and 10 closed milestone items');
+    expect(bearing).toContain('The current urgent `v7.2.0` pull is DX-047');
     expect(bearing).toContain('Stabilize V7.2, Then Shape V8 And V9 From Beyond');
     expect(bearing).not.toContain('The next release-facing action is release-readiness validation');
 
@@ -131,6 +134,10 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(dx046Design).toContain('Parent tracker: [#302](https://github.com/flyingrobots/bijou/issues/302)');
     expect(dx046Design).toContain('NavigationListBlock');
     expect(dx046Design).toContain('Tests To Write First');
+    expect(dx047Design).toContain('github_issue: 342');
+    expect(dx047Design).toContain('CounterDemoBlock');
+    expect(dx047Design).toContain('application state/update path');
+    expect(dx047Design).toContain('command-intent routing');
   });
 
   it('disables Markdown line-length linting for project docs', () => {


### PR DESCRIPTION
## Summary

Closes #342.

DX-047 adds the missing Blocks app-binding explanation that the release-video rehearsal exposed. DOGFOOD's Blocks docs now show how `CounterDemoBlock` becomes application code: app-owned state, key-to-command-intent routing, state update handling, render-time config, and pipe/accessibility lower-mode behavior.

Design: `docs/design/DX-047-blocks-app-binding-snippets.md`

## What changed

- Added a `CounterDemoBlock` app-binding walkthrough to `examples/docs/content/blocks-make-your-own.md`.
- Added DX-047 regression coverage for DOGFOOD-rendered visibility and snippet integrity against real counter block helper exports.
- Refreshed ROADMAP / BEARING / CHANGELOG signposts so v7.2.0 points at #342 as the active pull.

## Validation

- RED proof: `npx vitest run tests/cycles/DX-047/blocks-app-binding-snippets.test.ts` failed before the docs section existed.
- GREEN focused proof: `npx vitest run tests/cycles/DX-047/blocks-app-binding-snippets.test.ts`
- Focused regression set: `npx vitest run tests/cycles/DX-047/blocks-app-binding-snippets.test.ts tests/cycles/DX-031/dogfood-blocks-section.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.test.ts`
- `npm run dogfood:i18n:complete`
- `npm run dogfood:i18n:check`
- `npm run dogfood:i18n:debt`
- `npm run docs:inventory`
- `git diff --check`
- `npm run typecheck:test`
- `npm run lint`
- pre-push gate: DOGFOOD i18n complete/check/debt, typecheck:test, full `npm test` (349 files / 3863 tests), scripted interactive example smoke
