### PR TITLE
WF-152 Respecting the Dojo ratchet to 1055

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,8 +22,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   `BIJOU_VITEST_MAX_WORKERS`, enables incremental test typecheck metadata, and
   removes duplicate pre-commit lint and code-size checks that were already
   covered by `code-dojo:precommit`.
-- **Respecting the Dojo burndown** — WF-135/WF-151 lower live type-aware ESLint
-  findings from `4,517` to `697`, cutting `3,835` counted Code Dojo
+- **Respecting the Dojo burndown** — WF-135/WF-152 lower live type-aware ESLint
+  findings from `4,517` to `646`, cutting `3,886` counted Code Dojo
   violations across the initial 1000-count pass and follow-on fake-async,
   dead-fixture, explicit-formatting, script/example, MCP docs, flame, and
   app-frame render/settings/shell-layer/notification fixture cleanups, plus
@@ -84,9 +84,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   smoke-example orchestration fakes, DOGFOOD light-theme formatting, DOGFOOD
   locale frame/model helpers, block metadata loose-consumer fixtures, canonical
   app checked reads and formatting, i18n string-table value guards, event bus
-  dispatch/backpressure cleanup, block-tree render branding, and markdown/table
-  defensive input typing. The aggregate debt ceiling now ratchets from `4,940`
-  to `1,105`, with the next goalpost target set to `1,055` or lower, while touched
+  dispatch/backpressure cleanup, block-tree render branding, markdown/table
+  defensive input typing, app-frame/showcase explicit formatting and action
+  handling, node style cache typing, TUI CSS resolver/media guards,
+  shader/raster/layout safe reads, form filter and standard-block render guards,
+  workflow preflight indexing, and cleanup handle test fakes. The aggregate debt
+  ceiling now ratchets from `4,940` to `1,054`, with the next goalpost target
+  set to `1,004` or lower, while touched
   file/context budgets remain held under their stored ceilings, three
   file/context exceptions are removed, and the DOGFOOD raw-string debt baseline
   drops from `2,772` to `2,766`.

--- a/docs/code-dojo-exceptions.md
+++ b/docs/code-dojo-exceptions.md
@@ -27,8 +27,8 @@ Current count:
 | File/context baseline | 331 | Files over the Code Dojo context threshold. |
 | Mock-ban baseline | 22 | Existing test mock/spy violations. |
 | Code-size baseline | 55 | Files over the 500-line ratchet, including 4 over the 1000-line hard limit. |
-| ESLint baseline | 697 | Type-aware ESLint findings after the WF-151 ratchet pass. |
-| **Total** | **1,105** | Aggregate Code Dojo standards debt. |
+| ESLint baseline | 646 | Type-aware ESLint findings after the WF-152 ratchet pass. |
+| **Total** | **1,054** | Aggregate Code Dojo standards debt. |
 
 ## Goalpost Burndown Policy
 
@@ -53,8 +53,8 @@ The current ceiling is encoded in `package.json`:
 npm run code-dojo:debt
 ```
 
-The current ceiling is `1,105`. The next met goalpost must lower the ceiling to
-`1,055` or lower.
+The current ceiling is `1,054`. The next met goalpost must lower the ceiling to
+`1,004` or lower.
 
 ## Updating The Ceiling
 

--- a/docs/design/WF-152-respecting-dojo-ratchet-1055.md
+++ b/docs/design/WF-152-respecting-dojo-ratchet-1055.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Shaped.
+Implemented.
 
 ## Tracker
 
@@ -41,11 +41,27 @@ Live counts on `main` at `f46ab5b7`:
 
 Selected cleanup slice:
 
-- TBD after focused offender probing.
+- `examples/app-frame/main.ts`
+- `examples/showcase/app.ts`
+- `packages/bijou-node/src/style.ts`
+- `packages/bijou-tui/src/css/resolver.ts`
+- `packages/bijou-tui/src/layout-preset.ts`
+- `packages/bijou-tui/src/pipeline/middleware/surface-shaders.ts`
+- `packages/bijou-tui/src/raster-glyph.ts`
+- `packages/bijou-tui/src/types.test.ts`
+- `packages/bijou/src/core/forms/filter-interactive.ts`
+- `packages/bijou/src/core/standard-blocks/render.ts`
+- `scripts/workflow-shell-preflight.ts`
 
 Implemented counts on this branch before review:
 
-- TBD after implementation.
+- aggregate Code Dojo debt: `1,054`
+- ESLint findings: `646`
+- file/context baseline: `331`
+- mock-ban baseline: `22`
+- code-size baseline: `55`, including `4` legacy hard-limit files
+- DOGFOOD raw-string debt: `2,766`
+- next aggregate target: `1,004` or lower
 
 ## Scope
 
@@ -132,4 +148,4 @@ without re-running broad discovery first.
 - Aggregate Code Dojo debt is `1,055` or lower.
 - The ESLint baseline records the lower live count.
 - The Code Dojo exception ledger and `package.json` report the lower ceiling.
-- The next ratchet target is documented as `1,005` or lower.
+- The next ratchet target is documented as `1,004` or lower.

--- a/docs/design/WF-152-respecting-dojo-ratchet-1055.md
+++ b/docs/design/WF-152-respecting-dojo-ratchet-1055.md
@@ -1,0 +1,135 @@
+# WF-152 Respecting the Dojo Ratchet To 1055
+
+## Status
+
+Shaped.
+
+## Tracker
+
+- GitHub Issue: [#409](https://github.com/flyingrobots/bijou/issues/409)
+- Pull Request: TBD
+
+## Legend
+
+- Linked legend: WF, Workflow and Delivery
+- Sponsor human: James Ross
+- Sponsor agent: Codex
+
+## Hill
+
+Bijou keeps earning its place inside the Code Dojo by removing at least 50
+counted standards violations from the landed `main` ceiling without increasing
+any other ratchet.
+
+The current goalpost is not a release version. It is:
+
+```text
+Respectful Repo: Enter the Code Dojo
+```
+
+## Current Truth
+
+Live counts on `main` at `f46ab5b7`:
+
+- aggregate Code Dojo debt: `1,105`
+- ESLint findings: `697`
+- file/context baseline: `331`
+- mock-ban baseline: `22`
+- code-size baseline: `55`, including `4` legacy hard-limit files
+- DOGFOOD raw-string debt: `2,766`
+- next aggregate target: `1,055` or lower
+
+Selected cleanup slice:
+
+- TBD after focused offender probing.
+
+Implemented counts on this branch before review:
+
+- TBD after implementation.
+
+## Scope
+
+- Select a focused cleanup slice from current ESLint or Code Dojo offenders.
+- Prefer real type, data-shape, and control-flow fixes over suppressions or
+  cosmetic baseline churn.
+- Keep touched file/context, mock-ban, code-size, and DOGFOOD localization
+  ratchets flat or lower.
+- Update `scripts/code-dojo/baselines/eslint.json`, `package.json`,
+  `docs/code-dojo-exceptions.md`, and `docs/CHANGELOG.md` after the live count
+  is proven lower.
+
+## Non-Goals
+
+- No baseline increases.
+- No release-version scope.
+- No broad feature work.
+- No rebase, amend, force push, or draft PR.
+
+## Playback Questions
+
+1. Is aggregate Code Dojo debt at `1,055` or lower?
+2. Did the implementation remove at least `50` real counted violations?
+3. Did touched file/context, mock-ban, code-size, and DOGFOOD localization
+   ceilings stay flat or lower?
+4. Did focused tests for touched behavior pass?
+
+## Accessibility And Assistive Posture
+
+This is standards cleanup. Any touched rendered or terminal output must preserve
+existing text, focus, lower-mode, and screen-reader semantics unless a test
+explicitly proves an accessibility improvement.
+
+## Localization And Directionality Posture
+
+Avoid DOGFOOD copy edits unless the slice intentionally updates localization
+catalogs. If DOGFOOD-facing strings are touched, run the DOGFOOD i18n gates and
+hold the raw-string and missing-localization ratchets flat or lower.
+
+## Agent Inspectability And Explainability Posture
+
+The selected files, rule deltas, and validation commands must be captured in
+this design doc or the PR summary so the next agent can audit what changed
+without re-running broad discovery first.
+
+## Linked Invariants
+
+- TypeScript standards: `docs/typescript-code-standards.editors-edition.md`
+- Code Dojo exception ledger: `docs/code-dojo-exceptions.md`
+- Work doctrine: `docs/METHOD.md`
+
+## Implementation Outline
+
+1. Use `npm run code-dojo:eslint:offenders` and focused ESLint probes to select
+   a slice that can remove at least `50` findings.
+2. Write focused regressions only where cleanup exposes a behavior or module
+   boundary risk.
+3. Replace unsafe assertions, non-null assertions, implicit coercions, and fake
+   async shapes with typed helpers and explicit control flow.
+4. Ratchet the ESLint baseline and aggregate Code Dojo ceiling after the live
+   count is proven lower.
+5. Update docs and changelog with final counts and the next target.
+
+## Tests To Write First
+
+- Add focused regressions for any behavior-bearing cleanup.
+- For pure typing cleanup, run focused ESLint and existing tests for the touched
+  package or surface before updating baselines.
+
+## Validation Plan
+
+- Probe candidate files with `npm run code-dojo:eslint:offenders`.
+- Run focused raw ESLint on touched files.
+- Run `npm run code-dojo:slice -- <touched TypeScript files>`.
+- Run focused behavior tests for touched surfaces.
+- Check aggregate debt with `npm run code-dojo:debt`.
+- Confirm standards gates with `npm run code-dojo:verify`.
+- Validate documentation inventory with `npm run docs:inventory`.
+- Run `npm run lint` and `git diff --check`.
+
+## Acceptance Criteria
+
+- The selected touched files reduce live findings by at least `50`.
+- Aggregate Code Dojo debt is `1,055` or lower.
+- The ESLint baseline records the lower live count.
+- The Code Dojo exception ledger and `package.json` report the lower ceiling.
+- The next ratchet target is documented as `1,005` or lower.

--- a/docs/design/WF-152-respecting-dojo-ratchet-1055.md
+++ b/docs/design/WF-152-respecting-dojo-ratchet-1055.md
@@ -7,7 +7,7 @@ Shaped.
 ## Tracker
 
 - GitHub Issue: [#409](https://github.com/flyingrobots/bijou/issues/409)
-- Pull Request: TBD
+- Pull Request: [#410](https://github.com/flyingrobots/bijou/pull/410)
 
 ## Legend
 

--- a/examples/app-frame/main.ts
+++ b/examples/app-frame/main.ts
@@ -31,8 +31,7 @@ function createInitialPageModel(): PageModel {
 
 function updatePageModel(msg: Msg, model: PageModel): [PageModel, []] {
   if (msg.type === 'inc') return [{ ...model, count: model.count + 1 }, []];
-  if (msg.type === 'toggle-inspector') return [{ ...model, inspector: !model.inspector }, []];
-  return [model, []];
+  return [{ ...model, inspector: !model.inspector }, []];
 }
 
 function createPageKeyMap() {
@@ -65,7 +64,7 @@ export function createAppFrameDemo(ctx: BijouContext = initDefaultContext()) {
     paneA: {
       kind: 'pane',
       paneId: 'files',
-      render: (width) => boxSurface(`Files\n\n- src/app.ts\n- src/frame.ts\n- test/app.test.ts\n\n${width} cols`, {
+      render: (width) => boxSurface(`Files\n\n- src/app.ts\n- src/frame.ts\n- test/app.test.ts\n\n${String(width)} cols`, {
         width,
         ctx,
       }),
@@ -74,7 +73,7 @@ export function createAppFrameDemo(ctx: BijouContext = initDefaultContext()) {
       kind: 'pane',
       paneId: 'content',
       overflowX: 'scroll',
-      render: (width, height) => boxSurface(`Editor\n\ncount = ${model.count}\n\nfunction main() {\n  return 'v1.3 app frame';\n}\n\n${width}x${height}`, {
+      render: (width, height) => boxSurface(`Editor\n\ncount = ${String(model.count)}\n\nfunction main() {\n  return 'v1.3 app frame';\n}\n\n${String(width)}x${String(height)}`, {
         width,
         ctx,
       }),
@@ -95,7 +94,7 @@ export function createAppFrameDemo(ctx: BijouContext = initDefaultContext()) {
       stats: {
         kind: 'pane',
         paneId: 'stats',
-        render: (width) => boxSurface(`Stats: counter=${model.count}`, { width, ctx }),
+        render: (width) => boxSurface(`Stats: counter=${String(model.count)}`, { width, ctx }),
       },
       left: {
         kind: 'pane',

--- a/examples/showcase/app.ts
+++ b/examples/showcase/app.ts
@@ -112,7 +112,8 @@ function renderSidebar(
     showScrollbar: state.items.length > state.height,
     ctx,
     renderItem: ({ item, focused }) => {
-      const entry = findEntry(item.value);
+      const itemValue = typeof item.value === 'string' ? item.value : '';
+      const entry = findEntry(itemValue);
       const tierMark = (entry?.tier ?? 1) === 3 ? ' *' : '';
       const label = `${focused ? '>' : ' '} ${item.label}${tierMark}`;
       return focused ? ctx.style.styled(ctx.semantic('primary'), label) : label;
@@ -162,21 +163,14 @@ function createCategoryPage(
     },
 
     update(msg, model) {
-      // Force quit always works
       if (msg.type === 'force-quit') {
         return [model, [quit()]];
       }
 
-      // Quit confirmation modal intercepts
       if (model.quitConfirmOpen) {
-        switch (msg.type) {
-          case 'confirm-quit':
-            return [model, [quit()]];
-          case 'cancel-quit':
-            return [{ ...model, quitConfirmOpen: false }, []];
-          default:
-            return [model, []];
-        }
+        if (msg.type === 'confirm-quit') return [model, [quit()]];
+        if (msg.type === 'cancel-quit') return [{ ...model, quitConfirmOpen: false }, []];
+        return [model, []];
       }
 
       switch (msg.type) {
@@ -191,7 +185,6 @@ function createCategoryPage(
         case 'request-quit':
           return [{ ...model, quitConfirmOpen: true }, []];
         case 'cancel-quit':
-          // Close drawer if open, otherwise no-op
           if (model.drawerOpen) {
             const nextGen = model.drawerAnimGen + 1;
             return [{ ...model, drawerOpen: false, drawerAnimGen: nextGen }, [
@@ -225,6 +218,9 @@ function createCategoryPage(
           return [{ ...model, drawerProgress: clamp01(msg.value) }, []];
         case 'force-quit':
           return [model, [quit()]];
+        case 'mouse':
+        case 'pulse':
+          return [model, []];
       }
     },
 
@@ -345,8 +341,8 @@ function renderDrawerContent(ctx: BijouContext): string {
   return [
     'Bijou Component Showcase',
     '',
-    `${total} components across`,
-    `${CATEGORIES.length} categories.`,
+    `${String(total)} components across`,
+    `${String(CATEGORIES.length)} categories.`,
     '',
     `${kbd('up', { ctx })}/${kbd('down', { ctx })}  Navigate`,
     `${kbd('[', { ctx })}/${kbd(']', { ctx })}     Categories`,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release:readiness": "tsx scripts/release-readiness.ts",
     "docs:inventory": "tsx scripts/docs-inventory.ts",
     "code:size": "tsx scripts/code-size-gate.ts",
-    "code-dojo:debt": "tsx scripts/code-dojo-debt.ts --max 1105",
+    "code-dojo:debt": "tsx scripts/code-dojo-debt.ts --max 1054",
     "code-dojo:eslint:offenders": "node scripts/code-dojo/eslint-offenders.mjs",
     "code-dojo:fast": "node scripts/code-dojo/fast.mjs",
     "code-dojo:changed": "node scripts/code-dojo/changed.mjs",

--- a/packages/bijou-node/src/style.ts
+++ b/packages/bijou-node/src/style.ts
@@ -17,15 +17,6 @@ export interface ChalkStyleOptions {
  * @param noColor - Pass `true` to suppress all ANSI styling.
  * @returns A {@link StylePort} implemented via chalk.
  */
-export function chalkStyle(noColor?: boolean): StylePort;
-/**
- * Create a chalk-backed {@link StylePort} with detailed options.
- *
- * @param options - Configuration including `noColor` flag and explicit chalk `level`.
- * @returns A {@link StylePort} implemented via chalk.
- */
-export function chalkStyle(options?: ChalkStyleOptions): StylePort;
-// Implementation
 export function chalkStyle(arg?: boolean | ChalkStyleOptions): StylePort {
   const opts = typeof arg === 'boolean' ? { noColor: arg } : (arg ?? {});
   const isNoColor = opts.noColor ?? false;
@@ -93,8 +84,8 @@ export function chalkStyle(arg?: boolean | ChalkStyleOptions): StylePort {
 
   function styleCacheKey(token: TokenValue): string {
     return [
-      token.hex ?? '',
-      token.bg ?? '',
+      token.hex,
+      token.bg,
       token.modifiers?.join(',') ?? '',
     ].join('|');
   }

--- a/packages/bijou-tui/src/css/resolver.ts
+++ b/packages/bijou-tui/src/css/resolver.ts
@@ -34,7 +34,6 @@ export function resolveStyles(
 ): ResolvedStyles {
   const matchedRules: { rule: BCSSRule; specificity: number }[] = [];
 
-  // 1. Collect rules from main sheet
   for (const rule of sheet.rules) {
     const specificity = getMatchSpecificity(identity, rule.selectors);
     if (specificity > 0) {
@@ -42,27 +41,22 @@ export function resolveStyles(
     }
   }
 
-  // 2. Collect rules from active media queries
   for (const mq of sheet.mediaQueries) {
     if (matchesMediaQuery(mq.condition, terminal)) {
       for (const rule of mq.rules) {
         const specificity = getMatchSpecificity(identity, rule.selectors);
         if (specificity > 0) {
-          // Media query rules have slightly higher base priority in CSS
           matchedRules.push({ rule, specificity: specificity + 0.1 });
         }
       }
     }
   }
 
-  // 3. Sort by specificity (and then order of appearance)
   matchedRules.sort((a, b) => a.specificity - b.specificity);
 
-  // 4. Merge declarations into final object
   const finalStyles: ResolvedStyles = {};
   for (const { rule } of matchedRules) {
     for (const decl of rule.declarations) {
-      // !important handling
       if (decl.important || !isImportant(finalStyles, decl.property)) {
         finalStyles[decl.property] = resolveValue(decl.value, graph, mode);
         if (decl.important) {
@@ -81,16 +75,15 @@ export function resolveStyles(
 function resolveValue(value: string, graph?: TokenGraph, mode: ThemeMode = 'dark'): string {
   if (!graph) return value;
 
-  // Simple regex for var(path.to.token)
   const varRegex = /var\(([^)]+)\)/g;
   
-  return value.replace(varRegex, (_, path) => {
+  return value.replace(varRegex, (_match: string, path: unknown) => {
+    if (typeof path !== 'string') return 'inherit';
     try {
-      // Try to get as full token first, then fallback to color
       const resolved = graph.get(path.trim(), mode);
       return resolved.hex;
     } catch {
-      return 'inherit'; // Fallback for unresolved vars
+      return 'inherit';
     }
   });
 }
@@ -145,14 +138,19 @@ function getMatchSpecificity(identity: ComponentIdentity, selectors: BCSSSelecto
  * Evaluate a basic media query condition like "(width < 80)" or "(height >= 24)".
  */
 export function matchesMediaQuery(condition: string, terminal: { width: number; height: number }): boolean {
-  // Simple regex for (property op value)
   const regex = /\((width|height)\s*(<|>|<=|>=|==|!=)\s*(\d+)\)/;
   const match = regex.exec(condition);
   if (!match) return false;
 
-  const property = match[1] === 'width' ? terminal.width : terminal.height;
+  const propertyName = match[1];
   const op = match[2];
-  const value = parseInt(match[3]!, 10);
+  const rawValue = match[3];
+  if ((propertyName !== 'width' && propertyName !== 'height') || op === undefined || rawValue === undefined) {
+    return false;
+  }
+
+  const property = propertyName === 'width' ? terminal.width : terminal.height;
+  const value = Number.parseInt(rawValue, 10);
 
   switch (op) {
     case '<': return property < value;

--- a/packages/bijou-tui/src/layout-preset.ts
+++ b/packages/bijou-tui/src/layout-preset.ts
@@ -69,13 +69,13 @@ export function serializeLayoutState<PageModel>(
 
   for (const pageId of pages) {
     const visibility = perPage.minimizedByPage?.[pageId]
-      ?? model.minimizedByPage?.[pageId];
+      ?? model.minimizedByPage[pageId];
     const maximize = perPage.maximizedPaneByPage?.[pageId]
-      ?? model.maximizedPaneByPage?.[pageId];
+      ?? model.maximizedPaneByPage[pageId];
     const dock = perPage.dockStateByPage?.[pageId]
-      ?? model.dockStateByPage?.[pageId];
+      ?? model.dockStateByPage[pageId];
     const ratios = perPage.splitRatiosByPage?.[pageId]
-      ?? model.splitRatioOverrides?.[pageId];
+      ?? model.splitRatioOverrides[pageId];
 
     serializedPages[pageId] = {
       splitRatios: ratios ? { ...ratios } : {},

--- a/packages/bijou-tui/src/pipeline/middleware/surface-shaders.ts
+++ b/packages/bijou-tui/src/pipeline/middleware/surface-shaders.ts
@@ -169,17 +169,18 @@ function shadePackedSurface(
 
       const index = y * width + x;
       const off = index * CELL_STRIDE;
-      const alpha = buf[off + OFF_ALPHA]!;
-      const cell = surface.cells[index]!;
+      const a = buf[off + OFF_ALPHA];
+      const cell = surface.cells[index];
+      if (a == null || !cell) continue;
 
-      if (alpha & FLAG_FG_SET) {
-        const nextFg = shadePackedRgb(buf, off + OFF_FG_R, factor);
-        cell.fg = rgbToHex(nextFg[0], nextFg[1], nextFg[2]);
+      if (a & FLAG_FG_SET) {
+        const [r, g, b] = shadePackedRgb(buf, off + OFF_FG_R, factor);
+        cell.fg = rgbToHex(r, g, b);
       }
 
-      if (alpha & FLAG_BG_SET) {
-        const nextBg = shadePackedRgb(buf, off + OFF_BG_R, factor);
-        cell.bg = rgbToHex(nextBg[0], nextBg[1], nextBg[2]);
+      if (a & FLAG_BG_SET) {
+        const [r, g, b] = shadePackedRgb(buf, off + OFF_BG_R, factor);
+        cell.bg = rgbToHex(r, g, b);
       }
     }
   }
@@ -192,15 +193,14 @@ function shadePackedRgb(
   start: number,
   factor: number,
 ): readonly [number, number, number] {
-  const r = shadeChannel(buf[start]!, factor);
-  const g = shadeChannel(buf[start + 1]!, factor);
-  const b = shadeChannel(buf[start + 2]!, factor);
+  const r = shadeChannel(buf[start] ?? 0, factor);
+  const g = shadeChannel(buf[start + 1] ?? 0, factor);
+  const b = shadeChannel(buf[start + 2] ?? 0, factor);
   buf[start] = r;
   buf[start + 1] = g;
   buf[start + 2] = b;
-  return [r, g, b] as const;
+  return [r, g, b];
 }
-
 function shadeCellSurface(
   surface: Surface,
   context: SurfaceShaderContext,

--- a/packages/bijou-tui/src/raster-glyph.ts
+++ b/packages/bijou-tui/src/raster-glyph.ts
@@ -229,8 +229,8 @@ function renderBraille(
           );
           const adjustedSample = adjustSample(sample, (x * 2) + sx, (y * 4) + sy, adjustments);
           accumulateSampleColors(adjustedSample, colors, darkColors, lightColors, threshold);
-          if (adjustedSample !== undefined && adjustedSample.darkness >= threshold) {
-            code |= BRAILLE_DOT_MAP[sy]![sx]!;
+          if ((adjustedSample?.darkness ?? -1) >= threshold) {
+            code |= BRAILLE_DOT_MAP[sy]?.[sx] ?? 0;
           }
         }
       }
@@ -321,8 +321,8 @@ function adjustedDarkness(
 }
 
 function orderedDitherOffset(x: number, y: number): number {
-  const row = BAYER_4X4[Math.abs(Math.floor(y)) % BAYER_4X4.length]!;
-  const value = row[Math.abs(Math.floor(x)) % row.length]!;
+  const row = BAYER_4X4[Math.abs(Math.floor(y)) % BAYER_4X4.length];
+  const value = row?.[Math.abs(Math.floor(x)) % row.length] ?? 0;
   return ((value - 7.5) / 16) * ORDERED_DITHER_STRENGTH;
 }
 
@@ -558,10 +558,9 @@ function validateRgbaFrame(frame: RgbaFrame): void {
   if (width <= 0 || height <= 0) {
     throw new RangeError('RGBA frame width and height must be positive integers.');
   }
-
   const requiredLength = width * height * 4;
   if (frame.data.length < requiredLength) {
-    throw new RangeError(`RGBA frame data must contain at least ${requiredLength} values.`);
+    throw new RangeError(`RGBA frame data must contain at least ${String(requiredLength)} values.`);
   }
 }
 

--- a/packages/bijou-tui/src/types.test.ts
+++ b/packages/bijou-tui/src/types.test.ts
@@ -113,13 +113,13 @@ describe('isMouseMsg', () => {
 
 describe('command cleanup helpers', () => {
   it('recognizes disposable cleanup handles', () => {
-    const handle = { dispose() {} };
+    const handle = { dispose: () => undefined };
     expect(isCmdDisposable(handle)).toBe(true);
     expect(isCmdCleanup(handle)).toBe(true);
   });
 
   it('recognizes cleanup functions', () => {
-    const cleanup = () => {};
+    const cleanup = () => undefined;
     expect(isCmdDisposable(cleanup)).toBe(false);
     expect(isCmdCleanup(cleanup)).toBe(true);
   });

--- a/packages/bijou/src/core/forms/filter-interactive.ts
+++ b/packages/bijou/src/core/forms/filter-interactive.ts
@@ -85,7 +85,8 @@ export function defaultMatch<T>(query: string, option: FilterOption<T>): boolean
  * @returns The value of the selected (or default/first) option.
  */
 export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: BijouContext): Promise<T> {
-  if (options.options.length === 0) {
+  const firstOption = options.options[0];
+  if (firstOption === undefined) {
     throw new Error('[bijou] filter(): options array must contain at least one option');
   }
   const noColor = ctx.theme.noColor;
@@ -142,10 +143,10 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
     const filterDisplay = query || (options.placeholder ? styledFn(ctx.semantic('muted'), options.placeholder) : '');
     ctx.io.write(`\x1b[K  ${styledFn(ctx.semantic('info'), indicator)} ${filterDisplay}\n`);
 
-    // Visible items
     const vis = visibleItems();
     for (let i = 0; i < vis.length; i++) {
-      const opt = vis[i]!;
+      const opt = vis[i];
+      if (opt === undefined) continue;
       const isCurrent = scrollOffset + i === cursor;
       const prefix = isCurrent ? '❯' : ' ';
       if (isCurrent && !noColor) {
@@ -155,8 +156,7 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
       }
     }
 
-    // Status
-    const status = `${filtered.length}/${options.options.length} items`;
+    const status = `${String(filtered.length)}/${String(options.options.length)} items`;
     ctx.io.write(`\x1b[K  ${styledFn(ctx.semantic('muted'), status)}\n`);
   }
 
@@ -235,13 +235,12 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
         const selected = filtered[cursor];
         const resolvedLabel = selected ? selected.label : '(none)';
         cleanup(resolvedLabel);
-        resolve(filtered[cursor]?.value ?? options.defaultValue ?? options.options[0]!.value);
+        resolve(filtered[cursor]?.value ?? options.defaultValue ?? firstOption.value);
         return;
       }
 
       if (isKey(key, 'c', { ctrl: true })) {
-        // Ctrl+C — cancel from either mode
-        const fallbackValue = options.defaultValue ?? options.options[0]!.value;
+        const fallbackValue = options.defaultValue ?? firstOption.value;
         const fallbackOption = options.options.find((opt) => Object.is(opt.value, fallbackValue));
         handle.dispose();
         cleanup(fallbackOption?.label ?? '(none)');
@@ -256,7 +255,7 @@ export async function interactiveFilter<T>(options: FilterOptions<T>, ctx: Bijou
           // TODO: bare \x1b may false-trigger on slow connections where escape
           // sequences arrive as separate bytes. Timer-based disambiguation is a
           // shared debt with textarea-editor.ts — unify in a future PR.
-          const fallbackValue = options.defaultValue ?? options.options[0]!.value;
+          const fallbackValue = options.defaultValue ?? firstOption.value;
           const fallbackOption = options.options.find((opt) => Object.is(opt.value, fallbackValue));
           handle.dispose();
           cleanup(fallbackOption?.label ?? '(none)');

--- a/packages/bijou/src/core/standard-blocks/render.ts
+++ b/packages/bijou/src/core/standard-blocks/render.ts
@@ -298,7 +298,7 @@ function standardBlockRenderIdentity(blockName: StandardBlockName): StandardBloc
 }
 
 function normalizeOutputMode(mode: OutputMode | undefined): OutputMode {
-  return ALL_OUTPUT_MODES.includes(mode!) ? mode! : 'interactive';
+  return mode && ALL_OUTPUT_MODES.includes(mode) ? mode : 'interactive';
 }
 
 function renderSurfaceBounds(input: BlockRenderInput): RenderSurfaceBounds {
@@ -353,7 +353,7 @@ function ownSlotValue(slots: Readonly<Record<string, unknown>> | undefined, key:
 }
 
 export function slotValueText(value: unknown): string | undefined {
-  if (value === undefined || value === null) {
+  if (value == null) {
     return undefined;
   }
 
@@ -372,17 +372,10 @@ export function slotValueText(value: unknown): string | undefined {
     return value.metadata.blockName;
   }
 
-  switch (typeof value) {
-    case 'string':
-      return value;
-    case 'number':
-    case 'boolean':
-      return String(value);
-    case 'object':
-      return recordSlotText(value);
-    default:
-      return undefined;
-  }
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'object') return recordSlotText(value);
+  return undefined;
 }
 
 function slotValueVisualContent(value: unknown, textContent: string | undefined): string | Surface | undefined {
@@ -394,13 +387,9 @@ function slotValueVisualContent(value: unknown, textContent: string | undefined)
 }
 
 function isSurfaceSlotValue(value: unknown): value is Surface {
-  return Boolean(
-    value
-      && typeof value === 'object'
-      && typeof (value as Surface).width === 'number'
-      && typeof (value as Surface).height === 'number'
-      && typeof (value as Surface).get === 'function',
-  );
+  if (value == null || typeof value !== 'object') return false;
+  return 'width' in value && 'height' in value && 'get' in value
+    && typeof value.width === 'number' && typeof value.height === 'number' && typeof value.get === 'function';
 }
 
 function surfaceSlotText(surface: Surface): string | undefined {

--- a/scripts/code-dojo/baselines/eslint.json
+++ b/scripts/code-dojo/baselines/eslint.json
@@ -1,75 +1,107 @@
 {
   "schema": "code-dojo.eslint-baseline.v1",
-  "total": 697,
-  "errors": 697,
+  "total": 646,
+  "errors": 646,
   "warnings": 0,
   "rules": [
     {
-      "ruleId": "@typescript-eslint/array-type",
-      "count": 3
+      "ruleId": "@typescript-eslint/no-unsafe-argument",
+      "count": 17
     },
     {
-      "ruleId": "@typescript-eslint/consistent-type-assertions",
-      "count": 11
+      "ruleId": "@typescript-eslint/no-unsafe-return",
+      "count": 5
+    },
+    {
+      "ruleId": "@typescript-eslint/no-empty-function",
+      "count": 10
+    },
+    {
+      "ruleId": "@typescript-eslint/no-unused-vars",
+      "count": 14
+    },
+    {
+      "ruleId": "@typescript-eslint/no-non-null-assertion",
+      "count": 96
+    },
+    {
+      "ruleId": "@typescript-eslint/restrict-template-expressions",
+      "count": 165
+    },
+    {
+      "ruleId": "@typescript-eslint/no-unsafe-type-assertion",
+      "count": 110
     },
     {
       "ruleId": "@typescript-eslint/consistent-type-definitions",
       "count": 4
     },
     {
-      "ruleId": "@typescript-eslint/no-base-to-string",
-      "count": 4
-    },
-    {
-      "ruleId": "@typescript-eslint/no-confusing-void-expression",
-      "count": 2
-    },
-    {
-      "ruleId": "@typescript-eslint/no-deprecated",
-      "count": 5
-    },
-    {
-      "ruleId": "@typescript-eslint/no-dynamic-delete",
-      "count": 1
-    },
-    {
-      "ruleId": "@typescript-eslint/no-empty-function",
-      "count": 12
-    },
-    {
-      "ruleId": "@typescript-eslint/no-empty-object-type",
-      "count": 1
-    },
-    {
-      "ruleId": "@typescript-eslint/no-explicit-any",
-      "count": 22
-    },
-    {
-      "ruleId": "@typescript-eslint/no-floating-promises",
-      "count": 7
-    },
-    {
-      "ruleId": "@typescript-eslint/no-non-null-assertion",
-      "count": 115
-    },
-    {
-      "ruleId": "@typescript-eslint/no-redundant-type-constituents",
-      "count": 1
-    },
-    {
       "ruleId": "@typescript-eslint/no-unnecessary-condition",
-      "count": 44
+      "count": 38
     },
     {
-      "ruleId": "@typescript-eslint/no-unnecessary-type-arguments",
-      "count": 7
+      "ruleId": "@typescript-eslint/prefer-regexp-exec",
+      "count": 3
+    },
+    {
+      "ruleId": "@typescript-eslint/prefer-optional-chain",
+      "count": 4
     },
     {
       "ruleId": "@typescript-eslint/no-unnecessary-type-assertion",
       "count": 26
     },
     {
+      "ruleId": "@typescript-eslint/no-unsafe-assignment",
+      "count": 9
+    },
+    {
       "ruleId": "@typescript-eslint/no-unnecessary-type-conversion",
+      "count": 11
+    },
+    {
+      "ruleId": "@typescript-eslint/array-type",
+      "count": 3
+    },
+    {
+      "ruleId": "@typescript-eslint/switch-exhaustiveness-check",
+      "count": 5
+    },
+    {
+      "ruleId": "@typescript-eslint/no-explicit-any",
+      "count": 22
+    },
+    {
+      "ruleId": "@typescript-eslint/no-confusing-void-expression",
+      "count": 2
+    },
+    {
+      "ruleId": "@typescript-eslint/unbound-method",
+      "count": 2
+    },
+    {
+      "ruleId": "@typescript-eslint/non-nullable-type-assertion-style",
+      "count": 2
+    },
+    {
+      "ruleId": "@typescript-eslint/no-unnecessary-type-arguments",
+      "count": 7
+    },
+    {
+      "ruleId": "@typescript-eslint/no-base-to-string",
+      "count": 4
+    },
+    {
+      "ruleId": "no-useless-assignment",
+      "count": 3
+    },
+    {
+      "ruleId": "@typescript-eslint/no-floating-promises",
+      "count": 7
+    },
+    {
+      "ruleId": "@typescript-eslint/consistent-type-assertions",
       "count": 11
     },
     {
@@ -77,95 +109,63 @@
       "count": 8
     },
     {
-      "ruleId": "@typescript-eslint/no-unsafe-argument",
-      "count": 19
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unsafe-assignment",
+      "ruleId": "@typescript-eslint/require-await",
       "count": 9
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unsafe-call",
-      "count": 2
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unsafe-member-access",
-      "count": 5
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unsafe-return",
-      "count": 5
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unsafe-type-assertion",
-      "count": 113
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unused-vars",
-      "count": 14
-    },
-    {
-      "ruleId": "@typescript-eslint/non-nullable-type-assertion-style",
-      "count": 2
     },
     {
       "ruleId": "@typescript-eslint/prefer-for-of",
       "count": 6
     },
     {
-      "ruleId": "@typescript-eslint/prefer-nullish-coalescing",
-      "count": 16
+      "ruleId": "no-control-regex",
+      "count": 6
     },
     {
-      "ruleId": "@typescript-eslint/prefer-optional-chain",
+      "ruleId": "@typescript-eslint/no-unsafe-member-access",
       "count": 4
     },
     {
-      "ruleId": "@typescript-eslint/prefer-regexp-exec",
-      "count": 3
-    },
-    {
-      "ruleId": "@typescript-eslint/require-await",
-      "count": 9
-    },
-    {
-      "ruleId": "@typescript-eslint/restrict-plus-operands",
+      "ruleId": "@typescript-eslint/no-redundant-type-constituents",
       "count": 1
     },
     {
-      "ruleId": "@typescript-eslint/restrict-template-expressions",
-      "count": 177
+      "ruleId": "@typescript-eslint/no-deprecated",
+      "count": 5
     },
     {
-      "ruleId": "@typescript-eslint/switch-exhaustiveness-check",
-      "count": 9
-    },
-    {
-      "ruleId": "@typescript-eslint/unbound-method",
-      "count": 2
-    },
-    {
-      "ruleId": "@typescript-eslint/unified-signatures",
-      "count": 4
-    },
-    {
-      "ruleId": "no-control-regex",
-      "count": 6
+      "ruleId": "prefer-const",
+      "count": 1
     },
     {
       "ruleId": "no-restricted-imports",
       "count": 2
     },
     {
-      "ruleId": "no-useless-assignment",
-      "count": 3
-    },
-    {
       "ruleId": "no-useless-escape",
       "count": 1
     },
     {
-      "ruleId": "prefer-const",
+      "ruleId": "@typescript-eslint/unified-signatures",
+      "count": 3
+    },
+    {
+      "ruleId": "@typescript-eslint/no-empty-object-type",
+      "count": 1
+    },
+    {
+      "ruleId": "@typescript-eslint/prefer-nullish-coalescing",
+      "count": 16
+    },
+    {
+      "ruleId": "@typescript-eslint/no-unsafe-call",
+      "count": 1
+    },
+    {
+      "ruleId": "@typescript-eslint/restrict-plus-operands",
+      "count": 1
+    },
+    {
+      "ruleId": "@typescript-eslint/no-dynamic-delete",
       "count": 1
     }
   ]

--- a/scripts/workflow-shell-preflight.ts
+++ b/scripts/workflow-shell-preflight.ts
@@ -68,8 +68,7 @@ export function parseWorkflowRunSteps(source: string, workflowPath: string): rea
     currentStep = null;
   };
 
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]!;
+  for (const [index, line] of lines.entries()) {
     const indent = countLeadingSpaces(line);
 
     if (stepsIndent == null) {
@@ -105,7 +104,7 @@ function parseStepBlock(
   workflowPath: string,
   startLine: number,
 ): WorkflowShellStep | null {
-  let stepName = `run@${startLine}`;
+  let stepName = `run@${String(startLine)}`;
   let shell: string | null = null;
 
   for (const line of stepLines) {
@@ -120,8 +119,7 @@ function parseStepBlock(
     }
   }
 
-  for (let index = 0; index < stepLines.length; index += 1) {
-    const line = stepLines[index]!;
+  for (const [index, line] of stepLines.entries()) {
     const normalized = line.trimStart().replace(/^- /, '');
     if (!normalized.startsWith('run:')) continue;
 
@@ -142,7 +140,8 @@ function readYamlBlock(stepLines: readonly string[], startIndex: number, parentI
   const blockLines: string[] = [];
 
   for (let index = startIndex + 1; index < stepLines.length; index += 1) {
-    const line = stepLines[index]!;
+    const line = stepLines[index];
+    if (line === undefined) break;
     if (line.trim() === '') {
       if (blockIndent != null) {
         blockLines.push('');
@@ -204,7 +203,7 @@ export function runWorkflowShellPreflight(io: WorkflowShellPreflightIO = {}): nu
       stdout('FAIL\n');
       failures.push(
         [
-          `${relative(root, step.workflowPath)}:${step.line} (${step.stepName})`,
+          `${relative(root, step.workflowPath)}:${String(step.line)} (${step.stepName})`,
           error,
           step.script,
         ].join('\n'),


### PR DESCRIPTION
## Summary

Continue Respectful Repo: Enter the Code Dojo by ratcheting aggregate Code Dojo debt from the WF-151 landed ceiling of 1105 to 1055 or lower.

## Current baseline

- Aggregate Code Dojo debt: 1105
- ESLint baseline: 697
- file/context baseline: 331
- mock-ban baseline: 22
- code-size baseline: 55, including 4 legacy hard-limit files

## Plan

- Select a focused ESLint cleanup slice using `npm run code-dojo:eslint:offenders`.
- Fix real type/control-flow/data-shape issues without suppression churn.
- Keep all non-ESLint ratchets flat or lower.
- Update baseline and docs only after live counts prove the lower ceiling.

Closes #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved null-safety in UI rendering and styling to prevent runtime errors
  * Fixed CSS variable resolution and media query validation for better styling reliability
  * Enhanced type-safety in text conversion across interface components

* **Documentation**
  * Updated code quality metrics and baseline tracking
  * Added design documentation for ongoing quality improvement initiative

* **Chores**
  * Refactored internal error handling with defensive guards throughout the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->