### PR TITLE
DL-019 Theme rule selection and inspection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
               scripts/smoke-dogfood*) return 0 ;;
               tests/cycles/DF-*) return 0 ;;
               tests/cycles/*dogfood*) return 0 ;;
-              docs/DOGFOOD.md) return 0 ;;
+              docs/*) return 0 ;;
               docs/design/DF-*) return 0 ;;
               docs/legends/DF-*) return 0 ;;
               docs/method/legends/DF-*) return 0 ;;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,9 +20,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   the DOGFOOD i18n policy gates instead of only `docs/DOGFOOD.md` doing so.
 - **Theme rule inspection** — `minContrastWith()` candidates below the contrast
   floor now report `contrast-too-low` inspection reasons instead of looking
-  eligible, and rule dependencies now include `mix` transform references used
-  by target or `against` colors. Path candidates that resolve to invalid colors
-  are now inspected as invalid candidates instead of looking eligible.
+	  eligible, and rule dependencies now include `mix` transform references used
+	  by target or `against` colors. Path candidates that resolve to invalid colors
+	  are now inspected as invalid candidates instead of looking eligible, while
+	  circular candidate references remain deterministic graph errors.
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized
   deterministic test/support files from the WF-161 tranche and extracts
   declaration-boundary core, TUI, and standard-block modules behind stable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **DOGFOOD docs validation** — Local pre-push and CI path classification now
   treat all `docs/*` changes as DOGFOOD-relevant, so documentation edits run
   the DOGFOOD i18n policy gates instead of only `docs/DOGFOOD.md` doing so.
+- **Theme rule inspection** — `minContrastWith()` candidates below the contrast
+  floor now report `contrast-too-low` inspection reasons instead of looking
+  eligible.
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized
   deterministic test/support files from the WF-161 tranche and extracts
   declaration-boundary core, TUI, and standard-block modules behind stable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   the DOGFOOD i18n policy gates instead of only `docs/DOGFOOD.md` doing so.
 - **Theme rule inspection** — `minContrastWith()` candidates below the contrast
   floor now report `contrast-too-low` inspection reasons instead of looking
-  eligible.
+  eligible, and rule dependencies now include `mix` transform references used
+  by target or `against` colors.
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized
   deterministic test/support files from the WF-161 tranche and extracts
   declaration-boundary core, TUI, and standard-block modules behind stable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 	  are now inspected as invalid candidates instead of looking eligible, while
 	  circular candidate references remain deterministic graph errors. Rule target
 	  and `against` colors now fail deterministically when they resolve to
-	  non-colors instead of scoring candidates against an undefined ratio.
+	  non-colors instead of scoring candidates against an undefined ratio. Exact
+	  token paths ending in `.bg` now take precedence over virtual background-slot
+	  fallback references.
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized
   deterministic test/support files from the WF-161 tranche and extracts
   declaration-boundary core, TUI, and standard-block modules behind stable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,8 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 - **Theme rule inspection** — `minContrastWith()` candidates below the contrast
   floor now report `contrast-too-low` inspection reasons instead of looking
   eligible, and rule dependencies now include `mix` transform references used
-  by target or `against` colors.
+  by target or `against` colors. Path candidates that resolve to invalid colors
+  are now inspected as invalid candidates instead of looking eligible.
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized
   deterministic test/support files from the WF-161 tranche and extracts
   declaration-boundary core, TUI, and standard-block modules behind stable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+### Added
+
+- **Theme rule selection and inspection** — DL-019 adds Bijou-native selector
+  rules for contrast, vividness, closest-color, and ordered palette choices,
+  plus `TokenGraph.inspect()` facts that explain selected and rejected
+  candidates without adding an external design-token dependency.
+
 ### Fixed
 
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Fixed
 
+- **DOGFOOD docs validation** — Local pre-push and CI path classification now
+  treat all `docs/*` changes as DOGFOOD-relevant, so documentation edits run
+  the DOGFOOD i18n policy gates instead of only `docs/DOGFOOD.md` doing so.
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized
   deterministic test/support files from the WF-161 tranche and extracts
   declaration-boundary core, TUI, and standard-block modules behind stable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,9 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 	  eligible, and rule dependencies now include `mix` transform references used
 	  by target or `against` colors. Path candidates that resolve to invalid colors
 	  are now inspected as invalid candidates instead of looking eligible, while
-	  circular candidate references remain deterministic graph errors.
+	  circular candidate references remain deterministic graph errors. Rule target
+	  and `against` colors now fail deterministically when they resolve to
+	  non-colors instead of scoring candidates against an undefined ratio.
 - **Focused Code Dojo ratchet** — WF-162 splits the remaining oversized
   deterministic test/support files from the WF-161 tranche and extracts
   declaration-boundary core, TUI, and standard-block modules behind stable

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -30,11 +30,12 @@ Use these docs when you need to answer:
 1. [Foundations](./foundations.md)
 2. [Theme Token Vocabulary](./theme-tokens.md)
 3. [Theme Authoring Guide](./theme-authoring.md)
-4. [Patterns](./patterns.md)
-5. [Blocks](./blocks.md)
-6. [Pointer and Mouse Policy](./pointer.md)
-7. [Component Families](./component-families.md)
-8. [Data Visualization Policy](./data-visualization.md)
+4. [Theme Rule Recipes](./theme-rule-recipes.md)
+5. [Patterns](./patterns.md)
+6. [Blocks](./blocks.md)
+7. [Pointer and Mouse Policy](./pointer.md)
+8. [Component Families](./component-families.md)
+9. [Data Visualization Policy](./data-visualization.md)
 
 For the raw inventory and taxonomy work behind these docs, see [../archive/component-system-audit.md](../archive/component-system-audit.md).
 

--- a/docs/design-system/theme-rule-recipes.md
+++ b/docs/design-system/theme-rule-recipes.md
@@ -1,0 +1,115 @@
+# Theme Rule Recipes
+
+Theme rules let Bijou themes describe how semantic colors are selected instead
+of only storing final hex values.
+
+The runtime contract is unchanged:
+
+```text
+primitive colors
+  -> selector rules
+    -> TokenGraph
+      -> ThemeAccessors
+        -> terminal rendering
+```
+
+Rules live in `@flyingrobots/bijou`. They do not depend on external design
+token packages and they compile to the same `TokenValue` objects the renderer
+already consumes.
+
+## When To Use Rules
+
+Use a rule when a token should follow a stable decision:
+
+- readable foreground on a known surface
+- vivid accent that must not reuse success or error
+- muted candidate that still clears a contrast floor
+- closest palette color to a target
+- ordered ramp position such as the middle or final stop
+
+Do not use rules to hide one-off taste decisions. If the product needs exactly
+one named color, write the token directly.
+
+## Primitive To Semantic Flow
+
+Start with primitive colors, then derive product roles from them:
+
+```ts
+import {
+  bestContrastWith,
+  createTokenGraph,
+  mostVivid,
+  scope,
+} from '@flyingrobots/bijou';
+
+const graph = createTokenGraph({
+  palette: {
+    ink: '#0b1020',
+    paper: '#f8fafc',
+    blue: '#3399ff',
+    green: '#22c55e',
+    red: '#ef4444',
+  },
+  surface: {
+    primary: { fg: '#f8fafc', bg: { ref: 'palette.ink' } },
+  },
+  semantic: {
+    primary: bestContrastWith({ ref: 'surface.primary.bg' }, scope('palette')),
+    accent: mostVivid(scope('palette'), {
+      against: { ref: 'surface.primary.bg' },
+      minContrast: 4.5,
+      not: ['palette.green', 'palette.red'],
+    }),
+  },
+});
+```
+
+`semantic.primary` is now "the highest-contrast palette color on the primary
+surface." `semantic.accent` is "the most vivid readable palette color that is
+not reserved for success or error."
+
+## Inspect The Decision
+
+Rules are useful only when they can explain themselves:
+
+```ts
+const fact = graph.inspect('semantic.accent');
+```
+
+The inspection fact includes:
+
+- the rule id
+- the selected candidate
+- candidate paths and resolved colors
+- excluded candidates
+- contrast failures
+- dependency paths
+
+This is the data future Theme Inspector and Theme Lab surfaces should render.
+They should not infer token ownership from RGB equality or screenshots.
+
+## Selector Vocabulary
+
+`bestContrastWith(target, candidates)` chooses the highest-contrast candidate.
+
+`minContrastWith(target, candidates, { ratio })` chooses the first candidate
+that reaches the requested contrast ratio.
+
+`mostVivid(candidates, options)` chooses the highest-chroma readable candidate.
+
+`leastVivid(candidates, options)` chooses the lowest-chroma readable candidate.
+
+`closestColor(target, candidates)` chooses the closest RGB candidate.
+
+`nthColor(candidates, index)` chooses an ordered candidate by integer or
+relative index.
+
+Candidate scopes are deterministic. `scope('palette')` reads direct children
+of the `palette` scope in definition order.
+
+## Lower-Mode Rule
+
+Rules improve color choice. They do not make color the only source of meaning.
+
+Every UI that consumes these tokens still needs labels, symbols, structure, or
+state text that survives `NO_COLOR`, pipe output, and accessible lowering.

--- a/docs/design-system/theme-rule-recipes.md
+++ b/docs/design-system/theme-rule-recipes.md
@@ -95,9 +95,11 @@ They should not infer token ownership from RGB equality or screenshots.
 `minContrastWith(target, candidates, { ratio })` chooses the first candidate
 that reaches the requested contrast ratio.
 
-`mostVivid(candidates, options)` chooses the highest-chroma readable candidate.
+`mostVivid(candidates, options)` chooses the highest-chroma candidate; it is
+readable only when `against` and `minContrast` are provided.
 
-`leastVivid(candidates, options)` chooses the lowest-chroma readable candidate.
+`leastVivid(candidates, options)` chooses the lowest-chroma candidate; it uses
+the same readability rule.
 
 `closestColor(target, candidates)` chooses the closest RGB candidate.
 

--- a/docs/design/DL-019-theme-rule-selection-and-inspection.md
+++ b/docs/design/DL-019-theme-rule-selection-and-inspection.md
@@ -61,6 +61,19 @@ A Bijou theme author can define semantic theme roles through pure selector
 rules, compile them into the existing theme/token graph contract, and inspect
 which candidates were considered, rejected, and selected.
 
+## Playback Questions
+
+- Can a semantic foreground choose a readable color from a primitive palette
+  without hard-coding the final hex value?
+- Can a vivid accent selector exclude reserved success and error roles while
+  still proving contrast against its surface?
+- Can `TokenGraph.inspect()` explain every candidate read by a rule, including
+  selected, eligible, excluded, invalid, and contrast-failed candidates?
+- Can malformed rule inputs fail with the missing target, scope, candidate, or
+  exclusion path instead of silently choosing a surprising color?
+- Can the rule layer preserve existing `TokenGraph.get()` behavior for callers
+  that only need a resolved `TokenValue`?
+
 ## Current Truth
 
 Bijou already has:
@@ -169,6 +182,11 @@ semantic: {
 }
 ```
 
+Slot-path references ending in `.bg` are part of this cycle's contract. A
+reference such as `{ ref: "surface.primary.bg" }` resolves the background color
+of the `surface.primary` token while `{ ref: "surface.primary" }` keeps the
+existing foreground-reference behavior.
+
 The graph should expose inspection facts separately from resolved values:
 
 ```ts
@@ -182,8 +200,10 @@ Inspector rows:
 semantic.accent
   rule: most-vivid
   selected: palette.cyan (#38bdf8)
-  dependencies: surface.primary.bg, palette.cyan, palette.green, palette.red
+  dependencies: surface.primary.bg, palette.ink, palette.paper, palette.cyan,
+    palette.green, palette.red
   rejected:
+    palette.paper - eligible, not selected
     palette.green - excluded
     palette.red - excluded
     palette.ink - contrast below 4.5
@@ -192,43 +212,56 @@ semantic.accent
 ## Selector Vocabulary
 
 The initial selector vocabulary should cover the high-value color decisions.
+Selectors that compare against a target put the target first. Selectors that
+rank only a candidate collection put the collection first.
 
 `bestContrastWith(target, candidates)` chooses the candidate with the highest
-contrast ratio against the target.
+contrast ratio against the target. Equal scores keep candidate order.
 
-`minContrastWith(target, candidates, minRatio)` chooses the first candidate
+`minContrastWith(target, candidates, { ratio })` chooses the first candidate
 that clears the requested contrast ratio, using deterministic candidate order.
 
 `mostVivid(candidates, options)` chooses the highest-chroma candidate, with
-optional `against`, `minContrast`, and `not` constraints.
+optional `against`, `minContrast`, and `not` constraints. First-slice chroma is
+the deterministic RGB channel spread: `max(red, green, blue) - min(red, green,
+blue)`. If `minContrast` is present, `against` is required.
 
 `leastVivid(candidates, options)` chooses the lowest-chroma candidate, with the
-same optional constraints.
+same optional constraints and the same `minContrast` rule.
 
 `closestColor(target, candidates)` chooses the closest candidate to a target
-color. A simple deterministic RGB distance is acceptable for the first slice if
-the docs name it honestly.
+color. The first slice uses squared RGB distance and keeps candidate order for
+equal distances.
 
-`nth(candidates, index)` chooses a candidate by ordered position. Integer
-indices use array-style ordering, and fractional `0` through `1` indices choose
-relative positions.
+`nthColor(candidates, index)` chooses a candidate by ordered position. Integer
+indices use array-style ordering, negative integers count from the end, and
+out-of-range integers clamp to the nearest valid candidate. Fractional indices
+clamp to `0` through `1` and use `round((length - 1) * index)`.
 
 ## Runtime Contract
 
 Selectors are pure. They do not read process state, filesystem data, terminal
 facts, or clocks.
 
-Selectors return token values compatible with the existing `TokenGraph.get()`
-path. They may carry source metadata internally, but `get()` continues to
-return a `TokenValue`.
+Selector helpers return plain `ThemeColorRuleDefinition` data. The token graph
+evaluates that intermediate rule definition, and the existing `TokenGraph.get()`
+path still returns a resolved `TokenValue`.
 
 Rule failures are deterministic:
 
 - missing target references throw with the missing path
+- missing explicit candidate paths throw with the missing path
+- missing exclusion paths throw with the missing path
 - empty candidate scopes throw with the selector name
+- vividness selectors throw when `minContrast` is set without `against`
 - no minimum-contrast candidate throws unless the selector defines an explicit
   fallback
 - cycles remain cycle errors
+
+Inspection dependencies include target and `against` references plus every
+candidate path read from explicit candidate lists or scopes, whether the
+candidate was selected, eligible-but-not-selected, excluded, invalid, or below
+the contrast floor.
 
 ## Accessibility And Assistive Posture
 
@@ -281,14 +314,14 @@ equality guessing.
 ## Implementation Outline
 
 1. Add selector definition types to the core theme graph.
-2. Add deterministic candidate collection for explicit paths and scopes.
-3. Add contrast, vividness, closeness, and ordered selection helpers.
-4. Add `TokenGraph.inspect()` or an adjacent pure inspection API.
+2. Collect deterministic candidates from explicit paths and scopes.
+3. Implement contrast, vividness, closeness, and ordered selection helpers.
+4. Expose `TokenGraph.inspect()` or an adjacent pure inspection API.
 5. Preserve existing `TokenGraph.get()` behavior for raw, ref, mode, and
    transform definitions.
-6. Export the new types/helpers from the theme barrel and root package.
+6. Wire the new types and helpers into the theme barrel and root package.
 7. Document the recipe pattern in the design-system theme authoring docs.
-8. Update `docs/CHANGELOG.md`.
+8. Record the shipped behavior in `docs/CHANGELOG.md`.
 
 ## Tests To Write First
 
@@ -313,9 +346,9 @@ equality guessing.
 - Design-system docs show the primitive -> semantic rule -> UI token workflow.
 - Local validation includes focused theme tests, `npm run typecheck:test`,
   `npm run lint`, `npm run code-dojo:changed`, and `git diff --check`.
-- The cycle either lowers aggregate Code Dojo debt to `112` or lower, or stays
-  explicitly unfinished as a shaped design/prototype and does not claim the
-  repo goalpost.
+- Code Dojo debt remains verifiable through `npm run code-dojo:debt` and
+  `npm run code-dojo:verify`; this cycle does not claim the repo goalpost
+  unless that aggregate report reaches `112` or lower.
 
 ## Retrospective
 

--- a/docs/design/DL-019-theme-rule-selection-and-inspection.md
+++ b/docs/design/DL-019-theme-rule-selection-and-inspection.md
@@ -58,8 +58,9 @@ values.
 ## Hill
 
 A Bijou theme author can define semantic theme roles through pure selector
-rules, compile them into the existing theme/token graph contract, and inspect
-which candidates were considered, rejected, and selected.
+rules, replay the product questions below with tests, compile the rules into
+the existing theme/token graph contract, and inspect which candidates were
+considered, rejected, and selected.
 
 ## Playback Questions
 
@@ -157,7 +158,7 @@ const graph = createTokenGraph({
   },
   semantic: {
     primary: bestContrastWith(
-      { ref: "surface.primary.bg" },
+      { ref: "surface.primary.bg" }, // token background slot
       scope("palette"),
     ),
     accent: mostVivid(scope("palette"), {
@@ -249,10 +250,8 @@ path still returns a resolved `TokenValue`.
 
 Rule failures are deterministic:
 
-- missing target references throw with the missing path
-- missing explicit candidate paths throw with the missing path
-- missing exclusion paths throw with the missing path
-- empty candidate scopes throw with the selector name
+- missing target, explicit candidate, candidate-scope, and exclusion paths throw
+  with the missing path
 - vividness selectors throw when `minContrast` is set without `against`
 - no minimum-contrast candidate throws unless the selector defines an explicit
   fallback

--- a/docs/design/DL-019-theme-rule-selection-and-inspection.md
+++ b/docs/design/DL-019-theme-rule-selection-and-inspection.md
@@ -1,0 +1,322 @@
+---
+id: DL-019
+title: Theme Rule Selection And Inspection
+status: active
+lane: cool-ideas
+priority: medium
+github_issue: 444
+legend: DL
+---
+
+# DL-019 - Theme Rule Selection And Inspection
+
+Legend: [DL - Design Language](../legends/DL-design-language.md)
+
+## Decision Summary
+
+Bijou should adopt the strongest ideas from reactive design-token systems
+without importing an incompatible dependency or replacing the existing runtime
+theme contract.
+
+The runtime truth remains:
+
+```text
+Theme
+  -> ResolvedTheme
+    -> TokenGraph
+      -> ThemeAccessors
+        -> terminal cells, lower modes, and DTCG interop
+```
+
+This cycle adds a Bijou-native rule layer for theme authoring and inspection:
+
+- selector rules such as best contrast, minimum contrast, most vivid, least
+  vivid, closest color, and ordered choice
+- explicit candidate exclusions for reserved roles such as success and error
+- structured inspection facts explaining why a rule chose a token
+- dependency facts that Theme Inspector and tests can consume later
+- compiled output that remains a normal Bijou `Theme` or token graph entry
+
+No `design-book` runtime, dev, peer, optional, or generated dependency is added.
+The external package is useful prior art, but its license and general CSS
+surface do not belong in Bijou's Apache-2.0 zero-dependency core.
+
+## Sponsored Human
+
+A Bijou theme author wants to tune primitive palettes while keeping semantic
+roles stable. They should be able to say "choose readable text for this
+surface" or "choose a vivid accent that is not success or error" instead of
+manually maintaining every derived hex value.
+
+## Sponsored Agent
+
+An agent auditing theme behavior wants deterministic facts for rule inputs,
+candidate rejection, selected values, dependencies, and contrast proof so it
+can explain a theme without sampling screenshots or guessing from final RGB
+values.
+
+## Hill
+
+A Bijou theme author can define semantic theme roles through pure selector
+rules, compile them into the existing theme/token graph contract, and inspect
+which candidates were considered, rejected, and selected.
+
+## Current Truth
+
+Bijou already has:
+
+- a public `Theme` contract with `semantic`, `surface`, `border`, `ui`,
+  `status`, and `gradient` token families
+- a `TokenGraph` with references, light/dark definitions, transforms, cache
+  invalidation, and subscribers
+- `defineTheme()` for mode-aware token themes
+- `fromDTCG()` and `toDTCG()` for token document interop
+- `doctorTheme()` and `defineThemeSafePairs()` for concrete contrast checks
+- DOGFOOD Theme Lab and Theme Inspector surfaces for concrete token facts
+
+The missing piece is rule provenance. Today a derived token can be encoded as a
+manual hex, a direct reference, or a transform. It cannot yet say:
+
+- choose the highest-contrast color from this palette
+- choose the first color that reaches a contrast floor
+- choose the most vivid color that is still readable
+- exclude reserved role tokens from an accent search
+- explain which candidates failed and why
+
+## Problem
+
+Manual semantic token maintenance creates drift:
+
+- a primitive palette can change while semantic foregrounds stay stale
+- a vivid accent may accidentally reuse a destructive or success role
+- contrast proof happens after values are chosen instead of during selection
+- Theme Inspector can show final values but not why those values won
+- tests can assert concrete hex values but not the decision rule behind them
+
+The answer is not to replace Bijou's runtime theme model. The runtime model
+already encodes terminal-specific facts: `NO_COLOR`, foreground/background
+tokens, text modifiers, RGB caches, ANSI downsampling, lower-mode behavior, and
+safe-pair checks.
+
+## Scope
+
+This cycle adds pure core support for rule-based color selection and inspection.
+
+Included:
+
+- color candidate scopes represented as token paths or explicit color values
+- selector functions for contrast, vividness, closeness, ordered position, and
+  minimum contrast
+- explicit `not` exclusions by token path
+- selector result facts with candidate pass/fail reasons
+- dependency extraction for references and candidate scopes
+- `TokenGraph` support for rule definitions if that can land without breaking
+  existing callers
+- focused tests for selection, exclusion, dependency, and cycle behavior
+- design-system docs and changelog notes
+
+Out of scope:
+
+- no external `design-book` package integration
+- no CSS renderer
+- no typography, spacing, motion, or duration token categories
+- no Figma adapter
+- no Theme Lab redesign in this slice
+- no element-level renderer provenance
+- no app-frame theme-mode UX changes
+
+## API Direction
+
+The first public API should be small and structural. Exact names can move in
+implementation, but the shape should stay close to this:
+
+```ts
+const graph = createTokenGraph({
+  palette: {
+    ink: "#0b1020",
+    paper: "#f8fafc",
+    cyan: "#38bdf8",
+    green: "#22c55e",
+    red: "#ef4444",
+  },
+  surface: {
+    primary: { fg: "#f8fafc", bg: { ref: "palette.ink" } },
+  },
+  semantic: {
+    primary: bestContrastWith(
+      { ref: "surface.primary.bg" },
+      scope("palette"),
+    ),
+    accent: mostVivid(scope("palette"), {
+      against: { ref: "surface.primary.bg" },
+      minContrast: 4.5,
+      not: ["palette.green", "palette.red"],
+    }),
+  },
+});
+```
+
+If the fluent helper API is too large for the first slice, the serialized graph
+definition may use plain discriminated data instead:
+
+```ts
+semantic: {
+  primary: {
+    rule: "best-contrast-with",
+    target: { ref: "surface.primary.bg" },
+    candidates: { scope: "palette" },
+  },
+}
+```
+
+The graph should expose inspection facts separately from resolved values:
+
+```ts
+const fact = graph.inspect("semantic.accent", "dark");
+```
+
+The returned fact should be structured enough for tests and future Theme
+Inspector rows:
+
+```text
+semantic.accent
+  rule: most-vivid
+  selected: palette.cyan (#38bdf8)
+  dependencies: surface.primary.bg, palette.cyan, palette.green, palette.red
+  rejected:
+    palette.green - excluded
+    palette.red - excluded
+    palette.ink - contrast below 4.5
+```
+
+## Selector Vocabulary
+
+The initial selector vocabulary should cover the high-value color decisions.
+
+`bestContrastWith(target, candidates)` chooses the candidate with the highest
+contrast ratio against the target.
+
+`minContrastWith(target, candidates, minRatio)` chooses the first candidate
+that clears the requested contrast ratio, using deterministic candidate order.
+
+`mostVivid(candidates, options)` chooses the highest-chroma candidate, with
+optional `against`, `minContrast`, and `not` constraints.
+
+`leastVivid(candidates, options)` chooses the lowest-chroma candidate, with the
+same optional constraints.
+
+`closestColor(target, candidates)` chooses the closest candidate to a target
+color. A simple deterministic RGB distance is acceptable for the first slice if
+the docs name it honestly.
+
+`nth(candidates, index)` chooses a candidate by ordered position. Integer
+indices use array-style ordering, and fractional `0` through `1` indices choose
+relative positions.
+
+## Runtime Contract
+
+Selectors are pure. They do not read process state, filesystem data, terminal
+facts, or clocks.
+
+Selectors return token values compatible with the existing `TokenGraph.get()`
+path. They may carry source metadata internally, but `get()` continues to
+return a `TokenValue`.
+
+Rule failures are deterministic:
+
+- missing target references throw with the missing path
+- empty candidate scopes throw with the selector name
+- no minimum-contrast candidate throws unless the selector defines an explicit
+  fallback
+- cycles remain cycle errors
+
+## Accessibility And Assistive Posture
+
+Selector rules improve color quality, but they do not make color sufficient as
+the only meaning carrier. The same graceful-lowering rule applies:
+
+- no-color output must keep text, symbols, or structure
+- pipe output must not depend on swatches
+- accessible output must name state and intent
+
+Contrast-aware selection is proof that a chosen color is readable when color is
+available. It is not proof that the UI is accessible by itself.
+
+## Localization And Directionality Posture
+
+No user-facing localized copy is required for the core rule primitives. Rule
+ids, token paths, candidate paths, and inspection facts are developer-facing
+identifiers.
+
+Future DOGFOOD Theme Inspector prose that explains rule facts must flow through
+the DOGFOOD localization catalog. Token paths remain stable identifiers and are
+not localized.
+
+## Agent Inspectability / Explainability Posture
+
+Inspection facts are a first-class product requirement. An agent should be able
+to assert:
+
+- which selector rule resolved a token
+- which references and candidate scopes the rule read
+- which candidate won
+- which candidates were rejected
+- whether a candidate failed contrast, was excluded, or was the wrong type
+- which downstream token paths depend on the resolved token
+
+These facts should not require terminal rendering, screenshot analysis, or RGB
+equality guessing.
+
+## Linked Invariants
+
+- [Runtime Truth Wins](../invariants/runtime-truth-wins.md): resolved values
+  and inspection facts come from executing the graph.
+- [Tests Are the Spec](../invariants/tests-are-the-spec.md): selector behavior
+  lands through deterministic tests before docs claims.
+- [Graceful Lowering Preserves Meaning](../invariants/graceful-lowering-preserves-meaning.md):
+  color quality does not replace lower-mode structure.
+- [Docs Are the Demo](../invariants/docs-are-the-demo.md): future Theme Lab
+  surfaces should consume the same inspection facts tests assert.
+
+## Implementation Outline
+
+1. Add selector definition types to the core theme graph.
+2. Add deterministic candidate collection for explicit paths and scopes.
+3. Add contrast, vividness, closeness, and ordered selection helpers.
+4. Add `TokenGraph.inspect()` or an adjacent pure inspection API.
+5. Preserve existing `TokenGraph.get()` behavior for raw, ref, mode, and
+   transform definitions.
+6. Export the new types/helpers from the theme barrel and root package.
+7. Document the recipe pattern in the design-system theme authoring docs.
+8. Update `docs/CHANGELOG.md`.
+
+## Tests To Write First
+
+- `bestContrastWith()` chooses the readable foreground from a candidate scope.
+- `minContrastWith()` rejects candidates below the minimum ratio and selects
+  the first passing candidate.
+- `mostVivid()` respects `against`, `minContrast`, and `not` exclusions.
+- `leastVivid()` chooses the muted readable candidate.
+- `closestColor()` and `nth()` are deterministic.
+- selector definitions participate in graph dependency inspection.
+- circular selector references still fail deterministically.
+- existing graph reference and transform tests keep passing.
+
+## Acceptance Criteria
+
+- Bijou has no dependency on `design-book`.
+- Theme selectors are pure core functions.
+- Token graph rule definitions resolve to existing `TokenValue` objects.
+- Inspection facts explain selected and rejected candidates.
+- Exclusions by token path prevent reserved roles from winning accent rules.
+- The new API exports from `@flyingrobots/bijou`.
+- Design-system docs show the primitive -> semantic rule -> UI token workflow.
+- Local validation includes focused theme tests, `npm run typecheck:test`,
+  `npm run lint`, `npm run code-dojo:changed`, and `git diff --check`.
+- The cycle either lowers aggregate Code Dojo debt to `112` or lower, or stays
+  explicitly unfinished as a shaped design/prototype and does not claim the
+  repo goalpost.
+
+## Retrospective
+
+To be completed when the cycle lands.

--- a/docs/design/DL-019-theme-rule-selection-and-inspection.md
+++ b/docs/design/DL-019-theme-rule-selection-and-inspection.md
@@ -178,7 +178,7 @@ semantic: {
   primary: {
     rule: "best-contrast-with",
     target: { ref: "surface.primary.bg" },
-    candidates: { scope: "palette" },
+    candidates: { kind: "scope", path: "palette" },
   },
 }
 ```

--- a/packages/bijou/src/core/theme/graph-dependencies.ts
+++ b/packages/bijou/src/core/theme/graph-dependencies.ts
@@ -1,0 +1,26 @@
+import type { ColorDefinition, TokenDefinition } from './graph-types.js';
+import { isTokenDefinition } from './graph-guards.js';
+
+export function collectGraphDefinitionDependencies(def: ColorDefinition | TokenDefinition): readonly string[] {
+  const deps = new Set<string>();
+  if (isTokenDefinition(def)) {
+    collectColorDependencies(def.fg, deps);
+    if (def.bg !== undefined) collectColorDependencies(def.bg, deps);
+  } else {
+    collectColorDependencies(def, deps);
+  }
+  return [...deps];
+}
+
+function collectColorDependencies(def: ColorDefinition, deps: Set<string>): void {
+  if (typeof def === 'string') return;
+  if ('ref' in def) {
+    deps.add(def.ref);
+    for (const transform of def.transform ?? []) {
+      if (transform.type === 'mix') deps.add(transform.with);
+    }
+  } else if ('light' in def) {
+    collectColorDependencies(def.light, deps);
+    collectColorDependencies(def.dark, deps);
+  }
+}

--- a/packages/bijou/src/core/theme/graph-guards.ts
+++ b/packages/bijou/src/core/theme/graph-guards.ts
@@ -1,0 +1,31 @@
+import type { TokenValue } from './tokens.js';
+import type {
+  ColorDefinition,
+  ThemeColorRuleDefinition,
+  TokenDefinition,
+  TokenDefinitions,
+} from './graph-types.js';
+import { isThemeColorRuleDefinition } from './theme-rules.js';
+
+export type StoredDefinition = ColorDefinition | TokenDefinition | ThemeColorRuleDefinition;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isTokenValue(value: unknown): value is TokenValue {
+  return isRecord(value) && typeof value['hex'] === 'string';
+}
+
+export function isTokenDefinition(value: unknown): value is TokenDefinition {
+  return isRecord(value) && 'fg' in value;
+}
+
+export function isNestedDefinitions(value: unknown): value is TokenDefinitions {
+  return isRecord(value)
+    && !isTokenValue(value)
+    && !isTokenDefinition(value)
+    && !isThemeColorRuleDefinition(value)
+    && !('ref' in value)
+    && !('light' in value);
+}

--- a/packages/bijou/src/core/theme/graph-import.ts
+++ b/packages/bijou/src/core/theme/graph-import.ts
@@ -1,0 +1,39 @@
+import type { TokenInput, TokenDefinitions } from './graph-types.js';
+import type { StoredDefinition } from './graph-guards.js';
+import { isNestedDefinitions, isTokenValue } from './graph-guards.js';
+
+export function importTokenDefinitions(
+  definitions: Map<string, StoredDefinition>,
+  defs: TokenDefinitions,
+  basePath = '',
+): void {
+  for (const [key, value] of Object.entries(defs)) {
+    const fullPath = basePath ? `${basePath}.${key}` : key;
+
+    if (isTokenValue(value)) {
+      setTokenDefinition(definitions, fullPath, value);
+    } else if (isNestedDefinitions(value)) {
+      importTokenDefinitions(definitions, value, fullPath);
+    } else {
+      definitions.set(fullPath, value);
+    }
+  }
+}
+
+export function setTokenDefinition(
+  definitions: Map<string, StoredDefinition>,
+  path: string,
+  definition: TokenInput,
+): void {
+  if (isTokenValue(definition)) {
+    definitions.set(path, {
+      fg: definition.hex,
+      bg: definition.bg,
+      modifiers: definition.modifiers,
+      fgRGB: definition.fgRGB,
+      bgRGB: definition.bgRGB,
+    });
+  } else {
+    definitions.set(path, definition);
+  }
+}

--- a/packages/bijou/src/core/theme/graph-resolve.ts
+++ b/packages/bijou/src/core/theme/graph-resolve.ts
@@ -60,13 +60,13 @@ export function createGraphColorResolver(
   }
 
   function resolveReferenceTarget(path: string, mode: ThemeMode, visited: Set<string>): string | undefined {
+    const target = definitions.get(path);
+    if (target !== undefined) return isTokenDefinition(target) ? resolveColor(target.fg, mode, visited) : resolveColor(target, mode, visited);
     if (path.endsWith('.bg')) {
       const base = definitions.get(path.slice(0, -3));
       if (base !== undefined && isTokenDefinition(base) && base.bg !== undefined) return resolveColor(base.bg, mode, visited);
     }
-    const target = definitions.get(path);
-    if (target === undefined) return undefined;
-    return isTokenDefinition(target) ? resolveColor(target.fg, mode, visited) : resolveColor(target, mode, visited);
+    return undefined;
   }
 
   function applyTransforms(

--- a/packages/bijou/src/core/theme/graph-resolve.ts
+++ b/packages/bijou/src/core/theme/graph-resolve.ts
@@ -1,0 +1,98 @@
+import type { RGB } from './tokens.js';
+import { hexToRgb, rgbToHex, tryHexToRgb } from './color.js';
+import type { StoredDefinition } from './graph-guards.js';
+import { isTokenDefinition } from './graph-guards.js';
+import { applyGraphColorTransform } from './graph-transform.js';
+import { evaluateThemeColorRule } from './theme-rule-evaluate.js';
+import { isThemeColorRuleDefinition } from './theme-rules.js';
+import type {
+  ColorDefinition,
+  ColorTransform,
+  ThemeColorRuleDefinition,
+  ThemeRuleInspection,
+} from './graph-types.js';
+
+type ThemeMode = 'light' | 'dark';
+
+export interface GraphColorResolver {
+  resolveColor(def: ColorDefinition | StoredDefinition, mode: ThemeMode, visited: Set<string>): string;
+  resolveRgb(hex: string | undefined): RGB | undefined;
+  inspectRule(rule: ThemeColorRuleDefinition, path: string, mode: ThemeMode): ThemeRuleInspection;
+}
+
+export function createGraphColorResolver(
+  definitions: ReadonlyMap<string, StoredDefinition>,
+  rgbCache: Map<string, RGB | null>,
+): GraphColorResolver {
+  function resolveRgb(hex: string | undefined): RGB | undefined {
+    if (hex == null) return undefined;
+    if (rgbCache.has(hex)) return rgbCache.get(hex) ?? undefined;
+    const rgb = tryHexToRgb(hex);
+    rgbCache.set(hex, rgb ?? null);
+    return rgb;
+  }
+
+  function resolveColor(def: ColorDefinition | StoredDefinition, mode: ThemeMode, visited: Set<string>): string {
+    if (typeof def === 'string') return normalizeColor(def);
+    if (isThemeColorRuleDefinition(def)) return inspectRule(def, lastVisitedPath(visited), mode, visited).hex;
+    if ('light' in def && 'dark' in def) return resolveColor(mode === 'light' ? def.light : def.dark, mode, visited);
+    if ('ref' in def) return resolveReference(def, mode, visited);
+    throw new Error(`Invalid color definition: ${JSON.stringify(def)}`);
+  }
+
+  function inspectRule(
+    rule: ThemeColorRuleDefinition,
+    path: string,
+    mode: ThemeMode,
+    visited = new Set([path]),
+  ): ThemeRuleInspection {
+    return evaluateThemeColorRule(rule, { definitions, mode, path, visited, resolveColor });
+  }
+
+  function resolveReference(def: Extract<ColorDefinition, { readonly ref: string }>, mode: ThemeMode, visited: Set<string>): string {
+    if (visited.has(def.ref)) {
+      throw new Error(`Circular token reference detected: ${Array.from(visited).join(' -> ')} -> ${def.ref}`);
+    }
+    visited.add(def.ref);
+    const target = resolveReferenceTarget(def.ref, mode, visited);
+    if (target === undefined) throw new Error(`Token reference not found: ${def.ref}`);
+    return applyTransforms(target, def.transform ?? [], mode, visited);
+  }
+
+  function resolveReferenceTarget(path: string, mode: ThemeMode, visited: Set<string>): string | undefined {
+    if (path.endsWith('.bg')) {
+      const base = definitions.get(path.slice(0, -3));
+      if (base !== undefined && isTokenDefinition(base) && base.bg !== undefined) return resolveColor(base.bg, mode, visited);
+    }
+    const target = definitions.get(path);
+    if (target === undefined) return undefined;
+    return isTokenDefinition(target) ? resolveColor(target.fg, mode, visited) : resolveColor(target, mode, visited);
+  }
+
+  function applyTransforms(
+    color: string,
+    transforms: readonly ColorTransform[],
+    mode: ThemeMode,
+    visited: Set<string>,
+  ): string {
+    let next = color;
+    for (const transform of transforms) {
+      next = applyGraphColorTransform(next, transform, path => resolveColor({ ref: path }, mode, visited));
+    }
+    return next;
+  }
+
+  return { resolveColor, resolveRgb, inspectRule };
+}
+
+function normalizeColor(color: string): string {
+  try {
+    return rgbToHex(hexToRgb(color));
+  } catch {
+    return color;
+  }
+}
+
+function lastVisitedPath(visited: ReadonlySet<string>): string {
+  return [...visited].at(-1) ?? '<inline>';
+}

--- a/packages/bijou/src/core/theme/graph-transform.ts
+++ b/packages/bijou/src/core/theme/graph-transform.ts
@@ -1,0 +1,40 @@
+import type { TokenValue } from './tokens.js';
+import type { ColorTransform } from './graph-types.js';
+import { complementary, darken, desaturate, hexToRgb, lighten, mix, rgbToHex, saturate } from './color.js';
+
+export type ResolveTransformReference = (path: string) => string;
+
+export function applyGraphColorTransform(
+  color: string,
+  transform: ColorTransform,
+  resolveReference: ResolveTransformReference,
+): string {
+  const token: TokenValue = { hex: color };
+  let result: TokenValue;
+
+  switch (transform.type) {
+    case 'darken': result = darken(token, transform.amount); break;
+    case 'lighten': result = lighten(token, transform.amount); break;
+    case 'saturate': result = saturate(token, transform.amount); break;
+    case 'desaturate': result = desaturate(token, transform.amount); break;
+    case 'complementary': result = complementary(token); break;
+    case 'inverse': result = invert(token); break;
+    case 'mix': {
+      result = mix(token, { hex: resolveReference(transform.with) }, transform.ratio ?? 0.5);
+      break;
+    }
+    default: {
+      const exhaustive: never = transform;
+      throw new Error(`Unknown transform type: ${String(exhaustive)}`);
+    }
+  }
+
+  return result.hex;
+}
+
+function invert(token: TokenValue): TokenValue {
+  const rgb = hexToRgb(token.hex);
+  return {
+    hex: rgbToHex([255 - rgb[0], 255 - rgb[1], 255 - rgb[2]]),
+  };
+}

--- a/packages/bijou/src/core/theme/graph-types.ts
+++ b/packages/bijou/src/core/theme/graph-types.ts
@@ -38,10 +38,101 @@ export interface TokenDefinition {
   bgRGB?: RGB;
 }
 
+export interface ThemeRuleCandidateScope {
+  readonly kind: 'scope';
+  readonly path: string;
+  readonly not?: readonly string[];
+}
+
+export interface ThemeRuleCandidatePath {
+  readonly kind: 'path';
+  readonly path: string;
+}
+
+export interface ThemeRuleCandidateValue {
+  readonly kind: 'value';
+  readonly value: string;
+  readonly label?: string;
+}
+
+export type ThemeRuleCandidateInput = string | ThemeRuleCandidatePath | ThemeRuleCandidateValue;
+export type ThemeRuleCandidateSource = ThemeRuleCandidateScope | readonly ThemeRuleCandidateInput[];
+
+interface ContrastRuleDefinition {
+  readonly rule: 'best-contrast-with' | 'min-contrast-with';
+  readonly target: ColorDefinition;
+  readonly candidates: ThemeRuleCandidateSource;
+  readonly ratio?: number;
+}
+
+interface VividRuleDefinition {
+  readonly rule: 'most-vivid' | 'least-vivid';
+  readonly candidates: ThemeRuleCandidateSource;
+  readonly against?: ColorDefinition;
+  readonly minContrast?: number;
+  readonly not?: readonly string[];
+}
+
+interface ClosestRuleDefinition {
+  readonly rule: 'closest-color';
+  readonly target: ColorDefinition;
+  readonly candidates: ThemeRuleCandidateSource;
+}
+
+interface NthRuleDefinition {
+  readonly rule: 'nth-color';
+  readonly candidates: ThemeRuleCandidateSource;
+  readonly index: number;
+}
+
+export type ThemeColorRuleDefinition =
+  | ContrastRuleDefinition
+  | VividRuleDefinition
+  | ClosestRuleDefinition
+  | NthRuleDefinition;
+
+export type ThemeRuleCandidateReason =
+  | 'selected'
+  | 'eligible'
+  | 'excluded'
+  | 'contrast-too-low'
+  | 'not-selected'
+  | 'invalid';
+
+export interface ThemeRuleCandidateInspection {
+  readonly path?: string;
+  readonly label: string;
+  readonly hex?: string;
+  readonly ratio?: number;
+  readonly score?: number;
+  readonly reasons: readonly ThemeRuleCandidateReason[];
+}
+
+export interface ThemeRuleInspection {
+  readonly kind: 'rule';
+  readonly path: string;
+  readonly mode: 'light' | 'dark';
+  readonly rule: ThemeColorRuleDefinition['rule'];
+  readonly hex: string;
+  readonly selected?: ThemeRuleCandidateInspection;
+  readonly candidates: readonly ThemeRuleCandidateInspection[];
+  readonly dependencies: readonly string[];
+}
+
+export interface ThemeTokenInspection {
+  readonly kind: 'token' | 'color';
+  readonly path: string;
+  readonly mode: 'light' | 'dark';
+  readonly hex: string;
+  readonly dependencies: readonly string[];
+}
+
+export type TokenGraphInspection = ThemeRuleInspection | ThemeTokenInspection;
+
 /**
  * Union of possible input values for a token path.
  */
-export type TokenInput = ColorDefinition | TokenDefinition | TokenValue;
+export type TokenInput = ColorDefinition | TokenDefinition | TokenValue | ThemeColorRuleDefinition;
 
 /**
  * A flat or nested map of token definitions.

--- a/packages/bijou/src/core/theme/graph.test.ts
+++ b/packages/bijou/src/core/theme/graph.test.ts
@@ -99,4 +99,17 @@ describe('TokenGraph', () => {
 
     expect(graph.get('gray').hex).toBe('#808080');
   });
+
+  it('prefers exact token paths before virtual background slots', () => {
+    const graph = createTokenGraph({
+      'surface.primary': { fg: '#111111', bg: '#222222' },
+      'surface.primary.bg': '#abcdef',
+      semantic: {
+        exact: { ref: 'surface.primary.bg' },
+      },
+    });
+
+    expect(graph.get('surface.primary.bg').hex).toBe('#abcdef');
+    expect(graph.get('semantic.exact').hex).toBe('#abcdef');
+  });
 });

--- a/packages/bijou/src/core/theme/graph.ts
+++ b/packages/bijou/src/core/theme/graph.ts
@@ -1,36 +1,27 @@
 import type { TokenValue, RGB } from './tokens.js';
-import { hexToRgb, tryHexToRgb, rgbToHex, lighten, darken, mix, complementary, saturate, desaturate } from './color.js';
-import type { ColorDefinition, TokenDefinition, TokenDefinitions, ColorTransform, TokenInput } from './graph-types.js';
+import type {
+  ColorDefinition,
+  TokenDefinition,
+  TokenDefinitions,
+  TokenGraphInspection,
+  TokenInput,
+} from './graph-types.js';
+import { isTokenDefinition, type StoredDefinition } from './graph-guards.js';
+import { importTokenDefinitions, setTokenDefinition } from './graph-import.js';
+import { createGraphColorResolver } from './graph-resolve.js';
+import { isThemeColorRuleDefinition } from './theme-rules.js';
+import { collectGraphDefinitionDependencies } from './graph-dependencies.js';
 
 export type ThemeMode = 'light' | 'dark';
 
 export interface TokenGraph {
   get(path: string, mode?: ThemeMode): TokenValue;
   getColor(def: ColorDefinition, mode?: ThemeMode): string;
+  inspect(path: string, mode?: ThemeMode): TokenGraphInspection;
   set(path: string, definition: TokenInput): void;
   on(handler: (path: string) => void): { dispose(): void };
   import(defs: TokenDefinitions): void;
   dispose(): void;
-}
-
-type StoredDefinition = ColorDefinition | TokenDefinition;
-
-function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === 'object' && value !== null && !Array.isArray(value); }
-
-function isTokenValue(value: unknown): value is TokenValue {
-  return isRecord(value) && typeof value['hex'] === 'string';
-}
-
-function isTokenDefinition(value: unknown): value is TokenDefinition {
-  return isRecord(value) && 'fg' in value;
-}
-
-function isNestedDefinitions(value: unknown): value is TokenDefinitions {
-  return isRecord(value)
-    && !isTokenValue(value)
-    && !isTokenDefinition(value)
-    && !('ref' in value)
-    && !('light' in value);
 }
 
 export function createTokenGraph(initial?: TokenDefinitions): TokenGraph {
@@ -38,117 +29,13 @@ export function createTokenGraph(initial?: TokenDefinitions): TokenGraph {
   const subscribers = new Set<(path: string) => void>();
   const tokenCache = new Map<string, TokenValue>();
   const rgbCache = new Map<string, RGB | null>();
+  const resolver = createGraphColorResolver(definitions, rgbCache);
 
-  if (initial) {
-    importInternal('', initial);
-  }
-
-  function importInternal(basePath: string, defs: TokenDefinitions): void {
-    for (const [key, value] of Object.entries(defs)) {
-      const fullPath = basePath ? `${basePath}.${key}` : key;
-
-      if (isTokenValue(value)) {
-        definitions.set(fullPath, {
-          fg: value.hex,
-          bg: value.bg,
-          modifiers: value.modifiers,
-          fgRGB: value.fgRGB,
-          bgRGB: value.bgRGB,
-        });
-      } else if (isNestedDefinitions(value)) {
-        importInternal(fullPath, value);
-      } else {
-        definitions.set(fullPath, value);
-      }
-    }
-  }
+  if (initial) importTokenDefinitions(definitions, initial);
 
   function clearCaches(): void {
     tokenCache.clear();
     rgbCache.clear();
-  }
-
-  function resolveRgb(hex: string | undefined): RGB | undefined {
-    if (hex == null) return undefined;
-    if (rgbCache.has(hex)) {
-      return rgbCache.get(hex) ?? undefined;
-    }
-
-    const rgb = tryHexToRgb(hex);
-    rgbCache.set(hex, rgb ?? null);
-    return rgb;
-  }
-
-  function resolveColor(def: ColorDefinition, mode: ThemeMode, visited: Set<string>): string {
-    if (typeof def === 'string') {
-      try {
-        return rgbToHex(hexToRgb(def));
-      } catch {
-        return def;
-      }
-    }
-
-    if ('light' in def && 'dark' in def) {
-      return resolveColor(mode === 'light' ? def.light : def.dark, mode, visited);
-    }
-
-    if ('ref' in def) {
-      if (visited.has(def.ref)) {
-        throw new Error(`Circular token reference detected: ${Array.from(visited).join(' -> ')} -> ${def.ref}`);
-      }
-      visited.add(def.ref);
-
-      const target = definitions.get(def.ref);
-      if (!target) {
-        throw new Error(`Token reference not found: ${def.ref}`);
-      }
-
-      let color: string;
-      if (isTokenDefinition(target)) {
-        color = resolveColor(target.fg, mode, visited);
-      } else {
-        color = resolveColor(target, mode, visited);
-      }
-
-      if (def.transform) {
-        for (const t of def.transform) {
-          color = applyTransform(color, t, mode, visited);
-        }
-      }
-
-      return color;
-    }
-
-    throw new Error(`Invalid color definition: ${JSON.stringify(def)}`);
-  }
-
-  function applyTransform(color: string, transform: ColorTransform, mode: ThemeMode, visited: Set<string>): string {
-    const dummyToken: TokenValue = { hex: color };
-    let result: TokenValue;
-
-    switch (transform.type) {
-      case 'darken': result = darken(dummyToken, transform.amount); break;
-      case 'lighten': result = lighten(dummyToken, transform.amount); break;
-      case 'saturate': result = saturate(dummyToken, transform.amount); break;
-      case 'desaturate': result = desaturate(dummyToken, transform.amount); break;
-      case 'complementary': result = complementary(dummyToken); break;
-      case 'inverse': {
-        const rgb = hexToRgb(color);
-        result = { hex: rgbToHex([255 - rgb[0], 255 - rgb[1], 255 - rgb[2]]) };
-        break;
-      }
-      case 'mix': {
-        const otherColor = resolveColor({ ref: transform.with }, mode, visited);
-        result = mix(dummyToken, { hex: otherColor }, transform.ratio ?? 0.5);
-        break;
-      }
-      default: {
-        const exhaustive: never = transform;
-        throw new Error(`Unknown transform type: ${String(exhaustive)}`);
-      }
-    }
-
-    return result.hex;
   }
 
   const graph: TokenGraph = {
@@ -160,51 +47,33 @@ export function createTokenGraph(initial?: TokenDefinitions): TokenGraph {
       const def = definitions.get(path);
       if (!def) throw new Error(`Token not found: ${path}`);
 
-      if (isTokenDefinition(def)) {
-        const tokenDef = def;
-        const token = {
-          hex: resolveColor(tokenDef.fg, mode, new Set([path])),
-          bg: tokenDef.bg ? resolveColor(tokenDef.bg, mode, new Set([path])) : undefined,
-          modifiers: tokenDef.modifiers,
-        };
-        const resolved: TokenValue = {
-          ...token,
-          fgRGB: tokenDef.fgRGB ?? resolveRgb(token.hex),
-          bgRGB: token.bg != null ? (tokenDef.bgRGB ?? resolveRgb(token.bg)) : undefined,
-        };
-        tokenCache.set(cacheKey, resolved);
-        return resolved;
-      }
-
-      const hex = resolveColor(def, mode, new Set([path]));
-      const resolved: TokenValue = {
-        hex,
-        fgRGB: resolveRgb(hex),
-      };
+      const resolved = isTokenDefinition(def)
+        ? resolveTokenValue(path, def, mode)
+        : resolveColorValue(path, def, mode);
       tokenCache.set(cacheKey, resolved);
       return resolved;
     },
 
     getColor(def, mode = 'dark') {
-      return resolveColor(def, mode, new Set());
+      return resolver.resolveColor(def, mode, new Set());
+    },
+
+    inspect(path, mode = 'dark') {
+      const def = definitions.get(path);
+      if (!def) throw new Error(`Token not found: ${path}`);
+      if (isThemeColorRuleDefinition(def)) return resolver.inspectRule(def, path, mode);
+      return {
+        kind: isTokenDefinition(def) ? 'token' : 'color',
+        path,
+        mode,
+        hex: graph.get(path, mode).hex,
+        dependencies: collectGraphDefinitionDependencies(def),
+      };
     },
 
     set(path, definition) {
-      if (isTokenValue(definition)) {
-        definitions.set(path, {
-          fg: definition.hex,
-          bg: definition.bg,
-          modifiers: definition.modifiers,
-          fgRGB: definition.fgRGB,
-          bgRGB: definition.bgRGB,
-        });
-      } else {
-        definitions.set(path, definition);
-      }
-      clearCaches();
-      for (const handler of subscribers) {
-        handler(path);
-      }
+      setTokenDefinition(definitions, path, definition);
+      notify(path);
     },
 
     on(handler) {
@@ -217,11 +86,8 @@ export function createTokenGraph(initial?: TokenDefinitions): TokenGraph {
     },
 
     import(defs) {
-      importInternal('', defs);
-      clearCaches();
-      for (const handler of subscribers) {
-        handler('*');
-      }
+      importTokenDefinitions(definitions, defs);
+      notify('*');
     },
 
     dispose() {
@@ -230,6 +96,31 @@ export function createTokenGraph(initial?: TokenDefinitions): TokenGraph {
       subscribers.clear();
     },
   };
+
+  function resolveTokenValue(path: string, def: TokenDefinition, mode: ThemeMode): TokenValue {
+    const hex = resolver.resolveColor(def.fg, mode, new Set([path]));
+    const bg = def.bg ? resolver.resolveColor(def.bg, mode, new Set([path])) : undefined;
+    return {
+      hex,
+      ...(bg === undefined ? {} : { bg }),
+      ...(def.modifiers === undefined ? {} : { modifiers: def.modifiers }),
+      fgRGB: def.fgRGB ?? resolver.resolveRgb(hex),
+      ...(bg === undefined ? {} : { bgRGB: def.bgRGB ?? resolver.resolveRgb(bg) }),
+    };
+  }
+
+  function resolveColorValue(path: string, def: StoredDefinition, mode: ThemeMode): TokenValue {
+    const hex = resolver.resolveColor(def, mode, new Set([path]));
+    return {
+      hex,
+      fgRGB: resolver.resolveRgb(hex),
+    };
+  }
+
+  function notify(path: string): void {
+    clearCaches();
+    for (const handler of subscribers) handler(path);
+  }
 
   return graph;
 }

--- a/packages/bijou/src/core/theme/index.ts
+++ b/packages/bijou/src/core/theme/index.ts
@@ -1,12 +1,3 @@
-/**
- * Theme module barrel — re-exports all theme types, presets, utilities,
- * gradient helpers, resolver, DTCG interop, color downsampling, and
- * color manipulation functions.
- *
- * @module
- */
-
-// Token types
 export type {
   RGB,
   GradientStop,
@@ -45,15 +36,12 @@ export type {
   TokenThemeMode,
 } from './builder.js';
 
-// Presets
 export { BIJOU_DARK, BIJOU_LIGHT, CYAN_MAGENTA, TEAL_ORANGE_PINK, PRESETS, tv } from './presets.js';
 
 export * from './styled.js';
 
-// Theme extension
 export { extendTheme } from './extend.js';
 
-// Theme doctor
 export { defineThemeSafePairs, doctorTheme, themeContrastRatio } from './doctor.js';
 export type {
   ThemeContrastPair,
@@ -68,26 +56,19 @@ export type {
   ThemeSafePairOptions,
 } from './doctor.js';
 
-// Gradient
 export { lerp3, gradientText } from './gradient.js';
 
-// Resolver
 export {
   isNoColor,
   createThemeResolver,
   createResolved,
 } from './resolve.js';
 export type { ResolvedTheme, ThemeResolver, ThemeResolverOptions } from './resolve.js';
-
-
-// Gradient options
 export type { GradientTextOptions } from './gradient.js';
 
-// DTCG interop
 export { fromDTCG, toDTCG } from './dtcg.js';
 export type { DTCGDocument, DTCGToken, DTCGGroup } from './dtcg.js';
 
-// Color downsampling
 export {
   rgbToAnsi256,
   nearestAnsi256,
@@ -95,20 +76,41 @@ export {
   ansi256ToAnsi16,
   type ColorLevel,
 } from './downsample.js';
-// Theme accessors
 export { createThemeAccessors, type ThemeAccessors } from './accessors.js';
 
-// Reactive Token Graph
 export { createTokenGraph } from './graph.js';
 export type { TokenGraph, ThemeMode } from './graph.js';
+export {
+  bestContrastWith,
+  closestColor,
+  colorCandidate,
+  isThemeColorRuleDefinition,
+  leastVivid,
+  minContrastWith,
+  mostVivid,
+  nthColor,
+  scope,
+  tokenCandidate,
+} from './theme-rules.js';
+export type { MinContrastRuleOptions, VividRuleOptions } from './theme-rules.js';
 export type {
   ColorDefinition,
   TokenDefinition,
   TokenDefinitions,
   ColorTransform,
+  ThemeColorRuleDefinition,
+  ThemeRuleCandidateInput,
+  ThemeRuleCandidateInspection,
+  ThemeRuleCandidateReason,
+  ThemeRuleCandidateScope,
+  ThemeRuleCandidateSource,
+  ThemeRuleCandidatePath,
+  ThemeRuleCandidateValue,
+  ThemeRuleInspection,
+  ThemeTokenInspection,
+  TokenGraphInspection,
 } from './graph-types.js';
 
-// Color manipulation
 export {
   color,
   colorHex,

--- a/packages/bijou/src/core/theme/theme-rule-candidates.ts
+++ b/packages/bijou/src/core/theme/theme-rule-candidates.ts
@@ -5,6 +5,7 @@ import type {
   ThemeColorRuleDefinition,
   ThemeRuleCandidateInput,
 } from './graph-types.js';
+import { hasThemeRulePath } from './theme-rule-paths.js';
 
 type ThemeMode = 'light' | 'dark';
 
@@ -27,15 +28,8 @@ export function collectThemeRuleCandidates(
   rule: ThemeColorRuleDefinition,
   context: ThemeRuleCandidateContext,
 ): readonly ThemeRuleCandidate[] {
-  const excluded = new Set<string>();
-  if ((rule.rule === 'most-vivid' || rule.rule === 'least-vivid') && rule.not !== undefined) {
-    for (const path of rule.not) excluded.add(path);
-  }
-
-  if (isCandidateScope(rule.candidates) && rule.candidates.not !== undefined) {
-    for (const path of rule.candidates.not) excluded.add(path);
-  }
-
+  const excluded = collectExcludedPaths(rule);
+  for (const path of excluded) assertKnownPath(context.definitions, path, 'exclusion');
   const inputs = candidateInputs(rule.candidates, context.definitions);
   return inputs.map(input => resolveCandidate(input, excluded, context));
 }
@@ -44,7 +38,16 @@ function candidateInputs(
   candidates: ThemeColorRuleDefinition['candidates'],
   definitions: ReadonlyMap<string, StoredDefinition>,
 ): readonly ThemeRuleCandidateInput[] {
-  return isCandidateScope(candidates) ? scopeInputs(candidates.path, definitions) : candidates;
+  if (!isCandidateScope(candidates)) {
+    return candidates.map(input => {
+      const path = candidatePath(input);
+      if (path !== undefined) assertKnownPath(definitions, path, 'candidate');
+      return input;
+    });
+  }
+  const inputs = scopeInputs(candidates.path, definitions);
+  if (inputs.length === 0) throw new Error(`Theme rule candidate scope not found: ${candidates.path}`);
+  return inputs;
 }
 
 function isCandidateScope(
@@ -75,24 +78,52 @@ function resolveCandidate(
   const rawValue = candidateRawValue(input);
   const label = candidateLabel(input, path, rawValue);
 
-  try {
-    const hex = path === undefined
-      ? rgbToHex(hexToRgb(rawValue ?? label))
-      : context.resolveColor({ ref: path }, context.mode, new Set(context.visited));
+  if (path !== undefined) {
+    const hex = context.resolveColor({ ref: path }, context.mode, new Set(context.visited));
     return {
       label,
-      ...(path === undefined ? {} : { path }),
+      path,
       hex,
-      excluded: path !== undefined && excluded.has(path),
+      excluded: excluded.has(path),
+      invalid: false,
+    };
+  }
+
+  try {
+    const hex = rgbToHex(hexToRgb(rawValue ?? label));
+    return {
+      label,
+      hex,
+      excluded: false,
       invalid: false,
     };
   } catch {
     return {
       label,
-      ...(path === undefined ? {} : { path }),
-      excluded: path !== undefined && excluded.has(path),
+      excluded: false,
       invalid: true,
     };
+  }
+}
+
+function collectExcludedPaths(rule: ThemeColorRuleDefinition): ReadonlySet<string> {
+  const excluded = new Set<string>();
+  if ((rule.rule === 'most-vivid' || rule.rule === 'least-vivid') && rule.not !== undefined) {
+    for (const path of rule.not) excluded.add(path);
+  }
+  if (isCandidateScope(rule.candidates) && rule.candidates.not !== undefined) {
+    for (const path of rule.candidates.not) excluded.add(path);
+  }
+  return excluded;
+}
+
+function assertKnownPath(
+  definitions: ReadonlyMap<string, StoredDefinition>,
+  path: string,
+  role: 'candidate' | 'exclusion',
+): void {
+  if (!hasThemeRulePath(definitions, path)) {
+    throw new Error(`Theme rule ${role} path not found: ${path}`);
   }
 }
 

--- a/packages/bijou/src/core/theme/theme-rule-candidates.ts
+++ b/packages/bijou/src/core/theme/theme-rule-candidates.ts
@@ -90,7 +90,8 @@ function resolveCandidate(
       excluded: path !== undefined && excluded.has(path),
       invalid: false,
     };
-  } catch {
+  } catch (error) {
+    if (shouldPropagateCandidateError(error)) throw error;
     return {
       label,
       ...(path === undefined ? {} : { path }),
@@ -98,6 +99,10 @@ function resolveCandidate(
       invalid: true,
     };
   }
+}
+
+function shouldPropagateCandidateError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith('Circular token reference');
 }
 
 function collectExcludedPaths(rule: ThemeColorRuleDefinition): ReadonlySet<string> {

--- a/packages/bijou/src/core/theme/theme-rule-candidates.ts
+++ b/packages/bijou/src/core/theme/theme-rule-candidates.ts
@@ -1,0 +1,117 @@
+import { hexToRgb, rgbToHex } from './color.js';
+import type { StoredDefinition } from './graph-guards.js';
+import type {
+  ColorDefinition,
+  ThemeColorRuleDefinition,
+  ThemeRuleCandidateInput,
+} from './graph-types.js';
+
+type ThemeMode = 'light' | 'dark';
+
+export interface ThemeRuleCandidateContext {
+  readonly definitions: ReadonlyMap<string, StoredDefinition>;
+  readonly mode: ThemeMode;
+  readonly visited: Set<string>;
+  resolveColor(def: ColorDefinition, mode: ThemeMode, visited: Set<string>): string;
+}
+
+export interface ThemeRuleCandidate {
+  readonly path?: string;
+  readonly label: string;
+  readonly hex?: string;
+  readonly excluded: boolean;
+  readonly invalid: boolean;
+}
+
+export function collectThemeRuleCandidates(
+  rule: ThemeColorRuleDefinition,
+  context: ThemeRuleCandidateContext,
+): readonly ThemeRuleCandidate[] {
+  const excluded = new Set<string>();
+  if ((rule.rule === 'most-vivid' || rule.rule === 'least-vivid') && rule.not !== undefined) {
+    for (const path of rule.not) excluded.add(path);
+  }
+
+  if (isCandidateScope(rule.candidates) && rule.candidates.not !== undefined) {
+    for (const path of rule.candidates.not) excluded.add(path);
+  }
+
+  const inputs = candidateInputs(rule.candidates, context.definitions);
+  return inputs.map(input => resolveCandidate(input, excluded, context));
+}
+
+function candidateInputs(
+  candidates: ThemeColorRuleDefinition['candidates'],
+  definitions: ReadonlyMap<string, StoredDefinition>,
+): readonly ThemeRuleCandidateInput[] {
+  return isCandidateScope(candidates) ? scopeInputs(candidates.path, definitions) : candidates;
+}
+
+function isCandidateScope(
+  candidates: ThemeColorRuleDefinition['candidates'],
+): candidates is Extract<ThemeColorRuleDefinition['candidates'], { readonly kind: 'scope' }> {
+  return !isCandidateArray(candidates);
+}
+
+function isCandidateArray(
+  candidates: ThemeColorRuleDefinition['candidates'],
+): candidates is readonly ThemeRuleCandidateInput[] {
+  return Array.isArray(candidates);
+}
+
+function scopeInputs(scope: string, definitions: ReadonlyMap<string, StoredDefinition>): readonly ThemeRuleCandidateInput[] {
+  const prefix = `${scope}.`;
+  return [...definitions.keys()]
+    .filter(path => path.startsWith(prefix) && !path.slice(prefix.length).includes('.'))
+    .map(path => ({ kind: 'path' as const, path }));
+}
+
+function resolveCandidate(
+  input: ThemeRuleCandidateInput,
+  excluded: ReadonlySet<string>,
+  context: ThemeRuleCandidateContext,
+): ThemeRuleCandidate {
+  const path = candidatePath(input);
+  const rawValue = candidateRawValue(input);
+  const label = candidateLabel(input, path, rawValue);
+
+  try {
+    const hex = path === undefined
+      ? rgbToHex(hexToRgb(rawValue ?? label))
+      : context.resolveColor({ ref: path }, context.mode, new Set(context.visited));
+    return {
+      label,
+      ...(path === undefined ? {} : { path }),
+      hex,
+      excluded: path !== undefined && excluded.has(path),
+      invalid: false,
+    };
+  } catch {
+    return {
+      label,
+      ...(path === undefined ? {} : { path }),
+      excluded: path !== undefined && excluded.has(path),
+      invalid: true,
+    };
+  }
+}
+
+function candidatePath(input: ThemeRuleCandidateInput): string | undefined {
+  if (typeof input === 'string') return input.startsWith('#') ? undefined : input;
+  return input.kind === 'path' ? input.path : undefined;
+}
+
+function candidateRawValue(input: ThemeRuleCandidateInput): string | undefined {
+  if (typeof input === 'string') return input.startsWith('#') ? input : undefined;
+  return input.kind === 'value' ? input.value : undefined;
+}
+
+function candidateLabel(
+  input: ThemeRuleCandidateInput,
+  path: string | undefined,
+  rawValue: string | undefined,
+): string {
+  if (path !== undefined) return path;
+  if (typeof input === 'object' && input.kind === 'value' && input.label !== undefined) return input.label;
+  return rawValue ?? 'candidate';
+}

--- a/packages/bijou/src/core/theme/theme-rule-candidates.ts
+++ b/packages/bijou/src/core/theme/theme-rule-candidates.ts
@@ -78,29 +78,23 @@ function resolveCandidate(
   const rawValue = candidateRawValue(input);
   const label = candidateLabel(input, path, rawValue);
 
-  if (path !== undefined) {
-    const hex = context.resolveColor({ ref: path }, context.mode, new Set(context.visited));
-    return {
-      label,
-      path,
-      hex,
-      excluded: excluded.has(path),
-      invalid: false,
-    };
-  }
-
   try {
-    const hex = rgbToHex(hexToRgb(rawValue ?? label));
+    const sourceColor = path === undefined
+      ? rawValue ?? label
+      : context.resolveColor({ ref: path }, context.mode, new Set(context.visited));
+    const hex = rgbToHex(hexToRgb(sourceColor));
     return {
       label,
+      ...(path === undefined ? {} : { path }),
       hex,
-      excluded: false,
+      excluded: path !== undefined && excluded.has(path),
       invalid: false,
     };
   } catch {
     return {
       label,
-      excluded: false,
+      ...(path === undefined ? {} : { path }),
+      excluded: path !== undefined && excluded.has(path),
       invalid: true,
     };
   }

--- a/packages/bijou/src/core/theme/theme-rule-color-validation.ts
+++ b/packages/bijou/src/core/theme/theme-rule-color-validation.ts
@@ -1,0 +1,17 @@
+import { rgbToHex, tryHexToRgb } from './color.js';
+import type { ThemeColorRuleDefinition } from './graph-types.js';
+
+type ThemeRuleColorRole = 'target' | 'against';
+
+export function normalizeThemeRuleColor(
+  color: string,
+  rule: ThemeColorRuleDefinition['rule'],
+  path: string,
+  role: ThemeRuleColorRole,
+): string {
+  const rgb = tryHexToRgb(color);
+  if (rgb === undefined) {
+    throw new Error(`Theme rule "${rule}" for "${path}" has invalid ${role} color: ${color}`);
+  }
+  return rgbToHex(rgb);
+}

--- a/packages/bijou/src/core/theme/theme-rule-evaluate.ts
+++ b/packages/bijou/src/core/theme/theme-rule-evaluate.ts
@@ -72,7 +72,7 @@ function rankCandidate(
   against: string | undefined,
 ): RankedCandidate {
   const ratio = candidate.hex !== undefined && against !== undefined ? themeContrastRatio(candidate.hex, against) : undefined;
-  const minContrast = vividMinContrast(rule);
+  const minContrast = ruleMinContrast(rule);
   const contrastOk = minContrast === undefined || (ratio ?? 0) >= minContrast;
   const score = scoreThemeRuleCandidate(rule, candidate.hex, target, ratio);
   return {
@@ -125,6 +125,10 @@ function vividAgainst(rule: ThemeColorRuleDefinition): ColorDefinition | undefin
 
 function vividMinContrast(rule: ThemeColorRuleDefinition): number | undefined {
   return rule.rule === 'most-vivid' || rule.rule === 'least-vivid' ? rule.minContrast : undefined;
+}
+
+function ruleMinContrast(rule: ThemeColorRuleDefinition): number | undefined {
+  return rule.rule === 'min-contrast-with' ? rule.ratio ?? 4.5 : vividMinContrast(rule);
 }
 
 function addColorDeps(def: ColorDefinition, deps: Set<string>): void {

--- a/packages/bijou/src/core/theme/theme-rule-evaluate.ts
+++ b/packages/bijou/src/core/theme/theme-rule-evaluate.ts
@@ -1,5 +1,6 @@
 import { themeContrastRatio } from './doctor.js';
 import type { StoredDefinition } from './graph-guards.js';
+import { normalizeThemeRuleColor } from './theme-rule-color-validation.js';
 import { collectThemeRuleCandidates, type ThemeRuleCandidate } from './theme-rule-candidates.js';
 import { nthThemeRuleIndex, scoreThemeRuleCandidate } from './theme-rule-metrics.js';
 import type {
@@ -54,13 +55,15 @@ function rankCandidates(
   candidates: readonly ThemeRuleCandidate[],
   context: ThemeRuleContext,
 ): readonly RankedCandidate[] {
-  const target = 'target' in rule ? context.resolveColor(rule.target, context.mode, new Set(context.visited)) : undefined;
+  const target = 'target' in rule
+    ? normalizeThemeRuleColor(context.resolveColor(rule.target, context.mode, new Set(context.visited)), rule.rule, context.path, 'target')
+    : undefined;
   const againstDef = vividAgainst(rule);
   if (vividMinContrast(rule) !== undefined && againstDef === undefined) {
     throw new Error(`Theme rule "${rule.rule}" for "${context.path}" requires "against" when "minContrast" is set.`);
   }
   const against = againstDef !== undefined
-    ? context.resolveColor(againstDef, context.mode, new Set(context.visited))
+    ? normalizeThemeRuleColor(context.resolveColor(againstDef, context.mode, new Set(context.visited)), rule.rule, context.path, 'against')
     : target;
   return candidates.map(candidate => rankCandidate(rule, candidate, target, against));
 }

--- a/packages/bijou/src/core/theme/theme-rule-evaluate.ts
+++ b/packages/bijou/src/core/theme/theme-rule-evaluate.ts
@@ -133,8 +133,12 @@ function ruleMinContrast(rule: ThemeColorRuleDefinition): number | undefined {
 
 function addColorDeps(def: ColorDefinition, deps: Set<string>): void {
   if (typeof def === 'string') return;
-  if ('ref' in def) deps.add(def.ref);
-  else if ('light' in def) {
+  if ('ref' in def) {
+    deps.add(def.ref);
+    for (const transform of def.transform ?? []) {
+      if (transform.type === 'mix') deps.add(transform.with);
+    }
+  } else if ('light' in def) {
     addColorDeps(def.light, deps);
     addColorDeps(def.dark, deps);
   }

--- a/packages/bijou/src/core/theme/theme-rule-evaluate.ts
+++ b/packages/bijou/src/core/theme/theme-rule-evaluate.ts
@@ -56,6 +56,9 @@ function rankCandidates(
 ): readonly RankedCandidate[] {
   const target = 'target' in rule ? context.resolveColor(rule.target, context.mode, new Set(context.visited)) : undefined;
   const againstDef = vividAgainst(rule);
+  if (vividMinContrast(rule) !== undefined && againstDef === undefined) {
+    throw new Error(`Theme rule "${rule.rule}" for "${context.path}" requires "against" when "minContrast" is set.`);
+  }
   const against = againstDef !== undefined
     ? context.resolveColor(againstDef, context.mode, new Set(context.visited))
     : target;

--- a/packages/bijou/src/core/theme/theme-rule-evaluate.ts
+++ b/packages/bijou/src/core/theme/theme-rule-evaluate.ts
@@ -1,0 +1,134 @@
+import { themeContrastRatio } from './doctor.js';
+import type { StoredDefinition } from './graph-guards.js';
+import { collectThemeRuleCandidates, type ThemeRuleCandidate } from './theme-rule-candidates.js';
+import { nthThemeRuleIndex, scoreThemeRuleCandidate } from './theme-rule-metrics.js';
+import type {
+  ColorDefinition,
+  ThemeColorRuleDefinition,
+  ThemeRuleCandidateInspection,
+  ThemeRuleCandidateReason,
+  ThemeRuleInspection,
+} from './graph-types.js';
+
+type ThemeMode = 'light' | 'dark';
+
+export interface ThemeRuleContext {
+  readonly definitions: ReadonlyMap<string, StoredDefinition>;
+  readonly mode: ThemeMode;
+  readonly path: string;
+  readonly visited: Set<string>;
+  resolveColor(def: ColorDefinition, mode: ThemeMode, visited: Set<string>): string;
+}
+
+interface RankedCandidate extends ThemeRuleCandidate {
+  readonly ratio?: number;
+  readonly score: number;
+  readonly selectable: boolean;
+}
+
+export function evaluateThemeColorRule(
+  rule: ThemeColorRuleDefinition,
+  context: ThemeRuleContext,
+): ThemeRuleInspection {
+  const candidates = collectThemeRuleCandidates(rule, context);
+  const ranked = rankCandidates(rule, candidates, context);
+  const selected = chooseCandidate(rule, ranked);
+  if (selected === undefined) {
+    throw new Error(`Theme rule "${rule.rule}" for "${context.path}" has no selectable candidates.`);
+  }
+
+  return {
+    kind: 'rule',
+    path: context.path,
+    mode: context.mode,
+    rule: rule.rule,
+    hex: selected.hex ?? selected.label,
+    selected: inspectCandidate(selected, true),
+    candidates: ranked.map(candidate => inspectCandidate(candidate, candidate === selected)),
+    dependencies: collectDependencies(rule, candidates),
+  };
+}
+
+function rankCandidates(
+  rule: ThemeColorRuleDefinition,
+  candidates: readonly ThemeRuleCandidate[],
+  context: ThemeRuleContext,
+): readonly RankedCandidate[] {
+  const target = 'target' in rule ? context.resolveColor(rule.target, context.mode, new Set(context.visited)) : undefined;
+  const againstDef = vividAgainst(rule);
+  const against = againstDef !== undefined
+    ? context.resolveColor(againstDef, context.mode, new Set(context.visited))
+    : target;
+  return candidates.map(candidate => rankCandidate(rule, candidate, target, against));
+}
+
+function rankCandidate(
+  rule: ThemeColorRuleDefinition,
+  candidate: ThemeRuleCandidate,
+  target: string | undefined,
+  against: string | undefined,
+): RankedCandidate {
+  const ratio = candidate.hex !== undefined && against !== undefined ? themeContrastRatio(candidate.hex, against) : undefined;
+  const minContrast = vividMinContrast(rule);
+  const contrastOk = minContrast === undefined || (ratio ?? 0) >= minContrast;
+  const score = scoreThemeRuleCandidate(rule, candidate.hex, target, ratio);
+  return {
+    ...candidate,
+    ...(ratio === undefined ? {} : { ratio }),
+    score,
+    selectable: candidate.hex !== undefined && !candidate.excluded && !candidate.invalid && contrastOk,
+  };
+}
+
+function chooseCandidate(rule: ThemeColorRuleDefinition, ranked: readonly RankedCandidate[]): RankedCandidate | undefined {
+  const selectable = ranked.filter(candidate => candidate.selectable);
+  if (rule.rule === 'min-contrast-with') return selectable.find(candidate => (candidate.ratio ?? 0) >= (rule.ratio ?? 4.5));
+  if (rule.rule === 'nth-color') return selectable[nthThemeRuleIndex(selectable.length, rule.index)];
+  return selectable.reduce<RankedCandidate | undefined>(
+    (best, candidate) => best === undefined || candidate.score > best.score ? candidate : best,
+    undefined,
+  );
+}
+
+function inspectCandidate(candidate: RankedCandidate, selected: boolean): ThemeRuleCandidateInspection {
+  const reasons: ThemeRuleCandidateReason[] = [];
+  if (selected) reasons.push('selected');
+  else if (candidate.excluded) reasons.push('excluded');
+  else if (candidate.invalid) reasons.push('invalid');
+  else if (!candidate.selectable) reasons.push('contrast-too-low');
+  else reasons.push('eligible', 'not-selected');
+  return {
+    label: candidate.label,
+    ...(candidate.path === undefined ? {} : { path: candidate.path }),
+    ...(candidate.hex === undefined ? {} : { hex: candidate.hex }),
+    ...(candidate.ratio === undefined ? {} : { ratio: candidate.ratio }),
+    score: candidate.score,
+    reasons,
+  };
+}
+
+function collectDependencies(rule: ThemeColorRuleDefinition, candidates: readonly ThemeRuleCandidate[]): readonly string[] {
+  const deps = new Set<string>();
+  if ('target' in rule) addColorDeps(rule.target, deps);
+  const against = vividAgainst(rule);
+  if (against !== undefined) addColorDeps(against, deps);
+  for (const candidate of candidates) if (candidate.path !== undefined) deps.add(candidate.path);
+  return [...deps];
+}
+
+function vividAgainst(rule: ThemeColorRuleDefinition): ColorDefinition | undefined {
+  return rule.rule === 'most-vivid' || rule.rule === 'least-vivid' ? rule.against : undefined;
+}
+
+function vividMinContrast(rule: ThemeColorRuleDefinition): number | undefined {
+  return rule.rule === 'most-vivid' || rule.rule === 'least-vivid' ? rule.minContrast : undefined;
+}
+
+function addColorDeps(def: ColorDefinition, deps: Set<string>): void {
+  if (typeof def === 'string') return;
+  if ('ref' in def) deps.add(def.ref);
+  else if ('light' in def) {
+    addColorDeps(def.light, deps);
+    addColorDeps(def.dark, deps);
+  }
+}

--- a/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
+++ b/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
@@ -50,4 +50,18 @@ describe('theme rule inspection', () => {
       'support.tint',
     ]));
   });
+
+  it('propagates circular candidate reference failures', () => {
+    const graph = createTokenGraph({
+      palette: {
+        ok: '#ffffff',
+      },
+      semantic: {
+        a: bestContrastWith('#000000', ['semantic.b', 'palette.ok']),
+        b: { ref: 'semantic.a' },
+      },
+    });
+
+    expect(() => graph.get('semantic.a')).toThrow(/Circular token reference/);
+  });
 });

--- a/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
+++ b/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
@@ -3,6 +3,26 @@ import { createTokenGraph } from './graph.js';
 import { bestContrastWith, scope } from './theme-rules.js';
 
 describe('theme rule inspection', () => {
+  it('marks invalid resolved path candidates without aborting inspection', () => {
+    const graph = createTokenGraph({
+      palette: {
+        broken: 'not-a-color',
+        paper: '#ffffff',
+      },
+      surface: {
+        canvas: { fg: '#ffffff', bg: '#000000' },
+      },
+      semantic: {
+        primary: bestContrastWith({ ref: 'surface.canvas.bg' }, scope('palette')),
+      },
+    });
+
+    expect(graph.get('semantic.primary').hex).toBe('#ffffff');
+    const inspected = graph.inspect('semantic.primary');
+    if (inspected.kind !== 'rule') throw new Error('Expected rule inspection.');
+    expect(inspected.candidates.find(candidate => candidate.path === 'palette.broken')?.reasons).toContain('invalid');
+  });
+
   it('includes mix transform references in rule dependencies', () => {
     const graph = createTokenGraph({
       palette: {

--- a/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
+++ b/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
@@ -64,4 +64,21 @@ describe('theme rule inspection', () => {
 
     expect(() => graph.get('semantic.a')).toThrow(/Circular token reference/);
   });
+
+  it('rejects invalid rule target colors', () => {
+    const graph = createTokenGraph({
+      palette: {
+        ink: '#000000',
+        paper: '#ffffff',
+      },
+      surface: {
+        bad: 'not-a-color',
+      },
+      semantic: {
+        primary: bestContrastWith({ ref: 'surface.bad' }, scope('palette')),
+      },
+    });
+
+    expect(() => graph.get('semantic.primary')).toThrow(/invalid target color/);
+  });
 });

--- a/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
+++ b/packages/bijou/src/core/theme/theme-rule-inspection.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createTokenGraph } from './graph.js';
+import { bestContrastWith, scope } from './theme-rules.js';
+
+describe('theme rule inspection', () => {
+  it('includes mix transform references in rule dependencies', () => {
+    const graph = createTokenGraph({
+      palette: {
+        ink: '#000000',
+        paper: '#ffffff',
+      },
+      support: {
+        tint: '#777777',
+      },
+      surface: {
+        canvas: { fg: '#ffffff', bg: '#000000' },
+      },
+      semantic: {
+        primary: bestContrastWith({
+          ref: 'surface.canvas.bg',
+          transform: [{ type: 'mix', with: 'support.tint', ratio: 0.5 }],
+        }, scope('palette')),
+      },
+    });
+
+    const inspected = graph.inspect('semantic.primary');
+    if (inspected.kind !== 'rule') throw new Error('Expected rule inspection.');
+    expect(inspected.dependencies).toEqual(expect.arrayContaining([
+      'surface.canvas.bg',
+      'support.tint',
+    ]));
+  });
+});

--- a/packages/bijou/src/core/theme/theme-rule-metrics.ts
+++ b/packages/bijou/src/core/theme/theme-rule-metrics.ts
@@ -1,0 +1,39 @@
+import { hexToRgb } from './color.js';
+import type { ThemeColorRuleDefinition } from './graph-types.js';
+
+export function scoreThemeRuleCandidate(
+  rule: ThemeColorRuleDefinition,
+  hex: string | undefined,
+  target: string | undefined,
+  ratio: number | undefined,
+): number {
+  if (hex === undefined) return Number.NEGATIVE_INFINITY;
+  if (rule.rule === 'best-contrast-with' || rule.rule === 'min-contrast-with') return ratio ?? 0;
+  if (rule.rule === 'closest-color') {
+    return target === undefined ? Number.NEGATIVE_INFINITY : -rgbDistance(hex, target);
+  }
+  if (rule.rule === 'least-vivid') return -chroma(hex);
+  if (rule.rule === 'nth-color') return 0;
+  return chroma(hex);
+}
+
+export function nthThemeRuleIndex(length: number, index: number): number {
+  if (length === 0) return -1;
+  if (Number.isInteger(index)) {
+    return index < 0 ? Math.max(0, length + index) : Math.min(length - 1, index);
+  }
+
+  const clamped = Math.max(0, Math.min(1, index));
+  return Math.round((length - 1) * clamped);
+}
+
+function chroma(hex: string): number {
+  const [r, g, b] = hexToRgb(hex);
+  return Math.max(r, g, b) - Math.min(r, g, b);
+}
+
+function rgbDistance(a: string, b: string): number {
+  const ar = hexToRgb(a);
+  const br = hexToRgb(b);
+  return (ar[0] - br[0]) ** 2 + (ar[1] - br[1]) ** 2 + (ar[2] - br[2]) ** 2;
+}

--- a/packages/bijou/src/core/theme/theme-rule-paths.ts
+++ b/packages/bijou/src/core/theme/theme-rule-paths.ts
@@ -1,0 +1,8 @@
+import { isTokenDefinition, type StoredDefinition } from './graph-guards.js';
+
+export function hasThemeRulePath(definitions: ReadonlyMap<string, StoredDefinition>, path: string): boolean {
+  if (definitions.has(path)) return true;
+  if (!path.endsWith('.bg')) return false;
+  const token = definitions.get(path.slice(0, -3));
+  return token !== undefined && isTokenDefinition(token) && token.bg !== undefined;
+}

--- a/packages/bijou/src/core/theme/theme-rules.test.ts
+++ b/packages/bijou/src/core/theme/theme-rules.test.ts
@@ -44,6 +44,9 @@ describe('theme rule selectors', () => {
     });
 
     expect(graph.get('semantic.muted').hex).toBe('#999999');
+    const inspected = graph.inspect('semantic.muted');
+    if (inspected.kind !== 'rule') throw new Error('Expected rule inspection.');
+    expect(inspected.candidates.find(candidate => candidate.path === 'palette.weak')?.reasons).toContain('contrast-too-low');
   });
 
   it('keeps reserved roles out of vivid accent selection and explains rejection', () => {

--- a/packages/bijou/src/core/theme/theme-rules.test.ts
+++ b/packages/bijou/src/core/theme/theme-rules.test.ts
@@ -71,6 +71,13 @@ describe('theme rule selectors', () => {
     if (inspected.kind !== 'rule') throw new Error('Expected rule inspection.');
     expect(inspected.selected?.path).toBe('palette.blue');
     expect(inspected.candidates.find(candidate => candidate.path === 'palette.red')?.reasons).toContain('excluded');
+    expect(inspected.dependencies).toEqual(expect.arrayContaining([
+      'surface.canvas.bg',
+      'palette.red',
+      'palette.green',
+      'palette.blue',
+      'palette.gray',
+    ]));
   });
 
   it('supports deterministic ordered and closest-color selection', () => {
@@ -99,5 +106,33 @@ describe('theme rule selectors', () => {
     });
 
     expect(() => graph.get('semantic.a')).toThrow(/Circular token reference/);
+  });
+
+  it('fails malformed candidate contracts with explicit paths', () => {
+    const missingCandidate = createTokenGraph({
+      palette: { ok: '#ffffff' },
+      semantic: { bad: bestContrastWith('#000000', ['palette.missing']) },
+    });
+    const missingScope = createTokenGraph({
+      semantic: { bad: bestContrastWith('#000000', scope('palette')) },
+    });
+    const missingExclusion = createTokenGraph({
+      palette: { ok: '#ffffff' },
+      semantic: {
+        bad: mostVivid(scope('palette'), {
+          against: '#000000',
+          not: ['palette.missing'],
+        }),
+      },
+    });
+    const missingAgainst = createTokenGraph({
+      palette: { ok: '#ffffff' },
+      semantic: { bad: mostVivid(scope('palette'), { minContrast: 4.5 }) },
+    });
+
+    expect(() => missingCandidate.get('semantic.bad')).toThrow(/candidate path not found: palette\.missing/);
+    expect(() => missingScope.get('semantic.bad')).toThrow(/candidate scope not found: palette/);
+    expect(() => missingExclusion.get('semantic.bad')).toThrow(/exclusion path not found: palette\.missing/);
+    expect(() => missingAgainst.get('semantic.bad')).toThrow(/requires "against"/);
   });
 });

--- a/packages/bijou/src/core/theme/theme-rules.test.ts
+++ b/packages/bijou/src/core/theme/theme-rules.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { createTokenGraph } from './graph.js';
+import {
+  bestContrastWith,
+  closestColor,
+  minContrastWith,
+  mostVivid,
+  nthColor,
+  scope,
+} from './theme-rules.js';
+
+describe('theme rule selectors', () => {
+  it('chooses the highest contrast candidate from a scope', () => {
+    const graph = createTokenGraph({
+      palette: {
+        black: '#000000',
+        gray: '#777777',
+        white: '#ffffff',
+      },
+      surface: {
+        canvas: { fg: '#ffffff', bg: '#000000' },
+      },
+      semantic: {
+        primary: bestContrastWith({ ref: 'surface.canvas.bg' }, scope('palette')),
+      },
+    });
+
+    expect(graph.get('semantic.primary').hex).toBe('#ffffff');
+  });
+
+  it('chooses the first candidate that clears a minimum contrast ratio', () => {
+    const graph = createTokenGraph({
+      palette: {
+        weak: '#222222',
+        pass: '#999999',
+        stronger: '#ffffff',
+      },
+      surface: {
+        canvas: { fg: '#ffffff', bg: '#000000' },
+      },
+      semantic: {
+        muted: minContrastWith({ ref: 'surface.canvas.bg' }, scope('palette'), { ratio: 4.5 }),
+      },
+    });
+
+    expect(graph.get('semantic.muted').hex).toBe('#999999');
+  });
+
+  it('keeps reserved roles out of vivid accent selection and explains rejection', () => {
+    const graph = createTokenGraph({
+      palette: {
+        red: '#ff0000',
+        green: '#00ff00',
+        blue: '#3399ff',
+        gray: '#777777',
+      },
+      surface: {
+        canvas: { fg: '#ffffff', bg: '#000000' },
+      },
+      semantic: {
+        accent: mostVivid(scope('palette'), {
+          against: { ref: 'surface.canvas.bg' },
+          minContrast: 4.5,
+          not: ['palette.red', 'palette.green'],
+        }),
+      },
+    });
+
+    expect(graph.get('semantic.accent').hex).toBe('#3399ff');
+    const inspected = graph.inspect('semantic.accent');
+    if (inspected.kind !== 'rule') throw new Error('Expected rule inspection.');
+    expect(inspected.selected?.path).toBe('palette.blue');
+    expect(inspected.candidates.find(candidate => candidate.path === 'palette.red')?.reasons).toContain('excluded');
+  });
+
+  it('supports deterministic ordered and closest-color selection', () => {
+    const graph = createTokenGraph({
+      ramp: {
+        low: '#111111',
+        mid: '#777777',
+        high: '#eeeeee',
+      },
+      semantic: {
+        ordered: nthColor(scope('ramp'), 0.5),
+        close: closestColor('#777778', scope('ramp')),
+      },
+    });
+
+    expect(graph.get('semantic.ordered').hex).toBe('#777777');
+    expect(graph.get('semantic.close').hex).toBe('#777777');
+  });
+
+  it('keeps circular rule references deterministic', () => {
+    const graph = createTokenGraph({
+      semantic: {
+        a: bestContrastWith({ ref: 'semantic.b' }, ['#000000', '#ffffff']),
+        b: bestContrastWith({ ref: 'semantic.a' }, ['#000000', '#ffffff']),
+      },
+    });
+
+    expect(() => graph.get('semantic.a')).toThrow(/Circular token reference/);
+  });
+});

--- a/packages/bijou/src/core/theme/theme-rules.ts
+++ b/packages/bijou/src/core/theme/theme-rules.ts
@@ -1,0 +1,131 @@
+import type {
+  ColorDefinition,
+  ThemeColorRuleDefinition,
+  ThemeRuleCandidateInput,
+  ThemeRuleCandidateScope,
+  ThemeRuleCandidateSource,
+} from './graph-types.js';
+
+export interface MinContrastRuleOptions {
+  readonly ratio: number;
+}
+
+export interface VividRuleOptions {
+  readonly against?: ColorDefinition;
+  readonly minContrast?: number;
+  readonly not?: readonly string[];
+}
+
+export function scope(path: string, options: { readonly not?: readonly string[] } = {}): ThemeRuleCandidateScope {
+  assertNonEmpty(path, 'Theme rule scope path');
+  return Object.freeze({
+    kind: 'scope' as const,
+    path,
+    ...(options.not === undefined ? {} : { not: [...options.not] }),
+  });
+}
+
+export function tokenCandidate(path: string): ThemeRuleCandidateInput {
+  assertNonEmpty(path, 'Theme rule candidate path');
+  return Object.freeze({
+    kind: 'path' as const,
+    path,
+  });
+}
+
+export function colorCandidate(value: string, label?: string): ThemeRuleCandidateInput {
+  assertNonEmpty(value, 'Theme rule candidate color');
+  return Object.freeze({
+    kind: 'value' as const,
+    value,
+    ...(label === undefined ? {} : { label }),
+  });
+}
+
+export function bestContrastWith(
+  target: ColorDefinition,
+  candidates: ThemeRuleCandidateSource,
+): ThemeColorRuleDefinition {
+  return Object.freeze({
+    rule: 'best-contrast-with' as const,
+    target,
+    candidates,
+  });
+}
+
+export function minContrastWith(
+  target: ColorDefinition,
+  candidates: ThemeRuleCandidateSource,
+  options: MinContrastRuleOptions,
+): ThemeColorRuleDefinition {
+  return Object.freeze({
+    rule: 'min-contrast-with' as const,
+    target,
+    candidates,
+    ratio: options.ratio,
+  });
+}
+
+export function mostVivid(
+  candidates: ThemeRuleCandidateSource,
+  options: VividRuleOptions = {},
+): ThemeColorRuleDefinition {
+  return vividRule('most-vivid', candidates, options);
+}
+
+export function leastVivid(
+  candidates: ThemeRuleCandidateSource,
+  options: VividRuleOptions = {},
+): ThemeColorRuleDefinition {
+  return vividRule('least-vivid', candidates, options);
+}
+
+export function closestColor(
+  target: ColorDefinition,
+  candidates: ThemeRuleCandidateSource,
+): ThemeColorRuleDefinition {
+  return Object.freeze({
+    rule: 'closest-color' as const,
+    target,
+    candidates,
+  });
+}
+
+export function nthColor(candidates: ThemeRuleCandidateSource, index: number): ThemeColorRuleDefinition {
+  return Object.freeze({
+    rule: 'nth-color' as const,
+    candidates,
+    index,
+  });
+}
+
+export function isThemeColorRuleDefinition(value: unknown): value is ThemeColorRuleDefinition {
+  if (typeof value !== 'object' || value === null || Array.isArray(value) || !('rule' in value)) return false;
+  const rule = value.rule;
+  return rule === 'best-contrast-with'
+    || rule === 'min-contrast-with'
+    || rule === 'most-vivid'
+    || rule === 'least-vivid'
+    || rule === 'closest-color'
+    || rule === 'nth-color';
+}
+
+function vividRule(
+  rule: 'most-vivid' | 'least-vivid',
+  candidates: ThemeRuleCandidateSource,
+  options: VividRuleOptions,
+): ThemeColorRuleDefinition {
+  return Object.freeze({
+    rule,
+    candidates,
+    ...(options.against === undefined ? {} : { against: options.against }),
+    ...(options.minContrast === undefined ? {} : { minContrast: options.minContrast }),
+    ...(options.not === undefined ? {} : { not: [...options.not] }),
+  });
+}
+
+function assertNonEmpty(value: string, label: string): void {
+  if (value.trim() === '') {
+    throw new Error(`${label} is required.`);
+  }
+}

--- a/packages/bijou/src/index.part07.ts
+++ b/packages/bijou/src/index.part07.ts
@@ -1,6 +1,4 @@
-// Theme engine
 export {
-  // Types
   type RGB,
   type GradientStop,
   type TextModifier,
@@ -31,16 +29,13 @@ export {
   type ThemeTokenRef,
   type TokenTheme,
   type TokenThemeMode,
-  // Presets
   BIJOU_DARK,
   BIJOU_LIGHT,
   CYAN_MAGENTA,
   TEAL_ORANGE_PINK,
   PRESETS,
   tv,
-  // Theme extension
   extendTheme,
-  // Theme doctor
   defineThemeSafePairs,
   doctorTheme,
   themeContrastRatio,
@@ -54,34 +49,27 @@ export {
   type ThemeSafePairBuilder,
   type ThemeSafePairKind,
   type ThemeSafePairOptions,
-  // Gradient
   lerp3,
   gradientText,
-  // Gradient options
   type GradientTextOptions,
-  // Resolver
   isNoColor,
   createThemeResolver,
   createResolved,
   type ResolvedTheme,
   type ThemeResolver,
   type ThemeResolverOptions,
-  // DTCG interop
   fromDTCG,
   toDTCG,
   type DTCGDocument,
   type DTCGToken,
   type DTCGGroup,
-  // Color downsampling
   rgbToAnsi256,
   nearestAnsi256,
   rgbToAnsi16,
   ansi256ToAnsi16,
   type ColorLevel,
-  // Theme accessors
   createThemeAccessors,
   type ThemeAccessors,
-  // Color manipulation
   color,
   colorHex,
   colorRgb,
@@ -98,14 +86,36 @@ export {
   desaturate,
   type ColorRef,
   type ResolvedColor,
-  // Reactive Token Graph
   createTokenGraph,
+  bestContrastWith,
+  closestColor,
+  colorCandidate,
+  isThemeColorRuleDefinition,
+  leastVivid,
+  minContrastWith,
+  mostVivid,
+  nthColor,
+  scope,
+  tokenCandidate,
   type TokenGraph,
   type ThemeMode,
   type ColorDefinition,
   type TokenDefinition,
   type TokenDefinitions,
   type ColorTransform,
+  type MinContrastRuleOptions,
+  type VividRuleOptions,
+  type ThemeColorRuleDefinition,
+  type ThemeRuleCandidateInput,
+  type ThemeRuleCandidateInspection,
+  type ThemeRuleCandidateReason,
+  type ThemeRuleCandidateScope,
+  type ThemeRuleCandidateSource,
+  type ThemeRuleCandidatePath,
+  type ThemeRuleCandidateValue,
+  type ThemeRuleInspection,
+  type ThemeTokenInspection,
+  type TokenGraphInspection,
 } from './core/theme/index.js';
 
 export * from './core/theme/styled.js';

--- a/scripts/hooks.test.ts
+++ b/scripts/hooks.test.ts
@@ -20,12 +20,10 @@ describe('git hooks', () => {
     const typecheckIndex = hook.indexOf('npm run typecheck:test');
     const testIndex = hook.indexOf('npm run test:run');
     const interactiveSmokeIndex = hook.indexOf('npm run verify:interactive-examples');
-
     expect(pathGateIndex).toBeGreaterThanOrEqual(0);
     expect(skipIndex).toBeGreaterThan(pathGateIndex);
     expect(fullPushIndex).toBeGreaterThan(pathGateIndex);
-    expect(hook).toContain('examples/docs/*)');
-    expect(hook).toContain('scripts/dogfood-*)');
+    for (const pattern of ['docs/*)', 'examples/docs/*)', 'scripts/dogfood-*)']) expect(hook).toContain(pattern);
     expect(i18nCompleteIndex).toBeGreaterThanOrEqual(0);
     expect(i18nCheckIndex).toBeGreaterThan(i18nCompleteIndex);
     expect(i18nDebtIndex).toBeGreaterThan(i18nCheckIndex);
@@ -38,8 +36,8 @@ describe('git hooks', () => {
   });
 
   it('CI workflow policy is parsed from the test job instead of raw string scanning', () => {
+    const workflow = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf8');
     const policy = readCiWorkflowPolicy(resolve(ROOT, '.github/workflows/ci.yml'));
-
     expect(policy.testJob.checkoutUses).toBe('actions/checkout@v6');
     expect(policy.testJob.checkoutFetchDepth).toBeGreaterThanOrEqual(2);
     expect(policy.testJob.i18nPolicyGateName).toBe('DOGFOOD i18n policy gate');
@@ -48,6 +46,7 @@ describe('git hooks', () => {
     expect(policy.testJob.i18nPolicyGateRun).toContain('npm run dogfood:i18n:complete -- --base HEAD^');
     expect(policy.testJob.i18nPolicyGateRun).toContain('npm run dogfood:i18n:debt -- --base HEAD^');
     expect(policy.testJob.i18nPolicyGateRun).toContain('npm run dogfood:i18n:check');
+    expect(workflow).toContain('docs/*)');
     expect(policy.testJob.testRunCommand).toBe('npm run test:run');
   });
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -18,7 +18,7 @@ is_dogfood_relevant_path() {
     scripts/smoke-dogfood*) return 0 ;;
     tests/cycles/DF-*) return 0 ;;
     tests/cycles/*dogfood*) return 0 ;;
-    docs/DOGFOOD.md) return 0 ;;
+    docs/*) return 0 ;;
     docs/design/DF-*) return 0 ;;
     docs/legends/DF-*) return 0 ;;
     docs/method/legends/DF-*) return 0 ;;

--- a/tests/cycles/DL-019/theme-rule-selection-and-inspection.test.ts
+++ b/tests/cycles/DL-019/theme-rule-selection-and-inspection.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { readRepoFile } from '../repo.js';
+
+describe('DL-019 theme rule selection and inspection', () => {
+  it('qualifies vivid selector readability in recipe docs', () => {
+    const recipes = readRepoFile('docs/design-system/theme-rule-recipes.md');
+    const normalized = recipes.replace(/\s+/g, ' ');
+
+    expect(normalized).toContain(
+      '`mostVivid(candidates, options)` chooses the highest-chroma candidate; ' +
+      'it is readable only when `against` and `minContrast` are provided.',
+    );
+    expect(normalized).toContain(
+      '`leastVivid(candidates, options)` chooses the lowest-chroma candidate; ' +
+      'it uses the same readability rule.',
+    );
+  });
+});

--- a/tests/cycles/DL-019/theme-rule-selection-and-inspection.test.ts
+++ b/tests/cycles/DL-019/theme-rule-selection-and-inspection.test.ts
@@ -15,4 +15,11 @@ describe('DL-019 theme rule selection and inspection', () => {
       'it uses the same readability rule.',
     );
   });
+
+  it('documents serialized scope data with the runtime discriminant', () => {
+    const design = readRepoFile('docs/design/DL-019-theme-rule-selection-and-inspection.md');
+
+    expect(design).toContain('candidates: { kind: "scope", path: "palette" }');
+    expect(design).not.toContain('candidates: { scope: "palette" }');
+  });
 });

--- a/tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
+++ b/tests/cycles/WF-129/path-gate-dogfood-ci.test.ts
@@ -32,7 +32,7 @@ describe('WF-129 path-gate DOGFOOD CI', () => {
       'scripts/smoke-dogfood*',
       'tests/cycles/DF-*',
       'tests/cycles/*dogfood*',
-      'docs/DOGFOOD.md',
+      'docs/*',
       'docs/design/DF-*',
       'docs/legends/DF-*',
       'docs/method/legends/DF-*',


### PR DESCRIPTION
## Summary

- shapes DL-019 for Bijou-native theme rule selection and inspection
- records the dependency boundary: no `design-book` integration or dependency
- defines the selector, inspection, accessibility, localization, and validation contract before implementation

## Method

Refs #444
Design: `docs/design/DL-019-theme-rule-selection-and-inspection.md`

## Validation

- pre-commit Code Dojo gate during `git commit`
- pre-push full verification during `git push`
  - `npm run code-dojo:debt`
  - file/context threshold scan
  - mock-ban scan
  - ESLint baseline scan
  - `npm run code:size`
  - `npm run typecheck:test`
  - full Vitest suite in 18 chunks
  - scripted interactive examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new design document describing theme rule selection and inspection behavior.
  * Outlined supported rule types for choosing theme token candidates, including contrast-based, vividness-based, closest-color, and ordered selection options.
  * Defined expected inspection details, failure handling, and compatibility requirements for theme token lookup.
  * Included implementation steps, test coverage ideas, and acceptance criteria for the new API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->