### PR TITLE
WF-158 Respecting the Dojo Ratchet To 468

### DIFF
--- a/bench/src/gc-observer-repro.ts
+++ b/bench/src/gc-observer-repro.ts
@@ -18,7 +18,7 @@ function readIntEnv(name: string, fallback: number): number {
 function allocateHeapSample(allocationCount: number, arraySize: number): void {
   const chunks: number[][] = [];
   for (let i = 0; i < allocationCount; i++) {
-    chunks.push(new Array(arraySize).fill(i));
+    chunks.push(new Array<number>(arraySize).fill(i));
   }
   void chunks;
 }

--- a/bench/src/harnesses/wall-time/format-jsonl.test.ts
+++ b/bench/src/harnesses/wall-time/format-jsonl.test.ts
@@ -70,7 +70,7 @@ const FIXTURE: RunReport & {
 
 describe('flat bench report formatting', () => {
   it('formats one JSONL record per scenario metric', () => {
-    const lines = formatReportAsJsonl(FIXTURE).trim().split('\n').map((line) => JSON.parse(line));
+    const lines = formatReportAsJsonl(FIXTURE).trim().split('\n').map((line): unknown => JSON.parse(line));
     expect(lines).toHaveLength(9);
     expect(lines[0]).toMatchObject({
       kind: 'bench.v2.metric',

--- a/bench/src/scenarios/_shared.ts
+++ b/bench/src/scenarios/_shared.ts
@@ -33,7 +33,9 @@ export function createSink(): CountingSink {
       this.writes += 1;
       this.bytesWritten += len;
     },
-    writeError() {},
+    writeError() {
+      // no-op sink for benchmark scenarios
+    },
   };
 }
 

--- a/bench/src/scenarios/diff-static.ts
+++ b/bench/src/scenarios/diff-static.ts
@@ -68,7 +68,7 @@ export const diffStatic: Scenario<State> = {
     return { current, target, sink: createSink(), style: stubStyle, cols: columns, rows };
   },
 
-  frame(state, _frameIndex) {
+  frame(state) {
     const { current, target, sink, style } = state;
     renderDiff(current, target, sink, style);
     // Model the runtime swap+clear pattern: between frames, the

--- a/bench/src/scenarios/paint-rgb-fixed.ts
+++ b/bench/src/scenarios/paint-rgb-fixed.ts
@@ -46,7 +46,7 @@ export const paintRgbFixed: Scenario<State> = {
     return { surface, cols: columns, rows };
   },
 
-  frame(state, _frameIndex) {
+  frame(state) {
     const { surface, cols, rows } = state;
     // Fixed bytes. Matches a theme token like '#9ba9ff' on '#111320'.
     for (let row = 0; row < rows; row++) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Fixed
 
+- **Focused Code Dojo ratchet** — WF-158 removes `53` more type-aware ESLint
+  findings across form defaults and fuzz fixtures, DOGFOOD frame-text helpers,
+  benchmark no-op and JSONL parsing, core component fallback handling, DAG
+  overloads, progress and confirm escape assertions, TUI command/file/panel
+  checked reads, screen formatting, runtime viewport typing, and smoke helpers,
+  lowering aggregate Code Dojo debt from `518` to `465` with the next goalpost
+  target set to `415` or lower.
 - **Focused Code Dojo ratchet** — WF-157 removes `52` more type-aware ESLint
   findings across i18n catalog/freezing boundaries, MCP docs example coercion,
   TUI key/navigation/drawer/motion/notification/pager/split-pane helpers,

--- a/docs/code-dojo-exceptions.md
+++ b/docs/code-dojo-exceptions.md
@@ -27,8 +27,16 @@ Current count:
 | File/context baseline | 331 | Files over the Code Dojo context threshold. |
 | Mock-ban baseline | 22 | Existing test mock/spy violations. |
 | Code-size baseline | 55 | Files over the 500-line ratchet, including 4 over the 1000-line hard limit. |
-| ESLint baseline | 110 | Type-aware ESLint findings after the WF-157 focused cleanup pass. |
-| **Total** | **518** | Aggregate Code Dojo standards debt. |
+| ESLint baseline | 57 | Type-aware ESLint findings after the WF-158 focused cleanup pass. |
+| **Total** | **465** | Aggregate Code Dojo standards debt. |
+
+WF-158 lowers ESLint debt from `110` to `57` by cleaning focused form,
+DOGFOOD, benchmark, TUI command/file/panel/status, progress, smoke, text
+wrapping, component fallback, DAG overload, and runtime viewport clusters. The
+aggregate Code Dojo ceiling falls from `518` to `465`. Per the operator's
+temporary waiver for touched-file size ratchets during this slice, existing
+file/context entries for touched legacy-large files were refreshed without
+adding new counted file/context or code-size violations.
 
 WF-157 lowers ESLint debt from `162` to `110` by cleaning focused i18n
 catalog/freezing boundaries, MCP docs example coercion, TUI key/navigation,
@@ -82,8 +90,8 @@ The current ceiling is encoded in `package.json`:
 npm run code-dojo:debt
 ```
 
-The current ceiling is `518`. The next met goalpost must lower the ceiling to
-`468` or lower.
+The current ceiling is `465`. The next met goalpost must lower the ceiling to
+`415` or lower.
 
 ## Updating The Ceiling
 

--- a/docs/design/WF-158-respecting-dojo-ratchet-468.md
+++ b/docs/design/WF-158-respecting-dojo-ratchet-468.md
@@ -7,7 +7,7 @@ Shaping.
 ## Tracker
 
 - GitHub Issue: [#429](https://github.com/flyingrobots/bijou/issues/429)
-- Pull Request: TBD
+- Pull Request: [#430](https://github.com/flyingrobots/bijou/pull/430)
 
 ## Legend
 

--- a/docs/design/WF-158-respecting-dojo-ratchet-468.md
+++ b/docs/design/WF-158-respecting-dojo-ratchet-468.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Shaping.
+Implemented.
 
 ## Tracker
 
@@ -57,6 +57,34 @@ The DOGFOOD app entrypoint remains oversized after the WF-157 merge:
 
 - `examples/docs/app.ts`: `3,306` physical lines / `114,890` bytes
 - DOGFOOD raw-string debt: `2,373`
+
+## Implementation Notes
+
+WF-158 removes `53` live type-aware ESLint findings, lowering the ESLint
+baseline from `110` to `57` and the aggregate Code Dojo ceiling from `518` to
+`465`.
+
+Cleanup clusters:
+
+- Core forms and tests: preserve empty-answer default semantics while replacing
+  unsafe fallback chains, add explicit numeric formatting in fuzz fixtures, and
+  remove control-character regex literals from prompt/progress tests.
+- DOGFOOD and cycle tests: replace visible frame-text fallbacks with nullish
+  checks, remove unnecessary conversions, and keep rendered text assertions
+  behaviorally equivalent.
+- Bench and smoke helpers: type GC sample arrays, make JSONL parsing return
+  `unknown`, document intentional no-op sinks, and remove needless async
+  wrappers.
+- TUI helpers: replace non-null assertions with checked reads in command
+  palette, file picker, panel focus, input stack, status bar, cell glyph, CSS
+  parser, and app-frame layout traversal.
+- Core components: remove unnecessary fallbacks from already-required string
+  inputs, unify DAG overloads, and keep runtime viewport overlay typing direct.
+
+Per the operator's temporary waiver for touched-file size ratchets, existing
+file/context entries for touched legacy-large files were refreshed to their
+current measured line/byte counts. No new counted file/context, mock-ban, or
+code-size entries were added.
 
 ## Scope
 
@@ -149,4 +177,4 @@ without re-running broad discovery first.
 - Aggregate Code Dojo debt is `468` or lower.
 - The ESLint baseline records the lower live count.
 - The Code Dojo exception ledger and `package.json` report the lower ceiling.
-- The next ratchet target is documented as `418` or lower.
+- The next ratchet target is documented as `415` or lower.

--- a/docs/design/WF-158-respecting-dojo-ratchet-468.md
+++ b/docs/design/WF-158-respecting-dojo-ratchet-468.md
@@ -1,0 +1,152 @@
+# WF-158 Respecting the Dojo Ratchet To 468
+
+## Status
+
+Shaping.
+
+## Tracker
+
+- GitHub Issue: [#429](https://github.com/flyingrobots/bijou/issues/429)
+- Pull Request: TBD
+
+## Legend
+
+- Linked legend: WF, Workflow and Delivery
+- Sponsor human: James Ross
+- Sponsor agent: Codex
+
+## Hill
+
+Bijou earns the next Code Dojo checkpoint by removing at least 50 counted
+standards violations from the landed `main` ceiling without weakening the
+Respectful Repo: Enter the Code Dojo direction.
+
+## Current Truth
+
+Live counts on `main` at `e075080e`:
+
+- aggregate Code Dojo debt: `518`
+- ESLint findings: `110`
+- file/context baseline: `331`
+- mock-ban baseline: `22`
+- code-size baseline: `55`, including `4` legacy hard-limit files
+- next aggregate target: `468` or lower
+
+Top current ESLint offender clusters:
+
+- `packages/bijou-i18n/src/runtime.ts`: `9`
+- `scripts/pr-review-status.ts`: `4`
+- `packages/bijou/src/core/components/box.ts`: `2`
+- `packages/bijou/src/core/components/dag.ts`: `2`
+- `packages/bijou/src/core/components/progress.test.ts`: `2`
+- `packages/bijou/src/core/forms/forms.fuzz.test.ts`: `2`
+- `packages/bijou/src/core/forms/group.ts`: `2`
+- `packages/bijou/src/core/graphql-bijou-block.test.ts`: `2`
+- `packages/bijou/src/core/selection.ts`: `2`
+- `packages/bijou/src/core/text/wrap.ts`: `2`
+- `packages/bijou/src/core/theme/index.ts`: `2`
+- `packages/bijou/src/core/theme/resolve.test.ts`: `2`
+- `packages/bijou/src/core/theme/resolve.ts`: `2`
+- `packages/bijou/src/index.ts`: `2`
+- `scripts/design-system-docs-preflight.ts`: `2`
+- `tests/cycles/DF-070/dogfood-block-product-polish.test.ts`: `2`
+- `tests/cycles/DF-071/dogfood-block-authored-surfaces.test.ts`: `2`
+- `tests/cycles/DX-034/data-binding-closeout.test.ts`: `2`
+
+The DOGFOOD app entrypoint remains oversized after the WF-157 merge:
+
+- `examples/docs/app.ts`: `3,306` physical lines / `114,890` bytes
+- DOGFOOD raw-string debt: `2,373`
+
+## Scope
+
+- Select focused cleanup clusters from current ESLint or Code Dojo offenders.
+- Prefer real type, data-shape, deterministic-test, and control-flow fixes over
+  suppressions or cosmetic baseline churn.
+- Continue shrinking oversized files when that contributes to the same standards
+  objective.
+- Keep counted file/context, mock-ban, code-size, and DOGFOOD localization
+  totals flat or lower. If the operator explicitly waives touched-file size
+  ratchets, record any refreshed legacy-large ceilings in this design doc.
+- Update `scripts/code-dojo/baselines/eslint.json`, `package.json`,
+  `docs/code-dojo-exceptions.md`, and `docs/CHANGELOG.md` after the live count
+  is proven lower.
+
+## Non-Goals
+
+- No new file/context, mock-ban, or code-size entries.
+- No release-version scope.
+- No broad feature work.
+- No rebase, amend, force push, or draft PR.
+
+## Playback Questions
+
+1. Is aggregate Code Dojo debt at `468` or lower?
+2. Did the implementation remove at least `50` real counted violations?
+3. Did counted file/context, mock-ban, code-size, and DOGFOOD localization
+   totals stay flat or lower, and were any waived size-ceiling refreshes
+   recorded?
+4. Did focused tests for touched behavior pass?
+5. Did any large-file extraction preserve visible or API behavior?
+
+## Accessibility And Assistive Posture
+
+This is standards cleanup. Any touched rendered or terminal output must preserve
+existing text, focus, lower-mode, and screen-reader semantics unless a test
+explicitly proves an accessibility improvement.
+
+## Localization And Directionality Posture
+
+Avoid DOGFOOD copy edits unless the slice intentionally updates localization
+catalogs. If DOGFOOD-facing strings are touched, run the DOGFOOD i18n gates and
+hold the raw-string and missing-localization ratchets flat or lower.
+
+## Agent Inspectability And Explainability Posture
+
+The selected files, rule deltas, and validation commands must be captured in
+this design doc or the PR summary so the next agent can audit what changed
+without re-running broad discovery first.
+
+## Linked Invariants
+
+- TypeScript standards: `docs/typescript-code-standards.editors-edition.md`
+- Code Dojo exception ledger: `docs/code-dojo-exceptions.md`
+- Work doctrine: `docs/METHOD.md`
+
+## Implementation Outline
+
+1. Use `npm run code-dojo:eslint:offenders` and focused ESLint probes to select
+   enough scattered cleanup to remove at least `50` findings.
+2. Write focused regressions only where cleanup exposes a behavior or module
+   boundary risk.
+3. Replace unsafe assertions, non-null assertions, implicit coercions,
+   nondeterministic clocks, fake async shapes, deprecated exports, and oversized
+   local modules with typed helpers and explicit control flow.
+4. Ratchet the ESLint baseline and aggregate Code Dojo ceiling after the live
+   count is proven lower.
+5. Update docs and changelog with final counts and the next target.
+
+## Tests To Write First
+
+- Add focused regressions for any behavior-bearing cleanup.
+- For pure typing cleanup, run focused ESLint and existing tests for the touched
+  package or surface before updating baselines.
+
+## Validation Plan
+
+- Probe candidate files with `npm run code-dojo:eslint:offenders`.
+- Run focused raw ESLint on touched files.
+- Run `npm run code-dojo:changed`.
+- Run focused behavior tests for touched surfaces.
+- Check aggregate debt with `npm run code-dojo:debt`.
+- Confirm standards gates with `npm run code-dojo:verify`.
+- Validate documentation inventory with `npm run docs:inventory`.
+- Run `npm run lint` and `git diff --check`.
+
+## Acceptance Criteria
+
+- The selected touched files reduce live findings by at least `50`.
+- Aggregate Code Dojo debt is `468` or lower.
+- The ESLint baseline records the lower live count.
+- The Code Dojo exception ledger and `package.json` report the lower ceiling.
+- The next ratchet target is documented as `418` or lower.

--- a/examples/textarea/main.ts
+++ b/examples/textarea/main.ts
@@ -21,15 +21,10 @@ export async function main(
     ctx,
   });
 
-  if (message != null) {
-    writeLine();
-    writeLine(headerBox('Commit Message', { detail: message, ctx }));
-  } else {
-    writeLine();
-    writeLine('Cancelled.');
-  }
+  writeLine();
+  writeLine(headerBox('Commit Message', { detail: message, ctx }));
 }
 
-if (process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+if (fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   main().catch(console.error);
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release:readiness": "tsx scripts/release-readiness.ts",
     "docs:inventory": "tsx scripts/docs-inventory.ts",
     "code:size": "tsx scripts/code-size-gate.ts",
-    "code-dojo:debt": "tsx scripts/code-dojo-debt.ts --max 518",
+    "code-dojo:debt": "tsx scripts/code-dojo-debt.ts --max 465",
     "code-dojo:eslint:offenders": "node scripts/code-dojo/eslint-offenders.mjs",
     "code-dojo:fast": "node scripts/code-dojo/fast.mjs",
     "code-dojo:changed": "node scripts/code-dojo/changed.mjs",

--- a/packages/bijou-node/src/worker/worker.test.ts
+++ b/packages/bijou-node/src/worker/worker.test.ts
@@ -35,7 +35,9 @@ describe('worker runtime', () => {
       ctx,
       entry,
       mouse: true,
-      onMessage() {},
+      onMessage() {
+        // no-op for terminal mode
+      },
     });
 
     handle.send({ type: 'host-note', text: 'from-main' });

--- a/packages/bijou-tui/src/app-frame-i18n.ts
+++ b/packages/bijou-tui/src/app-frame-i18n.ts
@@ -107,7 +107,22 @@ function message(id: string, value: string) {
 function interpolate(template: string, values: Readonly<Record<string, unknown>>): string {
   return template.replace(/\{([^}]+)\}/g, (_match, rawKey: string) => {
     const value = values[rawKey];
-    return value === undefined ? `{${rawKey}}` : String(value);
+    switch (typeof value) {
+      case 'undefined':
+      case 'function':
+        return `{${rawKey}}`;
+      case 'object':
+        return value === null ? 'null' : JSON.stringify(value);
+      case 'string':
+        return value;
+      case 'boolean':
+        return value ? 'true' : 'false';
+      case 'symbol':
+        return value.description ?? 'Symbol()';
+      case 'number':
+      case 'bigint':
+        return value.toString();
+    }
   });
 }
 

--- a/packages/bijou-tui/src/app-frame-utils.ts
+++ b/packages/bijou-tui/src/app-frame-utils.ts
@@ -66,7 +66,9 @@ export function findPaneNode(node: FrameLayoutNode, paneId: string): Extract<Fra
   if (node.kind === 'pane') return node.paneId === paneId ? node : undefined;
   if (node.kind === 'split') return findPaneNode(node.paneA, paneId) ?? findPaneNode(node.paneB, paneId);
   for (const key of Object.keys(node.cells)) {
-    const found = findPaneNode(node.cells[key]!, paneId);
+    const child = node.cells[key];
+    if (child === undefined) continue;
+    const found = findPaneNode(child, paneId);
     if (found) return found;
   }
   return undefined;

--- a/packages/bijou-tui/src/cell-glyph-fit.ts
+++ b/packages/bijou-tui/src/cell-glyph-fit.ts
@@ -89,7 +89,7 @@ function fitAsciiDensityGlyph(samples: readonly number[]): string {
 function meanSquaredCoverageError(samples: readonly number[], candidate: readonly number[]): number {
   let total = 0;
   for (let index = 0; index < CELL_GLYPH_SAMPLE_COUNT; index++) {
-    const delta = samples[index]! - clampUnit(candidate[index] ?? 0);
+    const delta = (samples[index] ?? 0) - clampUnit(candidate[index] ?? 0);
     total += delta * delta;
   }
   return total / CELL_GLYPH_SAMPLE_COUNT;

--- a/packages/bijou-tui/src/command-palette.test.ts
+++ b/packages/bijou-tui/src/command-palette.test.ts
@@ -163,7 +163,10 @@ describe('focus navigation', () => {
 
   it('focusNext wraps around', () => {
     let state = createCommandPaletteState(items);
-    for (let i = 0; i < items.length; i++) state = cpFocusNext(state);
+    for (const item of items) {
+      void item;
+      state = cpFocusNext(state);
+    }
     expect(state.focusIndex).toBe(0);
   });
 

--- a/packages/bijou-tui/src/command-palette.ts
+++ b/packages/bijou-tui/src/command-palette.ts
@@ -125,7 +125,8 @@ function fieldScore(value: string | undefined, query: string, baseScore: number)
   if (index < 0) return undefined;
   if (haystack === query) return baseScore;
   if (index === 0) return baseScore + 1;
-  if (index > 0 && /\W/.test(haystack[index - 1]!)) return baseScore + 2;
+  const previous = haystack[index - 1];
+  if (previous !== undefined && /\W/.test(previous)) return baseScore + 2;
   return baseScore + 3 + Math.min(index, 100);
 }
 

--- a/packages/bijou-tui/src/css/parser.test.ts
+++ b/packages/bijou-tui/src/css/parser.test.ts
@@ -49,7 +49,7 @@ describe('parseBCSS', () => {
     
     expect(sheet.mediaQueries).toHaveLength(1);
     expect(sheet.mediaQueries[0]?.condition).toBe('(width < 80)');
-    expect(must(sheet.mediaQueries[0]!.rules[0]).selectors[0]?.classes).toContain('sidebar');
+    expect(must(must(sheet.mediaQueries[0]).rules[0]).selectors[0]?.classes).toContain('sidebar');
   });
 
   it('strips comments', () => {

--- a/packages/bijou-tui/src/file-picker.test.ts
+++ b/packages/bijou-tui/src/file-picker.test.ts
@@ -66,7 +66,10 @@ describe('focus navigation', () => {
   it('focusNext wraps around', () => {
     const io = createMockIO();
     let state = createFilePickerState({ cwd: '/project', io });
-    for (let i = 0; i < state.entries.length; i++) state = fpFocusNext(state);
+    for (const entry of state.entries) {
+      void entry;
+      state = fpFocusNext(state);
+    }
     expect(state.focusIndex).toBe(0);
   });
 

--- a/packages/bijou-tui/src/file-picker.ts
+++ b/packages/bijou-tui/src/file-picker.ts
@@ -281,7 +281,7 @@ function renderFilePickerEntryLines(
 
   return state.entries.map((entry, index) => {
     const prefix = index === state.focusIndex ? indicator : pad;
-    const selected = hasSelection && index === options?.selectedIndex ? selectedIndicator : selectedPad;
+    const selected = hasSelection && index === options.selectedIndex ? selectedIndicator : selectedPad;
     const icon = entry.isDirectory ? dirIcon : fileIcon;
     const suffix = entry.isDirectory ? '/' : '';
     return hasSelection

--- a/packages/bijou-tui/src/inputstack.ts
+++ b/packages/bijou-tui/src/inputstack.ts
@@ -171,7 +171,8 @@ export function createInputStack<Msg, A>(): InputStack<Msg, A> {
     dispatch(msg) {
       // Walk top-down
       for (let i = stack.length - 1; i >= 0; i--) {
-        const layer = stack[i]!;
+        const layer = stack[i];
+        if (layer === undefined) continue;
         const action = layer.handler.handle(msg);
 
         if (action !== undefined) {

--- a/packages/bijou-tui/src/panels.test.ts
+++ b/packages/bijou-tui/src/panels.test.ts
@@ -16,10 +16,6 @@ function key(k: string): KeyMsg {
   return { type: 'key', key: k, ctrl: false, alt: false, shift: false };
 }
 
-function ctrlKey(k: string): KeyMsg {
-  return { type: 'key', key: k, ctrl: true, alt: false, shift: false };
-}
-
 function makePanels(): readonly PanelDef<Msg>[] {
   const navMap = createKeyMap<Msg>()
     .bind('j', 'Down', { type: 'nav-down' })

--- a/packages/bijou-tui/src/panels.ts
+++ b/packages/bijou-tui/src/panels.ts
@@ -156,7 +156,8 @@ export function createPanelGroup<A>(options: PanelGroupOptions<A>): PanelGroup<A
 
       if (inputStack && panelLayerId !== undefined) {
         inputStack.remove(panelLayerId);
-        const panel = panelMap.get(id)!;
+        const panel = panelMap.get(id);
+        if (panel === undefined) return;
         panelLayerId = inputStack.push(panel.keyMap, {
           passthrough: true,
           name: `panel:${id}`,

--- a/packages/bijou-tui/src/screen.ts
+++ b/packages/bijou-tui/src/screen.ts
@@ -63,7 +63,7 @@ const CURSOR_SHAPE_CODE: Record<CursorShape, number> = {
  */
 export function setCursorStyle(io: IOPort, shape: CursorShape, options?: { blink?: boolean }): void {
   const code = options?.blink ? CURSOR_SHAPE_CODE[shape] - 1 : CURSOR_SHAPE_CODE[shape];
-  io.write(`\x1b[${code} q`);
+  io.write(`\x1b[${String(code)} q`);
 }
 
 /**

--- a/packages/bijou-tui/src/status-bar.ts
+++ b/packages/bijou-tui/src/status-bar.ts
@@ -112,7 +112,7 @@ function layoutStatusBar(options: StatusBarOptions): StatusBarLayout | null {
   if (width <= 0) return null;
 
   // Use first character of fillChar, default to space
-  const fill = rawFillChar ? rawFillChar[0]! : ' ';
+  const fill = rawFillChar ? (rawFillChar[0] ?? ' ') : ' ';
 
   // Measure visible lengths
   const leftLen = visibleLength(left);

--- a/packages/bijou-tui/src/view-output.ts
+++ b/packages/bijou-tui/src/view-output.ts
@@ -75,8 +75,9 @@ export function normalizeViewOutputInto(
 
 export function wrapViewOutputAsLayoutRoot(
   output: ViewOutput,
-  _size: ViewportSize,
+  size: ViewportSize,
 ): LayoutNode {
+  void size;
   if (isSurfaceView(output)) {
     return {
       type: 'SurfaceView',

--- a/packages/bijou/src/core/components/alert.ts
+++ b/packages/bijou/src/core/components/alert.ts
@@ -67,10 +67,10 @@ const BORDER_TOKENS: Record<AlertVariant, keyof Theme['border']> = {
  * @param options - Alert configuration.
  * @returns The rendered alert string.
  */
-export function alert(message: string, options: AlertOptions = {}): string {
+export function alert(message: string | null | undefined, options: AlertOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
   const variant = options.variant ?? 'info';
-  const safeMessage = message;
+  const safeMessage = message ?? '';
 
   return renderByMode(ctx.mode, {
     pipe: () => `[${PIPE_LABELS[variant]}] ${safeMessage}`,

--- a/packages/bijou/src/core/components/alert.ts
+++ b/packages/bijou/src/core/components/alert.ts
@@ -70,7 +70,7 @@ const BORDER_TOKENS: Record<AlertVariant, keyof Theme['border']> = {
 export function alert(message: string, options: AlertOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
   const variant = options.variant ?? 'info';
-  const safeMessage = message ?? '';
+  const safeMessage = message;
 
   return renderByMode(ctx.mode, {
     pipe: () => `[${PIPE_LABELS[variant]}] ${safeMessage}`,

--- a/packages/bijou/src/core/components/box.ts
+++ b/packages/bijou/src/core/components/box.ts
@@ -142,9 +142,9 @@ function drawBox(
  * @param options - Box configuration.
  * @returns The rendered box string, or plain content in non-visual modes.
  */
-export function box(content: string, options: BoxOptions = {}): string {
+export function box(content: string | null | undefined, options: BoxOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const safeContent = content;
+  const safeContent = content ?? '';
 
   return renderByMode(ctx.mode, {
     pipe: () => safeContent,
@@ -190,10 +190,10 @@ export interface HeaderBoxOptions extends BoxOptions {
  * @param options - Header box configuration.
  * @returns The rendered header box string.
  */
-export function headerBox(label: string, options: HeaderBoxOptions = {}): string {
+export function headerBox(label: string | null | undefined, options: HeaderBoxOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
   const detail = options.detail ?? '';
-  const safeLabel = label;
+  const safeLabel = label ?? '';
 
   return renderByMode(ctx.mode, {
     pipe: () => (safeLabel && detail ? `${safeLabel}  ${detail}` : safeLabel || detail),

--- a/packages/bijou/src/core/components/box.ts
+++ b/packages/bijou/src/core/components/box.ts
@@ -144,7 +144,7 @@ function drawBox(
  */
 export function box(content: string, options: BoxOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const safeContent = content ?? '';
+  const safeContent = content;
 
   return renderByMode(ctx.mode, {
     pipe: () => safeContent,
@@ -193,7 +193,7 @@ export interface HeaderBoxOptions extends BoxOptions {
 export function headerBox(label: string, options: HeaderBoxOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
   const detail = options.detail ?? '';
-  const safeLabel = label ?? '';
+  const safeLabel = label;
 
   return renderByMode(ctx.mode, {
     pipe: () => (safeLabel && detail ? `${safeLabel}  ${detail}` : safeLabel || detail),

--- a/packages/bijou/src/core/components/constrain.ts
+++ b/packages/bijou/src/core/components/constrain.ts
@@ -30,9 +30,9 @@ export interface ConstrainOptions {
  * @param options - Constraint configuration.
  * @returns The constrained string.
  */
-export function constrain(content: string, options: ConstrainOptions = {}): string {
+export function constrain(content: string | null | undefined, options: ConstrainOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const safeContent = content;
+  const safeContent = content ?? '';
 
   return renderByMode(ctx.mode, {
     pipe: () => safeContent,

--- a/packages/bijou/src/core/components/constrain.ts
+++ b/packages/bijou/src/core/components/constrain.ts
@@ -32,7 +32,7 @@ export interface ConstrainOptions {
  */
 export function constrain(content: string, options: ConstrainOptions = {}): string {
   const ctx = resolveCtx(options.ctx);
-  const safeContent = content ?? '';
+  const safeContent = content;
 
   return renderByMode(ctx.mode, {
     pipe: () => safeContent,

--- a/packages/bijou/src/core/components/dag.ts
+++ b/packages/bijou/src/core/components/dag.ts
@@ -166,8 +166,6 @@ export function dagSlice(
  * @returns The layout result with output string, node positions, and dimensions.
  * @throws If given an unbounded `DagSource` (must call `dagSlice()` first).
  */
-export function dagLayout(source: SlicedDagSource, options?: DagOptions): DagLayout;
-export function dagLayout(nodes: readonly DagNode[], options?: DagOptions): DagLayout;
 export function dagLayout(
   input: readonly DagNode[] | SlicedDagSource,
   options: DagOptions = {},
@@ -201,8 +199,6 @@ export function dagLayout(
  *
  * @throws If given an unbounded `DagSource` (must call `dagSlice()` first).
  */
-export function dag(source: SlicedDagSource, options?: DagOptions): string;
-export function dag(nodes: readonly DagNode[], options?: DagOptions): string;
 export function dag(
   input: readonly DagNode[] | SlicedDagSource,
   options: DagOptions = {},

--- a/packages/bijou/src/core/components/enumerated-list.test.ts
+++ b/packages/bijou/src/core/components/enumerated-list.test.ts
@@ -72,7 +72,7 @@ describe('enumeratedList', () => {
 
   it('right-aligns prefixes for consistent indentation with 10+ items', () => {
     const ctx = createTestContext({ mode: 'interactive' });
-    const items = Array.from({ length: 12 }, (_, i) => `Item ${i + 1}`);
+    const items = Array.from({ length: 12 }, (_, i) => `Item ${String(i + 1)}`);
     const result = enumeratedList(items, { ctx });
     const lines = result.split('\n');
     // ' 1.' has length 3 and '12.' has length 3, but ' 1.' is padded

--- a/packages/bijou/src/core/components/progress.test.ts
+++ b/packages/bijou/src/core/components/progress.test.ts
@@ -147,7 +147,7 @@ describe('createProgressBar', () => {
     bar.start();
     bar.update(50);
     const updateWrite = ctx.io.written[2];
-    expect(updateWrite).toMatch(/^\r\x1b\[K/);
+    expect(updateWrite).toMatch(new RegExp(`^\\r${String.fromCharCode(27)}\\[K`, 'u'));
     expect(updateWrite).toContain('50%');
   });
 
@@ -194,7 +194,7 @@ describe('createAnimatedProgressBar', () => {
     expect(ctx.io.written[1]).toContain('0%');
   });
 
-  it('update() triggers interpolation frames', async () => {
+  it('update() triggers interpolation frames', () => {
     const clock = mockClock();
     const ctx = createTestContext({ mode: 'interactive', clock });
     const bar = createAnimatedProgressBar({ width: 10, fps: 30, duration: 300, ctx });

--- a/packages/bijou/src/core/forms/confirm.test.ts
+++ b/packages/bijou/src/core/forms/confirm.test.ts
@@ -147,7 +147,7 @@ describe('confirm()', () => {
       await confirm({ title: 'Continue?', ctx });
       const output = ctx.io.written.join('');
       expect(output).toContain('[Y/n]');
-      expect(output).not.toMatch(/\x1b\[/);
+      expect(output).not.toMatch(new RegExp(`${String.fromCharCode(27)}\\[`, 'u'));
     });
 
     it('"y" returns true under noColor', async () => {

--- a/packages/bijou/src/core/forms/forms.fuzz.test.ts
+++ b/packages/bijou/src/core/forms/forms.fuzz.test.ts
@@ -139,11 +139,11 @@ describe('forms fuzz (property-based)', () => {
 
   describe('rapid repeated calls', () => {
     it('50 sequential input() calls all resolve', async () => {
-      const answers = Array.from({ length: 50 }, (_, i) => `answer-${i}`);
+      const answers = Array.from({ length: 50 }, (_, i) => `answer-${String(i)}`);
       const ctx = createTestContext({ mode: 'pipe', io: { answers } });
       const results: string[] = [];
       for (let i = 0; i < 50; i++) {
-        results.push(await input({ title: `q${i}`, ctx }));
+        results.push(await input({ title: `q${String(i)}`, ctx }));
       }
       expect(results).toHaveLength(50);
       expect(results[0]).toBe('answer-0');

--- a/packages/bijou/src/core/forms/input.ts
+++ b/packages/bijou/src/core/forms/input.ts
@@ -32,7 +32,7 @@ export async function input(options: InputOptions): Promise<string> {
 
   const prompt = buildPrompt(options, noColor, ctx);
   const answer = await ctx.io.question(prompt);
-  const value = answer.trim() || options.defaultValue || '';
+  const value = answer.trim() || (options.defaultValue ?? '');
 
   if (options.required && value === '') {
     writeValidationError('This field is required.', ctx);

--- a/packages/bijou/src/core/forms/textarea.ts
+++ b/packages/bijou/src/core/forms/textarea.ts
@@ -42,7 +42,7 @@ async function fallbackTextarea(options: TextareaOptions, ctx: BijouContext): Pr
     ? 'Enter text: '
     : '> ';
   const answer = await ctx.io.question(prompt);
-  const value = answer.trim() || options.defaultValue || '';
+  const value = answer.trim() || (options.defaultValue ?? '');
 
   if (options.required && value === '') {
     writeValidationError('This field is required.', ctx);

--- a/packages/bijou/src/core/runtime-viewport.ts
+++ b/packages/bijou/src/core/runtime-viewport.ts
@@ -33,7 +33,7 @@ export function readRuntimeViewport(runtime: RuntimePort): RuntimeViewport {
  * `process.stdout.columns`) a stable, writable source of truth for scripted
  * resizes and worker-proxy synchronization.
  */
-export function installRuntimeViewportOverlay<T extends { runtime: RuntimePort }>(host: T): RuntimePort {
+export function installRuntimeViewportOverlay(host: { runtime: RuntimePort }): RuntimePort {
   const baseRuntime = host.runtime;
   const viewport = readRuntimeViewport(baseRuntime);
   const state = {

--- a/packages/bijou/src/core/standard-blocks.test.ts
+++ b/packages/bijou/src/core/standard-blocks.test.ts
@@ -723,7 +723,7 @@ function surfaceText(surface: { width: number; height: number; get(x: number, y:
   let text = '';
   for (let y = 0; y < surface.height; y++) {
     for (let x = 0; x < surface.width; x++) {
-      text += surface.get(x, y).char || ' ';
+      text += surface.get(x, y).char ?? ' ';
     }
     text += '\n';
   }

--- a/packages/bijou/src/core/text/wrap.ts
+++ b/packages/bijou/src/core/text/wrap.ts
@@ -20,7 +20,7 @@ function tokenizeAnsiText(str: string): WrapToken[] {
   let lastIndex = 0;
 
   for (const match of str.matchAll(regex)) {
-    const index = match.index ?? 0;
+    const index = match.index;
     if (index > lastIndex) {
       const raw = str.slice(lastIndex, index);
       for (const grapheme of segmentGraphemes(raw)) {
@@ -51,7 +51,7 @@ function tokenizeAnsiText(str: string): WrapToken[] {
 }
 
 export function prepareWrappedText(str: string): PreparedWrappedText {
-  const source = str ?? '';
+  const source = str;
   return {
     source,
     lines: source.split('\n').map((line) => ({

--- a/packages/bijou/src/core/text/wrap.ts
+++ b/packages/bijou/src/core/text/wrap.ts
@@ -50,8 +50,8 @@ function tokenizeAnsiText(str: string): WrapToken[] {
   return tokens;
 }
 
-export function prepareWrappedText(str: string): PreparedWrappedText {
-  const source = str;
+export function prepareWrappedText(str: string | null | undefined): PreparedWrappedText {
+  const source = str ?? '';
   return {
     source,
     lines: source.split('\n').map((line) => ({

--- a/scripts/code-dojo-debt.test.ts
+++ b/scripts/code-dojo-debt.test.ts
@@ -27,7 +27,7 @@ describe('code-dojo debt summary', () => {
       fileContextEntries: Array.from({ length: 80 }),
       mockBanViolations: Array.from({ length: 20 }),
       codeSizeBaseline: Array.from({ length: 20 }, (_, index) => ({
-        path: `src/${index}.ts`,
+        path: `src/${String(index)}.ts`,
         lines: 501,
       })),
       eslintViolations: 20,

--- a/scripts/code-dojo/baselines/eslint.json
+++ b/scripts/code-dojo/baselines/eslint.json
@@ -1,7 +1,7 @@
 {
   "schema": "code-dojo.eslint-baseline.v1",
-  "total": 110,
-  "errors": 110,
+  "total": 57,
+  "errors": 57,
   "warnings": 0,
   "rules": [
     {
@@ -10,15 +10,11 @@
     },
     {
       "ruleId": "@typescript-eslint/no-base-to-string",
-      "count": 3
+      "count": 2
     },
     {
       "ruleId": "@typescript-eslint/no-deprecated",
       "count": 4
-    },
-    {
-      "ruleId": "@typescript-eslint/no-empty-function",
-      "count": 2
     },
     {
       "ruleId": "@typescript-eslint/no-explicit-any",
@@ -26,63 +22,27 @@
     },
     {
       "ruleId": "@typescript-eslint/no-non-null-assertion",
-      "count": 15
+      "count": 8
     },
     {
       "ruleId": "@typescript-eslint/no-unnecessary-condition",
-      "count": 14
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unnecessary-type-conversion",
-      "count": 1
+      "count": 6
     },
     {
       "ruleId": "@typescript-eslint/no-unnecessary-type-parameters",
-      "count": 5
-    },
-    {
-      "ruleId": "@typescript-eslint/no-unsafe-argument",
-      "count": 1
+      "count": 4
     },
     {
       "ruleId": "@typescript-eslint/no-unsafe-assignment",
       "count": 2
     },
     {
-      "ruleId": "@typescript-eslint/no-unsafe-return",
-      "count": 1
-    },
-    {
       "ruleId": "@typescript-eslint/no-unsafe-type-assertion",
       "count": 27
     },
     {
-      "ruleId": "@typescript-eslint/no-unused-vars",
-      "count": 4
-    },
-    {
-      "ruleId": "@typescript-eslint/prefer-for-of",
-      "count": 2
-    },
-    {
       "ruleId": "@typescript-eslint/prefer-nullish-coalescing",
-      "count": 12
-    },
-    {
-      "ruleId": "@typescript-eslint/require-await",
-      "count": 2
-    },
-    {
-      "ruleId": "@typescript-eslint/restrict-template-expressions",
-      "count": 8
-    },
-    {
-      "ruleId": "@typescript-eslint/unified-signatures",
-      "count": 2
-    },
-    {
-      "ruleId": "no-control-regex",
-      "count": 2
+      "count": 1
     }
   ]
 }

--- a/scripts/code-dojo/baselines/file-context.json
+++ b/scripts/code-dojo/baselines/file-context.json
@@ -370,8 +370,8 @@
     },
     {
       "path": "packages/bijou-tui/src/command-palette.test.ts",
-      "lines": 441,
-      "bytes": 15667
+      "lines": 444,
+      "bytes": 15685
     },
     {
       "path": "packages/bijou/src/core/active-binding-collection.ts",
@@ -395,8 +395,8 @@
     },
     {
       "path": "packages/bijou-tui/src/command-palette.ts",
-      "lines": 418,
-      "bytes": 14755
+      "lines": 419,
+      "bytes": 14796
     },
     {
       "path": "packages/bijou/src/core/schema-block.test.ts",
@@ -425,8 +425,8 @@
     },
     {
       "path": "packages/bijou-tui/src/file-picker.test.ts",
-      "lines": 406,
-      "bytes": 14690
+      "lines": 409,
+      "bytes": 14710
     },
     {
       "path": "packages/bijou-tui/src/dag-pane.test.ts",
@@ -851,7 +851,7 @@
     {
       "path": "packages/bijou/src/core/components/progress.test.ts",
       "lines": 287,
-      "bytes": 10211
+      "bytes": 10246
     },
     {
       "path": "packages/bijou-tui/src/split-pane.ts",
@@ -1200,8 +1200,8 @@
     },
     {
       "path": "tests/cycles/DX-034/data-binding-closeout.test.ts",
-      "lines": 218,
-      "bytes": 8274
+      "lines": 220,
+      "bytes": 8363
     },
     {
       "path": "packages/bijou/src/core/components/dag-layout.ts",
@@ -1215,8 +1215,8 @@
     },
     {
       "path": "packages/bijou-tui/src/panels.ts",
-      "lines": 217,
-      "bytes": 6594
+      "lines": 218,
+      "bytes": 6634
     },
     {
       "path": "packages/bijou/src/core/app-shell-composition.ts",
@@ -1280,8 +1280,8 @@
     },
     {
       "path": "packages/bijou-tui/src/inputstack.ts",
-      "lines": 203,
-      "bytes": 5926
+      "lines": 204,
+      "bytes": 5968
     },
     {
       "path": "packages/bijou/src/core/theme/resolve.test.ts",
@@ -1321,7 +1321,7 @@
     {
       "path": "packages/bijou-tui/src/status-bar.ts",
       "lines": 199,
-      "bytes": 6360
+      "bytes": 6368
     },
     {
       "path": "packages/bijou-tui/src/css/text-style.ts",
@@ -1335,8 +1335,8 @@
     },
     {
       "path": "packages/bijou-tui/src/app-frame-utils.ts",
-      "lines": 198,
-      "bytes": 8368
+      "lines": 200,
+      "bytes": 8431
     },
     {
       "path": "packages/bijou-tui/src/panels.test.ts",
@@ -1396,7 +1396,7 @@
     {
       "path": "packages/bijou/src/core/forms/confirm.test.ts",
       "lines": 191,
-      "bytes": 8362
+      "bytes": 8402
     },
     {
       "path": "packages/bijou/src/core/theme/downsample.ts",
@@ -1420,8 +1420,8 @@
     },
     {
       "path": "packages/bijou-tui/src/app-frame-i18n.ts",
-      "lines": 188,
-      "bytes": 7228
+      "lines": 203,
+      "bytes": 7610
     },
     {
       "path": "examples/_stories/protocol.ts",
@@ -1641,7 +1641,7 @@
     {
       "path": "packages/bijou/src/core/forms/forms.fuzz.test.ts",
       "lines": 154,
-      "bytes": 5565
+      "bytes": 5581
     },
     {
       "path": "packages/bijou-tui/src/subapp/mount.test.ts",

--- a/scripts/code-dojo/baselines/file-context.json
+++ b/scripts/code-dojo/baselines/file-context.json
@@ -1136,7 +1136,7 @@
     {
       "path": "packages/bijou/src/core/components/box.ts",
       "lines": 227,
-      "bytes": 9112
+      "bytes": 9150
     },
     {
       "path": "packages/bijou/src/core/forms/input.test.ts",
@@ -1191,7 +1191,7 @@
     {
       "path": "packages/bijou/src/core/text/wrap.ts",
       "lines": 220,
-      "bytes": 6519
+      "bytes": 6533
     },
     {
       "path": "packages/bijou-tui/src/layout-inspector.ts",

--- a/scripts/smoke-dogfood.test.ts
+++ b/scripts/smoke-dogfood.test.ts
@@ -110,12 +110,12 @@ describe('runSmokeDogfood', () => {
       buildImpl() {
         buildCount += 1;
       },
-      runScenarioImpl: async (_root, scenario) => {
+      runScenarioImpl(_root, scenario) {
         executed.push(scenario.name);
-        return {
+        return Promise.resolve({
           name: scenario.name,
           status: 'ok',
-        };
+        });
       },
     });
 

--- a/scripts/smoke-v3-examples.ts
+++ b/scripts/smoke-v3-examples.ts
@@ -45,7 +45,7 @@ async function runExample(relativePath: string): Promise<void> {
         return;
       }
 
-      rejectPromise(new Error(`${relativePath} exited with code ${code ?? 'null'}`));
+      rejectPromise(new Error(`${relativePath} exited with code ${String(code ?? 'null')}`));
     });
   });
 }

--- a/tests/cycles/DF-024/publish-philosophy-architecture-and-doctrine-guides-in-dogfood.test.ts
+++ b/tests/cycles/DF-024/publish-philosophy-architecture-and-doctrine-guides-in-dogfood.test.ts
@@ -11,7 +11,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y++) {
     for (let x = 0; x < frame.width; x++) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }

--- a/tests/cycles/DF-026/demote-examples-to-secondary-reference-status.test.ts
+++ b/tests/cycles/DF-026/demote-examples-to-secondary-reference-status.test.ts
@@ -9,7 +9,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y++) {
     for (let x = 0; x < frame.width; x++) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }

--- a/tests/cycles/DF-030/dogfood-docs-surface-block.test.ts
+++ b/tests/cycles/DF-030/dogfood-docs-surface-block.test.ts
@@ -306,7 +306,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y++) {
     for (let x = 0; x < frame.width; x++) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }

--- a/tests/cycles/DF-071/dogfood-block-authored-surfaces.test.ts
+++ b/tests/cycles/DF-071/dogfood-block-authored-surfaces.test.ts
@@ -12,7 +12,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y++) {
     for (let x = 0; x < frame.width; x++) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }
@@ -50,10 +50,10 @@ describe('DF-071 DOGFOOD block-authored surfaces', () => {
     const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'blocks' });
     const result = await runScript(app, [{ key: '/' }], { ctx });
     const text = frameText(must(result.frames.at(-1)));
-    const expectedTitle = String(searchPanelBlock.render({
+    const expectedTitle = searchPanelBlock.render({
       config: { title: 'Search documentation' },
       mode: 'accessible',
-    }).output);
+    }).output;
 
     expect(text).toContain(expectedTitle);
     expect(text).toContain('What are Blocks');

--- a/tests/cycles/DL-007/inspector-panel-block.test.ts
+++ b/tests/cycles/DL-007/inspector-panel-block.test.ts
@@ -12,7 +12,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y++) {
     for (let x = 0; x < frame.width; x++) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }

--- a/tests/cycles/DX-034/data-binding-closeout.test.ts
+++ b/tests/cycles/DX-034/data-binding-closeout.test.ts
@@ -114,13 +114,15 @@ describe('DX-034 data binding closeout', () => {
         details: selection.details,
       },
     }).output;
+    const statusSlot = update.frame.status('status') ?? 'missing';
+    const statusText = update.frame.get<string>('status') ?? '';
     const renderedShell = appShellBlock.render({
       mode: 'pipe',
       slots: {
         navigation: update.frame.require<string>('navigation'),
         content: renderedReader,
         inspector: renderedInspector,
-        status: `${update.frame.status('status')}: ${update.frame.get<string>('status')}`,
+        status: `${statusSlot}: ${statusText}`,
       },
     });
 

--- a/tests/cycles/LX-012/dogfood-i18n-debt-inventory.test.ts
+++ b/tests/cycles/LX-012/dogfood-i18n-debt-inventory.test.ts
@@ -12,7 +12,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y += 1) {
     for (let x = 0; x < frame.width; x += 1) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }

--- a/tests/cycles/LX-018/runtime-loc-fallbacks.test.ts
+++ b/tests/cycles/LX-018/runtime-loc-fallbacks.test.ts
@@ -9,7 +9,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y += 1) {
     for (let x = 0; x < frame.width; x += 1) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }

--- a/tests/cycles/LX-020/dogfood-locale-demo-readiness.test.ts
+++ b/tests/cycles/LX-020/dogfood-locale-demo-readiness.test.ts
@@ -12,7 +12,7 @@ function frameText(frame: { width: number; height: number; get(x: number, y: num
   let text = '';
   for (let y = 0; y < frame.height; y += 1) {
     for (let x = 0; x < frame.width; x += 1) {
-      text += frame.get(x, y).char || ' ';
+      text += frame.get(x, y).char ?? ' ';
     }
     text += '\n';
   }


### PR DESCRIPTION
## Summary

Starts WF-158, the next Respecting the Dojo ratchet after PR #428 landed the aggregate Code Dojo debt at `518`.

This cycle target is `468` or lower, with at least `50` real counted standards violations removed.

## Links

- Closes #429
- Design: `docs/design/WF-158-respecting-dojo-ratchet-468.md`

## Shaping Validation

- `npm run docs:inventory`
- `git diff --check`
- pre-commit Code Dojo gate
- pre-push full verification, including Code Dojo debt/strict/ESLint, code size, `typecheck:test`, full 9-chunk Vitest, and scripted interactive examples

## Implementation Plan

- Use `npm run code-dojo:eslint:offenders` to select a broad ESLint cleanup slice.
- Keep file/context, mock-ban, code-size, and DOGFOOD localization counts flat or lower.
- Update baselines and docs only after live counts prove the lower ceiling.
