### PR TITLE
DL-020 Dogfood rule-authored themes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Fixed
 
+- **DOGFOOD Theme Lab readability** — DOGFOOD docs now render Markdown prose
+  with the active semantic foreground, choose contrast-filtered docs chrome
+  colors for light shells, and show the active shell palette first in Theme
+  Lab.
 - **DOGFOOD docs validation** — Local pre-push and CI path classification now
   treat all `docs/*` changes as DOGFOOD-relevant, so documentation edits run
   the DOGFOOD i18n policy gates instead of only `docs/DOGFOOD.md` doing so.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   rules for contrast, vividness, closest-color, and ordered palette choices,
   plus `TokenGraph.inspect()` facts that explain selected and rejected
   candidates without adding an external design-token dependency.
+- **Rule-authored first-party themes** — DL-020 moves the owned `bijou-dark` and
+  `bijou-light` presets onto primitive palettes plus selector rules while
+  preserving the public `Theme` shape, DTCG round trips, and resolved theme
+  accessors.
 
 ### Fixed
 

--- a/docs/design-system/theme-rule-recipes.md
+++ b/docs/design-system/theme-rule-recipes.md
@@ -17,6 +17,12 @@ Rules live in `@flyingrobots/bijou`. They do not depend on external design
 token packages and they compile to the same `TokenValue` objects the renderer
 already consumes.
 
+Bijou dogfoods this flow for the owned `bijou-dark` and `bijou-light` presets:
+their primitive ink, brand, and surface palettes compile through `TokenGraph`
+rules into the same public `Theme` objects existing consumers already use.
+Legacy vivid themes and third-party palette fixtures remain literal
+compatibility presets.
+
 ## When To Use Rules
 
 Use a rule when a token should follow a stable decision:

--- a/docs/design/DL-020-dogfood-rule-authored-first-party-themes.md
+++ b/docs/design/DL-020-dogfood-rule-authored-first-party-themes.md
@@ -1,0 +1,107 @@
+---
+id: DL-020
+title: Dogfood Rule-Authored First-Party Themes
+status: active
+lane: cool-ideas
+priority: medium
+github_issue: 446
+legend: DL
+---
+
+# DL-020 - Dogfood Rule-Authored First-Party Themes
+
+Legend: [DL - Design Language](../legends/DL-design-language.md)
+
+## Decision Summary
+
+DL-019 added Bijou-native theme selector rules and inspection facts. This cycle
+uses that system inside Bijou's own first-party defaults instead of keeping the
+new rule layer as a demo-only API.
+
+The public runtime contract remains unchanged:
+
+```text
+rule-authored preset definitions
+  -> TokenGraph
+    -> concrete Theme
+      -> ResolvedTheme
+        -> terminal rendering, DTCG interop, and inspectors
+```
+
+No external design-token dependency is introduced. The work is a narrow dogfood
+pass over Bijou-owned themes only.
+
+## Sponsored Human
+
+A Bijou theme maintainer wants to adjust primitive palette choices and trust the
+system to derive readable semantic roles, accents, borders, and UI affordances
+without manually copying final hex values across every token family.
+
+## Sponsored Agent
+
+An agent auditing first-party themes wants deterministic provenance facts for
+why default theme tokens were selected, so it can review rule behavior instead
+of reverse-engineering intent from literal hex equality.
+
+## Hill
+
+`bijou-dark` and `bijou-light` are authored from primitive palette definitions
+plus selector rules, materialize to the existing `Theme` shape, and expose rule
+inspection facts that explain their first-party semantic choices.
+
+## Playback Questions
+
+- Can Bijou-owned defaults use selector rules while preserving the public
+  `Theme` object shape and registry keys?
+- Can tests prove first-party semantic choices through `TokenGraph.inspect()`
+  rather than only final hex assertions?
+- Can DTCG round trips, resolver behavior, RGB caches, and gradient consumers
+  keep working with compiled rule-authored presets?
+- Can third-party and legacy themes stay literal compatibility fixtures in this
+  slice?
+
+## Scope
+
+Included:
+
+- a small first-party preset authoring layer that compiles token graph
+  definitions into `Theme`
+- rule-authored `bijou-dark` and `bijou-light`
+- tests for compiled values, registry identity, and rule inspection provenance
+- docs/changelog updates that make dogfooding explicit
+
+Out of scope:
+
+- external `design-book` integration
+- public breaking changes to `Theme`
+- rewriting `cyan-magenta`, `teal-orange-pink`, `nord`, or `catppuccin`
+- Theme Lab UI redesign
+
+## Runtime Contract
+
+Preset compilation must be pure and deterministic. It cannot read process state,
+terminal facts, filesystem data, clocks, or network data.
+
+The compiled object remains a normal `Theme`. Existing consumers can continue to
+read `theme.semantic.primary.hex`, `theme.status.success`, `theme.gradient`, and
+surface tokens without knowing how first-party themes were authored.
+
+Inspection provenance is exposed through the token graph used during
+compilation. Tests may assert rule ids, selected candidate paths, dependencies,
+and selected hex values.
+
+## Localization And Directionality Posture
+
+This slice does not add DOGFOOD user-facing copy. Rule ids, token paths, design
+document prose, and changelog entries are developer-facing documentation and
+stable identifiers. Future DOGFOOD UI that renders these facts must use the
+localization catalog.
+
+## Linked Invariants
+
+- [Runtime Truth Wins](../invariants/runtime-truth-wins.md): compiled presets
+  and inspection facts come from executing the graph.
+- [Tests Are the Spec](../invariants/tests-are-the-spec.md): dogfood behavior
+  lands through deterministic tests.
+- [Docs Are the Demo](../invariants/docs-are-the-demo.md): the docs record that
+  Bijou's defaults use the system they document.

--- a/docs/design/DL-020-dogfood-rule-authored-first-party-themes.md
+++ b/docs/design/DL-020-dogfood-rule-authored-first-party-themes.md
@@ -86,9 +86,19 @@ The compiled object remains a normal `Theme`. Existing consumers can continue to
 read `theme.semantic.primary.hex`, `theme.status.success`, `theme.gradient`, and
 surface tokens without knowing how first-party themes were authored.
 
-Inspection provenance is exposed through the token graph used during
-compilation. Tests may assert rule ids, selected candidate paths, dependencies,
-and selected hex values.
+The preset authoring layer records the original rule definitions against the
+compiled `Theme` identity. `createResolved()` uses those definitions when
+present, so `ResolvedTheme.tokenGraph` remains rule-authored for first-party
+presets. Cloned themes and DTCG imports fall back to concrete token graphs.
+
+Tests may assert rule ids, selected candidate paths, dependencies, and selected
+hex values from the same resolved graph inspectors consume.
+
+## Accessibility And Assistive Posture
+
+This slice improves color choice but does not make color the only carrier of
+meaning. Existing labels, text structure, `NO_COLOR` behavior, and lower-mode
+rendering remain the accessibility contract.
 
 ## Localization And Directionality Posture
 
@@ -96,6 +106,35 @@ This slice does not add DOGFOOD user-facing copy. Rule ids, token paths, design
 document prose, and changelog entries are developer-facing documentation and
 stable identifiers. Future DOGFOOD UI that renders these facts must use the
 localization catalog.
+
+## Agent Inspectability / Explainability Posture
+
+The primary agent-facing value is provenance. An audit should be able to inspect
+`semantic.accent` and `decision.primaryText`, see the selector rule, enumerate
+candidates, and explain exclusions without comparing screenshots or final hex
+equality.
+
+## Implementation Outline
+
+1. Add a small preset compiler that materializes graph definitions into `Theme`.
+2. Move `bijou-dark` and `bijou-light` into rule-authored preset modules.
+3. Preserve first-party rule definitions through `createResolved()`.
+4. Keep literal legacy and third-party presets unchanged.
+5. Update docs and changelog after the tests prove the behavior.
+
+## Tests To Write First
+
+- a red provenance test showing literal defaults expose `token` inspection
+  instead of `rule`
+- a dark-theme accent test proving `most-vivid` selects `brand.accent`
+- a light-theme primary text test proving `min-contrast-with` selects
+  `ink.primary`
+- existing preset and DTCG tests proving resolved values stay compatible
+
+## Retrospective / Closeout Notes
+
+Close this cycle when CI is green, CodeRabbit is green, review threads are
+resolved, and the PR summary records the rule probe values.
 
 ## Linked Invariants
 

--- a/examples/docs/app-docs-theme-contrast.ts
+++ b/examples/docs/app-docs-theme-contrast.ts
@@ -1,0 +1,62 @@
+import { themeContrastRatio } from '../../packages/bijou/src/index.js';
+import {
+  pickStandoutColor,
+  sampleColorRamp,
+  type LandingThemeTokens,
+} from './app-landing.js';
+
+export const DOCS_READABLE_TEXT_RATIO = 7;
+export const DOCS_BODY_TEXT_RATIO = 4.5;
+export const DOCS_CHROME_RATIO = 3;
+
+export function docsPanelBackground(theme: LandingThemeTokens): string {
+  return sampleColorRamp(theme.waveRamp, 0.06);
+}
+
+export function docsReadableColor(
+  theme: LandingThemeTokens,
+  background: string,
+  base: string,
+  minRatio: number,
+): string {
+  return pickReadableColor(background, base, docsReadableCandidates(theme), minRatio);
+}
+
+export function pickReadableColor(
+  background: string,
+  base: string,
+  candidates: readonly string[],
+  minRatio: number,
+): string {
+  const readableCandidates = uniqueColors(candidates)
+    .filter((candidate) => (themeContrastRatio(candidate, background) ?? 0) >= minRatio);
+  return pickStandoutColor(
+    background,
+    base,
+    readableCandidates.length > 0 ? readableCandidates : candidates,
+  );
+}
+
+export function docsReadableCandidates(theme: LandingThemeTokens): readonly string[] {
+  return [
+    sampleColorRamp(theme.logoRamp, 0.98),
+    sampleColorRamp(theme.logoRamp, 0.88),
+    sampleColorRamp(theme.logoRamp, 0.72),
+    sampleColorRamp(theme.logoRamp, 0.5),
+    sampleColorRamp(theme.logoRamp, 0.28),
+    sampleColorRamp(theme.logoRamp, 0.12),
+    sampleColorRamp(theme.logoRamp, 0.02),
+    sampleColorRamp(theme.waveRamp, 0.98),
+    sampleColorRamp(theme.waveRamp, 0.88),
+    sampleColorRamp(theme.waveRamp, 0.72),
+    sampleColorRamp(theme.waveRamp, 0.5),
+    sampleColorRamp(theme.waveRamp, 0.28),
+    sampleColorRamp(theme.waveRamp, 0.12),
+    sampleColorRamp(theme.waveRamp, 0.02),
+    theme.background,
+  ];
+}
+
+function uniqueColors(colors: readonly string[]): readonly string[] {
+  return Array.from(new Set(colors));
+}

--- a/examples/docs/app-docs-theme-tokens.ts
+++ b/examples/docs/app-docs-theme-tokens.ts
@@ -1,40 +1,59 @@
 import type { PreferenceListTheme, TokenValue } from '../../packages/bijou/src/index.js';
 import {
-  pickStandoutColor,
   sampleColorRamp,
   type LandingThemeTokens,
 } from './app-landing.js';
+import {
+  DOCS_BODY_TEXT_RATIO,
+  DOCS_CHROME_RATIO,
+  DOCS_READABLE_TEXT_RATIO,
+  docsPanelBackground,
+  docsReadableCandidates,
+  docsReadableColor,
+  pickReadableColor,
+} from './app-docs-theme-contrast.js';
 
 export function docsThemeAccentToken(theme: LandingThemeTokens): TokenValue {
-  return { hex: sampleColorRamp(theme.logoRamp, 0.78), modifiers: ['bold'] };
+  return {
+    hex: docsReadableColor(theme, theme.background, sampleColorRamp(theme.logoRamp, 0.78), DOCS_BODY_TEXT_RATIO),
+    modifiers: ['bold'],
+  };
 }
 
 export function docsThemeBorderToken(theme: LandingThemeTokens): TokenValue {
-  return { hex: sampleColorRamp(theme.waveRamp, 0.58) };
+  const background = docsPanelBackground(theme);
+  return {
+    hex: docsReadableColor(theme, background, sampleColorRamp(theme.waveRamp, 0.58), DOCS_CHROME_RATIO),
+  };
 }
 
 export function docsThemeMutedBorderToken(theme: LandingThemeTokens): TokenValue {
-  return { hex: sampleColorRamp(theme.waveRamp, 0.36), modifiers: ['dim'] };
+  const background = docsPanelBackground(theme);
+  return {
+    hex: docsReadableColor(theme, background, sampleColorRamp(theme.waveRamp, 0.36), DOCS_CHROME_RATIO),
+  };
 }
 
 export function docsThemeSurfaceToken(theme: LandingThemeTokens): TokenValue {
+  const background = docsPanelBackground(theme);
   return {
-    hex: sampleColorRamp(theme.waveRamp, 0.44),
-    bg: sampleColorRamp(theme.waveRamp, 0.06),
+    hex: docsReadableColor(theme, background, sampleColorRamp(theme.waveRamp, 0.44), DOCS_READABLE_TEXT_RATIO),
+    bg: background,
   };
 }
 
 export function docsThemeSelectedRowBgToken(theme: LandingThemeTokens): TokenValue {
+  const background = sampleColorRamp(theme.waveRamp, 0.12);
   return {
-    hex: sampleColorRamp(theme.waveRamp, 0.62),
-    bg: sampleColorRamp(theme.waveRamp, 0.12),
+    hex: docsReadableColor(theme, background, sampleColorRamp(theme.waveRamp, 0.62), DOCS_READABLE_TEXT_RATIO),
+    bg: background,
   };
 }
 
 export function docsThemeDescriptionToken(theme: LandingThemeTokens): TokenValue {
+  const background = docsPanelBackground(theme);
   return {
-    hex: sampleColorRamp(theme.waveRamp, 0.58),
-    modifiers: ['dim'],
+    hex: docsReadableColor(theme, background, sampleColorRamp(theme.waveRamp, 0.58), DOCS_BODY_TEXT_RATIO),
   };
 }
 
@@ -42,12 +61,7 @@ export function resolveDocsThemeActiveHeaderTabToken(theme: LandingThemeTokens):
   const base = docsThemeSurfaceToken(theme).hex;
   const background = sampleColorRamp(theme.waveRamp, 0.14);
   return {
-    hex: pickStandoutColor(background, base, [
-      sampleColorRamp(theme.logoRamp, 0.98),
-      sampleColorRamp(theme.logoRamp, 0.84),
-      sampleColorRamp(theme.waveRamp, 0.88),
-      sampleColorRamp(theme.logoRamp, 0.62),
-    ]),
+    hex: docsReadableColor(theme, background, base, DOCS_BODY_TEXT_RATIO),
     bg: background,
     modifiers: ['bold'],
   };
@@ -62,26 +76,26 @@ export function docsThemeProgressTokens(theme: LandingThemeTokens): {
   const surface = docsThemeSurfaceToken(theme);
   const background = surface.bg ?? theme.background;
   const base = surface.hex;
-  const filledStart = pickStandoutColor(background, base, [
+  const filledStart = pickReadableColor(background, base, [
     sampleColorRamp(theme.waveRamp, 0.58),
     sampleColorRamp(theme.logoRamp, 0.34),
     sampleColorRamp(theme.waveRamp, 0.74),
-  ]);
-  const filledEnd = pickStandoutColor(background, filledStart, [
+    ...docsReadableCandidates(theme),
+  ], DOCS_CHROME_RATIO);
+  const filledEnd = pickReadableColor(background, filledStart, [
     sampleColorRamp(theme.logoRamp, 0.78),
     sampleColorRamp(theme.logoRamp, 0.96),
     sampleColorRamp(theme.waveRamp, 0.9),
-  ]);
+    ...docsReadableCandidates(theme),
+  ], DOCS_CHROME_RATIO);
   return {
     filledToken: { hex: filledStart, modifiers: ['bold'] },
     filledEndToken: { hex: filledEnd, modifiers: ['bold'] },
-    emptyToken: { hex: sampleColorRamp(theme.waveRamp, 0.22), modifiers: ['dim'] },
+    emptyToken: {
+      hex: docsReadableColor(theme, background, sampleColorRamp(theme.waveRamp, 0.22), DOCS_CHROME_RATIO),
+    },
     labelToken: {
-      hex: pickStandoutColor(background, base, [
-        sampleColorRamp(theme.logoRamp, 0.9),
-        sampleColorRamp(theme.waveRamp, 0.84),
-        sampleColorRamp(theme.logoRamp, 0.7),
-      ]),
+      hex: docsReadableColor(theme, background, base, DOCS_BODY_TEXT_RATIO),
       modifiers: ['bold'],
     },
   };
@@ -94,15 +108,17 @@ export function docsThemePreferenceListTheme(theme: LandingThemeTokens): Prefere
     toggleOnToken: docsThemeAccentToken(theme),
     toggleOffToken: docsThemeMutedBorderToken(theme),
     choiceToken: docsThemeAccentToken(theme),
-    infoToken: { hex: sampleColorRamp(theme.waveRamp, 0.82) },
+    infoToken: {
+      hex: docsReadableColor(theme, docsPanelBackground(theme), sampleColorRamp(theme.waveRamp, 0.82), DOCS_BODY_TEXT_RATIO),
+    },
     descriptionToken: docsThemeDescriptionToken(theme),
   };
 }
 
 export function docsThemeUnfocusedGutterToken(theme: LandingThemeTokens): TokenValue {
+  const background = sampleColorRamp(theme.waveRamp, 0.08);
   return {
-    hex: sampleColorRamp(theme.waveRamp, 0.38),
-    bg: sampleColorRamp(theme.waveRamp, 0.08),
-    modifiers: ['dim'],
+    hex: docsReadableColor(theme, background, sampleColorRamp(theme.waveRamp, 0.38), DOCS_CHROME_RATIO),
+    bg: background,
   };
 }

--- a/examples/docs/app-theme-lab.ts
+++ b/examples/docs/app-theme-lab.ts
@@ -1,0 +1,146 @@
+import {
+  BIJOU_DARK,
+  BIJOU_LIGHT,
+  boxSurface,
+  createSurface,
+  separatorSurface,
+  type BijouContext,
+  type Surface,
+} from '../../packages/bijou/src/index.js';
+import type { LocalizationPort } from '../../packages/bijou-i18n/src/index.js';
+import { column, proseSurface, spacer } from '../_shared/example-surfaces.js';
+import type { DocsShellThemeChoice } from './app-docs-shell-theme.js';
+import {
+  docsThemeBorderToken,
+  docsThemeMutedBorderToken,
+  docsThemeSurfaceToken,
+} from './app-docs-theme-tokens.js';
+import type { LandingThemeTokens } from './app-landing.js';
+import { dogfoodSafePairSummary, themeColorReuseSummary } from './app-theme-diagnostics.js';
+import { renderThemeTokenPalette } from './app-theme-token-palette.js';
+import { dogfoodLocalizedText } from './localization.js';
+
+interface ThemeLabPaneOptions {
+  readonly width: number;
+  readonly ctx: BijouContext;
+  readonly landingTheme: LandingThemeTokens;
+  readonly activeTheme: DocsShellThemeChoice;
+  readonly shellThemes: readonly DocsShellThemeChoice[];
+  readonly localization?: LocalizationPort;
+}
+
+function dogfoodText(
+  localization: LocalizationPort | undefined,
+  id: string,
+  fallback: string,
+  values: Readonly<Record<string, unknown>> = {},
+): string {
+  return dogfoodLocalizedText(localization, id, fallback, values);
+}
+
+export function renderThemeLabPane(options: ThemeLabPaneOptions): Surface {
+  const { width, ctx, landingTheme, activeTheme, shellThemes, localization } = options;
+  const paneWidth = themeLabPaneInnerWidth(width);
+  const bodyWidth = Math.max(24, paneWidth - 2);
+  const shellGallery = shellThemes
+    .map((shellTheme, index) => {
+      const marker = shellTheme.id === activeTheme.id ? '* ' : '  ';
+      return `${marker}${String(index + 1)}. ${shellTheme.label} -> ${shellTheme.theme.name}`;
+    })
+    .join('\n');
+  const defaultSummary = [
+    dogfoodText(localization, 'themeInspector.active', 'Active: {label}', { label: activeTheme.label }),
+    dogfoodText(localization, 'themeInspector.theme', 'Theme: {name}', { name: activeTheme.theme.name }),
+    dogfoodSafePairSummary(activeTheme.theme, localization),
+    dogfoodText(localization, 'themeLab.defaultDark', 'Default dark preset: {name} ({summary})', {
+      name: BIJOU_DARK.name,
+      summary: dogfoodSafePairSummary(BIJOU_DARK, localization),
+    }),
+    dogfoodText(localization, 'themeLab.defaultLight', 'Default light preset: {name} ({summary})', {
+      name: BIJOU_LIGHT.name,
+      summary: dogfoodSafePairSummary(BIJOU_LIGHT, localization),
+    }),
+    dogfoodText(localization, 'themeLab.colorReuseLine', 'Color reuse: dark {dark}; light {light}.', {
+      dark: themeColorReuseSummary(BIJOU_DARK, localization),
+      light: themeColorReuseSummary(BIJOU_LIGHT, localization),
+    }),
+    dogfoodText(
+      localization,
+      'themeLab.swatchCoverage',
+      'Swatches include semantic.primary, surface.primary, and gradient.brand rows.',
+    ),
+    dogfoodText(localization, 'themeLab.f10Hint', 'F10 opens the Theme Inspector drawer from the docs shell.'),
+  ].join('\n');
+
+  return themeLabInsetPaneSurface(column([
+    themeLabSeparatorSurface(dogfoodText(localization, 'themeLab.separator', 'docs • Theme Lab'), paneWidth, ctx, landingTheme),
+    spacer(1, 1),
+    themeLabBox(defaultSummary, dogfoodText(localization, 'themeLab.postureTitle', 'theme posture'), paneWidth, bodyWidth, ctx, landingTheme),
+    spacer(1, 1),
+    themeLabBox(shellGallery, dogfoodText(localization, 'themeLab.galleryTitle', 'shell gallery'), paneWidth, bodyWidth, ctx, landingTheme),
+    spacer(1, 1),
+    themeLabPalette(activeTheme.theme, activeTheme.label, paneWidth, bodyWidth, ctx, landingTheme, localization),
+    spacer(1, 1),
+    themeLabPalette(BIJOU_DARK, dogfoodText(localization, 'themeLab.darkSwatchesTitle', 'bijou-dark token swatches'), paneWidth, bodyWidth, ctx, landingTheme, localization),
+    spacer(1, 1),
+    themeLabPalette(BIJOU_LIGHT, dogfoodText(localization, 'themeLab.lightSwatchesTitle', 'bijou-light token swatches'), paneWidth, bodyWidth, ctx, landingTheme, localization),
+  ]), width);
+}
+
+function themeLabBox(
+  text: string,
+  title: string,
+  paneWidth: number,
+  bodyWidth: number,
+  ctx: BijouContext,
+  theme: LandingThemeTokens,
+): Surface {
+  return boxSurface(proseSurface(text, bodyWidth), {
+    title,
+    width: Math.max(28, paneWidth),
+    borderToken: docsThemeMutedBorderToken(theme),
+    bgToken: docsThemeSurfaceToken(theme),
+    padding: { left: 1, right: 1 },
+    ctx,
+  });
+}
+
+function themeLabPalette(
+  theme: typeof BIJOU_DARK,
+  title: string,
+  paneWidth: number,
+  bodyWidth: number,
+  ctx: BijouContext,
+  landingTheme: LandingThemeTokens,
+  localization: LocalizationPort | undefined,
+): Surface {
+  return boxSurface(renderThemeTokenPalette(theme, bodyWidth, localization, {
+    maxRows: 28,
+    chromeTheme: ctx.theme.theme,
+  }), {
+    title,
+    width: Math.max(28, paneWidth),
+    borderToken: docsThemeMutedBorderToken(landingTheme),
+    bgToken: docsThemeSurfaceToken(landingTheme),
+    padding: { left: 1, right: 1 },
+    ctx,
+  });
+}
+
+function themeLabSeparatorSurface(label: string, width: number, ctx: BijouContext, theme: LandingThemeTokens): Surface {
+  return separatorSurface({ label, width, ctx, borderToken: docsThemeBorderToken(theme) });
+}
+
+function themeLabPaneInnerWidth(width: number): number {
+  const inset = width >= 3 ? 1 : 0;
+  return Math.max(1, width - (inset * 2));
+}
+
+function themeLabInsetPaneSurface(content: Surface, width: number): Surface {
+  const safeWidth = Math.max(1, width);
+  const inset = safeWidth >= 3 ? 1 : 0;
+  const innerWidth = Math.max(1, safeWidth - (inset * 2));
+  const result = createSurface(safeWidth, content.height);
+  result.blit(content, inset, 0, 0, 0, innerWidth, content.height);
+  return result;
+}

--- a/examples/docs/app.ts
+++ b/examples/docs/app.ts
@@ -1,7 +1,5 @@
 import { readFileSync } from 'node:fs';
 import {
-  BIJOU_DARK,
-  BIJOU_LIGHT,
   boxSurface,
   createSurface,
   inspector,
@@ -178,7 +176,7 @@ import {
   standardBlockLoweringMarkdown,
   standardBlockPreviewMarkdown,
 } from './app-standard-block-docs.js';
-import { dogfoodSafePairSummary, themeColorReuseSummary } from './app-theme-diagnostics.js';
+import { dogfoodSafePairSummary } from './app-theme-diagnostics.js';
 import {
   clampThemeInspectorScroll,
   resolveThemeInspectorScrollY,
@@ -188,6 +186,7 @@ import {
   themeInspectorScrollTarget,
   themeInspectorViewportHeight,
 } from './app-theme-inspector-state.js';
+import { renderThemeLabPane } from './app-theme-lab.js';
 import { renderThemeTokenPalette } from './app-theme-token-palette.js';
 export { DOGFOOD_THEME_SAFE_PAIRS } from './dogfood-shell-themes.js';
 export { stripMarkdownFrontmatter } from './app-markdown.js';
@@ -1500,89 +1499,6 @@ function applyDocsShellThemeToContext(ctx: BijouContext, themeId: string | undef
   return applyShellThemeStateToContext(DOCS_SHELL_THEME_STATE, ctx, themeId);
 }
 
-function renderThemeLabPane(
-  width: number,
-  ctx: BijouContext,
-  landingTheme: LandingThemeTokens,
-  localization: LocalizationPort | undefined,
-): Surface {
-  const paneWidth = resolvePaneInnerWidth(width);
-  const bodyWidth = Math.max(24, paneWidth - 2);
-  const shellGallery = DOCS_SHELL_THEME_CHOICES
-    .map((shellTheme, index) => `${String(index + 1)}. ${shellTheme.label} -> ${shellTheme.theme.name}`)
-    .join('\n');
-  const defaultSummary = [
-    dogfoodText(localization, 'themeLab.defaultDark', 'Default dark preset: {name} ({summary})', {
-      name: BIJOU_DARK.name,
-      summary: dogfoodSafePairSummary(BIJOU_DARK, localization),
-    }),
-    dogfoodText(localization, 'themeLab.defaultLight', 'Default light preset: {name} ({summary})', {
-      name: BIJOU_LIGHT.name,
-      summary: dogfoodSafePairSummary(BIJOU_LIGHT, localization),
-    }),
-    dogfoodText(localization, 'themeLab.colorReuseLine', 'Color reuse: dark {dark}; light {light}.', {
-      dark: themeColorReuseSummary(BIJOU_DARK, localization),
-      light: themeColorReuseSummary(BIJOU_LIGHT, localization),
-    }),
-    dogfoodText(
-      localization,
-      'themeLab.swatchCoverage',
-      'Swatches include semantic.primary, surface.primary, and gradient.brand rows.',
-    ),
-    dogfoodText(
-      localization,
-      'themeLab.f10Hint',
-      'F10 opens the Theme Inspector drawer from the docs shell.',
-    ),
-  ].join('\n');
-
-  return insetPaneSurface(column([
-    themedSeparatorSurface(dogfoodText(localization, 'themeLab.separator', 'docs • Theme Lab'), paneWidth, ctx, landingTheme),
-    spacer(1, 1),
-    boxSurface(proseSurface(defaultSummary, bodyWidth), {
-      title: dogfoodText(localization, 'themeLab.postureTitle', 'theme posture'),
-      width: Math.max(28, paneWidth),
-      borderToken: docsThemeBorderToken(landingTheme),
-      bgToken: docsThemeSurfaceToken(landingTheme),
-      padding: { left: 1, right: 1 },
-      ctx,
-    }),
-    spacer(1, 1),
-    boxSurface(proseSurface(shellGallery, bodyWidth), {
-      title: dogfoodText(localization, 'themeLab.galleryTitle', 'shell gallery'),
-      width: Math.max(28, paneWidth),
-      borderToken: docsThemeMutedBorderToken(landingTheme),
-      bgToken: docsThemeSurfaceToken(landingTheme),
-      padding: { left: 1, right: 1 },
-      ctx,
-    }),
-    spacer(1, 1),
-    boxSurface(renderThemeTokenPalette(BIJOU_DARK, bodyWidth, localization, {
-      maxRows: 28,
-      chromeTheme: ctx.theme.theme,
-    }), {
-      title: dogfoodText(localization, 'themeLab.darkSwatchesTitle', 'bijou-dark token swatches'),
-      width: Math.max(28, paneWidth),
-      borderToken: docsThemeMutedBorderToken(landingTheme),
-      bgToken: docsThemeSurfaceToken(landingTheme),
-      padding: { left: 1, right: 1 },
-      ctx,
-    }),
-    spacer(1, 1),
-    boxSurface(renderThemeTokenPalette(BIJOU_LIGHT, bodyWidth, localization, {
-      maxRows: 28,
-      chromeTheme: ctx.theme.theme,
-    }), {
-      title: dogfoodText(localization, 'themeLab.lightSwatchesTitle', 'bijou-light token swatches'),
-      width: Math.max(28, paneWidth),
-      borderToken: docsThemeMutedBorderToken(landingTheme),
-      bgToken: docsThemeSurfaceToken(landingTheme),
-      padding: { left: 1, right: 1 },
-      ctx,
-    }),
-  ]), width);
-}
-
 function renderThemeInspectorDrawer(
   model: RootModel,
   ctx: BijouContext,
@@ -2049,10 +1965,19 @@ function renderGuideReaderPane(
   const doc = selectedGuide(pageId, model);
   if (doc == null) {
     return insetPaneSurface(column([
-      themedSeparatorSurface('docs', paneWidth, ctx, theme),
+      themedSeparatorSurface(
+        dogfoodText(localization, 'docs.reader.separator', 'docs'),
+        paneWidth,
+        ctx,
+        theme,
+      ),
       spacer(1, 1),
       boxSurface(paragraphSurface(
-        'This section does not have published docs yet.',
+        dogfoodText(
+          localization,
+          'docs.reader.unpublished',
+          'This section does not have published docs yet.',
+        ),
         Math.max(20, paneWidth - 6),
       ), {
         width: Math.max(22, paneWidth),
@@ -2078,7 +2003,14 @@ function renderGuideReaderPane(
     );
   }
   if (doc.id === THEME_LAB_GUIDE_ID) {
-    return renderThemeLabPane(width, ctx, theme, localization);
+    return renderThemeLabPane({
+      width,
+      ctx,
+      landingTheme: theme,
+      activeTheme: resolveDocsShellThemeById(model.activeShellThemeId),
+      shellThemes: DOCS_SHELL_THEME_CHOICES,
+      localization,
+    });
   }
 
   const docsWidth = Math.max(24, paneWidth - 2);

--- a/packages/bijou/src/core/components/markdown-render.ts
+++ b/packages/bijou/src/core/components/markdown-render.ts
@@ -20,8 +20,6 @@ export function renderBlocks(
   width: number,
 ): string {
   const mode = ctx.mode;
-  // `static` mode intentionally falls through to styled rendering (same as
-  // `interactive`). Only `pipe` and `accessible` get special treatment.
   const lines: string[] = [];
 
   for (const block of blocks) {
@@ -225,7 +223,9 @@ function wrapInlineMarkdown(
 ): string[] {
   const rendered = parseInline(text, ctx);
   if (ctx.mode === 'interactive' || ctx.mode === 'static') {
-    return wrapStyledInlineText(rendered, width);
+    return wrapStyledInlineText(rendered, width).map((line) => (
+      ctx.style.styled(ctx.semantic('primary'), line)
+    ));
   }
   return wordWrap(rendered, width);
 }

--- a/packages/bijou/src/core/components/markdown.part04.test.ts
+++ b/packages/bijou/src/core/components/markdown.part04.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { auditStyle, createTestContext } from '../../adapters/test/index.js';
+import { markdown } from './markdown.js';
+
+describe('markdown()', () => {
+  it('styles wrapped paragraph prose with the primary semantic token', () => {
+    const style = auditStyle();
+    const ctx = createTestContext({
+      mode: 'interactive',
+      runtime: { columns: 80 },
+      style,
+    });
+
+    markdown('Readable prose belongs to the active theme.', { ctx });
+
+    expect(style.wasStyled(ctx.semantic('primary'), 'Readable prose')).toBe(true);
+  });
+});

--- a/packages/bijou/src/core/theme/bijou-dark-preset.ts
+++ b/packages/bijou/src/core/theme/bijou-dark-preset.ts
@@ -1,0 +1,82 @@
+import type { Theme } from './tokens.js';
+import { compileRuleAuthoredPreset } from './preset-authoring.js';
+import { minContrastWith, mostVivid, scope } from './theme-rules.js';
+
+/**
+ * BIJOU_DARK — the calm first-party dark theme.
+ *
+ * This preset is intentionally less saturated than the legacy cyan/magenta
+ * palette. It keeps neutral surfaces dominant, separates focus/brand/status
+ * roles, and preserves readable foregrounds across dense product surfaces.
+ */
+export const BIJOU_DARK: Theme = compileRuleAuthoredPreset({
+  name: 'bijou-dark',
+  mode: 'dark',
+  definitions: {
+    ink: { primary: '#f4e8bf', secondary: '#d8def0', elevated: '#f8f0d0', muted: '#a8b1c7' },
+    brand: { primary: '#7aa7e8', accent: '#f2c45d', success: '#8bd67d', error: '#ff8a80', info: '#8fbaff' },
+    surfaceBase: {
+      primary: '#171827',
+      secondary: '#20243a',
+      elevated: '#29304d',
+      overlay: '#10121f',
+      muted: '#131625',
+    },
+    borderBase: { muted: '#77809d' },
+    uiBase: { trackEmpty: '#2a3150' },
+    decision: {
+      primaryText: minContrastWith({ ref: 'surface.primary.bg' }, scope('ink'), { ratio: 4.5 }),
+    },
+    status: {
+      success: { ref: 'brand.success' },
+      error: { ref: 'brand.error' },
+      warning: { ref: 'brand.accent' },
+      info: { ref: 'brand.info' },
+      pending: { fg: { ref: 'ink.muted' }, modifiers: ['dim'] },
+      active: { ref: 'semantic.accent' },
+      muted: { fg: { ref: 'ink.muted' }, modifiers: ['dim', 'strikethrough'] },
+    },
+    semantic: {
+      success: { ref: 'status.success' },
+      error: { ref: 'status.error' },
+      warning: { ref: 'status.warning' },
+      info: { ref: 'status.info' },
+      accent: mostVivid(scope('brand'), {
+        against: { ref: 'surface.primary.bg' },
+        minContrast: 4.5,
+        not: ['brand.success', 'brand.error'],
+      }),
+      muted: { fg: { ref: 'ink.muted' }, modifiers: ['dim'] },
+      primary: { fg: { ref: 'decision.primaryText' }, modifiers: ['bold'] },
+    },
+    border: {
+      primary: { ref: 'brand.primary' },
+      secondary: { ref: 'semantic.accent' },
+      success: { ref: 'semantic.success' },
+      warning: { ref: 'semantic.warning' },
+      error: { ref: 'semantic.error' },
+      muted: { ref: 'borderBase.muted' },
+    },
+    ui: {
+      cursor: { ref: 'semantic.accent' },
+      focusGutter: { fg: { ref: 'semantic.accent' }, bg: { ref: 'surface.primary.bg' }, modifiers: ['bold'] },
+      scrollThumb: { ref: 'brand.primary' },
+      scrollTrack: { ref: 'borderBase.muted' },
+      sectionHeader: { fg: { ref: 'semantic.accent' }, modifiers: ['bold'] },
+      logo: { ref: 'semantic.accent' },
+      tableHeader: { fg: { ref: 'decision.primaryText' }, modifiers: ['bold'] },
+      trackEmpty: { ref: 'uiBase.trackEmpty' },
+    },
+    surface: {
+      primary: { fg: { ref: 'decision.primaryText' }, bg: { ref: 'surfaceBase.primary' } },
+      secondary: { fg: { ref: 'ink.secondary' }, bg: { ref: 'surfaceBase.secondary' } },
+      elevated: { fg: { ref: 'ink.elevated' }, bg: { ref: 'surfaceBase.elevated' } },
+      overlay: { fg: { ref: 'ink.elevated' }, bg: { ref: 'surfaceBase.overlay' } },
+      muted: { fg: { ref: 'ink.muted' }, bg: { ref: 'surfaceBase.muted' } },
+    },
+  },
+  gradient: {
+    brand: [{ ref: 'brand.primary' }, { ref: 'semantic.accent' }, { ref: 'brand.error' }],
+    progress: [{ ref: 'brand.primary' }, { ref: 'brand.success' }, { ref: 'semantic.accent' }, { ref: 'brand.error' }],
+  },
+});

--- a/packages/bijou/src/core/theme/bijou-light-preset.ts
+++ b/packages/bijou/src/core/theme/bijou-light-preset.ts
@@ -1,0 +1,85 @@
+import type { Theme } from './tokens.js';
+import { compileRuleAuthoredPreset } from './preset-authoring.js';
+import { minContrastWith, mostVivid, scope } from './theme-rules.js';
+
+/**
+ * BIJOU_LIGHT — the calm first-party light theme.
+ *
+ * The light preset mirrors the dark theme's roles while using ink-forward
+ * foregrounds instead of pastel text, so dense terminal surfaces remain
+ * scannable on bright backgrounds.
+ */
+export const BIJOU_LIGHT: Theme = compileRuleAuthoredPreset({
+  name: 'bijou-light',
+  mode: 'light',
+  definitions: {
+    ink: { primary: '#1e2433', secondary: '#252b38', elevated: '#1e2433', muted: '#5e6778' },
+    brand: { primary: '#285c9e', accent: '#7a5200', success: '#246a3d', error: '#a33a3a', info: '#285c9e' },
+    surfaceBase: {
+      primary: '#fbf7ea',
+      secondary: '#efe7d2',
+      elevated: '#fffdf6',
+      overlay: '#f5eddb',
+      muted: '#ece4d1',
+    },
+    borderBase: {
+      muted: '#6f7888',
+      scrollTrack: '#718399',
+    },
+    uiBase: { trackEmpty: '#ded6c3' },
+    decision: {
+      primaryText: minContrastWith({ ref: 'surface.primary.bg' }, scope('ink'), { ratio: 4.5 }),
+    },
+    status: {
+      success: { ref: 'brand.success' },
+      error: { ref: 'brand.error' },
+      warning: { ref: 'brand.accent' },
+      info: { ref: 'brand.info' },
+      pending: { fg: { ref: 'ink.muted' }, modifiers: ['dim'] },
+      active: { ref: 'semantic.accent' },
+      muted: { fg: { ref: 'ink.muted' }, modifiers: ['dim', 'strikethrough'] },
+    },
+    semantic: {
+      success: { ref: 'status.success' },
+      error: { ref: 'status.error' },
+      warning: { ref: 'status.warning' },
+      info: { ref: 'status.info' },
+      accent: mostVivid(scope('brand'), {
+        against: { ref: 'surface.primary.bg' },
+        minContrast: 4.5,
+        not: ['brand.success', 'brand.error'],
+      }),
+      muted: { fg: { ref: 'ink.muted' }, modifiers: ['dim'] },
+      primary: { fg: { ref: 'decision.primaryText' }, modifiers: ['bold'] },
+    },
+    border: {
+      primary: { ref: 'brand.primary' },
+      secondary: { ref: 'semantic.accent' },
+      success: { ref: 'semantic.success' },
+      warning: { ref: 'semantic.warning' },
+      error: { ref: 'semantic.error' },
+      muted: { ref: 'borderBase.muted' },
+    },
+    ui: {
+      cursor: { ref: 'semantic.accent' },
+      focusGutter: { fg: { ref: 'semantic.accent' }, bg: { ref: 'surface.primary.bg' }, modifiers: ['bold'] },
+      scrollThumb: { ref: 'brand.primary' },
+      scrollTrack: { ref: 'borderBase.scrollTrack' },
+      sectionHeader: { fg: { ref: 'semantic.accent' }, modifiers: ['bold'] },
+      logo: { ref: 'semantic.accent' },
+      tableHeader: { fg: { ref: 'decision.primaryText' }, modifiers: ['bold'] },
+      trackEmpty: { ref: 'uiBase.trackEmpty' },
+    },
+    surface: {
+      primary: { fg: { ref: 'decision.primaryText' }, bg: { ref: 'surfaceBase.primary' } },
+      secondary: { fg: { ref: 'ink.secondary' }, bg: { ref: 'surfaceBase.secondary' } },
+      elevated: { fg: { ref: 'ink.elevated' }, bg: { ref: 'surfaceBase.elevated' } },
+      overlay: { fg: { ref: 'ink.elevated' }, bg: { ref: 'surfaceBase.overlay' } },
+      muted: { fg: { ref: 'ink.muted' }, bg: { ref: 'surfaceBase.muted' } },
+    },
+  },
+  gradient: {
+    brand: [{ ref: 'brand.primary' }, { ref: 'semantic.accent' }, { ref: 'brand.error' }],
+    progress: [{ ref: 'brand.primary' }, { ref: 'brand.success' }, { ref: 'semantic.accent' }, { ref: 'brand.error' }],
+  },
+});

--- a/packages/bijou/src/core/theme/preset-authoring.test.ts
+++ b/packages/bijou/src/core/theme/preset-authoring.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { createResolved } from './resolve.js';
+import { BIJOU_DARK, BIJOU_LIGHT } from './presets.js';
+
+describe('rule-authored first-party presets', () => {
+  it('exposes bijou-dark accent selection provenance in the resolved token graph', () => {
+    const resolved = createResolved(BIJOU_DARK, false, 'dark');
+    const inspection = resolved.tokenGraph.inspect('semantic.accent', 'dark');
+
+    expect(inspection.kind).toBe('rule');
+    if (inspection.kind !== 'rule') throw new Error('semantic.accent should be rule-authored');
+    expect(inspection.rule).toBe('most-vivid');
+    expect(inspection.hex).toBe(BIJOU_DARK.semantic.accent.hex);
+    expect(inspection.selected?.path).toBe('brand.accent');
+    expect(inspection.dependencies).toContain('surface.primary.bg');
+    expect(inspection.dependencies).toContain('brand.success');
+    expect(inspection.dependencies).toContain('brand.error');
+  });
+
+  it('uses a contrast rule for bijou-light primary text selection', () => {
+    const resolved = createResolved(BIJOU_LIGHT, false, 'light');
+    const inspection = resolved.tokenGraph.inspect('decision.primaryText', 'light');
+
+    expect(inspection.kind).toBe('rule');
+    if (inspection.kind !== 'rule') throw new Error('decision.primaryText should be rule-authored');
+    expect(inspection.rule).toBe('min-contrast-with');
+    expect(inspection.hex).toBe(BIJOU_LIGHT.semantic.primary.hex);
+    expect(inspection.selected?.path).toBe('ink.primary');
+    expect(inspection.dependencies).toContain('surface.primary.bg');
+    expect(inspection.dependencies).toContain('ink.primary');
+  });
+});

--- a/packages/bijou/src/core/theme/preset-authoring.ts
+++ b/packages/bijou/src/core/theme/preset-authoring.ts
@@ -1,0 +1,119 @@
+import { hexToRgb } from './color.js';
+import { createTokenGraph, type ThemeMode, type TokenGraph } from './graph.js';
+import type { ColorDefinition, TokenDefinitions } from './graph-types.js';
+import type {
+  GradientStop,
+  RGB,
+  Theme,
+  TokenValue,
+} from './tokens.js';
+
+interface RuleAuthoredPresetOptions {
+  readonly name: string;
+  readonly mode: ThemeMode;
+  readonly definitions: TokenDefinitions;
+  readonly gradient: {
+    readonly brand: readonly ColorDefinition[];
+    readonly progress: readonly ColorDefinition[];
+  };
+}
+
+const RULE_AUTHORED_DEFINITIONS = new WeakMap<Theme, TokenDefinitions>();
+
+export function compileRuleAuthoredPreset(options: RuleAuthoredPresetOptions): Theme {
+  const graph = createTokenGraph(options.definitions);
+  const theme: Theme = {
+    name: options.name,
+    status: {
+      success: readToken(graph, options.mode, 'status.success'),
+      error: readToken(graph, options.mode, 'status.error'),
+      warning: readToken(graph, options.mode, 'status.warning'),
+      info: readToken(graph, options.mode, 'status.info'),
+      pending: readToken(graph, options.mode, 'status.pending'),
+      active: readToken(graph, options.mode, 'status.active'),
+      muted: readToken(graph, options.mode, 'status.muted'),
+    },
+    semantic: {
+      success: readToken(graph, options.mode, 'semantic.success'),
+      error: readToken(graph, options.mode, 'semantic.error'),
+      warning: readToken(graph, options.mode, 'semantic.warning'),
+      info: readToken(graph, options.mode, 'semantic.info'),
+      accent: readToken(graph, options.mode, 'semantic.accent'),
+      muted: readToken(graph, options.mode, 'semantic.muted'),
+      primary: readToken(graph, options.mode, 'semantic.primary'),
+    },
+    gradient: readGradients(graph, options.mode, options.gradient),
+    border: {
+      primary: readToken(graph, options.mode, 'border.primary'),
+      secondary: readToken(graph, options.mode, 'border.secondary'),
+      success: readToken(graph, options.mode, 'border.success'),
+      warning: readToken(graph, options.mode, 'border.warning'),
+      error: readToken(graph, options.mode, 'border.error'),
+      muted: readToken(graph, options.mode, 'border.muted'),
+    },
+    ui: {
+      cursor: readToken(graph, options.mode, 'ui.cursor'),
+      focusGutter: readToken(graph, options.mode, 'ui.focusGutter'),
+      scrollThumb: readToken(graph, options.mode, 'ui.scrollThumb'),
+      scrollTrack: readToken(graph, options.mode, 'ui.scrollTrack'),
+      sectionHeader: readToken(graph, options.mode, 'ui.sectionHeader'),
+      logo: readToken(graph, options.mode, 'ui.logo'),
+      tableHeader: readToken(graph, options.mode, 'ui.tableHeader'),
+      trackEmpty: readToken(graph, options.mode, 'ui.trackEmpty'),
+    },
+    surface: {
+      primary: readToken(graph, options.mode, 'surface.primary'),
+      secondary: readToken(graph, options.mode, 'surface.secondary'),
+      elevated: readToken(graph, options.mode, 'surface.elevated'),
+      overlay: readToken(graph, options.mode, 'surface.overlay'),
+      muted: readToken(graph, options.mode, 'surface.muted'),
+    },
+  };
+  RULE_AUTHORED_DEFINITIONS.set(theme, options.definitions);
+  return theme;
+}
+
+export function ruleAuthoredDefinitions(theme: Theme): TokenDefinitions | undefined {
+  return RULE_AUTHORED_DEFINITIONS.get(theme);
+}
+
+function readToken(graph: TokenGraph, mode: ThemeMode, path: string): TokenValue {
+  return cloneToken(graph.get(path, mode));
+}
+
+function readGradients(
+  graph: TokenGraph,
+  mode: ThemeMode,
+  definitions: RuleAuthoredPresetOptions['gradient'],
+): Theme['gradient'] {
+  return {
+    brand: gradient(graph, mode, definitions.brand),
+    progress: gradient(graph, mode, definitions.progress),
+  };
+}
+
+function gradient(
+  graph: TokenGraph,
+  mode: ThemeMode,
+  definitions: readonly ColorDefinition[],
+): GradientStop[] {
+  const max = Math.max(1, definitions.length - 1);
+  return definitions.map((definition, index) => ({
+    pos: index / max,
+    color: hexToRgb(graph.getColor(definition, mode)),
+  }));
+}
+
+function cloneToken(token: TokenValue): TokenValue {
+  return {
+    hex: token.hex,
+    ...(token.bg === undefined ? {} : { bg: token.bg }),
+    ...(token.modifiers === undefined ? {} : { modifiers: [...token.modifiers] }),
+    ...(token.fgRGB === undefined ? {} : { fgRGB: cloneRgb(token.fgRGB) }),
+    ...(token.bgRGB === undefined ? {} : { bgRGB: cloneRgb(token.bgRGB) }),
+  };
+}
+
+function cloneRgb(rgb: RGB): RGB {
+  return [rgb[0], rgb[1], rgb[2]];
+}

--- a/packages/bijou/src/core/theme/presets.ts
+++ b/packages/bijou/src/core/theme/presets.ts
@@ -1,7 +1,9 @@
 import type { Theme, TokenValue, TextModifier } from './tokens.js';
 import { tryHexToRgb } from './color.js';
+import { BIJOU_DARK } from './bijou-dark-preset.js';
+import { BIJOU_LIGHT } from './bijou-light-preset.js';
 
-const FULL_HEX_RE = /^#[0-9a-fA-F]{6}$/;
+export { BIJOU_DARK, BIJOU_LIGHT };
 
 /**
  * Shorthand helper to create a TokenValue with less boilerplate.
@@ -38,25 +40,6 @@ export function populateTokenRGB(token: TokenValue): TokenValue {
     delete token.bgRGB;
   }
   return token;
-}
-
-function rgb(hex: string): [number, number, number] {
-  if (!FULL_HEX_RE.test(hex)) {
-    throw new Error(`rgb() expects a 7-character #rrggbb hex color, got "${hex}".`);
-  }
-  return [
-    Number.parseInt(hex.slice(1, 3), 16),
-    Number.parseInt(hex.slice(3, 5), 16),
-    Number.parseInt(hex.slice(5, 7), 16),
-  ];
-}
-
-function gradient(hexes: readonly string[]): { readonly pos: number; readonly color: [number, number, number] }[] {
-  const max = Math.max(1, hexes.length - 1);
-  return hexes.map((hex, index) => ({
-    pos: index / max,
-    color: rgb(hex),
-  }));
 }
 
 /**
@@ -127,134 +110,6 @@ export const CYAN_MAGENTA: Theme = {
     elevated:  { hex: '#ffffff', bg: '#0f3460' },
     overlay:   { hex: '#ffffff', bg: '#1a1a2e' },
     muted:     { hex: '#808080', bg: '#0a0a14' },
-  },
-};
-
-/**
- * BIJOU_DARK — the calm first-party dark theme.
- *
- * This preset is intentionally less saturated than the legacy cyan/magenta
- * palette. It keeps neutral surfaces dominant, separates focus/brand/status
- * roles, and preserves readable foregrounds across dense product surfaces.
- */
-export const BIJOU_DARK: Theme = {
-  name: 'bijou-dark',
-
-  status: {
-    success: tv('#8bd67d'),
-    error:   tv('#ff8a80'),
-    warning: tv('#f2c45d'),
-    info:    tv('#8fbaff'),
-    pending: tv('#a8b1c7', ['dim']),
-    active:  tv('#f2c45d'),
-    muted:   tv('#a8b1c7', ['dim', 'strikethrough']),
-  },
-
-  semantic: {
-    success: tv('#8bd67d'),
-    error:   tv('#ff8a80'),
-    warning: tv('#f2c45d'),
-    info:    tv('#8fbaff'),
-    accent:  tv('#f2c45d'),
-    muted:   tv('#a8b1c7', ['dim']),
-    primary: tv('#f4e8bf', ['bold']),
-  },
-
-  gradient: {
-    brand: gradient(['#7aa7e8', '#f2c45d', '#ff8a80']),
-    progress: gradient(['#7aa7e8', '#8bd67d', '#f2c45d', '#ff8a80']),
-  },
-
-  border: {
-    primary:   tv('#7aa7e8'),
-    secondary: tv('#f2c45d'),
-    success:   tv('#8bd67d'),
-    warning:   tv('#f2c45d'),
-    error:     tv('#ff8a80'),
-    muted:     tv('#77809d'),
-  },
-
-  ui: {
-    cursor:        tv('#f2c45d'),
-    focusGutter:   { hex: '#f2c45d', bg: '#171827', modifiers: ['bold'] },
-    scrollThumb:   tv('#7aa7e8'),
-    scrollTrack:   tv('#77809d'),
-    sectionHeader: tv('#f2c45d', ['bold']),
-    logo:          tv('#f2c45d'),
-    tableHeader:   tv('#f4e8bf', ['bold']),
-    trackEmpty:    tv('#2a3150'),
-  },
-
-  surface: {
-    primary:   { hex: '#f4e8bf', bg: '#171827' },
-    secondary: { hex: '#d8def0', bg: '#20243a' },
-    elevated:  { hex: '#f8f0d0', bg: '#29304d' },
-    overlay:   { hex: '#f8f0d0', bg: '#10121f' },
-    muted:     { hex: '#a8b1c7', bg: '#131625' },
-  },
-};
-
-/**
- * BIJOU_LIGHT — the calm first-party light theme.
- *
- * The light preset mirrors the dark theme's roles while using ink-forward
- * foregrounds instead of pastel text, so dense terminal surfaces remain
- * scannable on bright backgrounds.
- */
-export const BIJOU_LIGHT: Theme = {
-  name: 'bijou-light',
-
-  status: {
-    success: tv('#246a3d'),
-    error:   tv('#a33a3a'),
-    warning: tv('#7a5200'),
-    info:    tv('#285c9e'),
-    pending: tv('#5e6778', ['dim']),
-    active:  tv('#7a5200'),
-    muted:   tv('#5e6778', ['dim', 'strikethrough']),
-  },
-
-  semantic: {
-    success: tv('#246a3d'),
-    error:   tv('#a33a3a'),
-    warning: tv('#7a5200'),
-    info:    tv('#285c9e'),
-    accent:  tv('#7a5200'),
-    muted:   tv('#5e6778', ['dim']),
-    primary: tv('#1e2433', ['bold']),
-  },
-
-  gradient: {
-    brand: gradient(['#285c9e', '#7a5200', '#a33a3a']),
-    progress: gradient(['#285c9e', '#246a3d', '#7a5200', '#a33a3a']),
-  },
-
-  border: {
-    primary:   tv('#285c9e'),
-    secondary: tv('#7a5200'),
-    success:   tv('#246a3d'),
-    warning:   tv('#7a5200'),
-    error:     tv('#a33a3a'),
-    muted:     tv('#6f7888'),
-  },
-
-  ui: {
-    cursor:        tv('#7a5200'),
-    focusGutter:   { hex: '#7a5200', bg: '#fbf7ea', modifiers: ['bold'] },
-    scrollThumb:   tv('#285c9e'),
-    scrollTrack:   tv('#718399'),
-    sectionHeader: tv('#7a5200', ['bold']),
-    logo:          tv('#7a5200'),
-    tableHeader:   tv('#1e2433', ['bold']),
-    trackEmpty:    tv('#ded6c3'),
-  },
-
-  surface: {
-    primary:   { hex: '#1e2433', bg: '#fbf7ea' },
-    secondary: { hex: '#252b38', bg: '#efe7d2' },
-    elevated:  { hex: '#1e2433', bg: '#fffdf6' },
-    overlay:   { hex: '#1e2433', bg: '#f5eddb' },
-    muted:     { hex: '#5e6778', bg: '#ece4d1' },
   },
 };
 

--- a/packages/bijou/src/core/theme/resolve.ts
+++ b/packages/bijou/src/core/theme/resolve.ts
@@ -7,6 +7,7 @@ import { detectColorScheme } from '../detect/tty.js';
 import { PRESETS, CYAN_MAGENTA, populateTokenRGB } from './presets.js';
 import { createTokenGraph, type TokenGraph } from './graph.js';
 import type { TokenDefinitions } from './graph-types.js';
+import { ruleAuthoredDefinitions } from './preset-authoring.js';
 
 /** Walk all token values in a theme and populate fgRGB/bgRGB. */
 function populateThemeRGB(theme: Theme): void {
@@ -26,12 +27,7 @@ function populateThemeRGB(theme: Theme): void {
   }
 }
 
-/**
- * Check the no-color.org spec: `NO_COLOR` defined (any value) means no color.
- *
- * @param runtime - RuntimePort for reading env vars.
- * @returns True if the `NO_COLOR` environment variable is set.
- */
+/** Check no-color.org: `NO_COLOR` defined means no color. */
 export function isNoColor(runtime: RuntimePort): boolean {
   const env = createEnvAccessor(runtime);
   return env('NO_COLOR') !== undefined;
@@ -70,16 +66,10 @@ export interface ResolvedTheme {
   hex(token: TokenValue): string;
 }
 
-/**
- * Create a ResolvedTheme from a Theme and a noColor flag.
- * @param theme - The theme to wrap.
- * @param noColor - Whether color output should be suppressed.
- * @param colorScheme - Terminal color scheme. Defaults to `'dark'`.
- * @returns ResolvedTheme with convenience accessors.
- */
+/** Create a ResolvedTheme from a Theme and noColor flag. */
 export function createResolved(theme: Theme, noColor: boolean, colorScheme: ColorScheme = 'dark'): ResolvedTheme {
   populateThemeRGB(theme);
-  const tokenGraph = createTokenGraph(themeTokenDefinitions(theme));
+  const tokenGraph = createTokenGraph(ruleAuthoredDefinitions(theme) ?? themeTokenDefinitions(theme));
   const statusTokens = new Map(Object.entries(theme.status));
 
   return {

--- a/scripts/docs-preview-landing.part04.test.ts
+++ b/scripts/docs-preview-landing.part04.test.ts
@@ -13,10 +13,18 @@ import {
   KEY_ENTER,
   KEY_F10,
   runScript,
+  themeContrastRatio,
   _resetDefaultContextForTesting,
 } from './docs-preview.test-support.js';
 
 import { must } from '@flyingrobots/bijou/adapters/test';
+import {
+  docsThemeDescriptionToken,
+  docsThemeSelectedRowBgToken,
+  docsThemeSurfaceToken,
+  docsThemeUnfocusedGutterToken,
+} from '../examples/docs/app-docs-theme-tokens.js';
+import { docsVisualThemeFromShellThemeChoice } from '../examples/docs/app-landing.js';
 
 describe('docs preview app', () => {
   afterEach(() => { _resetDefaultContextForTesting(); });
@@ -45,6 +53,38 @@ describe('docs preview app', () => {
     expect(dark?.theme.ui.cursor.hex).not.toBe(dark?.theme.status.info.hex);
     expect(light?.theme.semantic.primary.hex).not.toBe(light?.theme.semantic.accent.hex);
     expect(light?.theme.ui.cursor.hex).not.toBe(light?.theme.status.info.hex);
+  });
+
+  it('keeps DOGFOOD light docs chrome readable against its panel backgrounds', () => {
+    const shellThemes = docsShellThemesForTesting();
+    const dogfood = shellThemes.find((theme) => theme.id === 'dogfood');
+    const light = must(dogfood?.modes?.find((mode) => mode.id === 'light'));
+    const visualTheme = docsVisualThemeFromShellThemeChoice({
+      id: 'dogfood:light',
+      label: 'DOGFOOD / Light',
+      theme: light.theme,
+    });
+    const surfaceToken = docsThemeSurfaceToken(visualTheme);
+    const selectedToken = docsThemeSelectedRowBgToken(visualTheme);
+    const descriptionToken = docsThemeDescriptionToken(visualTheme);
+    const gutterToken = docsThemeUnfocusedGutterToken(visualTheme);
+
+    expect(themeContrastRatio(
+      surfaceToken.hex,
+      must(surfaceToken.bg),
+    )).toBeGreaterThanOrEqual(7);
+    expect(themeContrastRatio(
+      selectedToken.hex,
+      must(selectedToken.bg),
+    )).toBeGreaterThanOrEqual(7);
+    expect(themeContrastRatio(
+      descriptionToken.hex,
+      must(surfaceToken.bg),
+    )).toBeGreaterThanOrEqual(4.5);
+    expect(themeContrastRatio(
+      gutterToken.hex,
+      must(gutterToken.bg),
+    )).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/scripts/docs-preview-landing.part05.test.ts
+++ b/scripts/docs-preview-landing.part05.test.ts
@@ -1,5 +1,6 @@
 import {
   afterEach,
+  BIJOU_LIGHT,
   createDocsApp,
   createTestContext,
   describe,
@@ -8,6 +9,7 @@ import {
   it,
   KEY_DOWN,
   KEY_ENTER,
+  KEY_F2,
   KEY_F10,
   KEY_UP,
   runScript,
@@ -46,7 +48,7 @@ describe('docs preview app', () => {
 describe('docs preview app', () => {
   afterEach(() => { _resetDefaultContextForTesting(); });
 
-  it('publishes the Theme Lab page with default palettes and shell gallery facts', async () => {
+  it('publishes the Theme Lab page with active shell facts and palettes', async () => {
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 150, rows: 44 } });
     const app = createDocsApp(ctx, {
       initialRoute: 'docs',
@@ -56,12 +58,29 @@ describe('docs preview app', () => {
     const text = frameText(must(result.frames.at(-1)));
     expect((result.model).docsModel.activePageId).toBe('themes');
     expect(text).toContain('Theme Lab');
+    expect(text).toContain('Active: DOGFOOD / Dark');
+    expect(text).toContain('Theme: dogfood-dark');
     expect(text).toContain('Default dark preset: bijou-dark');
     expect(text).toContain('Default light preset: bijou-light');
     expect(text).toContain('Color reuse: dark');
-    expect(text).toContain('DOGFOOD / Dark -> dogfood-dark');
-    expect(text).toContain('bijou-dark token swatches');
+    expect(text).toContain('* 1. DOGFOOD / Dark -> dogfood-dark');
+    expect(text).toContain('DOGFOOD / Dark');
     expect(text).toContain('semantic.primary');
-    expect(text).toContain('gradient.brand');
+
+    const lightResult = await runScript(app, [
+      { key: KEY_F2 },
+      { key: KEY_DOWN },
+      { key: KEY_ENTER },
+      { key: KEY_F2 },
+    ], { ctx });
+    const lightText = frameText(must(lightResult.frames.at(-1)));
+
+    expect(lightResult.model.docsModel.activeShellThemeId).toBe('dogfood:light');
+    expect(lightText).toContain('Active: DOGFOOD / Light');
+    expect(lightText).toContain('Theme: dogfood-light');
+    expect(lightText).toContain('* 2. DOGFOOD / Light -> dogfood-light');
+    expect(lightText).toContain('DOGFOOD / Light');
+    expect(lightText).toContain(BIJOU_LIGHT.semantic.primary.hex);
+    expect(lightText).not.toContain('Active: DOGFOOD / Dark');
   });
 });


### PR DESCRIPTION
## Summary

This PR starts DL-020, a dogfood pass that moves Bijou-owned default theme authoring onto the native theme rule system added in DL-019 while preserving the public `Theme` contract.

## Links

- Refs #446
- Design: `docs/design/DL-020-dogfood-rule-authored-first-party-themes.md`

## Validation

- pre-push full verification passed for the shaping commit, including DOGFOOD i18n gates, Code Dojo gates, full Vitest chunks, and scripted interactive example smoke.

## Implementation Status

- Shaping artifact committed.
- Implementation commit will follow on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new design decision document covering first-party theme authoring for Bijou.
  * Clarified how the default light and dark themes are represented and compiled.
  * Documented the runtime expectations for consistent, pure preset compilation.
  * Included scope boundaries and related implementation invariants for easier reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->