### PR TITLE
Support any-event mouse input

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -290,6 +290,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   swallowed by the shell router. `@flyingrobots/bijou-tui` also exposes
   package-root page-scoped frame message helpers and scripted mouse driver
   helpers for deterministic pointer regressions.
+- **Mouse hover tracking** — `RunOptions.mouseMode` now lets interactive apps
+  request `press`, `drag`, or `any` SGR mouse tracking. The runtime and worker
+  host both support any-event `1003` tracking for hover-driven surfaces, and
+  the event bus now splits bundled SGR mouse packets before parsing so multiple
+  mouse moves delivered in one raw input chunk are not dropped.
 - **BlockLab navigation ownership** — `npm run blocklab` now lets the
   workbench's `up` / `down` and `j` / `k` story navigation bindings win over
   generic framed-shell scroll bindings, so the release-demo workbench moves the

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -729,6 +729,7 @@ Configuration is intentionally small and host-centered.
 | `LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES` | DOGFOOD locale adapter | Seed the initial DOGFOOD locale if no saved preference wins first. |
 | `HOME`, `XDG_STATE_HOME` | DOGFOOD locale adapter | Determine the default path for saving the selected DOGFOOD locale. |
 | `RunOptions.mouse` | TUI runtime | Enables SGR mouse reporting and parsing. |
+| `RunOptions.mouseMode` | TUI runtime | Selects `press`, `drag`, or any-event `1003` mouse tracking. |
 | `RunOptions.commandBackpressureThreshold` | TUI runtime | Sets the pending-command warning threshold. `0` disables the warning. |
 | `RunOptions.surfaceBudget` | TUI runtime | Enables non-fatal surface budget warnings after render. |
 | `RunOptions.css` | TUI runtime | Installs BCSS resolver and middleware for component styling. |

--- a/packages/bijou-node/src/worker/worker-data.ts
+++ b/packages/bijou-node/src/worker/worker-data.ts
@@ -2,6 +2,7 @@ export interface WorkerSerializableOptions {
   altScreen?: boolean;
   hideCursor?: boolean;
   mouse?: boolean;
+  mouseMode?: 'press' | 'drag' | 'any';
   css?: string;
 }
 
@@ -51,6 +52,7 @@ function isWorkerSerializableOptions(value: unknown): value is WorkerSerializabl
     && optionalBoolean(value['altScreen'])
     && optionalBoolean(value['hideCursor'])
     && optionalBoolean(value['mouse'])
+    && optionalMouseMode(value['mouseMode'])
     && optionalString(value['css']);
 }
 
@@ -62,6 +64,10 @@ function isRuntimeViewportData(value: unknown): value is BijouWorkerData['runtim
 
 function optionalBoolean(value: unknown): boolean {
   return value === undefined || typeof value === 'boolean';
+}
+
+function optionalMouseMode(value: unknown): boolean {
+  return value === undefined || value === 'press' || value === 'drag' || value === 'any';
 }
 
 function optionalString(value: unknown): boolean {

--- a/packages/bijou-node/src/worker/worker-mouse-mode.ts
+++ b/packages/bijou-node/src/worker/worker-mouse-mode.ts
@@ -1,0 +1,21 @@
+export type WorkerMouseTrackingMode = 'press' | 'drag' | 'any';
+
+export const DISABLE_MOUSE = '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l';
+
+interface WorkerMouseModeOptions {
+  readonly mouse?: boolean;
+  readonly mouseMode?: WorkerMouseTrackingMode;
+}
+
+export function resolveWorkerMouseMode(
+  options: WorkerMouseModeOptions,
+): WorkerMouseTrackingMode | undefined {
+  if (options.mouseMode !== undefined) return options.mouseMode;
+  return options.mouse === true ? 'drag' : undefined;
+}
+
+export function mouseModeEnableSequence(mode: WorkerMouseTrackingMode): string {
+  if (mode === 'press') return '\x1b[?1000h\x1b[?1002l\x1b[?1003l\x1b[?1006h';
+  if (mode === 'any') return '\x1b[?1000h\x1b[?1002l\x1b[?1003h\x1b[?1006h';
+  return '\x1b[?1000h\x1b[?1002h\x1b[?1003l\x1b[?1006h';
+}

--- a/packages/bijou-node/src/worker/worker-options.ts
+++ b/packages/bijou-node/src/worker/worker-options.ts
@@ -1,0 +1,34 @@
+import type { BijouContext } from '@flyingrobots/bijou';
+import type { WorkerMouseTrackingMode } from './worker-mouse-mode.js';
+
+/** Options for starting an app in a background worker. */
+export interface RunWorkerOptions {
+  /** The absolute path to the worker entry file. */
+  entry: string;
+  /** Optional Bijou context for the host thread. */
+  ctx?: BijouContext;
+  /** Enter the alternate screen buffer on startup. */
+  altScreen?: boolean;
+  /** Hide the cursor on startup. */
+  hideCursor?: boolean;
+  /** Enable mouse input. */
+  mouse?: boolean;
+  /** Mouse tracking mode. Supplying this implies `mouse: true`. */
+  mouseMode?: WorkerMouseTrackingMode;
+  /** Optional BCSS stylesheet string. */
+  css?: string;
+  /** Callback for custom data messages sent from the worker. */
+  onMessage?: (payload: unknown) => void;
+  /** Optional arguments passed to the Node.js worker process. */
+  execArgv?: string[];
+}
+
+/** Handle for a running background worker. */
+export interface WorkerHandle {
+  /** Sends a custom data message to the worker thread. */
+  send(payload: unknown): void;
+  /** Forcefully terminate the worker thread. */
+  terminate(): Promise<void>;
+  /** Resolves when the worker exits cleanly. */
+  onExit: Promise<void>;
+}

--- a/packages/bijou-node/src/worker/worker.proxy-mouse.test.ts
+++ b/packages/bijou-node/src/worker/worker.proxy-mouse.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
+import { stringToSurface } from '@flyingrobots/bijou';
+import type { RunOptions } from '@flyingrobots/bijou-tui';
+import { startWorkerApp } from './worker.js';
+
+describe('worker proxy mouse runtime', () => {
+  it('keeps mouse parsing enabled without forwarding terminal mouse control frames', async () => {
+    const posted: unknown[] = [];
+    const enableMouseAny = '\x1b[?1000h\x1b[?1002l\x1b[?1003h\x1b[?1006h';
+    const disableMouse = '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l';
+    let runAltScreen: boolean | undefined;
+    let runHideCursor: boolean | undefined;
+    let runMouseMode: RunOptions['mouseMode'] | undefined;
+    const run = <M>(_app: unknown, options: RunOptions<M>) => {
+      runAltScreen = options.altScreen;
+      runHideCursor = options.hideCursor;
+      runMouseMode = options.mouseMode;
+      options.ctx?.io.write(enableMouseAny);
+      options.ctx?.io.write(disableMouse);
+      options.ctx?.io.write('frame');
+      return Promise.resolve();
+    };
+
+    await startWorkerApp({
+      init: () => [null, []],
+      update: (msg, model) => [model, []],
+      view: () => stringToSurface('worker', 6, 1),
+    }, {
+      isMainThread: false,
+      parentPort: {
+        on() { return undefined; },
+        off() { return undefined; },
+        postMessage(message: unknown) { posted.push(message); },
+      },
+      workerData: {
+        isBijouWorker: true,
+        options: { mouseMode: 'any' },
+        runtime: { columns: 80, rows: 24 },
+      },
+      createWorker() {
+        throw new Error('unexpected createWorker');
+      },
+      createNodeContext() { return createTestContext({ mode: 'interactive' }); },
+      runApp: run,
+      scheduleTimeout(callback, ms) { return setTimeout(callback, ms); },
+    });
+
+    expect(runAltScreen).toBe(false);
+    expect(runHideCursor).toBe(false);
+    expect(runMouseMode).toBe('any');
+    expect(posted).not.toContainEqual({ type: 'render:frame', output: enableMouseAny });
+    expect(posted).not.toContainEqual({ type: 'render:frame', output: disableMouse });
+    expect(posted).toContainEqual({ type: 'render:frame', output: 'frame' });
+    expect(posted).toContainEqual({ type: 'quit' });
+  });
+});

--- a/packages/bijou-node/src/worker/worker.proxy.test.ts
+++ b/packages/bijou-node/src/worker/worker.proxy.test.ts
@@ -6,9 +6,13 @@ import { runInWorker, startWorkerApp, type MainMessage, type RunWorkerOptions } 
 
 describe('worker proxy runtime', () => {
   it('only accepts worker-safe run options at type level', () => {
-    const options: RunWorkerOptions = { entry: '/tmp/worker.mjs', mouse: true };
+    const options: RunWorkerOptions = {
+      entry: '/tmp/worker.mjs',
+      mouseMode: 'any',
+    };
 
     expect(options.entry).toBe('/tmp/worker.mjs');
+    expect(options.mouseMode).toBe('any');
 
     // @ts-expect-error worker rejects bus middleware hooks.
     const withMiddlewares: RunWorkerOptions = { entry: '/tmp/worker.mjs', middlewares: [] };
@@ -54,7 +58,7 @@ describe('worker proxy runtime', () => {
     };
 
     const handle = runInWorker(
-      { ctx, entry: '/tmp/worker.mjs' },
+      { ctx, entry: '/tmp/worker.mjs', mouseMode: 'any' },
       {
         isMainThread: true,
         parentPort: null,
@@ -71,6 +75,7 @@ describe('worker proxy runtime', () => {
     expect(ctorCalls).toHaveLength(1);
     expect(ctorCalls[0]?.options.workerData).toMatchObject({
       isBijouWorker: true,
+      options: { mouseMode: 'any' },
       runtime: { columns: 120, rows: 40 },
     });
 
@@ -134,4 +139,5 @@ describe('worker proxy runtime', () => {
     expect(runCalls).toBe(1);
     expect(posted).toContainEqual({ type: 'quit' });
   });
+
 });

--- a/packages/bijou-node/src/worker/worker.proxy.test.ts
+++ b/packages/bijou-node/src/worker/worker.proxy.test.ts
@@ -139,5 +139,4 @@ describe('worker proxy runtime', () => {
     expect(runCalls).toBe(1);
     expect(posted).toContainEqual({ type: 'quit' });
   });
-
 });

--- a/packages/bijou-node/src/worker/worker.test.ts
+++ b/packages/bijou-node/src/worker/worker.test.ts
@@ -26,7 +26,7 @@ describe('worker runtime', () => {
     expect(ctx.io.written.some((chunk) => chunk.includes('worker:from-main'))).toBe(true);
   });
 
-  it('disables only the mouse modes it enables', async () => {
+  it('restores all mouse tracking modes after mouse-enabled apps exit', async () => {
     const ctx = createTestContext({ mode: 'interactive' });
     const here = dirname(fileURLToPath(import.meta.url));
     const entry = resolve(here, 'fixtures/echo-worker.mjs');
@@ -44,8 +44,29 @@ describe('worker runtime', () => {
     await handle.onExit;
 
     const output = ctx.io.written.join('');
-    expect(output).toContain('\x1b[?1000h\x1b[?1002h\x1b[?1006h');
-    expect(output).toContain('\x1b[?1000l\x1b[?1002l\x1b[?1006l');
-    expect(output).not.toContain('\x1b[?1003l');
+    expect(output).toContain('\x1b[?1000h\x1b[?1002h\x1b[?1003l\x1b[?1006h');
+    expect(output).toContain('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l');
+  });
+
+  it('enables any-event mouse tracking for hover-driven worker apps', async () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const here = dirname(fileURLToPath(import.meta.url));
+    const entry = resolve(here, 'fixtures/echo-worker.mjs');
+
+    const handle = runInWorker({
+      ctx,
+      entry,
+      mouseMode: 'any',
+      onMessage() {
+        // no-op for terminal mode
+      },
+    });
+
+    handle.send({ type: 'host-note', text: 'from-main' });
+    await handle.onExit;
+
+    const output = ctx.io.written.join('');
+    expect(output).toContain('\x1b[?1000h\x1b[?1002l\x1b[?1003h\x1b[?1006h');
+    expect(output).toContain('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l');
   });
 });

--- a/packages/bijou-node/src/worker/worker.test.ts
+++ b/packages/bijou-node/src/worker/worker.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { createTestContext } from '@flyingrobots/bijou/adapters/test';
 import { runInWorker } from './worker.js';
+import { DISABLE_MOUSE } from './worker-mouse-mode.js';
 
 describe('worker runtime', () => {
   it('forwards custom data messages between the main thread and worker app', async () => {
@@ -24,6 +25,28 @@ describe('worker runtime', () => {
 
     expect(received).toEqual([{ type: 'ack', text: 'from-main' }]);
     expect(ctx.io.written.some((chunk) => chunk.includes('worker:from-main'))).toBe(true);
+  });
+
+  it('clears stale mouse tracking before non-mouse worker apps render', async () => {
+    const ctx = createTestContext({ mode: 'interactive' });
+    const here = dirname(fileURLToPath(import.meta.url));
+    const entry = resolve(here, 'fixtures/echo-worker.mjs');
+
+    const handle = runInWorker({
+      ctx,
+      entry,
+      onMessage() {
+        // no-op for terminal mode
+      },
+    });
+
+    handle.send({ type: 'host-note', text: 'from-main' });
+    await handle.onExit;
+
+    const disableIndex = ctx.io.written.indexOf(DISABLE_MOUSE);
+    const firstWorkerFrameIndex = ctx.io.written.findIndex((chunk) => chunk.includes('worker:'));
+    expect(disableIndex).toBeGreaterThanOrEqual(0);
+    expect(firstWorkerFrameIndex).toBeGreaterThan(disableIndex);
   });
 
   it('restores all mouse tracking modes after mouse-enabled apps exit', async () => {

--- a/packages/bijou-node/src/worker/worker.ts
+++ b/packages/bijou-node/src/worker/worker.ts
@@ -16,6 +16,13 @@ import {
   type BijouWorkerData,
   type WorkerSerializableOptions,
 } from './worker-data.js';
+import {
+  DISABLE_MOUSE,
+  mouseModeEnableSequence,
+  resolveWorkerMouseMode,
+} from './worker-mouse-mode.js';
+import type { RunWorkerOptions, WorkerHandle } from './worker-options.js';
+export type { RunWorkerOptions, WorkerHandle } from './worker-options.js';
 
 interface WorkerInstance {
   postMessage(message: unknown): void;
@@ -93,40 +100,6 @@ export function sendToMain(payload: unknown): void {
 }
 
 /**
- * Options for starting an app in a background worker.
- */
-export interface RunWorkerOptions {
-  /** The absolute path to the file containing the worker entry point. */
-  entry: string;
-  /** Optional Bijou context for the host thread. */
-  ctx?: BijouContext;
-  /** Enter the alternate screen buffer on startup. */
-  altScreen?: boolean;
-  /** Hide the cursor on startup. */
-  hideCursor?: boolean;
-  /** Enable mouse input (SGR mode). */
-  mouse?: boolean;
-  /** Optional BCSS stylesheet string. */
-  css?: string;
-  /** Optional callback for custom data messages sent from the worker via `sendToMain`. */
-  onMessage?: (payload: unknown) => void;
-  /** Optional arguments passed to the Node.js worker process (e.g. ['--import', 'tsx']). */
-  execArgv?: string[];
-}
-
-/**
- * Handle for a running background worker.
- */
-export interface WorkerHandle {
-  /** Sends a custom data message to the worker thread. */
-  send(payload: unknown): void;
-  /** Forcefully terminates the worker thread. */
-  terminate(): Promise<void>;
-  /** A promise that resolves when the worker exits cleanly. */
-  onExit: Promise<void>;
-}
-
-/**
  * Spawns a background worker thread to run the TEA application.
  * The main thread delegates all logic to the worker, only handling raw I/O
  * and frame rendering (to keep the TTY responsive).
@@ -146,20 +119,22 @@ export function runInWorker(
   installRuntimeViewportOverlay(ctx);
   const useAltScreen = options.altScreen ?? true;
   const useHideCursor = options.hideCursor ?? true;
-  const useMouse = options.mouse ?? false;
+  const mouseMode = resolveWorkerMouseMode(options);
+  const useMouse = mouseMode !== undefined;
 
   if (useAltScreen || useHideCursor) {
     ctx.io.write('\x1b[?1049h'); // ENTER_ALT_SCREEN
     if (useHideCursor) ctx.io.write('\x1b[?25l'); // HIDE_CURSOR
   }
   if (useMouse) {
-    ctx.io.write('\x1b[?1000h\x1b[?1002h\x1b[?1006h'); // ENABLE_MOUSE
+    ctx.io.write(mouseModeEnableSequence(mouseMode)); // ENABLE_MOUSE
   }
 
   const serializableOptions: WorkerSerializableOptions = {
     altScreen: options.altScreen,
     hideCursor: options.hideCursor,
     mouse: options.mouse,
+    mouseMode: options.mouseMode,
     css: options.css,
   };
   const worker = bindings.createWorker(resolvePath(options.entry), {
@@ -215,7 +190,7 @@ export function runInWorker(
       inputHandle.dispose();
       resizeHandle.dispose();
       if (useMouse) {
-        ctx.io.write('\x1b[?1000l\x1b[?1002l\x1b[?1006l'); // DISABLE_MOUSE
+        ctx.io.write(DISABLE_MOUSE);
       }
       if (useAltScreen || useHideCursor) {
         ctx.io.write('\x1b[?1049l'); // EXIT_ALT_SCREEN
@@ -229,6 +204,7 @@ export function runInWorker(
     onExit
   };
 }
+
 /**
  * The entry point for the worker thread. Must be called in the file
  * specified by `options.entry` in `runInWorker()`.
@@ -256,20 +232,27 @@ export async function startWorkerApp<Model, M>(
     initData.runtime.rows,
   );
 
+  const proxyMouseMode = resolveWorkerMouseMode(initData.options);
+  const ignoredProxyWrites = new Set<string>([DISABLE_MOUSE]);
+  if (proxyMouseMode !== undefined) {
+    ignoredProxyWrites.add(mouseModeEnableSequence(proxyMouseMode));
+  }
+
   proxyCtx.io.write = (data: string) => {
+    if (ignoredProxyWrites.has(data)) return;
     port.postMessage({ type: 'render:frame', output: data } satisfies MainMessage);
   };
   proxyCtx.io.writeError = (data: string) => {
     port.postMessage({ type: 'error', message: data } satisfies MainMessage);
   };
-  // We need to bypass the standard run() setup since the main thread
-  // already handled alt screen and mouse modes. We tell run() to do nothing.
+  // The main thread owns terminal mode; the worker still parses forwarded input.
   const proxyOptions: RunOptions<M> = {
-    ...initData.options,
+    css: initData.options.css,
     ctx: proxyCtx,
     altScreen: false,
     hideCursor: false,
-    mouse: false,
+    mouse: initData.options.mouse,
+    mouseMode: initData.options.mouseMode,
   };
   proxyCtx.io.rawInput = (handler) => {
     const listener = (msg: unknown) => {

--- a/packages/bijou-node/src/worker/worker.ts
+++ b/packages/bijou-node/src/worker/worker.ts
@@ -128,6 +128,8 @@ export function runInWorker(
   }
   if (useMouse) {
     ctx.io.write(mouseModeEnableSequence(mouseMode)); // ENABLE_MOUSE
+  } else {
+    ctx.io.write(DISABLE_MOUSE);
   }
 
   const serializableOptions: WorkerSerializableOptions = {

--- a/packages/bijou-tui/src/app-frame.test-support.part01.ts
+++ b/packages/bijou-tui/src/app-frame.test-support.part01.ts
@@ -23,7 +23,7 @@ export const KEY_CTRL_P = '\x10';
 export const KEY_ENTER = '\r';
 export const KEY_DOWN = '\x1b[B';
 export const KEY_BACKTICK = '`';
-export const ENABLE_MOUSE = '\x1b[?1000h\x1b[?1002h\x1b[?1006h';
+export const ENABLE_MOUSE = '\x1b[?1000h\x1b[?1002h\x1b[?1003l\x1b[?1006h';
 export function ctrlKey(key: string) {
   return { type: 'key' as const, key, ctrl: true, alt: false, shift: false };
 }

--- a/packages/bijou-tui/src/eventbus.part03.test.ts
+++ b/packages/bijou-tui/src/eventbus.part03.test.ts
@@ -126,4 +126,22 @@ describe('connectIO mouse', () => {
       { type: 'mouse', button: 'left', action: 'press', col: 4, row: 5 },
     ]);
   });
+
+  it('tokenizes bundled keyboard spans around SGR mouse packets', () => {
+    const bus = createEventBus<TestMsg>();
+    const { io, simulateKey } = createMockIO();
+    const received: BusMsg<TestMsg>[] = [];
+    bus.on((msg) => received.push(msg));
+
+    bus.connectIO(io, { mouse: true });
+    simulateKey('ab\x1b[<0;5;6Mcd');
+
+    expect(received).toMatchObject([
+      { type: 'key', key: 'a' },
+      { type: 'key', key: 'b' },
+      { type: 'mouse', button: 'left', action: 'press', col: 4, row: 5 },
+      { type: 'key', key: 'c' },
+      { type: 'key', key: 'd' },
+    ]);
+  });
 });

--- a/packages/bijou-tui/src/eventbus.part03.test.ts
+++ b/packages/bijou-tui/src/eventbus.part03.test.ts
@@ -95,4 +95,35 @@ describe('connectIO mouse', () => {
       expect(received[0].action).toBe('scroll-up');
     }
   });
+
+  it('emits every SGR mouse packet bundled in one raw input chunk', () => {
+    const bus = createEventBus<TestMsg>();
+    const { io, simulateKey } = createMockIO();
+    const received: BusMsg<TestMsg>[] = [];
+    bus.on((msg) => received.push(msg));
+
+    bus.connectIO(io, { mouse: true });
+    simulateKey('\x1b[<35;5;6M\x1b[<35;6;7M');
+
+    expect(received).toHaveLength(2);
+    expect(received).toMatchObject([
+      { type: 'mouse', button: 'none', action: 'move', col: 4, row: 5 },
+      { type: 'mouse', button: 'none', action: 'move', col: 5, row: 6 },
+    ]);
+  });
+
+  it('preserves keyboard input around bundled SGR mouse packets', () => {
+    const bus = createEventBus<TestMsg>();
+    const { io, simulateKey } = createMockIO();
+    const received: BusMsg<TestMsg>[] = [];
+    bus.on((msg) => received.push(msg));
+
+    bus.connectIO(io, { mouse: true });
+    simulateKey('a\x1b[<0;5;6M');
+
+    expect(received).toMatchObject([
+      { type: 'key', key: 'a' },
+      { type: 'mouse', button: 'left', action: 'press', col: 4, row: 5 },
+    ]);
+  });
 });

--- a/packages/bijou-tui/src/eventbus.ts
+++ b/packages/bijou-tui/src/eventbus.ts
@@ -29,7 +29,7 @@ import type { IOPort } from '@flyingrobots/bijou';
 import { defer, resolveClock, sleep, type ClockPort } from '@flyingrobots/bijou';
 import type { Cmd, CmdCleanup, CmdDisposable, CmdResult, KeyMsg, MouseMsg, PulseMsg, ResizeMsg } from './types.js';
 import { QUIT, isCmdCleanup } from './types.js';
-import { parseKey, parseMouse } from './keys.js';
+import { parseRawInputMessages } from './input-parser.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -332,20 +332,7 @@ export function createEventBus<M>(busOptions?: CreateEventBusOptions): EventBus<
       // Keyboard (and optionally mouse) input
       const inputHandle = io.rawInput((raw: string) => {
         if (disposed) return;
-
-        // When mouse is enabled, try parsing as mouse first
-        if (mouseEnabled) {
-          const mouseMsg = parseMouse(raw);
-          if (mouseMsg) {
-            emit(mouseMsg);
-            return;
-          }
-        }
-
-        const keyMsg = parseKey(raw);
-        // Skip unknown sequences (unrecognized escape sequences)
-        if (keyMsg.key === 'unknown') return;
-        emit(keyMsg);
+        for (const msg of parseRawInputMessages(raw, mouseEnabled)) emit(msg);
       });
 
       // Resize events

--- a/packages/bijou-tui/src/index.part01.ts
+++ b/packages/bijou-tui/src/index.part01.ts
@@ -19,6 +19,7 @@ export type {
   MouseMsg,
   MouseButton,
   MouseAction,
+  MouseTrackingMode,
   QuitSignal,
   RunOptions,
   RuntimeIssue,

--- a/packages/bijou-tui/src/input-parser.ts
+++ b/packages/bijou-tui/src/input-parser.ts
@@ -2,7 +2,13 @@ import type { KeyMsg, MouseMsg } from './types.js';
 import { parseKey, parseMouse } from './keys.js';
 
 const ESCAPE = String.fromCharCode(0x1b);
+const ESCAPE_CODE = 0x1b;
 const SGR_MOUSE_PACKET_RE = new RegExp(`${ESCAPE}\\[<\\d+;\\d+;\\d+[Mm]`, 'gu');
+
+interface KeyToken {
+  readonly message: KeyMsg | null;
+  readonly nextIndex: number;
+}
 
 function splitSgrMousePackets(raw: string): readonly string[] {
   const chunks: string[] = [];
@@ -16,6 +22,64 @@ function splitSgrMousePackets(raw: string): readonly string[] {
   }
   if (lastIndex < raw.length) chunks.push(raw.slice(lastIndex));
   return chunks.length === 0 ? [raw] : chunks;
+}
+
+function parseKeyMessages(raw: string): readonly KeyMsg[] {
+  const messages: KeyMsg[] = [];
+  let index = 0;
+  while (index < raw.length) {
+    const token = raw.charCodeAt(index) === ESCAPE_CODE
+      ? readEscapeKeyToken(raw, index)
+      : readSingleKeyToken(raw, index);
+    if (token.message !== null) messages.push(token.message);
+    index = token.nextIndex;
+  }
+  return messages;
+}
+
+function readSingleKeyToken(raw: string, index: number): KeyToken {
+  const message = parseKey(raw.slice(index, index + 1));
+  return {
+    message: message.key === 'unknown' ? null : message,
+    nextIndex: index + 1,
+  };
+}
+
+function readEscapeKeyToken(raw: string, index: number): KeyToken {
+  const sequenceEnd = findEscapeSequenceEnd(raw, index);
+  let message: KeyMsg | null = null;
+  let nextIndex = index + 1;
+  for (let end = index + 1; end <= sequenceEnd; end += 1) {
+    const parsed = parseKey(raw.slice(index, end));
+    if (parsed.key !== 'unknown') {
+      message = parsed;
+      nextIndex = end;
+    }
+  }
+
+  if (message !== null && (nextIndex > index + 1 || !isControlSequence(raw, index))) {
+    return { message, nextIndex };
+  }
+  return { message: null, nextIndex: sequenceEnd };
+}
+
+function findEscapeSequenceEnd(raw: string, index: number): number {
+  if (raw[index + 1] === '[') {
+    for (let end = index + 2; end < raw.length; end += 1) {
+      if (isCsiFinalByte(raw.charCodeAt(end))) return end + 1;
+    }
+    return raw.length;
+  }
+  if (raw[index + 1] === 'O') return Math.min(index + 3, raw.length);
+  return index + 1;
+}
+
+function isControlSequence(raw: string, index: number): boolean {
+  return raw[index + 1] === '[' || raw[index + 1] === 'O';
+}
+
+function isCsiFinalByte(code: number): boolean {
+  return code >= 0x40 && code <= 0x7e;
 }
 
 export function parseRawInputMessages(
@@ -34,8 +98,7 @@ export function parseRawInputMessages(
       }
     }
 
-    const keyMsg = parseKey(chunk);
-    if (keyMsg.key !== 'unknown') messages.push(keyMsg);
+    messages.push(...parseKeyMessages(chunk));
   }
   return messages;
 }

--- a/packages/bijou-tui/src/input-parser.ts
+++ b/packages/bijou-tui/src/input-parser.ts
@@ -1,0 +1,41 @@
+import type { KeyMsg, MouseMsg } from './types.js';
+import { parseKey, parseMouse } from './keys.js';
+
+const ESCAPE = String.fromCharCode(0x1b);
+const SGR_MOUSE_PACKET_RE = new RegExp(`${ESCAPE}\\[<\\d+;\\d+;\\d+[Mm]`, 'gu');
+
+function splitSgrMousePackets(raw: string): readonly string[] {
+  const chunks: string[] = [];
+  let lastIndex = 0;
+  for (const match of raw.matchAll(SGR_MOUSE_PACKET_RE)) {
+    if (match.index > lastIndex) {
+      chunks.push(raw.slice(lastIndex, match.index));
+    }
+    chunks.push(match[0]);
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < raw.length) chunks.push(raw.slice(lastIndex));
+  return chunks.length === 0 ? [raw] : chunks;
+}
+
+export function parseRawInputMessages(
+  raw: string,
+  mouseEnabled: boolean,
+): readonly (KeyMsg | MouseMsg)[] {
+  const messages: (KeyMsg | MouseMsg)[] = [];
+  const chunks = mouseEnabled ? splitSgrMousePackets(raw) : [raw];
+  for (const chunk of chunks) {
+    if (chunk.length === 0) continue;
+    if (mouseEnabled) {
+      const mouseMsg = parseMouse(chunk);
+      if (mouseMsg !== null) {
+        messages.push(mouseMsg);
+        continue;
+      }
+    }
+
+    const keyMsg = parseKey(chunk);
+    if (keyMsg.key !== 'unknown') messages.push(keyMsg);
+  }
+  return messages;
+}

--- a/packages/bijou-tui/src/input-parser.ts
+++ b/packages/bijou-tui/src/input-parser.ts
@@ -3,6 +3,8 @@ import { parseKey, parseMouse } from './keys.js';
 
 const ESCAPE = String.fromCharCode(0x1b);
 const ESCAPE_CODE = 0x1b;
+const X10_MOUSE_PACKET_LENGTH = 6;
+const X10_MOUSE_PREFIX = `${ESCAPE}[M`;
 const SGR_MOUSE_PACKET_RE = new RegExp(`${ESCAPE}\\[<\\d+;\\d+;\\d+[Mm]`, 'gu');
 
 interface KeyToken {
@@ -64,6 +66,9 @@ function readEscapeKeyToken(raw: string, index: number): KeyToken {
 }
 
 function findEscapeSequenceEnd(raw: string, index: number): number {
+  if (raw.startsWith(X10_MOUSE_PREFIX, index)) {
+    return Math.min(index + X10_MOUSE_PACKET_LENGTH, raw.length);
+  }
   if (raw[index + 1] === '[') {
     for (let end = index + 2; end < raw.length; end += 1) {
       if (isCsiFinalByte(raw.charCodeAt(end))) return end + 1;

--- a/packages/bijou-tui/src/mouse-mode.ts
+++ b/packages/bijou-tui/src/mouse-mode.ts
@@ -1,0 +1,20 @@
+import type { MouseTrackingMode, RunOptions } from './types.js';
+
+export const DISABLE_MOUSE = '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l';
+
+const ENABLE_MOUSE_PRESS = '\x1b[?1000h\x1b[?1002l\x1b[?1003l\x1b[?1006h';
+const ENABLE_MOUSE_DRAG = '\x1b[?1000h\x1b[?1002h\x1b[?1003l\x1b[?1006h';
+const ENABLE_MOUSE_ANY = '\x1b[?1000h\x1b[?1002l\x1b[?1003h\x1b[?1006h';
+
+export function resolveMouseMode<M>(
+  options: RunOptions<M> | undefined,
+): MouseTrackingMode | undefined {
+  if (options?.mouseMode !== undefined) return options.mouseMode;
+  return options?.mouse === true ? 'drag' : undefined;
+}
+
+export function mouseModeSequence(mode: MouseTrackingMode): string {
+  if (mode === 'press') return ENABLE_MOUSE_PRESS;
+  if (mode === 'any') return ENABLE_MOUSE_ANY;
+  return ENABLE_MOUSE_DRAG;
+}

--- a/packages/bijou-tui/src/runtime-interactive-input.part01.test.ts
+++ b/packages/bijou-tui/src/runtime-interactive-input.part01.test.ts
@@ -49,13 +49,13 @@ describe('run', () => {
 describe('run', () => {
   describe('interactive mode', () => {
     it('enables any-event mouse tracking when requested', async () => {
-          const { clock, ctx } = createInteractiveContext({ io: { keys: ['q'] } });
-          const promise = run(counterApp(), { ctx, mouseMode: 'any' });
-          await clock.advanceByAsync(50);
-          await promise;
-          expect(ctx.io.written).toContain(ENABLE_MOUSE_ANY);
-          expect(ctx.io.written).toContain(DISABLE_MOUSE);
-        });
+      const { clock, ctx } = createInteractiveContext({ io: { keys: ['q'] } });
+      const promise = run(counterApp(), { ctx, mouseMode: 'any' });
+      await clock.advanceByAsync(50);
+      await promise;
+      expect(ctx.io.written).toContain(ENABLE_MOUSE_ANY);
+      expect(ctx.io.written).toContain(DISABLE_MOUSE);
+    });
   });
 });
 

--- a/packages/bijou-tui/src/runtime-interactive-input.part01.test.ts
+++ b/packages/bijou-tui/src/runtime-interactive-input.part01.test.ts
@@ -1,4 +1,4 @@
-import { App, CLEAR_SCREEN, counterApp, createInteractiveContext, describe, DISABLE_MOUSE, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, expect, HIDE_CURSOR, HOME, it, quit, run, scheduleKeys, SHOW_CURSOR, textView, WRAP_DISABLE, WRAP_ENABLE } from './runtime.test-support.js';
+import { App, CLEAR_SCREEN, counterApp, createInteractiveContext, describe, DISABLE_MOUSE, ENABLE_MOUSE_ANY, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, expect, HIDE_CURSOR, HOME, it, quit, run, scheduleKeys, SHOW_CURSOR, textView, WRAP_DISABLE, WRAP_ENABLE } from './runtime.test-support.js';
 import { must } from '@flyingrobots/bijou/adapters/test';
 
 describe('run', () => {
@@ -42,6 +42,19 @@ describe('run', () => {
           expect(ctx.io.written).toContain(DISABLE_MOUSE);
           expect(ctx.io.written[ctx.io.written.length - 2]).toBe(DISABLE_MOUSE);
           expect(ctx.io.written[ctx.io.written.length - 1]).toBe(SHOW_CURSOR + WRAP_ENABLE + EXIT_ALT_SCREEN);
+        });
+  });
+});
+
+describe('run', () => {
+  describe('interactive mode', () => {
+    it('enables any-event mouse tracking when requested', async () => {
+          const { clock, ctx } = createInteractiveContext({ io: { keys: ['q'] } });
+          const promise = run(counterApp(), { ctx, mouseMode: 'any' });
+          await clock.advanceByAsync(50);
+          await promise;
+          expect(ctx.io.written).toContain(ENABLE_MOUSE_ANY);
+          expect(ctx.io.written).toContain(DISABLE_MOUSE);
         });
   });
 });

--- a/packages/bijou-tui/src/runtime.test-support.ts
+++ b/packages/bijou-tui/src/runtime.test-support.ts
@@ -19,7 +19,8 @@ import {
 } from './screen.js';
 import { scheduleKeys, scheduleResizes } from './runtime-schedule.test-support.js';
 
-const DISABLE_MOUSE = '\x1b[?1000l\x1b[?1002l\x1b[?1006l';
+const DISABLE_MOUSE = '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l';
+const ENABLE_MOUSE_ANY = '\x1b[?1000h\x1b[?1002l\x1b[?1003h\x1b[?1006h';
 const SHUTDOWN_DRAIN_TIMEOUT_MS = 1000;
 
 function counterApp(quitKey = 'q'): App<number> {
@@ -99,6 +100,7 @@ export {
   createTrackingClock,
   describe,
   DISABLE_MOUSE,
+  ENABLE_MOUSE_ANY,
   ENTER_ALT_SCREEN,
   EXIT_ALT_SCREEN,
   expect,

--- a/packages/bijou-tui/src/runtime.ts
+++ b/packages/bijou-tui/src/runtime.ts
@@ -13,6 +13,7 @@ import type { App, Cmd, RunOptions, ResizeMsg } from './types.js';
 import { isKeyMsg, isPulseMsg, isResizeMsg } from './types.js';
 import { clearAndHome, enterScreen, exitScreen, renderSurfaceFrame } from './screen.js';
 import { createEventBus } from './eventbus.js';
+import { DISABLE_MOUSE, mouseModeSequence, resolveMouseMode } from './mouse-mode.js';
 import {
   createPipeline,
   getRenderStageTimings,
@@ -30,8 +31,6 @@ import type { RuntimeIssue } from './types.js';
 
 type ErrorWritePort = Pick<WritePort, 'write'> & Partial<Pick<WritePort, 'writeError'>>;
 
-const DISABLE_MOUSE = '\x1b[?1000l\x1b[?1002l\x1b[?1006l';
-const ENABLE_MOUSE = '\x1b[?1000h\x1b[?1002h\x1b[?1006h';
 const FATAL_RENDER_ERROR_KEY = '__fatalRenderError';
 const SHUTDOWN_DRAIN_TIMEOUT_MS = 1000;
 
@@ -72,7 +71,8 @@ export async function runWithLifecycleHooks<Model, M>(
   installRuntimeViewportOverlay(ctx);
   const useAltScreen = options?.altScreen ?? true;
   const useHideCursor = options?.hideCursor ?? true;
-  const useMouse = options?.mouse ?? false;
+  const mouseMode = resolveMouseMode(options);
+  const useMouse = mouseMode !== undefined;
   const surfaceBudget = options?.surfaceBudget;
   const routedSurfaceBudgetWarnings = new Set<string>();
   installBCSSResolver(ctx, options?.css);
@@ -352,17 +352,15 @@ export async function runWithLifecycleHooks<Model, M>(
     if (resolveQuit) resolveQuit();
   }
 
-  // Setup screen
   if (useAltScreen || useHideCursor) {
     enterScreen(ctx.io);
   }
   if (useMouse) {
-    ctx.io.write(ENABLE_MOUSE);
+    ctx.io.write(mouseModeSequence(mouseMode));
   } else {
     ctx.io.write(DISABLE_MOUSE);
   }
 
-  // Render helper
   let renderQueued = false;
   let renderInFlight = false;
   let renderHandle: TimerHandle | null = null;

--- a/packages/bijou-tui/src/types.ts
+++ b/packages/bijou-tui/src/types.ts
@@ -43,8 +43,9 @@ export interface PulseMsg {
 /** Mouse button identifier. `"none"` is used for scroll and motion events without a button. */
 export type MouseButton = 'left' | 'middle' | 'right' | 'none';
 
-/** Mouse action type including press, release, move, and scroll directions. */
 export type MouseAction = 'press' | 'release' | 'move' | 'scroll-up' | 'scroll-down';
+
+export type MouseTrackingMode = 'press' | 'drag' | 'any';
 
 /** Represent a mouse input event with button, action, position, and modifiers. */
 export interface MouseMsg {
@@ -220,11 +221,6 @@ export interface App<Model, M = never> {
 
 // --- Runtime options ---
 
-/**
- * Configuration options for the TEA runtime.
- * 
- * @template M - Custom application message type.
- */
 export interface RunOptions<M = unknown> {
   /** Enter the alternate screen buffer on startup. */
   altScreen?: boolean;
@@ -232,6 +228,8 @@ export interface RunOptions<M = unknown> {
   hideCursor?: boolean;
   /** Enable mouse input (SGR mode). Default: false. */
   mouse?: boolean;
+  /** Mouse mode: `press`, `drag` (default), or hover-capable `any`. */
+  mouseMode?: MouseTrackingMode;
   /** Bijou context providing I/O and runtime ports. */
   ctx?: BijouContext;
   /** Optional middleware to intercept or modify messages. */

--- a/packages/bijou-tui/src/types.ts
+++ b/packages/bijou-tui/src/types.ts
@@ -40,14 +40,15 @@ export interface PulseMsg {
 
 // --- Mouse messages ---
 
-/** Mouse button identifier. `"none"` is used for scroll and motion events without a button. */
+/** Mouse button; `"none"` covers scroll and unbuttoned motion. */
 export type MouseButton = 'left' | 'middle' | 'right' | 'none';
 
+/** Mouse action. */
 export type MouseAction = 'press' | 'release' | 'move' | 'scroll-up' | 'scroll-down';
-
+/** SGR mouse tracking mode. */
 export type MouseTrackingMode = 'press' | 'drag' | 'any';
 
-/** Represent a mouse input event with button, action, position, and modifiers. */
+/** Mouse input event. */
 export interface MouseMsg {
   /** Discriminant tag identifying this as a mouse message. */
   readonly type: 'mouse';
@@ -221,6 +222,7 @@ export interface App<Model, M = never> {
 
 // --- Runtime options ---
 
+/** TEA runtime options. */
 export interface RunOptions<M = unknown> {
   /** Enter the alternate screen buffer on startup. */
   altScreen?: boolean;

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -16,6 +16,7 @@
       "@flyingrobots/bijou-i18n": ["./packages/bijou-i18n/src/index.ts"],
       "@flyingrobots/bijou-i18n-tools": ["./packages/bijou-i18n-tools/src/index.ts"],
       "@flyingrobots/bijou-i18n-tools-node": ["./packages/bijou-i18n-tools-node/src/index.ts"],
+      "@flyingrobots/bijou-tui": ["./packages/bijou-tui/src/index.ts"],
       "@flyingrobots/bijou/adapters/test": ["./packages/bijou/src/adapters/test/index.ts"],
       "@flyingrobots/bijou/perf": ["./packages/bijou/src/core/render/packed-cell.ts"]
     }


### PR DESCRIPTION
## Summary

- add `RunOptions.mouseMode` with `press`, `drag`, and any-event `any` SGR tracking
- split bundled SGR mouse packets before parsing so multiple mouse moves in one raw input chunk are delivered
- propagate mouse tracking mode through the Node worker host while keeping terminal control owned by the main thread
- document the runtime option and add regressions for runtime, event bus, and worker behavior

## Root Cause

Hover-heavy terminal demos can receive multiple SGR mouse packets in a single raw stdin chunk, but the event bus parsed only one raw chunk as one event. Apps that need hover movement also had no first-class way to request any-event mouse tracking (`1003`), so demos had to patch raw input and terminal mode setup externally.

## Validation

- `npm run code-dojo:ci`
- pre-push hook: DOGFOOD i18n gates, `typecheck:test`, full 19-chunk Vitest run, scripted interactive example smokes
- `git diff --check`
