### PR TITLE
WF-140 Respecting the Dojo ratchet to 1729

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,8 +22,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   `BIJOU_VITEST_MAX_WORKERS`, enables incremental test typecheck metadata, and
   removes duplicate pre-commit lint and code-size checks that were already
   covered by `code-dojo:precommit`.
-- **Respecting the Dojo burndown** — WF-135/WF-139 lower live type-aware ESLint
-  findings from `4,517` to `1,368`, cutting `3,161` counted Code Dojo
+- **Respecting the Dojo burndown** — WF-135/WF-140 lower live type-aware ESLint
+  findings from `4,517` to `1,318`, cutting `3,211` counted Code Dojo
   violations across the initial 1000-count pass and follow-on fake-async,
   dead-fixture, explicit-formatting, script/example, MCP docs, flame, and
   app-frame render/settings/shell-layer/notification fixture cleanups, plus
@@ -55,9 +55,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   cleanup, plus soak-runner scenario/index formatting, markdown wrapped-line
   and table-width reads, textarea editor line access, and typed record-gifs
   recorder import cleanup, plus UI scene IR, active-binding collection, layout
-  envelope, and TUI flex checked-read cleanup. The aggregate debt ceiling now
-  ratchets from `4,940` to `1,779`, with the next goalpost target set to
-  `1,729` or lower, while touched file/context budgets remain held under their
+  envelope, TUI flex checked-read cleanup, perf-gradient safe-read and
+  explicit-formatting cleanup, DAG edge-grid checked reads, box defensive-call
+  cleanup, and perf overlay size formatting. The aggregate debt ceiling now
+  ratchets from `4,940` to `1,729`, with the next goalpost target set to
+  `1,679` or lower, while touched file/context budgets remain held under their
   stored ceilings and two file/context exceptions are removed.
 - **Code Dojo ESLint ratchet 1** — the first standards burndown pass lowers
   live type-aware ESLint findings from `5,121` to `4,563`, updates the

--- a/docs/code-dojo-exceptions.md
+++ b/docs/code-dojo-exceptions.md
@@ -27,8 +27,8 @@ Current count:
 | File/context baseline | 333 | Files over the Code Dojo context threshold. |
 | Mock-ban baseline | 23 | Existing test mock/spy violations. |
 | Code-size baseline | 55 | Files over the 500-line ratchet, including 4 over the 1000-line hard limit. |
-| ESLint baseline | 1,368 | Type-aware ESLint findings after the WF-139 ratchet pass. |
-| **Total** | **1,779** | Aggregate Code Dojo standards debt. |
+| ESLint baseline | 1,318 | Type-aware ESLint findings after the WF-140 ratchet pass. |
+| **Total** | **1,729** | Aggregate Code Dojo standards debt. |
 
 ## Goalpost Burndown Policy
 
@@ -53,8 +53,8 @@ The current ceiling is encoded in `package.json`:
 npm run code-dojo:debt
 ```
 
-The current ceiling is `1,779`. The next met goalpost must lower the ceiling to
-`1,729` or lower.
+The current ceiling is `1,729`. The next met goalpost must lower the ceiling to
+`1,679` or lower.
 
 ## Updating The Ceiling
 

--- a/docs/design/WF-140-respecting-dojo-ratchet-1729.md
+++ b/docs/design/WF-140-respecting-dojo-ratchet-1729.md
@@ -1,0 +1,91 @@
+# WF-140 Respecting the Dojo Ratchet To 1729
+
+## Status
+
+Shaping.
+
+## Issue
+
+- GitHub Issue: [#385](https://github.com/flyingrobots/bijou/issues/385)
+
+## Context
+
+WF-139 landed the Respecting the Dojo burndown at `1,779` aggregate Code Dojo
+violations. The next ratchet must cut at least `50` more violations and set the
+ceiling to `1,729` or lower.
+
+The goal remains zero ESLint findings, zero Code Dojo warnings/errors/issues,
+and zero length-restriction violations. This cycle is one real cleanup slice
+toward that endpoint, not an exception shuffle.
+
+## Goal
+
+Reduce aggregate Code Dojo debt from `1,779` to `1,729` or lower by eliminating
+at least `50` live ESLint findings with behavior-preserving TypeScript fixes.
+
+## Candidate Slice
+
+Initial offender candidates:
+
+| File | Findings |
+| :--- | ---: |
+| `examples/docs/capture-main.ts` | 30 |
+| `examples/perf-gradient/main.ts` | 24 |
+| `packages/bijou/src/core/theme/builder.ts` | 13 |
+| **Candidate total** | **67** |
+
+The final slice may substitute equivalent compact offenders if a candidate
+exposes broader semantic work than this goalpost should carry.
+
+## Scope
+
+- Replace non-null assertions, unsafe assertions, and `any` escapes with checked
+  reads, typed helpers, or narrowed runtime guards.
+- Make numeric and unknown template interpolation explicit.
+- Preserve capture, perf-gradient, and theme behavior.
+- Lower `scripts/code-dojo/baselines/eslint.json`,
+  `docs/code-dojo-exceptions.md`, and `package.json` only after live counts
+  prove the reduction.
+
+## Non-Goals
+
+- ESLint rules, Code Dojo thresholds, and standards artifacts must not weaken.
+- File/context and code-size ceilings must not rise.
+- Broad DOGFOOD architecture rewrites are out of scope.
+- Exception churn cannot stand in for real cleanup.
+
+## Current Evidence
+
+Live counts on `main` at `7e029df7`:
+
+- aggregate Code Dojo debt: `1,779`
+- ESLint findings: `1,368`
+- file/context baseline: `333`
+- mock-ban baseline: `23`
+- code-size baseline: `55`, including `4` legacy hard-limit files
+- next aggregate target: `1,729` or lower
+
+## Playback Questions
+
+1. Is aggregate Code Dojo debt at `1,729` or lower?
+2. Did the implementation remove at least `50` real violations?
+3. Did touched file/context and code-size ceilings stay flat or lower?
+4. Did focused behavior tests for touched surfaces pass?
+
+## Validation Plan
+
+- Run focused Code Dojo gates for the touched files.
+- Run focused tests for capture/perf/theme surfaces selected for the final
+  slice.
+- Run `npm run code-dojo:debt`.
+- Run `npm run code-dojo:verify`.
+- Run `npm run lint` and `npm run lint:eslint`.
+
+## Acceptance Criteria
+
+- The selected touched TypeScript files have zero new ESLint findings and reduce
+  live findings by at least `50`.
+- Aggregate Code Dojo debt is `1,729` or lower.
+- `scripts/code-dojo/baselines/eslint.json` records the lower live ESLint count.
+- `docs/code-dojo-exceptions.md` and `package.json` report the lower ceiling.
+- Focused validation for the touched surfaces passes.

--- a/docs/design/WF-140-respecting-dojo-ratchet-1729.md
+++ b/docs/design/WF-140-respecting-dojo-ratchet-1729.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Shaping.
+Implemented.
 
 ## Issue
 
@@ -23,26 +23,28 @@ toward that endpoint, not an exception shuffle.
 Reduce aggregate Code Dojo debt from `1,779` to `1,729` or lower by eliminating
 at least `50` live ESLint findings with behavior-preserving TypeScript fixes.
 
-## Candidate Slice
+## Final Slice
 
-Initial offender candidates:
+The implemented cleanup removes exactly 50 live ESLint findings:
 
 | File | Findings |
 | :--- | ---: |
-| `examples/docs/capture-main.ts` | 30 |
 | `examples/perf-gradient/main.ts` | 24 |
-| `packages/bijou/src/core/theme/builder.ts` | 13 |
-| **Candidate total** | **67** |
+| `packages/bijou/src/core/components/dag-edges.test.ts` | 12 |
+| `packages/bijou/src/core/components/box.test.ts` | 12 |
+| `packages/bijou/src/core/components/perf-overlay.ts` | 2 |
+| **Slice total** | **50** |
 
-The final slice may substitute equivalent compact offenders if a candidate
-exposes broader semantic work than this goalpost should carry.
+The DOGFOOD capture candidate is intentionally deferred because touching that
+source currently activates a broader DOGFOOD i18n raw-copy cleanup than this
+goalpost should carry.
 
 ## Scope
 
 - Replace non-null assertions, unsafe assertions, and `any` escapes with checked
   reads, typed helpers, or narrowed runtime guards.
 - Make numeric and unknown template interpolation explicit.
-- Preserve capture, perf-gradient, and theme behavior.
+- Preserve perf-gradient and component behavior.
 - Lower `scripts/code-dojo/baselines/eslint.json`,
   `docs/code-dojo-exceptions.md`, and `package.json` only after live counts
   prove the reduction.
@@ -65,6 +67,13 @@ Live counts on `main` at `7e029df7`:
 - code-size baseline: `55`, including `4` legacy hard-limit files
 - next aggregate target: `1,729` or lower
 
+Implementation result:
+
+- aggregate Code Dojo debt: `1,729`
+- ESLint findings: `1,318`
+- live ESLint reduction: `50`
+- next aggregate target: `1,679` or lower
+
 ## Playback Questions
 
 1. Is aggregate Code Dojo debt at `1,729` or lower?
@@ -75,8 +84,7 @@ Live counts on `main` at `7e029df7`:
 ## Validation Plan
 
 - Run focused Code Dojo gates for the touched files.
-- Run focused tests for capture/perf/theme surfaces selected for the final
-  slice.
+- Run focused tests for the selected component surfaces.
 - Run `npm run code-dojo:debt`.
 - Run `npm run code-dojo:verify`.
 - Run `npm run lint` and `npm run lint:eslint`.

--- a/examples/perf-gradient/main.ts
+++ b/examples/perf-gradient/main.ts
@@ -30,7 +30,6 @@ const CAPPED_MS = Math.round(1000 / 60);
 const UNCAPPED_MS = 1; // >0 to yield to the event loop for key input
 const GRAPH_SAMPLES = 60;
 
-// --- Ring buffer for view() time history (zero-alloc after init) ---
 const vtRing = new Float64Array(GRAPH_SAMPLES);
 let vtRingHead = 0;
 let vtRingCount = 0;
@@ -43,7 +42,7 @@ function pushVt(ms: number): void {
 
 function readVt(i: number): number {
   const idx = (vtRingHead - vtRingCount + i + GRAPH_SAMPLES) % GRAPH_SAMPLES;
-  return vtRing[idx]!;
+  return vtRing[idx] ?? 0;
 }
 
 // --- Braille line chart renderer ---
@@ -67,7 +66,6 @@ function renderBrailleLineChart(
   const dotsH = chartH * 4; // vertical dot resolution
   const dotsW = chartW * 2; // horizontal dot resolution
 
-  // Build braille grid (one code point per char cell)
   const grid = new Uint8Array(chartW * chartH);
 
   // Plot the reference line
@@ -77,11 +75,11 @@ function renderBrailleLineChart(
     const refDotRow = refDotY % 4;
     for (let cx = 0; cx < chartW; cx++) {
       // Set both left and right dots for a full horizontal line
-      grid[refCharRow * chartW + cx] |= BRAILLE_DOT_LEFT[refDotRow]! | BRAILLE_DOT_RIGHT[refDotRow]!;
+      grid[refCharRow * chartW + cx] |= (BRAILLE_DOT_LEFT[refDotRow] ?? 0) | (BRAILLE_DOT_RIGHT[refDotRow] ?? 0);
     }
     // Draw the reference line first in ref color
     for (let cx = 0; cx < chartW; cx++) {
-      const code = BRAILLE_BASE | grid[refCharRow * chartW + cx]!;
+      const code = BRAILLE_BASE | (grid[refCharRow * chartW + cx] ?? 0);
       surface.set(sx + cx, sy + refCharRow, { char: String.fromCharCode(code), fg: refFg, bg });
     }
   }
@@ -96,14 +94,14 @@ function renderBrailleLineChart(
     const charRow = Math.floor(dotY / 4);
     const dotCol = dotX % 2;
     const dotRow = dotY % 4;
-    const bits = dotCol === 0 ? BRAILLE_DOT_LEFT[dotRow]! : BRAILLE_DOT_RIGHT[dotRow]!;
+    const bits = dotCol === 0 ? BRAILLE_DOT_LEFT[dotRow] ?? 0 : BRAILLE_DOT_RIGHT[dotRow] ?? 0;
     grid[charRow * chartW + charCol] |= bits;
   }
 
   // Render to surface
   for (let cy = 0; cy < chartH; cy++) {
     for (let cx = 0; cx < chartW; cx++) {
-      const code = grid[cy * chartW + cx]!;
+      const code = grid[cy * chartW + cx] ?? 0;
       if (code !== 0) {
         surface.set(sx + cx, sy + cy, {
           char: String.fromCharCode(BRAILLE_BASE | code),
@@ -192,7 +190,7 @@ function rgbHex(r: number, g: number, b: number): string {
   return `#${hexByte(r)}${hexByte(g)}${hexByte(b)}`;
 }
 
-const { cos, PI, max, min, round } = Math;
+const { cos, PI, max, round } = Math;
 
 // Reusable surface — only reallocated on resize
 let cachedSurface: ReturnType<typeof createSurface> | undefined;
@@ -217,7 +215,7 @@ function stampText(
   text: string, fg: string, bg: string,
 ): void {
   for (let j = 0; j < text.length; j++) {
-    surface.set(x + j, y, { char: text[j]!, fg, bg });
+    surface.set(x + j, y, { char: text[j] ?? ' ', fg, bg });
   }
 }
 
@@ -232,6 +230,8 @@ function openSimplexNoise2D(seed: number): (x: number, y: number) => number {
   const grads = [5,2, 2,5, -5,2, -2,5, 5,-2, 2,-5, -5,-2, -2,-5];
   const perm = new Uint8Array(256);
   const source = new Uint8Array(256);
+  const grad = (index: number): number => grads[index] ?? 0;
+  const p = (index: number): number => perm[index & 0xFF] ?? 0;
   for (let i = 0; i < 256; i++) source[i] = i;
   let s = (seed * 1664525 + 1013904223) | 0;
   s = (s * 1664525 + 1013904223) | 0;
@@ -256,30 +256,30 @@ function openSimplexNoise2D(seed: number): (x: number, y: number) => number {
     let dx = dx0, dy = dy0;
     let attn = 2 - dx * dx - dy * dy;
     if (attn > 0) {
-      const i = (perm[(perm[xsb & 0xFF] + ysb) & 0xFF] & 0x0E);
-      attn *= attn; value += attn * attn * (grads[i] * dx + grads[i + 1] * dy);
+      const i = p(p(xsb) + ysb) & 0x0E;
+      attn *= attn; value += attn * attn * (grad(i) * dx + grad(i + 1) * dy);
     }
     // (1,0)
     dx = dx0 - 1 - SQUISH; dy = dy0 - SQUISH;
     attn = 2 - dx * dx - dy * dy;
     if (attn > 0) {
-      const i = (perm[(perm[(xsb + 1) & 0xFF] + ysb) & 0xFF] & 0x0E);
-      attn *= attn; value += attn * attn * (grads[i] * dx + grads[i + 1] * dy);
+      const i = p(p(xsb + 1) + ysb) & 0x0E;
+      attn *= attn; value += attn * attn * (grad(i) * dx + grad(i + 1) * dy);
     }
     // (0,1)
     dx = dx0 - SQUISH; dy = dy0 - 1 - SQUISH;
     attn = 2 - dx * dx - dy * dy;
     if (attn > 0) {
-      const i = (perm[(perm[xsb & 0xFF] + ysb + 1) & 0xFF] & 0x0E);
-      attn *= attn; value += attn * attn * (grads[i] * dx + grads[i + 1] * dy);
+      const i = p(p(xsb) + ysb + 1) & 0x0E;
+      attn *= attn; value += attn * attn * (grad(i) * dx + grad(i + 1) * dy);
     }
     if (inSum > 1) {
       // (1,1)
       dx = dx0 - 1 - 2 * SQUISH; dy = dy0 - 1 - 2 * SQUISH;
       attn = 2 - dx * dx - dy * dy;
       if (attn > 0) {
-        const i = (perm[(perm[(xsb + 1) & 0xFF] + ysb + 1) & 0xFF] & 0x0E);
-        attn *= attn; value += attn * attn * (grads[i] * dx + grads[i + 1] * dy);
+        const i = p(p(xsb + 1) + ysb + 1) & 0x0E;
+        attn *= attn; value += attn * attn * (grad(i) * dx + grad(i + 1) * dy);
       }
     }
     return value * NORM;
@@ -287,6 +287,7 @@ function openSimplexNoise2D(seed: number): (x: number, y: number) => number {
 }
 
 const noise2D = openSimplexNoise2D(42);
+const out: { columns?: number; rows?: number } = process.stdout;
 const DENSITY = 'Ñ@#W$9876543210?!abcxyz;:+=-,._ ';
 
 function fillGradient(surface: ReturnType<typeof createSurface>, model: Model): void {
@@ -491,9 +492,9 @@ function renderFrame(model: Model) {
     { text: `frame ${String(model.frame).padStart(7)}`, fg: FG },
     { text: `time  ${(model.elapsed / 1000).toFixed(1).padStart(6)}s`, fg: FG },
     { text: `ft    ${model.frameTimeMs.toFixed(1).padStart(5)}ms`, fg: '#ffaa00' },
-    { text: `size  ${cols}×${rows}  (${cols * rows} cells)`, fg: FG },
+    { text: `size  ${String(cols)}×${String(rows)}  (${String(cols * rows)} cells)`, fg: FG },
     { text: `cap   ${model.capped ? '60fps' : 'OFF'}`, fg: model.capped ? FG : '#ff6666' },
-    { text: `mode  ${model.mode + 1}`, fg: FG },
+    { text: `mode  ${String(model.mode + 1)}`, fg: FG },
     { text: `mouse ${model.mouseDown ? 'DOWN' : 'up'}`, fg: FG },
     { text: '', fg: FG },
     { text: '── timing ────────────', fg: '#555555' },
@@ -504,7 +505,7 @@ function renderFrame(model: Model) {
     { text: `heap  ${mem.heapUsedMB.toFixed(1)}/${mem.heapTotalMB.toFixed(1)} MB`, fg: '#88aaff' },
     { text: `rss   ${mem.rssMB.toFixed(1)} MB`, fg: '#88aaff' },
     { text: `ext   ${mem.externalMB.toFixed(1)} MB`, fg: '#88aaff' },
-    { text: `gc    ${mem.gcCountSinceLastSample}/0.5s`, fg: mem.gcCountSinceLastSample > 5 ? '#ff6666' : '#88aaff' },
+    { text: `gc    ${String(mem.gcCountSinceLastSample)}/0.5s`, fg: mem.gcCountSinceLastSample > 5 ? '#ff6666' : '#88aaff' },
   ];
 
   const graphCharsW = 30; // braille chars wide (60 dot columns = 60 samples)
@@ -523,8 +524,7 @@ function renderFrame(model: Model) {
     }
 
     // Stats text
-    for (let i = 0; i < stats.length; i++) {
-      const s = stats[i]!;
+    for (const [i, s] of stats.entries()) {
       if (s.text.length > 0) {
         stampText(surface, 3, 2 + i, s.text, s.fg, BG);
       }
@@ -562,14 +562,12 @@ function renderFrame(model: Model) {
       maxVt > 16.7 ? 16.7 : undefined, // show 16.7ms ref line if in range
     );
 
-    // X axis label
-    const xLabel = `last ${GRAPH_SAMPLES}`;
+    const xLabel = `last ${String(GRAPH_SAMPLES)}`;
     stampText(surface, graphLeft, graphTop + graphCharsH, `╰${'─'.repeat(max(1, graphCharsW - xLabel.length - 1))} ${xLabel}`, '#555555', BG);
   }
 
-  // Controls hint
   const modeName = MODE_NAMES[model.mode] ?? '?';
-  const hint = ` space: cap │ 1-${MODE_COUNT}: mode (${modeName}) │ mouse: reverse │ q: quit `;
+  const hint = ` space: cap │ 1-${String(MODE_COUNT)}: mode (${modeName}) │ mouse: reverse │ q: quit `;
   if (rows > 2 && cols >= hint.length + 2) {
     const hintRow = rows - 1;
     const hintCol = round((cols - hint.length) / 2);
@@ -586,8 +584,8 @@ const app: App<Model, Msg> = {
     fps: 0,
     fpsAccum: 0,
     fpsSamples: 0,
-    cols: process.stdout.columns ?? 80,
-    rows: process.stdout.rows ?? 24,
+    cols: out.columns ?? 80,
+    rows: out.rows ?? 24,
     mouseDown: false,
     mode: 0,
     capped: true,
@@ -675,4 +673,4 @@ const app: App<Model, Msg> = {
     return surface;
   },
 };
-run(app, { mouse: true });
+await run(app, { mouse: true });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release:readiness": "tsx scripts/release-readiness.ts",
     "docs:inventory": "tsx scripts/docs-inventory.ts",
     "code:size": "tsx scripts/code-size-gate.ts",
-    "code-dojo:debt": "tsx scripts/code-dojo-debt.ts --max 1779",
+    "code-dojo:debt": "tsx scripts/code-dojo-debt.ts --max 1729",
     "code-dojo:eslint:offenders": "node scripts/code-dojo/eslint-offenders.mjs",
     "code-dojo:fast": "node scripts/code-dojo/fast.mjs",
     "code-dojo:changed": "node scripts/code-dojo/changed.mjs",

--- a/packages/bijou/src/core/components/box.test.ts
+++ b/packages/bijou/src/core/components/box.test.ts
@@ -8,7 +8,7 @@ describe('box', () => {
     const ctx = createTestContext({ mode: 'interactive' });
     const result = box('Hello World', { ctx });
     expect(result).toContain('Hello World');
-    expect(result).toContain('─'); // border chars
+    expect(result).toContain('─');
   });
   it('returns content only in pipe mode', () => {
     const ctx = createTestContext({ mode: 'pipe' });
@@ -44,7 +44,6 @@ describe('box() with bgToken', () => {
   it('applies bg fill in interactive mode', () => {
     const ctx = createTestContext({ mode: 'interactive' });
     const result = box('Hello', { bgToken, ctx });
-    // plainStyle is identity, so content is unchanged, but no error thrown
     expect(result).toContain('Hello');
     expect(result).toContain('─');
   });
@@ -57,7 +56,6 @@ describe('box() with bgToken', () => {
   it('skips bg fill in pipe mode', () => {
     const ctx = createTestContext({ mode: 'pipe' });
     const result = box('Hello', { bgToken, ctx });
-    // pipe mode returns raw content without borders
     expect(result).toBe('Hello');
   });
   it('skips bg fill in accessible mode', () => {
@@ -68,7 +66,6 @@ describe('box() with bgToken', () => {
   it('skips bg fill when noColor is true', () => {
     const ctx = createTestContext({ mode: 'interactive', noColor: true });
     const result = box('Hello', { bgToken, ctx });
-    // Still renders box, but no bg fill applied
     expect(result).toContain('Hello');
     expect(result).toContain('─');
   });
@@ -219,12 +216,12 @@ describe('box() with fillChar', () => {
 describe('defensive input handling', () => {
   it('handles null/undefined content gracefully', () => {
     const ctx = createTestContext({ mode: 'pipe' });
-    expect(box(null as any, { ctx })).toBe('');
-    expect(box(undefined as any, { ctx })).toBe('');
+    expect(Reflect.apply(box, undefined, [null, { ctx }])).toBe('');
+    expect(Reflect.apply(box, undefined, [undefined, { ctx }])).toBe('');
   });
   it('handles null/undefined label in headerBox gracefully', () => {
     const ctx = createTestContext({ mode: 'pipe' });
-    expect(headerBox(null as any, { ctx })).toBe('');
-    expect(headerBox(undefined as any, { ctx })).toBe('');
+    expect(Reflect.apply(headerBox, undefined, [null, { ctx }])).toBe('');
+    expect(Reflect.apply(headerBox, undefined, [undefined, { ctx }])).toBe('');
   });
 });

--- a/packages/bijou/src/core/components/dag-edges.test.ts
+++ b/packages/bijou/src/core/components/dag-edges.test.ts
@@ -113,8 +113,8 @@ describe('createGrid', () => {
 
   it('cells start with empty direction sets', () => {
     const g = createGrid(2, 2);
-    expect(g.dirs[0]![0]?.size).toBe(0);
-    expect(g.dirs[1]![1]?.size).toBe(0);
+    expect(g.dirs[0]?.[0]?.size).toBe(0);
+    expect(g.dirs[1]?.[1]?.size).toBe(0);
   });
 
   it('arrows set starts empty', () => {
@@ -131,9 +131,9 @@ describe('markEdge', () => {
     markEdge(g, 0, 0, 0, 1, RS, colCenter, 8, 3);
     // sRow = 0*6+3 = 3, dRow = 1*6-1 = 5
     // Vertical from row 3 through row 5, arrow at row 5
-    expect(g.dirs[3]![5]?.has('D')).toBe(true);
-    expect(g.dirs[4]![5]?.has('D')).toBe(true);
-    expect(g.dirs[4]![5]?.has('U')).toBe(true);
+    expect(g.dirs[3]?.[5]?.has('D')).toBe(true);
+    expect(g.dirs[4]?.[5]?.has('D')).toBe(true);
+    expect(g.dirs[4]?.[5]?.has('U')).toBe(true);
     expect(g.arrows.get(encodeArrowPos(5, 5))).toBe(1);
   });
 
@@ -145,8 +145,8 @@ describe('markEdge', () => {
     // mid = sRow+1 = 4, horizontal from col 7 to col 22
     // Check horizontal segment has L and R
     const midRow = 4;
-    expect(g.dirs[midRow]![10]?.has('L')).toBe(true);
-    expect(g.dirs[midRow]![10]?.has('R')).toBe(true);
+    expect(g.dirs[midRow]?.[10]?.has('L')).toBe(true);
+    expect(g.dirs[midRow]?.[10]?.has('R')).toBe(true);
   });
 
   it('detours same-column skip edges around intermediate node columns', () => {
@@ -157,13 +157,13 @@ describe('markEdge', () => {
 
     // The middle layer's center column should remain untouched so the edge
     // does not disappear under the intermediate node box.
-    expect(g.dirs[6]![8]?.size).toBe(0);
-    expect(g.dirs[7]![8]?.size).toBe(0);
-    expect(g.dirs[8]![8]?.size).toBe(0);
+    expect(g.dirs[6]?.[8]?.size).toBe(0);
+    expect(g.dirs[7]?.[8]?.size).toBe(0);
+    expect(g.dirs[8]?.[8]?.size).toBe(0);
 
-    // The detour path should run in the gap to the right.
-    expect(g.dirs[7]![17]?.has('D')).toBe(true);
-    expect(g.dirs[7]![17]?.has('U')).toBe(true);
+    // The detour path runs in the right gap.
+    expect(g.dirs[7]?.[17]?.has('D')).toBe(true);
+    expect(g.dirs[7]?.[17]?.has('U')).toBe(true);
   });
 });
 

--- a/packages/bijou/src/core/components/perf-overlay.ts
+++ b/packages/bijou/src/core/components/perf-overlay.ts
@@ -83,7 +83,7 @@ export function perfOverlaySurface(
   const entries: StatsPanelEntry[] = [
     { label: 'FPS', value: String(Math.round(stats.fps)) },
     { label: 'frame', value: fmt(stats.frameTimeMs, 2) + ' ms', sparkline: stats.frameTimeHistory },
-    { label: 'size', value: `${stats.width}×${stats.height}` },
+    { label: 'size', value: `${String(stats.width)}×${String(stats.height)}` },
   ];
 
   if (stats.heapUsedMB != null) {

--- a/scripts/code-dojo/baselines/eslint.json
+++ b/scripts/code-dojo/baselines/eslint.json
@@ -1,7 +1,7 @@
 {
   "schema": "code-dojo.eslint-baseline.v1",
-  "total": 1368,
-  "errors": 1368,
+  "total": 1318,
+  "errors": 1318,
   "warnings": 0,
   "rules": [
     {
@@ -46,11 +46,11 @@
     },
     {
       "ruleId": "@typescript-eslint/no-explicit-any",
-      "count": 47
+      "count": 43
     },
     {
       "ruleId": "@typescript-eslint/no-floating-promises",
-      "count": 9
+      "count": 8
     },
     {
       "ruleId": "@typescript-eslint/no-invalid-void-type",
@@ -58,7 +58,7 @@
     },
     {
       "ruleId": "@typescript-eslint/no-non-null-assertion",
-      "count": 274
+      "count": 253
     },
     {
       "ruleId": "@typescript-eslint/no-redundant-type-constituents",
@@ -66,7 +66,7 @@
     },
     {
       "ruleId": "@typescript-eslint/no-unnecessary-condition",
-      "count": 93
+      "count": 91
     },
     {
       "ruleId": "@typescript-eslint/no-unnecessary-type-arguments",
@@ -86,7 +86,7 @@
     },
     {
       "ruleId": "@typescript-eslint/no-unsafe-argument",
-      "count": 31
+      "count": 27
     },
     {
       "ruleId": "@typescript-eslint/no-unsafe-assignment",
@@ -106,11 +106,11 @@
     },
     {
       "ruleId": "@typescript-eslint/no-unsafe-type-assertion",
-      "count": 248
+      "count": 244
     },
     {
       "ruleId": "@typescript-eslint/no-unused-vars",
-      "count": 40
+      "count": 39
     },
     {
       "ruleId": "@typescript-eslint/non-nullable-type-assertion-style",
@@ -146,11 +146,11 @@
     },
     {
       "ruleId": "@typescript-eslint/restrict-plus-operands",
-      "count": 8
+      "count": 4
     },
     {
       "ruleId": "@typescript-eslint/restrict-template-expressions",
-      "count": 295
+      "count": 286
     },
     {
       "ruleId": "@typescript-eslint/switch-exhaustiveness-check",


### PR DESCRIPTION
## Summary

Refs #385.

Shape the next Respecting the Dojo ratchet cycle from `1,779` aggregate Code Dojo violations to `1,729` or lower.

## Design

- `docs/design/WF-140-respecting-dojo-ratchet-1729.md`

## Current counts

- aggregate Code Dojo debt: `1,779`
- ESLint findings: `1,368`
- file/context baseline: `333`
- mock-ban baseline: `23`
- code-size baseline: `55`, including `4` legacy hard-limit files
- next target: `1,729` or lower

## Validation

Shaping commit only:

- `npm run docs:inventory`
- `git diff --check`
- `npm run code-dojo:precommit`
- push pre-push full verification: Code Dojo gates, code:size, typecheck:test, full Vitest, scripted interactive examples
