### PR TITLE
Prepare v7.2 release gate

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -116,9 +116,9 @@ Current direction and active tensions. Historical ship data is in
   readiness (#341) repairs have landed as v7.2.0 demo-integrity lineage.
 - The Blocks app-binding (#342) and first-party theme variant (#343) repairs
   have landed as v7.2.0 demo-integrity lineage.
-- The selected `v7.2.0` DOGFOOD product pull is #335: keep release-story
-  surfaces inside DOGFOOD's main reader flow so What's New, the real GraphQL
-  proof chain, and changelog history are visible without wide-only side
+- The selected `v7.2.0` DOGFOOD product pull #335 has landed: release-story
+  surfaces now stay inside DOGFOOD's main reader flow so What's New, the real
+  GraphQL proof chain, and changelog history are visible without wide-only side
   metadata.
 - The next feature horizon remains `v8.0.0`: the Runtime Graph and Scene IR
   product contract built from the proof chain that v7.1.0 shipped.
@@ -137,9 +137,11 @@ Current direction and active tensions. Historical ship data is in
 
 ### 3. Stabilize V7.2, Then Shape V8 And V9 From Beyond
 
-- The `v7.2.0` milestone is the current active stabilization lane: 2 open and
-  15 closed milestone items as of the latest roadmap sync.
-- The `Beyond` milestone is the current post-v7 backlog: 31 open and 6 closed
+- The `v7.2.0` milestone is the current release-gate stabilization lane: 1 open
+  and 16 closed milestone items as of the latest roadmap sync.
+- The `v8.0.0` milestone is staged as the next feature horizon: 3 open and 0
+  closed milestone items as of the latest roadmap sync.
+- The `Beyond` milestone is the current post-v7 backlog: 39 open and 6 closed
   milestone items as of the latest roadmap sync.
 - `v7.2.0` should stay bounded to the framework input and DOGFOOD demo-integrity
   issues selected in #354, plus narrow security repairs such as #357.
@@ -178,15 +180,14 @@ Current direction and active tensions. Historical ship data is in
 
 ## Next Target
 
-With Code Dojo, DX-047/#342, and DL-018/#343 landed, the immediate
-`v7.2.0` focus is landing #335: DOGFOOD release-story surfaces through DF-078.
+With Code Dojo, DX-047/#342, DL-018/#343, and #335 landed, the immediate
+`v7.2.0` focus is closing #354 through release-gate validation.
 
 ```text
-Current What's New
-  -> release-story entry point
-    -> NavigationListBlock GraphQL proof walkthrough
-      -> CHANGELOG version boundaries
-        -> #354 demo-integrity closure
+DOGFOOD release-story surfaces
+  -> #354 criteria audit
+    -> release-readiness and preflight
+      -> v7.2.0 version/tag decision
 ```
 
 After `v7.2.0` stabilizes the current V7 surface, V8 must turn the proof chain
@@ -203,11 +204,10 @@ GraphQL SDL fixture
 
 Recommended pull order:
 
-1. Merge #335 release-story surfaces so DOGFOOD can explain What's New, the
-   real GraphQL proof chain, and changelog history from inside the app.
-2. Close the remaining #354 umbrella criteria once #335 is merged and the
-   dependency advisory audit remains clean.
-3. Run the normal `v7.2.0` release-prep checklist before any tag is created.
+1. Run the normal `v7.2.0` release-prep checklist before any tag is created.
+2. Close the remaining #354 umbrella criteria once release-readiness and
+   preflight remain clean.
+3. Prepare the `v7.2.0` version/tag release packet from merged `main`.
 4. Shape #302 into a V8 design packet with artifact semantics, receipt
    invariants, source-map ownership, lower-mode contracts, and failure cases.
 5. Promote only the Runtime Graph and Scene IR issues needed for that contract

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -317,6 +317,11 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### 🧭 Planning
 
+- **v7.2.0 release-gate sync** — `docs/ROADMAP.md` and `docs/BEARING.md` now
+  mark #335 as landed, refresh the GitHub milestone counts, stage the new
+  `v8.0.0` VISOR tracker separately from the v7.2 stabilization lane, and make
+  #354 release-readiness/preflight closure the next pull before any tag is
+  created.
 - **v7.2.0 stabilization train** —
   `docs/ROADMAP.md`, `docs/BEARING.md`, `docs/release.md`, and
   `docs/design/RE-041-v72-framework-input-stabilization.md` now select

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ requests assigned to each milestone. They are not issue-only totals. Do not
 compare release snapshot item totals to issue-only `gh issue list` output
 without also accounting for milestone pull requests.
 
-Last synced from GitHub milestone items: 2026-07-03.
+Last synced from GitHub milestone items: 2026-07-04.
 
 ## Current Release State
 
@@ -47,10 +47,11 @@ count reaches zero.
 
 | Horizon | Milestone | Open Items | Closed Items | Current Posture |
 | :--- | :--- | ---: | ---: | :--- |
-| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 2 | 15 | Active stabilization lane for demo integrity, framework input correctness, and narrow security repairs. |
+| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 1 | 16 | Release-gate lane for demo integrity, framework input correctness, and narrow security repairs. |
+| `v8.0.0` | [v8.0.0](https://github.com/flyingrobots/bijou/milestone/6) | 3 | 0 | Staged next feature horizon for VISOR and the Runtime Graph / Scene IR contract. |
 | `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 | Latest shipped release lineage after the release PR merges. Complete; do not reopen for new feature work. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Shipped release lineage. Complete; do not reopen for new feature work. |
-| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 31 | 6 | Active forward backlog. Promote shaped work from here into a versioned release. |
+| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 39 | 6 | Active forward backlog. Promote shaped work from here into a versioned release. |
 | `v6.0.0` | [v6.0.0](https://github.com/flyingrobots/bijou/milestone/1) | 0 | 30 | Skipped public release lane. Complete lineage retained for issue history. |
 
 ## Release Train Decision
@@ -112,7 +113,7 @@ Primary tracker:
   [#343](https://github.com/flyingrobots/bijou/issues/343) are landed DOGFOOD
   localization, light-theme, Blocks documentation, and theme-variant
   demo-integrity lineage
-- [#335](https://github.com/flyingrobots/bijou/issues/335) is the selected
+- [#335](https://github.com/flyingrobots/bijou/issues/335) is the landed
   DOGFOOD release-story surface pull for keeping What's New, the real GraphQL
   proof chain, and changelog boundaries in the main DOGFOOD reader flow
 - [#357](https://github.com/flyingrobots/bijou/issues/357) for the urgent
@@ -217,26 +218,25 @@ that a cross-repository release is the next smallest honest boundary.
 
 ## Next Pull
 
-The immediate implementation pull should land the **DOGFOOD release-story
-surfaces** repair from #335 through DF-078.
+The immediate pull should close the **v7.2.0 release gate** for #354.
 
-That pull should make DOGFOOD expose the current What's New story, the real
-NavigationListBlock GraphQL proof chain, and changelog version boundaries from
-inside the app's main reader flow, without adding first-run persistence unless
-a deterministic version-memory port lands in the same cycle.
+That pull should synchronize the roadmap with the now-landed #335 DOGFOOD
+release-story surfaces, run the normal release-readiness and preflight checks,
+and leave the branch ready for the `v7.2.0` version/tag decision if every gate
+is green. It should not add new product scope to the stabilization lane.
 
 ## Forward Goalposts
 
 These are planning recommendations from the open tracker state as of
-2026-07-03. `v7.1.0` is shipped lineage; `v7.2.0` is the active stabilization
-lane; `v8.0.0` and `v9.0.0` remain the intended feature horizons after the
-stabilization release.
+2026-07-04. `v7.1.0` is shipped lineage; `v7.2.0` is the release-gate
+stabilization lane; `v8.0.0` and `v9.0.0` remain the intended feature horizons
+after the stabilization release.
 
 | Target | Goalpost | Tracker | Why It Belongs There | Release Gate |
 | :--- | :--- | :--- | :--- | :--- |
 | `v7.1.0` | Shipped Post-V7 Minor | Landed DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329), release-prep guardrails [#270](https://github.com/flyingrobots/bijou/issues/270) and [#312](https://github.com/flyingrobots/bijou/issues/312), the v7.1.0 release PR, and `Unreleased` changelog work after `v7.0.0` | The repo shipped a meaningful post-V7 batch without turning it into a new product epoch. | Met: DX-046 green, #270/#312 green, release evidence packet written, #329 kept in `v7.1.0` without moving #302 out of `Beyond`, and no broad scope creep. |
-| `v7.2.0` | Demo Integrity And Framework Input Stabilization | Active goalpost [#354](https://github.com/flyingrobots/bijou/issues/354), framework input stories [#344](https://github.com/flyingrobots/bijou/issues/344), [#345](https://github.com/flyingrobots/bijou/issues/345), [#353](https://github.com/flyingrobots/bijou/issues/353), landed DOGFOOD repair stories [#340](https://github.com/flyingrobots/bijou/issues/340), [#341](https://github.com/flyingrobots/bijou/issues/341), [#342](https://github.com/flyingrobots/bijou/issues/342), [#343](https://github.com/flyingrobots/bijou/issues/343), selected release-story story [#335](https://github.com/flyingrobots/bijou/issues/335), and security patches [#357](https://github.com/flyingrobots/bijou/issues/357), [#370](https://github.com/flyingrobots/bijou/issues/370). | The v7.1 proof exists, but the release-video rehearsal exposed demo-breaking seams in localization, theme posture, Blocks docs, release-story surfaces, and mouse routing; GitHub/npm audit also reported narrow development-tooling and dependency advisories that are now triaged clean. | Workspace pointer fallthrough fixed, page-frame helper exports public, mouse test helpers available, DOGFOOD demo surfaces honest enough for release video, audit clean, #335 release-story surfaces implemented, and release-readiness green. |
-| `v8.0.0` | Runtime Graph And Scene IR Product Contract | Beyond: [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#301](https://github.com/flyingrobots/bijou/issues/301), [#302](https://github.com/flyingrobots/bijou/issues/302). Triage: [#306](https://github.com/flyingrobots/bijou/issues/306), [#321](https://github.com/flyingrobots/bijou/issues/321). | This is the current product direction after DX-043 through DX-046: portable scenes, GraphQL blocks, deterministic debug facts, and product fixtures need to become a stable contract. | Stable artifact semantics, DOGFOOD round-trip fixtures, terminal/frame-capture proof, lower-mode and source-map receipts, and failure tests. |
+| `v7.2.0` | Demo Integrity And Framework Input Stabilization | Release-gate goalpost [#354](https://github.com/flyingrobots/bijou/issues/354), framework input stories [#344](https://github.com/flyingrobots/bijou/issues/344), [#345](https://github.com/flyingrobots/bijou/issues/345), [#353](https://github.com/flyingrobots/bijou/issues/353), landed DOGFOOD repair stories [#340](https://github.com/flyingrobots/bijou/issues/340), [#341](https://github.com/flyingrobots/bijou/issues/341), [#342](https://github.com/flyingrobots/bijou/issues/342), [#343](https://github.com/flyingrobots/bijou/issues/343), landed release-story story [#335](https://github.com/flyingrobots/bijou/issues/335), and security patches [#357](https://github.com/flyingrobots/bijou/issues/357), [#370](https://github.com/flyingrobots/bijou/issues/370). | The v7.1 proof exists, but the release-video rehearsal exposed demo-breaking seams in localization, theme posture, Blocks docs, release-story surfaces, and mouse routing; GitHub/npm audit also reported narrow development-tooling and dependency advisories that are now triaged clean. | Workspace pointer fallthrough fixed, page-frame helper exports public, mouse test helpers available, DOGFOOD demo surfaces honest enough for release video, audit clean, #335 release-story surfaces implemented, and release-readiness green. |
+| `v8.0.0` | Runtime Graph And Scene IR Product Contract | Staged milestone tracker [#457](https://github.com/flyingrobots/bijou/issues/457), VISOR artifact bundle [#458](https://github.com/flyingrobots/bijou/issues/458), and packed Bijou cell adapter [#459](https://github.com/flyingrobots/bijou/issues/459). Candidate source lineage remains in Beyond: [#202](https://github.com/flyingrobots/bijou/issues/202), [#209](https://github.com/flyingrobots/bijou/issues/209), [#210](https://github.com/flyingrobots/bijou/issues/210), [#211](https://github.com/flyingrobots/bijou/issues/211), [#212](https://github.com/flyingrobots/bijou/issues/212), [#213](https://github.com/flyingrobots/bijou/issues/213), [#216](https://github.com/flyingrobots/bijou/issues/216), [#219](https://github.com/flyingrobots/bijou/issues/219), [#301](https://github.com/flyingrobots/bijou/issues/301), and [#302](https://github.com/flyingrobots/bijou/issues/302). | This is the current product direction after DX-043 through DX-046 and the VISOR planning turn: portable scenes, GraphQL blocks, deterministic debug facts, packed terminal cells, replay/capture evidence, and product fixtures need to become a stable contract. | Stable artifact semantics, DOGFOOD round-trip fixtures, terminal/frame-capture proof, lower-mode and source-map receipts, and failure tests. |
 | `v9.0.0` | Product Workbench And Operator Surfaces | Beyond: [#204](https://github.com/flyingrobots/bijou/issues/204), [#205](https://github.com/flyingrobots/bijou/issues/205), [#206](https://github.com/flyingrobots/bijou/issues/206), [#207](https://github.com/flyingrobots/bijou/issues/207), [#208](https://github.com/flyingrobots/bijou/issues/208), [#214](https://github.com/flyingrobots/bijou/issues/214), [#215](https://github.com/flyingrobots/bijou/issues/215), [#217](https://github.com/flyingrobots/bijou/issues/217), [#218](https://github.com/flyingrobots/bijou/issues/218), [#248](https://github.com/flyingrobots/bijou/issues/248), [#272](https://github.com/flyingrobots/bijou/issues/272), [#311](https://github.com/flyingrobots/bijou/issues/311), [#315](https://github.com/flyingrobots/bijou/issues/315), [#318](https://github.com/flyingrobots/bijou/issues/318). Triage: [#317](https://github.com/flyingrobots/bijou/issues/317), [#316](https://github.com/flyingrobots/bijou/issues/316). | Once V8 stabilizes the artifact contract, the next value is authoring and inspecting real product surfaces: BlockLab, Theme Lab, localization operations, artifact matrices, and host controls. | Storybook-grade BlockLab workflows, Theme Inspector/Lab provenance, localization workbench proof, artifact matrices, and playback-backed terminal input where applicable. |
 | `v10.0.0+` | Ecosystem Integration | Wesley, Geordi, and host integration follow-on work after V8/V9 shape the contracts | Cross-repository integration should consume proven Bijou contracts rather than define them under release pressure. | A cross-repo release packet with explicit dependency ordering, proof artifacts, and rollback boundaries. |
 
@@ -272,6 +272,14 @@ stabilization release.
 
 | Issue | Lane | Type | Work |
 | :--- | :--- | :--- | :--- |
+| [#455](https://github.com/flyingrobots/bijou/issues/455) | `lane:cool-ideas` | `type:enhancement` | DOGFOOD drawer-led chroma and focus language |
+| [#454](https://github.com/flyingrobots/bijou/issues/454) | `lane:cool-ideas` | `type:enhancement` / `type:docs` | Structured multilingual changelog source |
+| [#373](https://github.com/flyingrobots/bijou/issues/373) | `lane:cool-ideas` | `type:enhancement` | Post Code Dojo delta tables on pull requests |
+| [#372](https://github.com/flyingrobots/bijou/issues/372) | `lane:cool-ideas` | `type:enhancement` / `type:maintenance` | Code Dojo ratchet-candidate reports |
+| [#371](https://github.com/flyingrobots/bijou/issues/371) | `lane:cool-ideas` | `type:enhancement` | Code Dojo debt dashboard in DOGFOOD |
+| [#369](https://github.com/flyingrobots/bijou/issues/369) | `lane:bad-code` | `type:enhancement` / `type:maintenance` | Code Dojo debt reporting hides live slack under stored ceilings |
+| [#368](https://github.com/flyingrobots/bijou/issues/368) | `lane:bad-code` | `type:maintenance` | Docs-preview tests need typed model and frame helpers |
+| [#367](https://github.com/flyingrobots/bijou/issues/367) | `lane:bad-code` | `type:maintenance` | wizard() result typing pretends skipped fields are always present |
 | [#336](https://github.com/flyingrobots/bijou/issues/336) | `lane:cool-ideas` | `type:enhancement` | DOGFOOD future affordances: theme hotkey, tab badges, tutorial, and achievements |
 | [#202](https://github.com/flyingrobots/bijou/issues/202) | `lane:cool-ideas` | `type:enhancement` | CI-001 mermaidSurface component |
 | [#203](https://github.com/flyingrobots/bijou/issues/203) | `lane:cool-ideas` | `type:spike` | CI-002 deterministic time-travel debugger |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -139,10 +139,20 @@ Release gate:
 `v8.0.0` should be the next major release. Its job is to turn the portable scene
 and GraphQL block proof into a product contract, not just a compiler demo.
 
-Primary tracker:
+Primary staged milestone trackers:
 
-- [#302](https://github.com/flyingrobots/bijou/issues/302) for GraphQL-authored
-  UI scenes into Bijou Blocks
+- [#457](https://github.com/flyingrobots/bijou/issues/457) TRACKER: VISOR
+  warpspace for v8 Runtime Graph And Scene IR
+- [#458](https://github.com/flyingrobots/bijou/issues/458) VISOR: emit GraphQL
+  block artifact bundle with replay and visual scene facts
+- [#459](https://github.com/flyingrobots/bijou/issues/459) VISOR: validate
+  packed-bijou-cells/1 and adapt to Surface
+
+Candidate source lineage remains in `Beyond` until a staged V8 tracker pulls it
+into implementation scope:
+
+- [#302](https://github.com/flyingrobots/bijou/issues/302) remains the broad
+  GraphQL-authored UI scenes into Bijou Blocks source tracker
 - [#202](https://github.com/flyingrobots/bijou/issues/202),
   [#209](https://github.com/flyingrobots/bijou/issues/209),
   [#210](https://github.com/flyingrobots/bijou/issues/210),
@@ -358,6 +368,8 @@ gh issue list --state all --milestone v7.1.0
 gh pr list --state all --search 'milestone:"v7.1.0"'
 gh issue list --state all --milestone v7.2.0
 gh pr list --state all --search 'milestone:"v7.2.0"'
+gh issue list --state all --milestone v8.0.0
+gh pr list --state all --search 'milestone:"v8.0.0"'
 gh issue list --state all --milestone v7.0.0
 gh pr list --state all --search 'milestone:"v7.0.0"'
 gh issue list --state all --milestone Beyond

--- a/docs/release.md
+++ b/docs/release.md
@@ -415,8 +415,9 @@ npm audit --omit=dev --audit-level=high
 `release:readiness` is the repo-native local gauntlet. With `--milestone`, it
 first prints a release-readiness report and blocks before the gauntlet if:
 
-- the target GitHub milestone has open tracker issues
-- any milestone tracker issue still has `work-in-progress`
+- the target GitHub milestone has open tracker items, including issues or pull
+  requests
+- any milestone tracker item still has `work-in-progress`
 - `ROADMAP.md` and `BEARING.md` do not mention the target milestone
 - `CHANGELOG.md` does not have an `Unreleased` or versioned release boundary
 - `docs/releases/X.Y.Z/README.md` release evidence packet is missing

--- a/docs/releases/7.2.0/README.md
+++ b/docs/releases/7.2.0/README.md
@@ -1,0 +1,288 @@
+# Bijou 7.2.0 Release Evidence
+
+Bijou 7.2.0 is a narrow stabilization and demo-integrity release after the
+7.1.0 release-video rehearsal exposed user-facing seams in framework input,
+DOGFOOD localization and themes, Blocks documentation, release-story surfaces,
+dependency posture, and release bookkeeping.
+
+This packet was started on the release-gate branch before the public tag
+exists. The version bump, final release dry run, tag creation, publish
+workflow, npm registry verification, and GitHub Release verification remain
+final-main steps and must run only from the merged `origin/main` release
+commit.
+
+## Release Summary
+
+- Version: `7.2.0`
+- Tag: `v7.2.0` (pending final-main release step)
+- Previous public tag: `v7.1.0`
+- Release type: stable minor
+- npm dist-tag after publish: `latest`
+- Release-gate branch: `cycle/v72-release-gate-354`
+- Release date: pending final tag
+- Publish surface: npm workspace packages only
+
+## Tracker And Goalpost Map
+
+Each goalpost records the release-law evidence required by
+[`docs/release.md`](../../release.md): tracker, design, PRs, completed slices,
+deterministic proof or fixture, replay command, witness, and residual-risk
+disposition.
+
+### V7.2 Stabilization Goalpost
+
+- Tracker: [#354](https://github.com/flyingrobots/bijou/issues/354).
+- Design lineage:
+  [`RE-041`](../../design/RE-041-v72-framework-input-stabilization.md),
+  [`DX-047`](../../design/DX-047-blocks-app-binding-snippets.md),
+  [`DL-017`](../../design/DL-017-dogfood-light-theme-readiness.md),
+  [`DL-018`](../../design/DL-018-first-party-theme-variant-coverage.md),
+  [`LX-020`](../../design/LX-020-dogfood-locale-demo-readiness.md), and
+  [`DF-078`](../../design/DF-078-dogfood-release-story-surfaces.md).
+- Landed PRs: [#355](https://github.com/flyingrobots/bijou/pull/355),
+  [#359](https://github.com/flyingrobots/bijou/pull/359),
+  [#360](https://github.com/flyingrobots/bijou/pull/360),
+  [#361](https://github.com/flyingrobots/bijou/pull/361),
+  [#362](https://github.com/flyingrobots/bijou/pull/362),
+  [#452](https://github.com/flyingrobots/bijou/pull/452), and
+  [#460](https://github.com/flyingrobots/bijou/pull/460).
+- Completed slices: framework input fallthrough and helper exports, DOGFOOD
+  locale fallback honesty, DOGFOOD light-theme readability, first-party theme
+  variant coverage, Blocks app-binding snippets, and in-app release-story
+  surfaces.
+- Canonical proof inputs: the tests and DOGFOOD fixtures named in the
+  per-slice sections below.
+- Replay: run `npm run release:readiness` from the release branch and then run
+  `npm run release:readiness -- --milestone v7.2.0` after #354 is closed and
+  the final release prep branch is merged.
+- Witness: local release-gate validation on 2026-07-04 passed
+  `npm run release:preflight`, `npm run docs:inventory`,
+  `npm audit --omit=dev --audit-level=high`, and `npm run release:readiness`
+  without `--milestone`.
+- Residual risk: final milestone-aware readiness is expected to remain blocked
+  while #354 is open. After this release-gate PR lands and #354 closes, rerun
+  the milestone-aware command before any version tag is created.
+
+### Framework Input Stabilization
+
+- Trackers:
+  [#344](https://github.com/flyingrobots/bijou/issues/344),
+  [#345](https://github.com/flyingrobots/bijou/issues/345), and
+  [#353](https://github.com/flyingrobots/bijou/issues/353).
+- Design: [`RE-041`](../../design/RE-041-v72-framework-input-stabilization.md).
+- Landed PRs: [#355](https://github.com/flyingrobots/bijou/pull/355).
+- Completed slices: workspace mouse movement, release, and non-left press
+  events fall through to the active page; page-scoped frame helpers are exported
+  from the `@flyingrobots/bijou-tui` root; scripted driver helpers can generate
+  deterministic move, press, release, wheel, and raw SGR mouse sequences.
+- Canonical proof inputs:
+  `packages/bijou-tui/src/driver.test.ts`,
+  `packages/bijou-tui/src/index.test.ts`,
+  `packages/bijou-tui/src/app-frame.test.ts`, and WF-130 roadmap tests.
+- Replay: `npm test -- --run packages/bijou-tui/src/driver.test.ts packages/bijou-tui/src/index.test.ts packages/bijou-tui/src/app-frame.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts`.
+- Witness: PR #355 closed all three trackers and merged on 2026-06-15 at
+  `94db990f`.
+- Residual risk: no accepted release risk.
+
+### Mouse Hover Tracking
+
+- Tracker: release-video mouse input follow-up.
+- Design lineage: framework input stabilization plus the runtime/worker mouse
+  tests added in PR #453.
+- Landed PRs: [#453](https://github.com/flyingrobots/bijou/pull/453).
+- Completed slices: `RunOptions.mouseMode` supports `press`, `drag`, and
+  any-event `any` SGR tracking; the event bus splits bundled SGR mouse packets;
+  the Node worker host preserves mouse parsing while terminal control stays in
+  the main thread.
+- Canonical proof inputs: runtime, event-bus, and worker mouse tests touched by
+  PR #453.
+- Replay: `npm run code-dojo:ci`.
+- Witness: PR #453 merged on 2026-07-03 at `e15e771d` after full Code Dojo CI
+  and pre-push verification.
+- Residual risk: no accepted release risk.
+
+### DOGFOOD Locale Demo Readiness
+
+- Tracker: [#340](https://github.com/flyingrobots/bijou/issues/340).
+- Design: [`LX-020`](../../design/LX-020-dogfood-locale-demo-readiness.md).
+- Landed PRs: [#359](https://github.com/flyingrobots/bijou/pull/359).
+- Completed slices: non-English DOGFOOD release-demo paths avoid missing
+  localization marker text by falling back to source copy, while English-source
+  Markdown remains explicitly labeled and maintainer i18n gates remain intact.
+- Canonical proof inputs: DOGFOOD i18n completeness, build, and debt gates.
+- Replay: `npm run dogfood:i18n:complete && npm run dogfood:i18n:check && npm run dogfood:i18n:debt`.
+- Witness: PR #359 closed #340 and merged on 2026-06-15 at `65fb3969`.
+- Residual risk: full translation workbench remains future scope.
+
+### DOGFOOD Light Theme Readiness
+
+- Tracker: [#341](https://github.com/flyingrobots/bijou/issues/341).
+- Design: [`DL-017`](../../design/DL-017-dogfood-light-theme-readiness.md).
+- Landed PRs: [#360](https://github.com/flyingrobots/bijou/pull/360).
+- Completed slices: modal and drawer chrome paint panel backgrounds behind
+  border cells, light/dark subtle chrome clears the same diagnostic floor, and
+  DOGFOOD theme diagnostics cover chrome tokens used by borders, scrollbars,
+  focus gutters, and modal surfaces.
+- Canonical proof inputs:
+  `tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts`,
+  `tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts`,
+  `packages/bijou-tui/src/app-frame-overlays.test.ts`,
+  `packages/bijou-tui/src/app-frame.test.ts`,
+  `packages/bijou/src/core/theme/presets.test.ts`, and
+  `packages/bijou/src/core/theme/doctor.test.ts`.
+- Replay: `npm test -- --run tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts packages/bijou-tui/src/app-frame-overlays.test.ts packages/bijou-tui/src/app-frame.test.ts packages/bijou/src/core/theme/presets.test.ts packages/bijou/src/core/theme/doctor.test.ts`.
+- Witness: PR #360 closed #341 and merged on 2026-06-16 at `d06f8cd4`.
+- Residual risk: no accepted release risk.
+
+### First-Party Theme Variant Coverage
+
+- Tracker: [#343](https://github.com/flyingrobots/bijou/issues/343).
+- Design: [`DL-018`](../../design/DL-018-first-party-theme-variant-coverage.md).
+- Landed PRs: [#362](https://github.com/flyingrobots/bijou/pull/362).
+- Completed slices: DOGFOOD theme family exposes dark and light modes; other
+  first-party shell themes are classified as concrete single-mode themes; `Ctrl+T`
+  and command-palette switching give explicit feedback when no alternate mode
+  exists.
+- Canonical proof inputs:
+  `tests/cycles/DL-018/first-party-theme-variant-coverage.test.ts`,
+  `packages/bijou-tui/src/app-frame-notifications.part05.test.ts`,
+  `packages/bijou-tui/src/app-frame-modal-routing.part01.test.ts`, and
+  `scripts/docs-preview-landing.part04.test.ts`.
+- Replay: `npx vitest run --config vitest.config.ts tests/cycles/DL-018/first-party-theme-variant-coverage.test.ts packages/bijou-tui/src/app-frame-notifications.part05.test.ts packages/bijou-tui/src/app-frame-modal-routing.part01.test.ts scripts/docs-preview-landing.part04.test.ts`.
+- Witness: #343 was revalidated and closed on 2026-07-03 after PR #362 merged
+  at `6c78d196`.
+- Residual risk: product-grade Theme Lab work remains V9-plus scope.
+
+### Blocks App-Binding Snippets
+
+- Tracker: [#342](https://github.com/flyingrobots/bijou/issues/342).
+- Design: [`DX-047`](../../design/DX-047-blocks-app-binding-snippets.md).
+- Landed PRs: [#361](https://github.com/flyingrobots/bijou/pull/361).
+- Completed slices: DOGFOOD Blocks docs now show how `CounterDemoBlock` becomes
+  application-owned state, key-to-command-intent routing, update handling,
+  render-time config, and pipe/accessibility lower-mode output.
+- Canonical proof inputs:
+  `tests/cycles/DX-047/blocks-app-binding-snippets.test.ts` and
+  `tests/cycles/DX-031/dogfood-blocks-section.test.ts`.
+- Replay: `npx vitest run --config vitest.config.ts tests/cycles/DX-047/blocks-app-binding-snippets.test.ts tests/cycles/DX-031/dogfood-blocks-section.test.ts`.
+- Witness: PR #361 closed #342 and merged on 2026-07-02 at `6b56a97a`.
+- Residual risk: no accepted release risk.
+
+### DOGFOOD Release-Story Surfaces
+
+- Tracker: [#335](https://github.com/flyingrobots/bijou/issues/335).
+- Design: [`DF-078`](../../design/DF-078-dogfood-release-story-surfaces.md).
+- Landed PRs: [#452](https://github.com/flyingrobots/bijou/pull/452) and
+  [#460](https://github.com/flyingrobots/bijou/pull/460).
+- Completed slices: DOGFOOD Release includes Current Release Story, GraphQL
+  Proof Walkthrough, and CHANGELOG History in the main reader flow; localized
+  Markdown mirrors load at runtime; release-story guide chrome is cataloged;
+  CHANGELOG boundaries are derived from `docs/CHANGELOG.md`.
+- Canonical proof inputs:
+  `tests/cycles/DF-023/publish-repo-package-and-release-guides-in-dogfood.test.ts`
+  and `tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts`.
+- Replay: `npm test -- --run tests/cycles/DF-023/publish-repo-package-and-release-guides-in-dogfood.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts`.
+- Witness: PR #460 closed #335 and merged on 2026-07-04 at `b8b4eb2` after all
+  review threads were resolved and GitHub Actions were green.
+- Residual risk: structured multilingual changelog source is tracked separately
+  as future work in #454.
+
+### Code Dojo And Standards Ratchets
+
+- Trackers:
+  [#364](https://github.com/flyingrobots/bijou/issues/364) and
+  [#366](https://github.com/flyingrobots/bijou/issues/366).
+- Design: [`WF-134`](../../design/WF-134-code-dojo-eslint-ratchet-1.md) plus
+  the Code Dojo exception ledger.
+- Landed PRs: [#362](https://github.com/flyingrobots/bijou/pull/362) and
+  [#365](https://github.com/flyingrobots/bijou/pull/365), followed by later
+  ratchet slices recorded in `docs/CHANGELOG.md`.
+- Completed slices: installed the TypeScript Code Standards artifact, wired
+  Code Dojo hooks and CI lanes, made standards debt visible through ratcheting
+  baselines, and reduced live ESLint debt below the first ratchet target.
+- Canonical proof inputs:
+  `docs/typescript-code-standards.editors-edition.md`,
+  `docs/code-dojo-exceptions.md`, Code Dojo scripts, and WF-130 roadmap tests.
+- Replay: `npm run code-dojo:verify`.
+- Witness: current release-gate validation passed `npm run release:readiness`,
+  whose gauntlet includes build, lint, code size, typecheck, DOGFOOD gates,
+  workflow shell preflight, release metadata preflight, frame tests, examples,
+  canaries, DOGFOOD smoke, and the full chunked Vitest suite.
+- Residual risk: standards debt is ratcheted, not zero. The exception ledger
+  remains binding after release.
+
+### Dependency Security
+
+- Trackers:
+  [#357](https://github.com/flyingrobots/bijou/issues/357) and
+  [#370](https://github.com/flyingrobots/bijou/issues/370).
+- Designs and PRs:
+  [`WF-133`](../../design/WF-133-esbuild-security-patch.md) through
+  [#358](https://github.com/flyingrobots/bijou/pull/358), plus the Hono
+  Dependabot security update in
+  [#363](https://github.com/flyingrobots/bijou/pull/363).
+- Completed slices: `esbuild` resolves to `0.28.1`; `hono` resolves to
+  `4.12.25`; default-branch audit and Dependabot alert checks were verified
+  before #370 closed.
+- Canonical proof inputs: npm lockfile, `npm audit`, and Dependabot alert API.
+- Replay: `npm audit --omit=dev --audit-level=high`.
+- Witness: release-gate validation on 2026-07-04 reported
+  `found 0 vulnerabilities`.
+- Residual risk: no accepted release risk.
+
+## Automated Evidence Matrix
+
+| Gate | Command or source | Expected result | Status |
+| :--- | :--- | :--- | :--- |
+| Release metadata preflight | `npm run release:preflight` | Lock-step workspace metadata is valid. | Passed on branch; current package version remains `7.1.0` until the release-prep PR bumps to `7.2.0`. |
+| Docs inventory | `npm run docs:inventory` | Documentation manifest remains valid. | Passed on branch. |
+| Runtime dependency audit | `npm audit --omit=dev --audit-level=high` | Zero high or critical runtime vulnerabilities. | Passed: `found 0 vulnerabilities`. |
+| Focused roadmap proof | `npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts` | Roadmap snapshot, release posture, and Beyond count are self-consistent. | Passed on branch. |
+| Release gauntlet | `npm run release:readiness` | Local release-readiness gauntlet passes without live milestone checks. | Passed on branch. |
+| Milestone-aware readiness | `npm run release:readiness -- --milestone v7.2.0` | Blocks until the target milestone has zero open tracker items and no WIP labels. | Blocked only by open #354 after this packet was added and stale WIP labels were cleared. Rerun after this release-gate PR lands and #354 closes. |
+
+## Human Review Matrix
+
+| Surface | Review disposition |
+| :--- | :--- |
+| `docs/CHANGELOG.md` | Unreleased entries describe v7.2 framework input, mouse tracking, DOGFOOD demo integrity, Code Dojo, and security changes. Final release prep must move the relevant entries under a dated `7.2.0` boundary. |
+| `docs/ROADMAP.md` | Updated on 2026-07-04 from GitHub milestone state: v7.2 has one open release-gate issue, Beyond has 39 open items, and v8 is staged separately. |
+| `docs/BEARING.md` | Updated so the next target is #354 release-gate validation, not #335 implementation. |
+| `docs/releases/7.2.0/README.md` | This packet records initial release evidence and the remaining final-main checks. |
+| Package READMEs | No package front-door API positioning was changed by this release-gate branch. |
+| `ARCHITECTURE.md` | No port, adapter, package boundary, storage, or rendering-contract update is required by this release-gate branch. |
+
+## Deterministic Reproducibility
+
+All branch-local claims above are replayable from the branch tip with:
+
+```bash
+npm run release:preflight
+npm run docs:inventory
+npm audit --omit=dev --audit-level=high
+npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts
+npm run release:readiness
+```
+
+Before the public tag is created from merged `main`, run:
+
+```bash
+npm run release:readiness -- --milestone v7.2.0
+npm run release:preflight
+npm run docs:inventory
+npm audit --omit=dev --audit-level=high
+```
+
+The final tag must be created only after #354 is closed, the local checkout is
+clean, `main` exactly matches `origin/main`, the release-prep PR has merged,
+and CI / release dry-run evidence is green.
+
+## Residual Risk
+
+- The release-gate branch intentionally does not create or push `v7.2.0`.
+- The package versions remain `7.1.0` until a dedicated release-prep PR performs
+  the lock-step `7.2.0` bump.
+- `docs/CHANGELOG.md` still has an `Unreleased` boundary. Final release prep
+  must create the dated `7.2.0` section.
+- Code Dojo debt remains tracked by ratcheting baselines. This release improves
+  enforcement and lowers debt, but does not claim zero standards debt.

--- a/docs/releases/7.2.0/README.md
+++ b/docs/releases/7.2.0/README.md
@@ -78,10 +78,13 @@ disposition.
   from the `@flyingrobots/bijou-tui` root; scripted driver helpers can generate
   deterministic move, press, release, wheel, and raw SGR mouse sequences.
 - Canonical proof inputs:
-  `packages/bijou-tui/src/driver.test.ts`,
+  `packages/bijou-tui/src/driver.part02.test.ts`,
+  `packages/bijou-tui/src/driver.part03.test.ts`,
   `packages/bijou-tui/src/index.test.ts`,
-  `packages/bijou-tui/src/app-frame.test.ts`, and WF-130 roadmap tests.
-- Replay: `npm test -- --run packages/bijou-tui/src/driver.test.ts packages/bijou-tui/src/index.test.ts packages/bijou-tui/src/app-frame.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts`.
+  `packages/bijou-tui/src/app-frame-core.part02.test.ts`,
+  `packages/bijou-tui/src/app-frame-routing.part06.test.ts`, and WF-130
+  roadmap tests.
+- Replay: `npx vitest run --config vitest.config.ts packages/bijou-tui/src/driver.part02.test.ts packages/bijou-tui/src/driver.part03.test.ts packages/bijou-tui/src/index.test.ts packages/bijou-tui/src/app-frame-core.part02.test.ts packages/bijou-tui/src/app-frame-routing.part06.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts`.
 - Witness: PR #355 closed all three trackers and merged on 2026-06-15 at
   `94db990f`.
 - Residual risk: no accepted release risk.
@@ -126,13 +129,20 @@ disposition.
   DOGFOOD theme diagnostics cover chrome tokens used by borders, scrollbars,
   focus gutters, and modal surfaces.
 - Canonical proof inputs:
-  `tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts`,
+  `tests/cycles/DL-017/dogfood-light-theme-readiness.part01.test.ts`,
+  `tests/cycles/DL-017/dogfood-light-theme-readiness.part02.test.ts`,
+  `tests/cycles/DL-017/dogfood-light-theme-readiness.part03.test.ts`,
+  `tests/cycles/DL-017/dogfood-light-theme-readiness.part04.test.ts`,
+  `tests/cycles/DL-017/dogfood-light-theme-readiness.part05.test.ts`,
   `tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts`,
   `packages/bijou-tui/src/app-frame-overlays.test.ts`,
-  `packages/bijou-tui/src/app-frame.test.ts`,
+  `packages/bijou-tui/src/app-frame-render.part01.test.ts`,
+  `packages/bijou-tui/src/app-frame-render.part02.test.ts`,
+  `packages/bijou-tui/src/app-frame-input-overlays.part03.test.ts`,
+  `packages/bijou-tui/src/app-frame-settings.part02.test.ts`,
   `packages/bijou/src/core/theme/presets.test.ts`, and
   `packages/bijou/src/core/theme/doctor.test.ts`.
-- Replay: `npm test -- --run tests/cycles/DL-017/dogfood-light-theme-readiness.test.ts tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts packages/bijou-tui/src/app-frame-overlays.test.ts packages/bijou-tui/src/app-frame.test.ts packages/bijou/src/core/theme/presets.test.ts packages/bijou/src/core/theme/doctor.test.ts`.
+- Replay: `npx vitest run --config vitest.config.ts tests/cycles/DL-017/dogfood-light-theme-readiness.part01.test.ts tests/cycles/DL-017/dogfood-light-theme-readiness.part02.test.ts tests/cycles/DL-017/dogfood-light-theme-readiness.part03.test.ts tests/cycles/DL-017/dogfood-light-theme-readiness.part04.test.ts tests/cycles/DL-017/dogfood-light-theme-readiness.part05.test.ts tests/cycles/RE-017/frame-shell-theme-dogfood-demo.test.ts packages/bijou-tui/src/app-frame-overlays.test.ts packages/bijou-tui/src/app-frame-render.part01.test.ts packages/bijou-tui/src/app-frame-render.part02.test.ts packages/bijou-tui/src/app-frame-input-overlays.part03.test.ts packages/bijou-tui/src/app-frame-settings.part02.test.ts packages/bijou/src/core/theme/presets.test.ts packages/bijou/src/core/theme/doctor.test.ts`.
 - Witness: PR #360 closed #341 and merged on 2026-06-16 at `d06f8cd4`.
 - Residual risk: no accepted release risk.
 
@@ -165,8 +175,11 @@ disposition.
   render-time config, and pipe/accessibility lower-mode output.
 - Canonical proof inputs:
   `tests/cycles/DX-047/blocks-app-binding-snippets.test.ts` and
-  `tests/cycles/DX-031/dogfood-blocks-section.test.ts`.
-- Replay: `npx vitest run --config vitest.config.ts tests/cycles/DX-047/blocks-app-binding-snippets.test.ts tests/cycles/DX-031/dogfood-blocks-section.test.ts`.
+  `tests/cycles/DX-031/dogfood-blocks-section.part01.test.ts`,
+  `tests/cycles/DX-031/dogfood-blocks-section.part02.test.ts`,
+  `tests/cycles/DX-031/dogfood-blocks-section.part03.test.ts`, and
+  `tests/cycles/DX-031/dogfood-blocks-section.part04.test.ts`.
+- Replay: `npx vitest run --config vitest.config.ts tests/cycles/DX-047/blocks-app-binding-snippets.test.ts tests/cycles/DX-031/dogfood-blocks-section.part01.test.ts tests/cycles/DX-031/dogfood-blocks-section.part02.test.ts tests/cycles/DX-031/dogfood-blocks-section.part03.test.ts tests/cycles/DX-031/dogfood-blocks-section.part04.test.ts`.
 - Witness: PR #361 closed #342 and merged on 2026-07-02 at `6b56a97a`.
 - Residual risk: no accepted release risk.
 

--- a/docs/releases/7.2.0/README.md
+++ b/docs/releases/7.2.0/README.md
@@ -6,10 +6,11 @@ DOGFOOD localization and themes, Blocks documentation, release-story surfaces,
 dependency posture, and release bookkeeping.
 
 This packet was started on the release-gate branch before the public tag
-exists. The version bump, final release dry run, tag creation, publish
-workflow, npm registry verification, and GitHub Release verification remain
-final-main steps and must run only from the merged `origin/main` release
-commit.
+exists. The release-prep branch still owns the version bump, changelog
+boundary, package metadata validation, release-readiness replay, and Release
+Dry Run before merge. Tag creation, publish automation, npm registry
+verification, and GitHub Release verification remain final-main work and must
+run only from the merged `origin/main` release commit.
 
 ## Release Summary
 
@@ -249,8 +250,61 @@ disposition.
 | `docs/ROADMAP.md` | Updated on 2026-07-04 from GitHub milestone state: v7.2 has one open release-gate issue, Beyond has 39 open items, and v8 is staged separately. |
 | `docs/BEARING.md` | Updated so the next target is #354 release-gate validation, not #335 implementation. |
 | `docs/releases/7.2.0/README.md` | This packet records initial release evidence and the remaining final-main checks. |
+| `docs/releases/7.2.0/whats-new.md` | Staged before the version bump so DOGFOOD can load the v7.2 release overview when package metadata changes. |
+| `docs/releases/7.2.0/migration-guide.md` | Staged before the version bump so DOGFOOD can load the v7.2 migration guide when package metadata changes. |
 | Package READMEs | No package front-door API positioning was changed by this release-gate branch. |
 | `ARCHITECTURE.md` | No port, adapter, package boundary, storage, or rendering-contract update is required by this release-gate branch. |
+
+## Package And Registry Verification Plan
+
+The release-prep PR must perform and validate the package metadata mutation
+before it merges:
+
+```bash
+npm run version 7.2.0
+npm run release:preflight
+npm run docs:inventory
+npm run release:readiness -- --milestone v7.2.0
+```
+
+The **Release Dry Run** workflow must run against the release-prep branch or PR
+commit before the release PR merges. That dry run is the current authoritative
+packed-file and npm publish dry-run evidence for the automated publish matrix.
+
+After the release-prep PR merges and local `main` exactly matches
+`origin/main`, final tag preparation must replay the metadata and docs checks
+from that merged commit:
+
+```bash
+git fetch origin main --tags --prune
+git switch main
+git merge --ff-only origin/main
+git status --porcelain=v1
+git rev-parse HEAD origin/main
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+npm run release:preflight
+npm run docs:inventory
+```
+
+After the `v7.2.0` tag is pushed and the publish workflow passes, verify every
+published package resolves to version `7.2.0` with the stable `latest` dist-tag:
+
+```bash
+npm view @flyingrobots/bijou version dist-tags --json
+npm view @flyingrobots/bijou-node version dist-tags --json
+npm view @flyingrobots/bijou-tui version dist-tags --json
+npm view @flyingrobots/bijou-tui-app version dist-tags --json
+npm view create-bijou-tui-app version dist-tags --json
+npm view @flyingrobots/bijou-i18n version dist-tags --json
+npm view @flyingrobots/bijou-i18n-tools version dist-tags --json
+npm view @flyingrobots/bijou-i18n-tools-node version dist-tags --json
+npm view @flyingrobots/bijou-i18n-tools-xlsx version dist-tags --json
+npm view @flyingrobots/bijou-mcp version dist-tags --json
+```
+
+Tag creation, publish automation, npm registry verification, and GitHub Release
+verification remain final-main work. They must not run from this release-gate
+branch or from the release-prep branch before it has merged.
 
 ## Deterministic Reproducibility
 
@@ -267,15 +321,16 @@ npm run release:readiness
 Before the public tag is created from merged `main`, run:
 
 ```bash
-npm run release:readiness -- --milestone v7.2.0
+npm run version 7.2.0
 npm run release:preflight
 npm run docs:inventory
+npm run release:readiness -- --milestone v7.2.0
 npm audit --omit=dev --audit-level=high
 ```
 
-The final tag must be created only after #354 is closed, the local checkout is
-clean, `main` exactly matches `origin/main`, the release-prep PR has merged,
-and CI / release dry-run evidence is green.
+The final tag must be created only after #354 is closed, the release-prep PR
+has merged, the local checkout is clean, `main` exactly matches `origin/main`,
+and CI / Release Dry Run evidence is green.
 
 ## Residual Risk
 

--- a/docs/releases/7.2.0/README.md
+++ b/docs/releases/7.2.0/README.md
@@ -58,8 +58,9 @@ disposition.
   the final release prep branch is merged.
 - Witness: local release-gate validation on 2026-07-04 passed
   `npm run release:preflight`, `npm run docs:inventory`,
-  `npm audit --omit=dev --audit-level=high`, and `npm run release:readiness`
-  without `--milestone`.
+  `npm audit --audit-level=high`,
+  `npm audit --omit=dev --audit-level=high`, and
+  `npm run release:readiness` without `--milestone`.
 - Residual risk: final milestone-aware readiness is expected to remain blocked
   while #354 is open. After this release-gate PR lands and #354 closes, rerun
   the milestone-aware command before any version tag is created.
@@ -223,12 +224,17 @@ disposition.
   Dependabot security update in
   [#363](https://github.com/flyingrobots/bijou/pull/363).
 - Completed slices: `esbuild` resolves to `0.28.1`; `hono` resolves to
-  `4.12.25`; default-branch audit and Dependabot alert checks were verified
+  `4.12.25`; `package-lock.json` records `node_modules/esbuild` as a dev
+  dependency; default-branch audit and Dependabot alert checks were verified
   before #370 closed.
-- Canonical proof inputs: npm lockfile, `npm audit`, and Dependabot alert API.
-- Replay: `npm audit --omit=dev --audit-level=high`.
+- Canonical proof inputs: npm lockfile, dev-inclusive `npm audit`, runtime-only
+  `npm audit --omit=dev`, and Dependabot alert API.
+- Replay: run `npm audit --audit-level=high` for the full dependency graph,
+  then `npm audit --omit=dev --audit-level=high` for the runtime-only release
+  boundary.
 - Witness: release-gate validation on 2026-07-04 reported
-  `found 0 vulnerabilities`.
+  `found 0 vulnerabilities` for the dev-inclusive audit and the runtime-only
+  audit.
 - Residual risk: no accepted release risk.
 
 ## Automated Evidence Matrix
@@ -237,6 +243,7 @@ disposition.
 | :--- | :--- | :--- | :--- |
 | Release metadata preflight | `npm run release:preflight` | Lock-step workspace metadata is valid. | Passed on branch; current package version remains `7.1.0` until the release-prep PR bumps to `7.2.0`. |
 | Docs inventory | `npm run docs:inventory` | Documentation manifest remains valid. | Passed on branch. |
+| Dev-tooling dependency audit | `npm audit --audit-level=high` | Zero high or critical vulnerabilities across production and development dependencies, including dev-tooling packages such as `esbuild`. | Passed: `found 0 vulnerabilities`. |
 | Runtime dependency audit | `npm audit --omit=dev --audit-level=high` | Zero high or critical runtime vulnerabilities. | Passed: `found 0 vulnerabilities`. |
 | Focused roadmap proof | `npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts` | Roadmap snapshot, release posture, Beyond count, and Markdown policy are self-consistent. | Passed on branch. |
 | Release gauntlet | `npm run release:readiness` | Local release-readiness gauntlet passes without live milestone checks. | Passed on branch. |
@@ -264,6 +271,7 @@ before it merges:
 npm run version 7.2.0
 npm run release:preflight
 npm run docs:inventory
+npm audit --audit-level=high
 npm run release:readiness -- --milestone v7.2.0
 ```
 
@@ -313,6 +321,7 @@ All branch-local claims above are replayable from the branch tip with:
 ```bash
 npm run release:preflight
 npm run docs:inventory
+npm audit --audit-level=high
 npm audit --omit=dev --audit-level=high
 npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
 npm run release:readiness
@@ -325,6 +334,7 @@ npm run version 7.2.0
 npm run release:preflight
 npm run docs:inventory
 npm run release:readiness -- --milestone v7.2.0
+npm audit --audit-level=high
 npm audit --omit=dev --audit-level=high
 ```
 

--- a/docs/releases/7.2.0/README.md
+++ b/docs/releases/7.2.0/README.md
@@ -237,7 +237,7 @@ disposition.
 | Release metadata preflight | `npm run release:preflight` | Lock-step workspace metadata is valid. | Passed on branch; current package version remains `7.1.0` until the release-prep PR bumps to `7.2.0`. |
 | Docs inventory | `npm run docs:inventory` | Documentation manifest remains valid. | Passed on branch. |
 | Runtime dependency audit | `npm audit --omit=dev --audit-level=high` | Zero high or critical runtime vulnerabilities. | Passed: `found 0 vulnerabilities`. |
-| Focused roadmap proof | `npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts` | Roadmap snapshot, release posture, and Beyond count are self-consistent. | Passed on branch. |
+| Focused roadmap proof | `npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts` | Roadmap snapshot, release posture, Beyond count, and Markdown policy are self-consistent. | Passed on branch. |
 | Release gauntlet | `npm run release:readiness` | Local release-readiness gauntlet passes without live milestone checks. | Passed on branch. |
 | Milestone-aware readiness | `npm run release:readiness -- --milestone v7.2.0` | Blocks until the target milestone has zero open tracker items and no WIP labels. | Blocked only by open #354 after this packet was added and stale WIP labels were cleared. Rerun after this release-gate PR lands and #354 closes. |
 
@@ -260,7 +260,7 @@ All branch-local claims above are replayable from the branch tip with:
 npm run release:preflight
 npm run docs:inventory
 npm audit --omit=dev --audit-level=high
-npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts
+npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
 npm run release:readiness
 ```
 

--- a/docs/releases/7.2.0/README.md
+++ b/docs/releases/7.2.0/README.md
@@ -260,7 +260,7 @@ disposition.
 | Runtime dependency audit | `npm audit --omit=dev --audit-level=high` | Zero high or critical runtime vulnerabilities. | Passed: `found 0 vulnerabilities`. |
 | Focused roadmap proof | `npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts` | Roadmap snapshot, release posture, Beyond count, and Markdown policy are self-consistent. | Passed on branch. |
 | Release gauntlet | `npm run release:readiness` | Local release-readiness gauntlet passes without live milestone checks. | Passed on branch. |
-| Milestone-aware readiness | `npm run release:readiness -- --milestone v7.2.0` | Blocks until the target milestone has zero open tracker items and no WIP labels. | Blocked only by open #354 after this packet was added and stale WIP labels were cleared. Rerun after this release-gate PR lands and #354 closes. |
+| Milestone-aware readiness | `npm run release:readiness -- --milestone v7.2.0` | Blocks until the target milestone has zero open tracker items, including issues or pull requests, and no WIP labels. | Blocked by open #354 after this packet was added and stale WIP labels were cleared. The same gate will block any `v7.2.0` milestone PR left open. Rerun after this release-gate PR lands and #354 closes. |
 
 ## Human Review Matrix
 

--- a/docs/releases/7.2.0/migration-guide.md
+++ b/docs/releases/7.2.0/migration-guide.md
@@ -1,0 +1,79 @@
+# Migrating to Bijou 7.2.0
+
+Bijou 7.2.0 is a minor release from 7.1.0. It is intended to be additive for
+applications using documented public APIs.
+
+The release is still pending its final tag. These instructions are staged so
+the migration guide is available before the version bump lands.
+
+## Recommended Upgrade
+
+Update the runtime packages your app uses together:
+
+```bash
+npm install \
+  @flyingrobots/bijou@7.2.0 \
+  @flyingrobots/bijou-node@7.2.0 \
+  @flyingrobots/bijou-tui@7.2.0 \
+  @flyingrobots/bijou-tui-app@7.2.0
+```
+
+If your app uses localization tooling, keep those packages in lock-step too:
+
+```bash
+npm install \
+  @flyingrobots/bijou-i18n@7.2.0 \
+  @flyingrobots/bijou-i18n-tools@7.2.0 \
+  @flyingrobots/bijou-i18n-tools-node@7.2.0 \
+  @flyingrobots/bijou-i18n-tools-xlsx@7.2.0
+```
+
+If your app uses the Bijou MCP server, keep it lock-step too:
+
+```bash
+npm install @flyingrobots/bijou-mcp@7.2.0
+```
+
+## Runtime Behavior
+
+No breaking runtime migration is expected.
+
+Applications may notice better behavior in these areas:
+
+- page-scoped TUI frame helpers are exported from the public TUI package root
+- scripted driver helpers can replay mouse movement, press, release, wheel,
+  and raw SGR mouse sequences deterministically
+- DOGFOOD light-theme and locale-fallback examples provide clearer evidence for
+  release review and demos
+- Blocks app-binding documentation now includes concrete copyable snippets
+
+If your app had local test helpers for mouse replay or frame helper imports,
+prefer the package exports after upgrading.
+
+## DOGFOOD And Documentation
+
+The DOGFOOD release pages for 7.2.0 depend on the versioned docs in this
+directory. Keep `whats-new.md`, `migration-guide.md`, and `README.md` together
+when preparing a release branch, before changing package metadata to `7.2.0`.
+
+## Release Tooling
+
+Maintainers preparing the release should use both release-readiness modes:
+
+```bash
+npm run release:readiness
+npm run release:readiness -- --milestone v7.2.0
+```
+
+The plain command validates local release evidence before the milestone is
+closed. The milestone-aware command is the final release gate and must pass
+after the release-gate PR has merged, the target milestone has zero open tracker
+items, and no tracked work carries a `work-in-progress` label.
+
+## Compatibility Stance
+
+Bijou 7.2.0 should be a straightforward upgrade from 7.1.0 for application
+code. The main migration work is optional cleanup: remove local mouse replay
+fixtures that duplicate the public driver helpers, update imports to use the
+public TUI package root where possible, and treat the improved DOGFOOD release
+pages as review evidence rather than an application contract.

--- a/docs/releases/7.2.0/whats-new.md
+++ b/docs/releases/7.2.0/whats-new.md
@@ -1,0 +1,70 @@
+# What's New in Bijou 7.2.0
+
+Bijou 7.2.0 is a stabilization release for the V7 demo and documentation
+surface. It keeps the public Runtime Graph direction intentionally narrow while
+tightening framework input behavior, DOGFOOD readability, Blocks documentation,
+release evidence, and dependency review.
+
+The release is still pending its final tag. This document is staged before the
+version bump so DOGFOOD can load the 7.2.0 release copy when package metadata
+moves to the new version.
+
+## Framework Input Stabilization
+
+The TUI framework now has better coverage for page-scoped input fallthrough and
+scripted mouse sequences. Workspace mouse movement, release, wheel, and
+non-left press events can be replayed through deterministic driver helpers, and
+the public TUI package exposes the frame helper APIs needed by application
+code.
+
+This is the practical fix for release-demo workflows that need reliable mouse
+inspection without relying on terminal-specific manual behavior.
+
+## DOGFOOD Readability And Release Story
+
+DOGFOOD received another pass over the surfaces that made the 7.1 release-video
+rehearsal hard to inspect:
+
+- locale fallback copy now distinguishes missing translations from intentional
+  English source text
+- light-theme screenshots and fixture coverage keep color contrast and shell
+  state readable
+- in-app release-story pages now point reviewers at the V7.2 evidence packet
+  rather than asking them to infer the release state from scattered docs
+
+The goal is not a new product surface. The goal is that the existing proof
+surface tells the truth when somebody records or reviews it.
+
+## Blocks Documentation
+
+The Blocks app-binding guide now includes copyable snippets and deterministic
+fixtures for the current binding shape. The documentation remains scoped to
+the V7 proof path, but it gives readers enough structure to understand how
+bindings, actions, and DOGFOOD examples relate before the larger V8 work starts.
+
+## Theme Variant Coverage
+
+First-party dark and light theme variants have explicit coverage in the release
+packet. The release keeps theme behavior focused on readability and replay
+evidence rather than opening a broader design-system expansion.
+
+## Release Evidence
+
+The release gate now carries a versioned evidence packet before the version
+bump. That packet records trackers, landed PRs, replay commands, security audit
+scope, registry verification, release-readiness posture, and residual risk.
+
+Maintainers should treat this as the authoritative 7.2 release-prep checklist
+until the final tag is created from the merged `origin/main` release commit.
+
+## V8 Posture
+
+Bijou 7.2.0 intentionally stops short of the next Runtime Graph product. The
+forward path remains:
+
+```text
+GraphQL Blocks -> Bijou Blocks IR -> Geordi render targets -> TUI | Browser | Native UI
+```
+
+That work belongs to V8 and later. V7.2 makes the current release surface clean
+enough to move on without carrying avoidable release debt forward.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -25,6 +25,9 @@ docs/releases/next/
 
 ## Current Shaped Release Docs
 
+- [What's New (v7.2.0)](./7.2.0/whats-new.md)
+- [Migration Guide (v7.2.0)](./7.2.0/migration-guide.md)
+- [Release Evidence (v7.2.0)](./7.2.0/README.md)
 - [What's New (v7.1.0)](./7.1.0/whats-new.md)
 - [Migration Guide (v7.1.0)](./7.1.0/migration-guide.md)
 - [Release Evidence (v7.1.0)](./7.1.0/README.md)

--- a/scripts/release-readiness-tracker.ts
+++ b/scripts/release-readiness-tracker.ts
@@ -1,0 +1,137 @@
+import { spawnSync } from 'node:child_process';
+
+export interface ReleaseReadinessTrackerLabel {
+  readonly name: string;
+}
+
+export type ReleaseReadinessTrackerItemKind = 'issue' | 'pull-request';
+
+export interface ReleaseReadinessTrackerItemCommand {
+  readonly kind: ReleaseReadinessTrackerItemKind;
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+export interface ReleaseReadinessTrackerItem {
+  readonly kind?: ReleaseReadinessTrackerItemKind;
+  readonly number: number;
+  readonly title: string;
+  readonly state: string;
+  readonly labels?: readonly (string | ReleaseReadinessTrackerLabel)[];
+  readonly url?: string;
+}
+
+export function readMilestoneTrackerItems(milestone: string, cwd: string): readonly ReleaseReadinessTrackerItem[] {
+  const trackerItems: ReleaseReadinessTrackerItem[] = [];
+
+  for (const query of buildMilestoneTrackerItemCommands(milestone)) {
+    const result = spawnSync(query.command, query.args, {
+      cwd,
+      encoding: 'utf8',
+    });
+
+    const source = `${query.command} ${query.args[0] ?? ''} ${query.args[1] ?? ''}`.trim();
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`${source} exited with status ${String(result.status ?? 'null')}: ${result.stderr.trim()}`);
+    }
+
+    trackerItems.push(...parseTrackerItems(result.stdout, query.kind, source));
+  }
+
+  return Object.freeze(trackerItems);
+}
+
+export function buildMilestoneTrackerItemCommands(milestone: string): readonly ReleaseReadinessTrackerItemCommand[] {
+  return Object.freeze([
+    Object.freeze({
+      kind: 'issue',
+      command: 'gh',
+      args: [
+        'issue',
+        'list',
+        '--state',
+        'all',
+        '--milestone',
+        milestone,
+        '--limit',
+        '1000',
+        '--json',
+        'number,title,state,labels,url',
+      ],
+    }),
+    Object.freeze({
+      kind: 'pull-request',
+      command: 'gh',
+      args: [
+        'pr',
+        'list',
+        '--state',
+        'all',
+        '--search',
+        `milestone:"${milestone}"`,
+        '--limit',
+        '1000',
+        '--json',
+        'number,title,state,labels,url',
+      ],
+    }),
+  ]);
+}
+
+export function trackerItemLabelNames(item: ReleaseReadinessTrackerItem): readonly string[] {
+  return Object.freeze((item.labels ?? []).map((label) => (
+    typeof label === 'string' ? label : label.name
+  )));
+}
+
+export function formatTrackerItems(items: readonly ReleaseReadinessTrackerItem[]): string {
+  return items.map((item) => `#${String(item.number)}`).join(', ');
+}
+
+function parseTrackerItems(
+  stdout: string,
+  kind: ReleaseReadinessTrackerItemKind,
+  source: string,
+): readonly ReleaseReadinessTrackerItem[] {
+  const parsed: unknown = JSON.parse(stdout);
+  if (!Array.isArray(parsed)) throw new Error(`${source} did not return an array`);
+  return Object.freeze(parsed.map((value) => {
+    const item = requireJsonRecord(value, `${source} item`);
+    const number = item['number'];
+    const title = item['title'];
+    const state = item['state'];
+    const url = item['url'];
+    if (typeof number !== 'number' || typeof title !== 'string' || typeof state !== 'string') {
+      throw new Error(`${source} returned an item with an unexpected shape`);
+    }
+    const base = {
+      kind,
+      number,
+      title,
+      state,
+      labels: parseTrackerLabels(item['labels']),
+    };
+    return Object.freeze(typeof url === 'string' ? { ...base, url } : base);
+  }));
+}
+
+function parseTrackerLabels(value: unknown): readonly (string | ReleaseReadinessTrackerLabel)[] {
+  if (!Array.isArray(value)) return Object.freeze([]);
+  return Object.freeze(value.map((label) => {
+    if (typeof label === 'string') return label;
+    const record = requireJsonRecord(label, 'gh tracker label');
+    const name = record['name'];
+    if (typeof name !== 'string') throw new Error('gh tracker label is missing name');
+    return { name };
+  }));
+}
+
+function requireJsonRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} is not an object`);
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/scripts/release-readiness.part01.test.ts
+++ b/scripts/release-readiness.part01.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildReleaseReadinessPlan, buildReleaseReadinessReport, runReleaseReadiness, type ReleaseReadinessDocsSnapshot } from './release-readiness.js';
+import {
+  buildReleaseReadinessPlan,
+  buildReleaseReadinessReport,
+  runReleaseReadiness,
+  type ReleaseReadinessDocsSnapshot,
+} from './release-readiness.js';
 
 function releaseDocsSnapshot(
   milestone: string,

--- a/scripts/release-readiness.part02.test.ts
+++ b/scripts/release-readiness.part02.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  buildMilestoneTrackerItemCommands,
   buildReleaseReadinessReport,
   parseReleaseReadinessArgs,
   runReleaseReadiness,
@@ -48,56 +47,6 @@ describe('release-readiness', () => {
       expect(report.wipTrackerItems.map((item) => item.number)).toEqual([312]);
       expect(report.checks.find((check) => check.label === 'tracker-open-items')?.summary).toContain('#270');
       expect(report.checks.find((check) => check.label === 'tracker-wip-labels')?.summary).toContain('#312');
-    });
-
-  it('queries both milestone issues and pull requests for tracker state', () => {
-      const commands = buildMilestoneTrackerItemCommands('v7.2.0');
-
-      expect(commands.map((command) => command.kind)).toEqual(['issue', 'pull-request']);
-      expect(commands[0]?.args).toEqual([
-        'issue',
-        'list',
-        '--state',
-        'all',
-        '--milestone',
-        'v7.2.0',
-        '--limit',
-        '1000',
-        '--json',
-        'number,title,state,labels,url',
-      ]);
-      expect(commands[1]?.args).toEqual([
-        'pr',
-        'list',
-        '--state',
-        'all',
-        '--search',
-        'milestone:"v7.2.0"',
-        '--limit',
-        '1000',
-        '--json',
-        'number,title,state,labels,url',
-      ]);
-    });
-
-  it('classifies open milestone pull requests as blocking tracker items', () => {
-      const report = buildReleaseReadinessReport({
-        milestone: 'v7.2.0',
-        trackerItems: [{
-          kind: 'pull-request',
-          number: 461,
-          title: 'Release gate',
-          state: 'OPEN',
-          labels: [{ name: 'release' }],
-        }],
-        docs: releaseDocsSnapshot('v7.2.0'),
-      });
-      const openItemsCheck = report.checks.find((check) => check.label === 'tracker-open-items');
-
-      expect(report.status).toBe('blocked');
-      expect(openItemsCheck?.status).toBe('fail');
-      expect(openItemsCheck?.summary).toContain('v7.2.0 has 1 open tracker item(s): #461');
-      expect(openItemsCheck?.summary).not.toContain('open tracker issue');
     });
 
   it('blocks a milestone report when release docs or release packet evidence are stale', () => {

--- a/scripts/release-readiness.part02.test.ts
+++ b/scripts/release-readiness.part02.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildReleaseReadinessReport, parseReleaseReadinessArgs, runReleaseReadiness, type ReleaseReadinessDocsSnapshot } from './release-readiness.js';
+import {
+  buildMilestoneTrackerItemCommands,
+  buildReleaseReadinessReport,
+  parseReleaseReadinessArgs,
+  runReleaseReadiness,
+  type ReleaseReadinessDocsSnapshot,
+} from './release-readiness.js';
 
 function releaseDocsSnapshot(
   milestone: string,
@@ -42,6 +48,56 @@ describe('release-readiness', () => {
       expect(report.wipTrackerItems.map((item) => item.number)).toEqual([312]);
       expect(report.checks.find((check) => check.label === 'tracker-open-items')?.summary).toContain('#270');
       expect(report.checks.find((check) => check.label === 'tracker-wip-labels')?.summary).toContain('#312');
+    });
+
+  it('queries both milestone issues and pull requests for tracker state', () => {
+      const commands = buildMilestoneTrackerItemCommands('v7.2.0');
+
+      expect(commands.map((command) => command.kind)).toEqual(['issue', 'pull-request']);
+      expect(commands[0]?.args).toEqual([
+        'issue',
+        'list',
+        '--state',
+        'all',
+        '--milestone',
+        'v7.2.0',
+        '--limit',
+        '1000',
+        '--json',
+        'number,title,state,labels,url',
+      ]);
+      expect(commands[1]?.args).toEqual([
+        'pr',
+        'list',
+        '--state',
+        'all',
+        '--search',
+        'milestone:"v7.2.0"',
+        '--limit',
+        '1000',
+        '--json',
+        'number,title,state,labels,url',
+      ]);
+    });
+
+  it('classifies open milestone pull requests as blocking tracker items', () => {
+      const report = buildReleaseReadinessReport({
+        milestone: 'v7.2.0',
+        trackerItems: [{
+          kind: 'pull-request',
+          number: 461,
+          title: 'Release gate',
+          state: 'OPEN',
+          labels: [{ name: 'release' }],
+        }],
+        docs: releaseDocsSnapshot('v7.2.0'),
+      });
+      const openItemsCheck = report.checks.find((check) => check.label === 'tracker-open-items');
+
+      expect(report.status).toBe('blocked');
+      expect(openItemsCheck?.status).toBe('fail');
+      expect(openItemsCheck?.summary).toContain('v7.2.0 has 1 open tracker item(s): #461');
+      expect(openItemsCheck?.summary).not.toContain('open tracker issue');
     });
 
   it('blocks a milestone report when release docs or release packet evidence are stale', () => {

--- a/scripts/release-readiness.part03.test.ts
+++ b/scripts/release-readiness.part03.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMilestoneTrackerItemCommands,
+  buildReleaseReadinessReport,
+  type ReleaseReadinessDocsSnapshot,
+} from './release-readiness.js';
+
+function releaseDocsSnapshot(milestone: string): ReleaseReadinessDocsSnapshot {
+  const version = milestone.replace(/^v/, '');
+  return {
+    roadmap: `ROADMAP ${milestone}`,
+    bearing: `BEARING ${milestone}`,
+    changelog: `## [Unreleased]\n\n## [${version}]`,
+    releaseGuide: `release:readiness ${milestone} release-dry-run`,
+    releasePacketExists: true,
+  };
+}
+
+describe('release-readiness tracker items', () => {
+  it('queries both milestone issues and pull requests for tracker state', () => {
+      const commands = buildMilestoneTrackerItemCommands('v7.2.0');
+
+      expect(commands.map((command) => command.kind)).toEqual(['issue', 'pull-request']);
+      expect(commands[0]?.args).toEqual([
+        'issue',
+        'list',
+        '--state',
+        'all',
+        '--milestone',
+        'v7.2.0',
+        '--limit',
+        '1000',
+        '--json',
+        'number,title,state,labels,url',
+      ]);
+      expect(commands[1]?.args).toEqual([
+        'pr',
+        'list',
+        '--state',
+        'all',
+        '--search',
+        'milestone:"v7.2.0"',
+        '--limit',
+        '1000',
+        '--json',
+        'number,title,state,labels,url',
+      ]);
+    });
+
+  it('classifies open milestone pull requests as blocking tracker items', () => {
+      const report = buildReleaseReadinessReport({
+        milestone: 'v7.2.0',
+        trackerItems: [{
+          kind: 'pull-request',
+          number: 461,
+          title: 'Release gate',
+          state: 'OPEN',
+          labels: [{ name: 'release' }],
+        }],
+        docs: releaseDocsSnapshot('v7.2.0'),
+      });
+      const openItemsCheck = report.checks.find((check) => check.label === 'tracker-open-items');
+
+      expect(report.status).toBe('blocked');
+      expect(openItemsCheck?.status).toBe('fail');
+      expect(openItemsCheck?.summary).toContain('v7.2.0 has 1 open tracker item(s): #461');
+      expect(openItemsCheck?.summary).not.toContain('open tracker issue');
+    });
+
+  it('treats merged milestone pull requests as closed tracker items', () => {
+      const report = buildReleaseReadinessReport({
+        milestone: 'v7.2.0',
+        trackerItems: [{
+          kind: 'pull-request',
+          number: 360,
+          title: 'DOGFOOD Light Theme Readiness',
+          state: 'MERGED',
+          labels: [{ name: 'release' }],
+        }],
+        docs: releaseDocsSnapshot('v7.2.0'),
+      });
+      const openItemsCheck = report.checks.find((check) => check.label === 'tracker-open-items');
+
+      expect(report.status).toBe('ready');
+      expect(report.openTrackerItems).toEqual([]);
+      expect(openItemsCheck?.summary).toContain('v7.2.0 has zero open tracker items');
+    });
+});

--- a/scripts/release-readiness.ts
+++ b/scripts/release-readiness.ts
@@ -96,7 +96,7 @@ export function buildReleaseReadinessReport(options: {
   const milestone = options.milestone;
   const version = milestone.replace(/^v/, '');
   const plan = options.plan ?? buildReleaseReadinessPlan();
-  const openTrackerItems = options.trackerItems.filter((item) => item.state.toUpperCase() !== 'CLOSED');
+  const openTrackerItems = options.trackerItems.filter((item) => !isClosedTrackerItem(item));
   const wipTrackerItems = options.trackerItems.filter((item) => (
     trackerItemLabelNames(item).includes('work-in-progress')
   ));
@@ -158,6 +158,11 @@ export function buildReleaseReadinessReport(options: {
     openTrackerItems: Object.freeze(openTrackerItems.map((item) => Object.freeze({ ...item }))),
     wipTrackerItems: Object.freeze(wipTrackerItems.map((item) => Object.freeze({ ...item }))),
   });
+}
+
+function isClosedTrackerItem(item: ReleaseReadinessTrackerItem): boolean {
+  const state = item.state.toUpperCase();
+  return state === 'CLOSED' || state === 'MERGED';
 }
 
 export function formatReleaseReadinessReport(report: ReleaseReadinessReport): string {

--- a/scripts/release-readiness.ts
+++ b/scripts/release-readiness.ts
@@ -4,6 +4,12 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  formatTrackerItems,
+  readMilestoneTrackerItems,
+  trackerItemLabelNames,
+  type ReleaseReadinessTrackerItem,
+} from './release-readiness-tracker.js';
 
 export interface ReleaseReadinessStep {
   readonly label: string;
@@ -11,17 +17,13 @@ export interface ReleaseReadinessStep {
   readonly args: readonly string[];
 }
 
-export interface ReleaseReadinessTrackerLabel {
-  readonly name: string;
-}
-
-export interface ReleaseReadinessTrackerItem {
-  readonly number: number;
-  readonly title: string;
-  readonly state: string;
-  readonly labels?: readonly (string | ReleaseReadinessTrackerLabel)[];
-  readonly url?: string;
-}
+export { buildMilestoneTrackerItemCommands } from './release-readiness-tracker.js';
+export type {
+  ReleaseReadinessTrackerItem,
+  ReleaseReadinessTrackerItemCommand,
+  ReleaseReadinessTrackerItemKind,
+  ReleaseReadinessTrackerLabel,
+} from './release-readiness-tracker.js';
 
 export interface ReleaseReadinessDocsSnapshot {
   readonly roadmap: string;
@@ -109,8 +111,8 @@ export function buildReleaseReadinessReport(options: {
       label: 'tracker-open-items',
       status: openTrackerItems.length === 0 ? 'pass' : 'fail',
       summary: openTrackerItems.length === 0
-        ? `${milestone} has zero open tracker issues`
-        : `${milestone} has ${String(openTrackerItems.length)} open tracker issue(s): ${formatTrackerItems(openTrackerItems)}`,
+        ? `${milestone} has zero open tracker items`
+        : `${milestone} has ${String(openTrackerItems.length)} open tracker item(s): ${formatTrackerItems(openTrackerItems)}`,
     },
     {
       label: 'tracker-wip-labels',
@@ -242,31 +244,6 @@ export function parseReleaseReadinessArgs(args: readonly string[]): { readonly m
   return milestone == null ? {} : { milestone };
 }
 
-function readMilestoneTrackerItems(milestone: string, cwd: string): readonly ReleaseReadinessTrackerItem[] {
-  const result = spawnSync('gh', [
-    'issue',
-    'list',
-    '--state',
-    'all',
-    '--milestone',
-    milestone,
-    '--limit',
-    '1000',
-    '--json',
-    'number,title,state,labels,url',
-  ], {
-    cwd,
-    encoding: 'utf8',
-  });
-
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`gh issue list exited with status ${String(result.status ?? 'null')}: ${result.stderr.trim()}`);
-  }
-
-  return parseTrackerItems(result.stdout);
-}
-
 function readReleaseReadinessDocs(cwd: string, milestone: string): ReleaseReadinessDocsSnapshot {
   const version = milestone.replace(/^v/, '');
   return Object.freeze({
@@ -276,58 +253,6 @@ function readReleaseReadinessDocs(cwd: string, milestone: string): ReleaseReadin
     releaseGuide: readFileSync(resolve(cwd, 'docs/release.md'), 'utf8'),
     releasePacketExists: existsSync(resolve(cwd, 'docs/releases', version, 'README.md')),
   });
-}
-
-function trackerItemLabelNames(item: ReleaseReadinessTrackerItem): readonly string[] {
-  return Object.freeze((item.labels ?? []).map((label) => (
-    typeof label === 'string' ? label : label.name
-  )));
-}
-
-function formatTrackerItems(items: readonly ReleaseReadinessTrackerItem[]): string {
-  return items.map((item) => `#${String(item.number)}`).join(', ');
-}
-
-function parseTrackerItems(stdout: string): readonly ReleaseReadinessTrackerItem[] {
-  const parsed: unknown = JSON.parse(stdout);
-  if (!Array.isArray(parsed)) throw new Error('gh issue list did not return an array');
-  return Object.freeze(parsed.map((value) => {
-    const item = requireJsonRecord(value, 'gh issue list item');
-    const number = item['number'];
-    const title = item['title'];
-    const state = item['state'];
-    const url = item['url'];
-    if (typeof number !== 'number' || typeof title !== 'string' || typeof state !== 'string') {
-      throw new Error('gh issue list returned an item with an unexpected shape');
-    }
-    const base = {
-      number,
-      title,
-      state,
-      labels: parseTrackerLabels(item['labels']),
-    };
-    return Object.freeze(typeof url === 'string' ? { ...base, url } : base);
-  }));
-}
-
-function parseTrackerLabels(value: unknown): readonly (string | ReleaseReadinessTrackerLabel)[] {
-  if (!Array.isArray(value)) return Object.freeze([]);
-  return Object.freeze(value.map((label) => {
-    if (typeof label === 'string') return label;
-    const record = requireJsonRecord(label, 'gh issue label');
-    const name = record['name'];
-    if (typeof name !== 'string') throw new Error('gh issue label is missing name');
-    return { name };
-  }));
-}
-
-function requireJsonRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!isRecord(value)) throw new Error(`${label} is not an object`);
-  return value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function escapeMarkdownTableCell(text: string): string {

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts
@@ -13,17 +13,6 @@ function normalizeWhitespace(source: string): string {
   return source.replace(/\s+/g, ' ').trim();
 }
 
-function requireRecord(value: unknown): Record<string, unknown> {
-  if (!isRecord(value)) {
-    throw new Error('Expected JSON object');
-  }
-  return value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
 describe('WF-130 roadmap goalpost policy', () => {
   it('documents release packets, goalposts, stories, slices, gates, and proof', () => {
       expect(existsSync(resolve(ROOT, 'docs/method/releases/README.md'))).toBe(true);
@@ -49,7 +38,7 @@ describe('WF-130 roadmap goalpost policy', () => {
       const releaseRunbook = normalizeWhitespace(read('docs/release.md'));
       const dx046Design = normalizeWhitespace(read('docs/design/DX-046-graphql-authored-dogfood-block-fixture.md'));
 
-      expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-07-03.');
+      expect(roadmap).toContain('Last synced from GitHub milestone items: 2026-07-04.');
       expect(roadmap).toContain('The latest shipped public release is');
       expect(roadmap).toContain('v7.1.0');
       expect(roadmap).toContain('v7.0.0');
@@ -63,7 +52,8 @@ describe('WF-130 roadmap goalpost policy', () => {
       expect(roadmap).toContain('`v9.0.0`: Product Workbench And Operator Surfaces');
       expect(roadmap).toContain('`v10.0.0+`: Ecosystem Integration');
       expect(roadmap).toContain('v6.0.0` was never published as a public package release');
-      expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 2 | 15 |');
+      expect(roadmap).toContain('| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 1 | 16 |');
+      expect(roadmap).toContain('| `v8.0.0` | [v8.0.0](https://github.com/flyingrobots/bijou/milestone/6) | 3 | 0 |');
       expect(roadmap).toContain('| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 |');
       expect(roadmap).toContain('Latest shipped release lineage after the release PR merges.');
       expect(roadmap).toContain('#270 release-readiness guardrails, #312 DOGFOOD i18n debt coverage');
@@ -74,12 +64,13 @@ describe('WF-130 roadmap goalpost policy', () => {
       expect(roadmap).toContain('0 | 27');
       expect(roadmap).toContain('Shipped release lineage.');
       expect(roadmap).toContain('`Beyond`');
-      expect(roadmap).toContain('31 | 6');
+      expect(roadmap).toContain('39 | 6');
       expect(roadmap).toContain('Next Pull');
       expect(roadmap).toContain('DOGFOOD release-story surfaces');
-      expect(roadmap).toContain('DF-078');
+      expect(roadmap).toContain('v7.2.0 release gate');
       expect(roadmap).toContain('#335');
-      expect(roadmap).toContain('NavigationListBlock GraphQL proof chain');
+      expect(roadmap).toContain('#354');
+      expect(roadmap).toContain('release-readiness and preflight checks');
       expect(roadmap).toContain('versioned artifact semantics');
       expect(roadmap).toContain('DOGFOOD fixtures that round-trip');
       expect(roadmap).toContain('https://github.com/flyingrobots/bijou/issues/270');
@@ -121,10 +112,11 @@ describe('WF-130 roadmap goalpost policy', () => {
       expect(roadmap).not.toContain('Workflow, Capture, And CI Determinism');
       expect(bearing).toContain('The latest shipped public release is `v7.1.0`');
       expect(bearing).toContain('The next feature horizon remains `v8.0.0`');
-      expect(bearing).toContain('the immediate `v7.2.0` focus is landing #335');
+      expect(bearing).toContain('the immediate `v7.2.0` focus is closing #354');
       expect(bearing).toContain('`v7.2.0` is now selected as a narrow stabilization and demo-integrity release');
-      expect(bearing).toContain('`v7.2.0` milestone is the current active stabilization lane: 2 open and 15 closed milestone items');
-      expect(bearing).toContain('The selected `v7.2.0` DOGFOOD product pull is #335');
+      expect(bearing).toContain('`v7.2.0` milestone is the current release-gate stabilization lane: 1 open and 16 closed milestone items');
+      expect(bearing).toContain('`v8.0.0` milestone is staged as the next feature horizon: 3 open and 0 closed milestone items');
+      expect(bearing).toContain('The selected `v7.2.0` DOGFOOD product pull #335 has landed');
       expect(bearing).toContain('Stabilize V7.2, Then Shape V8 And V9 From Beyond');
       expect(bearing).not.toContain('The next selected product pull after that gate is DX-047');
       expect(bearing).not.toContain('The next release-facing action is release-readiness validation');
@@ -140,10 +132,4 @@ describe('WF-130 roadmap goalpost policy', () => {
       expect(dx046Design).toContain('Tests To Write First');
     });
 
-  it('disables Markdown line-length linting for project docs', () => {
-      const markdownlintConfig = requireRecord(JSON.parse(read('.markdownlint.json')));
-
-      expect(markdownlintConfig.MD013).toBe(false);
-      expect(markdownlintConfig['line-length']).toBe(false);
-    });
 });

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts
@@ -51,6 +51,29 @@ describe('WF-130 roadmap goalpost policy', () => {
       );
     });
 
+  it('keeps staged v8 tracker details and sync commands aligned to the milestone', () => {
+      const roadmap = read('docs/ROADMAP.md');
+      const v8Section = sectionBetween(
+        roadmap,
+        '### `v8.0.0`: Runtime Graph And Scene IR Product Contract',
+        '### `v9.0.0`: Product Workbench And Operator Surfaces',
+      );
+      const normalizedV8Section = normalizeWhitespace(v8Section);
+      const maintenanceRule = sectionBetween(roadmap, '## Maintenance Rule', 'When roadmap triage changes:');
+
+      expect(v8Section).toContain('[#457](https://github.com/flyingrobots/bijou/issues/457)');
+      expect(normalizedV8Section).toContain('TRACKER: VISOR warpspace for v8 Runtime Graph And Scene IR');
+      expect(v8Section).toContain('[#458](https://github.com/flyingrobots/bijou/issues/458)');
+      expect(normalizedV8Section).toContain('VISOR: emit GraphQL block artifact bundle with replay and visual scene facts');
+      expect(v8Section).toContain('[#459](https://github.com/flyingrobots/bijou/issues/459)');
+      expect(normalizedV8Section).toContain('VISOR: validate packed-bijou-cells/1 and adapt to Surface');
+      expect(normalizedV8Section).toContain('Candidate source lineage remains in `Beyond`');
+      expect(v8Section).toContain('[#302](https://github.com/flyingrobots/bijou/issues/302)');
+      expect(v8Section).not.toContain('- [#302](https://github.com/flyingrobots/bijou/issues/302) for GraphQL-authored');
+      expect(maintenanceRule).toContain('gh issue list --state all --milestone v8.0.0');
+      expect(maintenanceRule).toContain('gh pr list --state all --search \'milestone:"v8.0.0"\'');
+    });
+
   it('requires audit comments for moves across all release horizons', () => {
       const bearing = normalizeWhitespace(read('docs/BEARING.md'));
 

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
@@ -22,9 +22,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 describe('WF-130 roadmap goalpost policy', () => {
   it('disables Markdown line-length linting for project docs', () => {
-      const markdownlintConfig = requireRecord(JSON.parse(read('.markdownlint.json')));
+    const markdownlintConfig = requireRecord(JSON.parse(read('.markdownlint.json')));
 
-      expect(markdownlintConfig.MD013).toBe(false);
-      expect(markdownlintConfig['line-length']).toBe(false);
-    });
+    expect(markdownlintConfig.MD013).toBe(false);
+    expect(markdownlintConfig['line-length']).toBe(false);
+  });
+
+  it('keeps v7.2 release evidence replay commands aligned with split WF-130 proof files', () => {
+    const releaseEvidence = read('docs/releases/7.2.0/README.md');
+    const proofFiles = [
+      'tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts',
+      'tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts',
+      'tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts',
+    ];
+
+    for (const proofFile of proofFiles) {
+      expect(releaseEvidence).toContain(proofFile);
+    }
+  });
 });

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -39,5 +39,22 @@ describe('WF-130 roadmap goalpost policy', () => {
     for (const proofFile of proofFiles) {
       expect(releaseEvidence).toContain(proofFile);
     }
+  });
+
+  it('publishes discoverable v7.2 release docs before the version bump', () => {
+    const releaseDocs = [
+      'docs/releases/7.2.0/README.md',
+      'docs/releases/7.2.0/whats-new.md',
+      'docs/releases/7.2.0/migration-guide.md',
+    ];
+
+    for (const releaseDoc of releaseDocs) {
+      expect(existsSync(resolve(ROOT, releaseDoc))).toBe(true);
+    }
+
+    const releaseIndex = read('docs/releases/README.md');
+    expect(releaseIndex).toContain('[Release Evidence (v7.2.0)](./7.2.0/README.md)');
+    expect(releaseIndex).toContain('[What\'s New (v7.2.0)](./7.2.0/whats-new.md)');
+    expect(releaseIndex).toContain('[Migration Guide (v7.2.0)](./7.2.0/migration-guide.md)');
   });
 });

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
@@ -57,4 +57,32 @@ describe('WF-130 roadmap goalpost policy', () => {
     expect(releaseIndex).toContain('[What\'s New (v7.2.0)](./7.2.0/whats-new.md)');
     expect(releaseIndex).toContain('[Migration Guide (v7.2.0)](./7.2.0/migration-guide.md)');
   });
+
+  it('keeps the v7.2 release packet aligned with release-prep and registry gates', () => {
+    const releasePacket = read('docs/releases/7.2.0/README.md');
+    const publishedPackages = [
+      '@flyingrobots/bijou',
+      '@flyingrobots/bijou-node',
+      '@flyingrobots/bijou-tui',
+      '@flyingrobots/bijou-tui-app',
+      'create-bijou-tui-app',
+      '@flyingrobots/bijou-i18n',
+      '@flyingrobots/bijou-i18n-tools',
+      '@flyingrobots/bijou-i18n-tools-node',
+      '@flyingrobots/bijou-i18n-tools-xlsx',
+      '@flyingrobots/bijou-mcp',
+    ];
+
+    expect(releasePacket).toContain('## Package And Registry Verification Plan');
+    expect(releasePacket).toContain('npm run version 7.2.0');
+    expect(releasePacket).toContain('Release Dry Run');
+    expect(releasePacket).toMatch(
+      /Tag creation, publish automation, npm registry\s+verification, and GitHub Release verification remain final-main work/,
+    );
+    expect(releasePacket).not.toContain('The version bump, final release dry run, tag creation');
+
+    for (const packageName of publishedPackages) {
+      expect(releasePacket).toContain(`npm view ${packageName} version dist-tags --json`);
+    }
+  });
 });

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
@@ -20,6 +20,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function extractBashCommandBlocks(markdown: string): string[] {
+  return Array.from(markdown.matchAll(/```bash\n(?<command>[\s\S]*?)```/g)).map(
+    (match) => match.groups?.command.trim() ?? '',
+  );
+}
+
+function extractReferencedTestPaths(markdown: string): string[] {
+  const paths = Array.from(markdown.matchAll(/\b((?:packages|scripts|tests)\/[A-Za-z0-9._/-]+\.test\.ts)\b/g)).map(
+    (match) => match[1],
+  );
+
+  return Array.from(new Set(paths)).sort();
+}
+
 describe('WF-130 roadmap goalpost policy', () => {
   it('disables Markdown line-length linting for project docs', () => {
     const markdownlintConfig = requireRecord(JSON.parse(read('.markdownlint.json')));
@@ -30,6 +44,10 @@ describe('WF-130 roadmap goalpost policy', () => {
 
   it('keeps v7.2 release evidence replay commands aligned with split WF-130 proof files', () => {
     const releaseEvidence = read('docs/releases/7.2.0/README.md');
+    const commandBlocks = extractBashCommandBlocks(releaseEvidence);
+    const roadmapReplay = commandBlocks.find((commandBlock) =>
+      commandBlock.includes('tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts'),
+    );
     const proofFiles = [
       'tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts',
       'tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts',
@@ -37,8 +55,16 @@ describe('WF-130 roadmap goalpost policy', () => {
     ];
 
     for (const proofFile of proofFiles) {
-      expect(releaseEvidence).toContain(proofFile);
+      expect(roadmapReplay ?? '').toContain(proofFile);
     }
+  });
+
+  it('keeps v7.2 release evidence test paths replayable from the checkout', () => {
+    const releaseEvidence = read('docs/releases/7.2.0/README.md');
+    const referencedTestPaths = extractReferencedTestPaths(releaseEvidence);
+    const missingTestPaths = referencedTestPaths.filter((testPath) => !existsSync(resolve(ROOT, testPath)));
+
+    expect(missingTestPaths).toEqual([]);
   });
 
   it('publishes discoverable v7.2 release docs before the version bump', () => {

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
@@ -85,4 +85,14 @@ describe('WF-130 roadmap goalpost policy', () => {
       expect(releasePacket).toContain(`npm view ${packageName} version dist-tags --json`);
     }
   });
+
+  it('keeps dev-tooling dependency security in the v7.2 audit replay', () => {
+    const releasePacket = read('docs/releases/7.2.0/README.md');
+
+    expect(releasePacket).toContain('Dev-tooling dependency audit');
+    expect(releasePacket).toContain('`npm audit --audit-level=high`');
+    expect(releasePacket).toContain('`npm audit --omit=dev --audit-level=high`');
+    expect(releasePacket).toContain('`esbuild` resolves to `0.28.1`');
+    expect(releasePacket).toContain('`node_modules/esbuild`');
+  });
 });

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error('Expected JSON object');
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+describe('WF-130 roadmap goalpost policy', () => {
+  it('disables Markdown line-length linting for project docs', () => {
+      const markdownlintConfig = requireRecord(JSON.parse(read('.markdownlint.json')));
+
+      expect(markdownlintConfig.MD013).toBe(false);
+      expect(markdownlintConfig['line-length']).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

This PR closes the v7.2.0 release-gate bookkeeping for #354 after #335 landed.

It does four things:

- updates `ROADMAP.md`, `BEARING.md`, and `CHANGELOG.md` so v7.2.0 is in release-gate posture instead of still pointing at #335 implementation
- refreshes GitHub-backed milestone counts, including the staged `v8.0.0` VISOR tracker and the expanded `Beyond` issue table
- adds `docs/releases/7.2.0/README.md` as the initial release evidence packet
- updates and splits the WF-130 roadmap snapshot tests so the touched file stays under Code Dojo file/context limits

I also cleared stale `work-in-progress` labels from completed v7.2.0 tracker issues. The milestone-aware readiness report now blocks only on open #354, as expected for this PR.

## Tracker

Closes #354.

Milestone: `v7.2.0`

## Validation

- `npm run release:preflight`
- `npm run docs:inventory`
- `npm audit --omit=dev --audit-level=high`
- `npx vitest run --config vitest.config.ts tests/cycles/WF-130/roadmap-goalpost-policy.part01.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts`
- `npm run release:readiness`
- `npm run release:readiness -- --milestone v7.2.0` now reports all checks passing except `tracker-open-items`, which is #354 itself
- `git diff --check`
- pre-commit hook: Code Dojo file/context, mock-ban, code-size, ESLint, lockfile consistency
- pre-push hook: Code Dojo debt/strict gates, DOGFOOD i18n complete/check/debt, code size, `typecheck:test`, all 19 Vitest chunks, scripted interactive example smoke

## Final Release Note

This PR does not create or push `v7.2.0`. After merge, final release prep still needs the dedicated version bump, dated changelog boundary, final milestone-aware readiness pass from merged `main`, release dry run, tag, publish workflow, and npm/GitHub release verification.
