### PR TITLE
Restore roadmap milestone authority

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -78,16 +78,19 @@ Current direction and active tensions. Historical ship data is in
 
 ## Active Gravity
 
-### 0. Advance Runtime Graph And Scene IR From Proof To Product Fixture
+### 0. Close V8 Without Reopening Its Landed Product Contract
 
 - `DX-043`, `DX-044`, `DX-045`, and `DX-046` landed the portable
   `ui-scene-ir/1` seed,
   the first GraphQL-authored `bijou-block/1` proof, grouped block authoring,
   deterministic debug facts, and the first real GraphQL-authored DOGFOOD
   NavigationListBlock fixture for #302.
-- The broad #302 tracker now lives in `v8.0.0` with the VISOR Runtime Graph
-  and Scene IR contract work. The v7.1 feature proof and release-prep
-  guardrails are complete release lineage, not the full Runtime Graph product.
+- The broad #302 tracker and the #457 VISOR goalpost are closed `v8.0.0`
+  lineage. The #458 artifact bundle and #459 packed-cell adapter have landed;
+  the Runtime Graph and Scene IR contract is no longer the active design gap.
+- Dependency-security issue #482 is the remaining V8 blocker. Pull requests
+  #492 and #509 overlap on its remediation; select one reproducible path before
+  merge instead of treating both as independent release work.
 - The proof path that v7.1 now carries is:
 
   ```text
@@ -125,9 +128,9 @@ Current direction and active tensions. Historical ship data is in
   surfaces now stay inside DOGFOOD's main reader flow so What's New, the real
   GraphQL proof chain, and changelog history are visible without wide-only side
   metadata.
-- The next feature horizon remains `v8.0.0`: the Runtime Graph and Scene IR
-  product contract built from the proof chain that v7.1.0 shipped and the
-  release surface that v7.2.0 stabilized.
+- The next release remains `v8.0.0`, now in Runtime Graph release closeout.
+  The next major feature horizon is `v9.0.0`: Product Workbench, Sapphire
+  Design Language, compositional interaction state, and State Atlas proof.
 - The detailed release-horizon index lives in [ROADMAP.md](./ROADMAP.md), and
   the release process lives in [release.md](./release.md).
 
@@ -146,21 +149,21 @@ Current direction and active tensions. Historical ship data is in
 
 - The `v7.2.0` milestone is complete release lineage: 0 open and 19 closed
   milestone items as of the latest roadmap sync.
-- The `v8.0.0` milestone is the active feature horizon: 2 open milestone items
-  and 2 closed milestone items as of the latest roadmap sync.
+- The `v8.0.0` milestone is Runtime Graph release closeout: 3 open milestone
+  items and 4 closed milestone items as of the latest roadmap sync.
 - The `v8.1.0` milestone is replay, capture, debugger, and render-witness
   follow-through: 13 open and 0 closed milestone items.
-- The `v8.2.0` milestone is quality automation and Method hardening: 22 open
-  and 3 closed milestone items.
-- The `v9.0.0` milestone is Product Workbench and operator surfaces: 20 open
-  and 0 closed milestone items.
-- The `v10.0.0` milestone is renderer and host-systems integration: 9 open and
-  1 closed milestone item.
+- The `v8.2.0` milestone is quality automation and reliability: 26 open and 5
+  closed milestone items.
+- The `v9.0.0` milestone is Product Workbench and Sapphire Design Language: 36
+  open and 0 closed milestone items.
+- The `v10.0.0` milestone is renderer and host-systems integration: 11 open
+  and 1 closed milestone item.
 - The `Beyond` milestone is now a parking lane, not the active queue: 0 open
   and 6 closed milestone items as of the latest roadmap sync.
-- No open issue is currently unmilestoned; keep open unmilestoned searches
-  empty unless a maintainer is deliberately shaping work before release
-  assignment.
+- No open issue or pull request is currently unmilestoned; keep both open
+  unmilestoned searches empty unless a maintainer is deliberately shaping work
+  before release assignment.
 - Stale completed work-in-progress issues
   [#450](https://github.com/flyingrobots/bijou/issues/450) and
   [#383](https://github.com/flyingrobots/bijou/issues/383) were verified
@@ -170,20 +173,20 @@ Current direction and active tensions. Historical ship data is in
   `v7.2.0`, commented, and closed as completed.
 - `v7.2.0` must stay closed to the framework input and DOGFOOD demo-integrity
   issues selected in #354, plus narrow security repairs such as #357.
-- `v8.0.0` should organize Runtime Graph And Scene IR into a product contract:
-  versioned `bijou-block/1`, `ui-scene-ir/1`, receipts, source maps, lower
-  modes, debug facts, DOGFOOD round-trip fixtures, and capture evidence.
+- `v8.0.0` should preserve the landed Runtime Graph and Scene IR contracts,
+  resolve dependency security through one selected implementation, and produce
+  release evidence without absorbing unfinished V9 scope.
 - `v8.1.0` should harden replay, capture, debugger, render-witness, and Runtime
   Graph visualization proof after the first V8 contract lands.
-- `v8.2.0` should make Code Dojo, Method, tracker sync, and fixture-backed test
-  gates easier to inspect and harder to drift.
-- `v9.0.0` should organize the Product Workbench and operator surfaces:
-  BlockLab, DOGFOOD drawer/focus language, Theme Lab and Theme Inspector
-  provenance, localization operations, artifact matrices, and product-review
-  docs.
+- `v8.2.0` should make Code Dojo, Method, tracker sync, startup diagnostics,
+  and fixture-backed test gates easier to inspect and harder to drift.
+- `v9.0.0` should organize the Product Workbench and Sapphire Design Language:
+  BlockLab, perceptual colour, DOGFOOD interaction grammar, Theme Lab and Theme
+  Inspector provenance, State Atlas proof, localization operations, artifact
+  matrices, and product-review docs.
 - `v10.0.0` should hold Geordi/Wesley follow-through, renderer and host
-  systems, terminal shader/raster work, native-surface foundations, and
-  advanced host input controls.
+  systems, the Geordi native GPU cell host, terminal shader/raster work,
+  native-surface foundations, and advanced host input controls.
 
 ## Tensions
 
@@ -204,7 +207,8 @@ Current direction and active tensions. Historical ship data is in
 - **DOGFOOD Truth Debt**: DF-030 converted the docs app into a named Block
   contract. New DOGFOOD truth work should be shaped as a post-v7 candidate
   goalpost or a Beyond issue rather than reopening the closed V7 queue.
-- **Unmilestoned Regression Risk**: Open unmilestoned work is currently empty.
+- **Unmilestoned Regression Risk**: Open unmilestoned issues and pull requests
+  are currently empty.
   Work with `work-in-progress`, `roadmap`, or `needs-design` labels but no
   milestone must be made explicit before agents treat it as a release target.
 
@@ -239,7 +243,7 @@ have landed as the two bounded V8 implementation proofs. Their cycle designs
 remain [DX-049](./design/DX-049-visor-artifact-bundle-proof.md) and
 [RE-036](./design/RE-036-packed-bijou-cells-surface-adapter.md).
 
-The active prerequisite is
+The prior structural prerequisite was
 [#480](https://github.com/flyingrobots/bijou/issues/480): remove the `25`
 double-counted code-size roots and lower aggregate Code Dojo debt from `62` to
 `12` or less through bounded
@@ -258,8 +262,9 @@ preserves `Surface`, DOGFOOD i18n-debt analysis, framed-app overlays,
 `ui-scene-ir/1`, and the terminal differ behind stable facades, lowering the
 live ceiling to `22`. Tranche E
 [#489](https://github.com/flyingrobots/bijou/pull/489) preserves the final five
-public entrypoints as bounded families and reaches `12 + 0 = 12`. V8 tracker
-closeout and release preparation follow merged `62 -> 12` goalpost evidence.
+public entrypoints as bounded families and reaches `12 + 0 = 12`. Its remaining
+tracker closeout belongs to V8.2 quality lineage and does not block V8 release
+preparation.
 Rendering-cache authority debt is tracked separately in
 [#485](https://github.com/flyingrobots/bijou/issues/485); cache reuse remains
 out of scope for scroll measurements until revision- or digest-based
@@ -274,8 +279,9 @@ VISOR v8 tracker (#457)
           -> landed packed-cell Surface adapter (#459)
 ```
 
-The proof chain that V7 shipped must become a product contract before Bijou
-pulls in broad Geordi, Wesley, browser, or native-render work:
+The proof chain that V7 shipped is now a landed product contract. Broad Geordi,
+Wesley, browser, or native-render work should consume it rather than redefine
+it:
 
 ```text
 GraphQL SDL fixture
@@ -293,19 +299,20 @@ Recommended pull order:
    replay facts, and visual scene facts are implemented.
 3. Treat #459 as landed through PR #483: `packed-bijou-cells/1` now validates
    and adapts into a synchronized terminal `Surface`.
-4. Merge #489 after exact-head review to close #480 at Code Dojo debt `12`.
-5. Close #302 and #457 only after merged goalpost evidence and V8 contract
-   closeout agree.
-6. Use `v8.1.0` for replay, capture, debugger, render-witness, and graph proof
+4. Compare #492 and #509 as competing implementations of #482; select one
+   reproducible dependency-security path.
+5. Close #482 only when the selected exact head proves zero actionable
+   advisories through the documented audit commands.
+6. Prepare the V8 release packet without pulling unfinished V9 design-language
+   work into the release gate.
+7. Use `v8.1.0` for replay, capture, debugger, render-witness, and graph proof
    follow-through after V8 lands.
-7. Use `v8.2.0` for Code Dojo, Method, tracker-sync, and fixture-backed quality
-   automation.
-8. Keep `v9.0.0` for Product Workbench and operator surfaces after V8
-   stabilizes the source/artifact/IR contract.
-9. Keep `v10.0.0` for Geordi/Wesley, renderer, host, shader, raster, and native
-   surface work after the Bijou contracts are proven.
-10. Keep closed dependency PR #326 as superseded lineage, not active release
-   work.
+8. Use `v8.2.0` for Code Dojo, Method, tracker sync, startup diagnostics, and
+   fixture-backed quality automation.
+9. Use `v9.0.0` for Product Workbench, Sapphire Design Language, interaction
+   recipes, and State Atlas proof over the landed V8 contract.
+10. Use `v10.0.0` for Geordi/Wesley, renderer, host, native GPU, shader,
+    raster, and advanced input work after the Bijou contracts are proven.
 
 Non-goals for the next cycle:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,15 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Changed
 
+- **WF-167 roadmap milestone authority** — GitHub and the durable roadmap now
+  share one release model: V8 is the landed Runtime Graph contract plus
+  dependency-security closeout; V8.1 owns replay and render evidence; V8.2 owns
+  quality, reliability, diagnostics, and tracker synchronization; V9 combines
+  Product Workbench with the Sapphire Design Language, compositional
+  interaction recipes, and State Atlas proof; and V10 owns renderer, Geordi
+  native-GPU host, and systems integration. All open issues and pull requests
+  have explicit milestones, retargeted issues carry migration comments, and
+  stale `[Beyond]` title and contradictory lane/priority residue is removed.
 - **WF-165 Code Dojo goalpost, tranche E** — The TUI runtime, table,
   framed-app, DOGFOOD application, and DOGFOOD story catalog preserve their
   public entrypoints as typed facades over focused sub-150-line modules. Exact

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ requests assigned to each milestone. They are not issue-only totals. Do not
 compare release snapshot item totals to issue-only `gh issue list` output
 without also accounting for milestone pull requests.
 
-Last synced from GitHub milestone items: 2026-07-30.
+Last synced from GitHub milestone items: 2026-08-09.
 
 ## Current Release State
 
@@ -48,11 +48,11 @@ count reaches zero.
 | Horizon | Milestone | Open Items | Closed Items | Current Posture |
 | :--- | :--- | ---: | ---: | :--- |
 | `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 0 | 19 | Shipped demo-integrity and framework-input stabilization lineage. |
-| `v8.0.0` | [v8.0.0](https://github.com/flyingrobots/bijou/milestone/6) | 2 | 2 | Contract implementation landed; tracker closeout waits on the next Code Dojo goalpost. |
+| `v8.0.0` | [v8.0.0](https://github.com/flyingrobots/bijou/milestone/6) | 3 | 4 | Runtime Graph contract landed; release closeout is dependency-security remediation and release preparation. |
 | `v8.1.0` | [v8.1.0](https://github.com/flyingrobots/bijou/milestone/7) | 13 | 0 | Post-V8 replay, capture, debugger, and render-witness follow-through. |
-| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 22 | 3 | Quality automation, Method hardening, and Code Dojo visibility horizon. |
-| `v9.0.0` | [v9.0.0](https://github.com/flyingrobots/bijou/milestone/9) | 20 | 0 | Product Workbench and operator-surface horizon. |
-| `v10.0.0` | [v10.0.0](https://github.com/flyingrobots/bijou/milestone/10) | 9 | 1 | Renderer and host-systems integration horizon. |
+| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 26 | 5 | Quality automation, reliability, diagnostics, and tracker-authority horizon. |
+| `v9.0.0` | [v9.0.0](https://github.com/flyingrobots/bijou/milestone/9) | 36 | 0 | Product Workbench, Sapphire Design Language, and interaction-state horizon. |
+| `v10.0.0` | [v10.0.0](https://github.com/flyingrobots/bijou/milestone/10) | 11 | 1 | Renderer, native GPU host, and systems-integration horizon. |
 | `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 | Previous shipped release lineage. Complete; do not reopen for new feature work. |
 | `v7.0.0` | [v7.0.0](https://github.com/flyingrobots/bijou/milestone/2) | 0 | 27 | Shipped release lineage. Complete; do not reopen for new feature work. |
 | `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) | 0 | 6 | Parking lane for deliberately uncommitted work; no open active backlog remains here. |
@@ -94,8 +94,8 @@ Non-scope:
   changelog
 
 The `v7.1.0` GitHub milestone is closed release lineage. Keep #329, #270, #312,
-and the release PR there for history, keep parent #302 in the active `v8.0.0`
-Runtime Graph horizon, and do not move new feature work into `v7.1.0`.
+and the release PR there for history, keep parent #302 in the landed `v8.0.0`
+Runtime Graph lineage, and do not move new feature work into `v7.1.0`.
 
 ### `v7.2.0`: Shipped Stabilization And Demo Integrity
 
@@ -138,15 +138,21 @@ Release gate:
   theme-variant, What's New, GraphQL proof, and changelog surfaces
 - normal release-readiness evidence before tagging
 
-### `v8.0.0`: Runtime Graph And Scene IR Product Contract
+### `v8.0.0`: Runtime Graph Release Closeout
 
-`v8.0.0` should be the next major release. Its job is to turn the portable scene
-and GraphQL block proof into a product contract, not just a compiler demo.
+`v8.0.0` should be the next major release. Its Runtime Graph and Scene IR
+product contract has landed. Its remaining job is to select one reproducible
+dependency-security remediation, reach zero actionable advisories, and prepare
+the release without importing unfinished V9 design-language scope.
 
-Primary staged milestone trackers:
+Landed contract lineage:
+
+This lineage supplies versioned artifact semantics and DOGFOOD fixtures that
+round-trip through source, artifact, IR, terminal proof, and debug facts.
 
 - [#457](https://github.com/flyingrobots/bijou/issues/457) TRACKER: VISOR
-  warpspace for v8 Runtime Graph And Scene IR
+  warpspace for v8 Runtime Graph And Scene IR, shaped by the landed
+  [`DX-048`](./design/DX-048-v8-runtime-graph-scene-ir-contract.md) contract
 - [#458](https://github.com/flyingrobots/bijou/issues/458) VISOR: emit GraphQL
   block artifact bundle with replay and visual scene facts, shaped by
   [`DX-049`](./design/DX-049-visor-artifact-bundle-proof.md) as the first
@@ -158,17 +164,23 @@ Primary staged milestone trackers:
 - [#302](https://github.com/flyingrobots/bijou/issues/302) as the broad
   GraphQL-authored UI scenes into Bijou Blocks source tracker
 
+Active release-closeout tracker:
+
+- [#482](https://github.com/flyingrobots/bijou/issues/482) owns the uncovered
+  Dependabot advisories
+- [#492](https://github.com/flyingrobots/bijou/pull/492) and
+  [#509](https://github.com/flyingrobots/bijou/pull/509) are competing
+  implementations of that security outcome; their overlap must be resolved
+  before either is selected for merge
+
 Release gate:
 
-- versioned artifact semantics for `bijou-block/1`, `ui-scene-ir/1`, receipts,
-  source maps, lower modes, and debug facts
-- one or more DOGFOOD fixtures that round-trip from source to artifact to IR to
-  terminal proof with stable hashes
-- deterministic frame-capture or playback evidence reviewers can inspect
-- failure tests for invalid references, duplicate identities, missing product
-  facts, and broken lowering assumptions
-- an explicit Wesley/Geordi boundary note, without requiring those repositories
-  to ship first
+- the landed artifact, IR, receipt, source-map, lower-mode, debug-fact, and
+  packed-cell contracts remain green
+- one security remediation path is selected with reproducible audit evidence
+- actionable dependency advisories reach zero
+- the release packet records the exact dependency and contract proof
+- no unfinished Sapphire Design Language issue becomes a V8 release blocker
 
 ### `v8.1.0`: Replay, Capture, And Render Witnesses
 
@@ -204,17 +216,17 @@ Release gate:
 - graph visualization surfaces that consume Runtime Graph facts rather than
   reinterpreting source data ad hoc
 
-### `v8.2.0`: Quality Automation And Method Hardening
+### `v8.2.0`: Quality Automation And Reliability
 
 `v8.2.0` should make the repo's quality system easier to see, enforce, and
 iterate. Its job is to keep Code Dojo and Method gates fast enough for daily
-work while preserving the no-debt-growth release posture.
+work while preserving the no-debt-growth release posture, startup diagnostics,
+and an explainable tracker-to-roadmap authority boundary.
 
 Primary tracker:
 
 - Code Dojo goalposts, structural debt, visibility, and ratchet automation:
   [#480](https://github.com/flyingrobots/bijou/issues/480),
-  [#482](https://github.com/flyingrobots/bijou/issues/482),
   [#467](https://github.com/flyingrobots/bijou/pull/467),
   [#481](https://github.com/flyingrobots/bijou/issues/481),
   [#477](https://github.com/flyingrobots/bijou/issues/477),
@@ -225,6 +237,8 @@ Primary tracker:
   [#371](https://github.com/flyingrobots/bijou/issues/371), and
   [#369](https://github.com/flyingrobots/bijou/issues/369)
 - Method, tracker, and CI seam hardening:
+  [#514](https://github.com/flyingrobots/bijou/issues/514),
+  [#515](https://github.com/flyingrobots/bijou/pull/515),
   [#479](https://github.com/flyingrobots/bijou/issues/479),
   [#376](https://github.com/flyingrobots/bijou/issues/376),
   [#472](https://github.com/flyingrobots/bijou/issues/472),
@@ -234,6 +248,10 @@ Primary tracker:
   [#268](https://github.com/flyingrobots/bijou/issues/268), and
   [#249](https://github.com/flyingrobots/bijou/issues/249)
 - fixture and typing repairs:
+  [#508](https://github.com/flyingrobots/bijou/issues/508),
+  [#507](https://github.com/flyingrobots/bijou/issues/507),
+  [#491](https://github.com/flyingrobots/bijou/issues/491),
+  [#490](https://github.com/flyingrobots/bijou/issues/490),
   [#473](https://github.com/flyingrobots/bijou/issues/473),
   [#368](https://github.com/flyingrobots/bijou/issues/368),
   [#367](https://github.com/flyingrobots/bijou/issues/367), and
@@ -252,11 +270,12 @@ Release gate:
 - typed DOGFOOD and docs-preview fixtures that reduce brittle smoke-test
   coupling
 
-### `v9.0.0`: Product Workbench And Operator Surfaces
+### `v9.0.0`: Product Workbench And Sapphire Design Language
 
 `v9.0.0` should be the major release after the V8 contract exists. Its job is to
-make Bijou authoring, inspection, localization, and product review feel like a
-real workbench instead of scattered fixtures.
+make Bijou authoring, inspection, localization, interaction state, and product
+review feel like one authored system instead of scattered fixtures. This is
+where Bijou turns its visual identity into an unmistakable application grammar.
 
 Primary tracker:
 
@@ -271,12 +290,19 @@ Primary tracker:
   [#248](https://github.com/flyingrobots/bijou/issues/248), and
   [#272](https://github.com/flyingrobots/bijou/issues/272)
 - theme and design-token workbench:
+  campaign tracker [#501](https://github.com/flyingrobots/bijou/issues/501),
   [#352](https://github.com/flyingrobots/bijou/issues/352),
   [#347](https://github.com/flyingrobots/bijou/issues/347),
   [#311](https://github.com/flyingrobots/bijou/issues/311),
   [#315](https://github.com/flyingrobots/bijou/issues/315),
   [#317](https://github.com/flyingrobots/bijou/issues/317), and
-  [#318](https://github.com/flyingrobots/bijou/issues/318)
+  [#318](https://github.com/flyingrobots/bijou/issues/318), with its
+  perceptual-colour and Theme Lab cohort
+  [#494](https://github.com/flyingrobots/bijou/issues/494)-[#506](https://github.com/flyingrobots/bijou/issues/506)
+- interaction grammar and proof:
+  compositional state recipes
+  [#512](https://github.com/flyingrobots/bijou/issues/512) and the generated
+  State Atlas [#513](https://github.com/flyingrobots/bijou/issues/513)
 - localization and docs operations:
   [#454](https://github.com/flyingrobots/bijou/issues/454),
   [#206](https://github.com/flyingrobots/bijou/issues/206),
@@ -288,7 +314,12 @@ Release gate:
 - Storybook-grade BlockLab or equivalent DOGFOOD fixture workflows
 - artifact matrices and capture proof that make product review reproducible
 - Theme Lab and Theme Inspector provenance surfaces backed by token facts
-- localization workbench and scanner coverage that make translation debt visible
+- focused and unfocused selection, ownership, availability, and activation
+  remain distinguishable through capability-aware recipes and non-color cues
+- a generated State Atlas exposes recipe provenance, contrast, lowering, and
+  intentional semantic-state collapse across capability profiles
+- localization workbench proof and scanner coverage that make translation debt
+  visible
 - structured changelog and product-review docs that reduce release-flow and
   i18n burden
 
@@ -308,6 +339,8 @@ Primary tracker:
   [#350](https://github.com/flyingrobots/bijou/issues/350), and
   [#219](https://github.com/flyingrobots/bijou/issues/219)
 - terminal shader, raster, and native-render foundations:
+  native GPU cell-host issue [#510](https://github.com/flyingrobots/bijou/issues/510)
+  and design PR [#511](https://github.com/flyingrobots/bijou/pull/511),
   [#348](https://github.com/flyingrobots/bijou/issues/348),
   [#346](https://github.com/flyingrobots/bijou/issues/346), and
   [#215](https://github.com/flyingrobots/bijou/issues/215)
@@ -336,7 +369,14 @@ validates `packed-bijou-cells/1` receipts and adapts them byte-for-byte into a
 terminal `Surface` through
 [#483](https://github.com/flyingrobots/bijou/pull/483).
 
-The active prerequisite is the third Code Dojo goalpost
+The active V8 pull is dependency-security selection. Issue
+[#482](https://github.com/flyingrobots/bijou/issues/482) is the outcome;
+[#492](https://github.com/flyingrobots/bijou/pull/492) and
+[#509](https://github.com/flyingrobots/bijou/pull/509) are overlapping
+implementations. Compare their exact-head audit evidence, select one path, and
+close the other as superseded only after the selected path is explicit.
+
+The V8.2 quality runway also records the third Code Dojo goalpost
 [#480](https://github.com/flyingrobots/bijou/issues/480): remove all `25`
 double-counted code-size roots and lower aggregate debt from `62` to `12` or
 less through bounded review tranches. Landed tranche A
@@ -358,24 +398,24 @@ TUI runtime, table, framed-app, DOGFOOD application, and DOGFOOD story catalog
 remain stable facades over bounded families, removing the final five
 double-counted roots and reaching `12 + 0 = 12`. The cycle design is
 [WF-165](./design/WF-165-respecting-dojo-ratchet-12.md). V8 tracker closeout
-and release preparation follow merged goalpost evidence; no tag or publication
-is part of this structural cycle.
+no longer depends on expanding that quality campaign; #480 remains V8.2
+tracker lineage. No tag or publication is part of this roadmap cycle.
 
 ## Forward Goalposts
 
 These are planning recommendations from the open tracker state as of
-2026-07-30. `v7.1.0` and `v7.2.0` are shipped lineage; `v8.0.0`, `v8.1.0`,
+2026-08-09. `v7.1.0` and `v7.2.0` are shipped lineage; `v8.0.0`, `v8.1.0`,
 `v8.2.0`, `v9.0.0`, and `v10.0.0` are the explicit forward release horizons.
 
 | Target | Goalpost | Tracker | Why It Belongs There | Release Gate |
 | :--- | :--- | :--- | :--- | :--- |
 | `v7.1.0` | Shipped Post-V7 Minor | Landed DX-046 [#329](https://github.com/flyingrobots/bijou/issues/329), release-prep guardrails [#270](https://github.com/flyingrobots/bijou/issues/270) and [#312](https://github.com/flyingrobots/bijou/issues/312), the v7.1.0 release PR, and `Unreleased` changelog work after `v7.0.0` | The repo shipped a meaningful post-V7 batch without turning it into a new product epoch. | Met: DX-046 green, #270/#312 green, release evidence packet written, #329 kept in `v7.1.0` without pulling #302 backward, and no broad scope creep. |
 | `v7.2.0` | Demo Integrity And Framework Input Stabilization | Release-gate goalpost [#354](https://github.com/flyingrobots/bijou/issues/354), framework input stories [#344](https://github.com/flyingrobots/bijou/issues/344), [#345](https://github.com/flyingrobots/bijou/issues/345), [#353](https://github.com/flyingrobots/bijou/issues/353), landed DOGFOOD repair stories [#340](https://github.com/flyingrobots/bijou/issues/340), [#341](https://github.com/flyingrobots/bijou/issues/341), [#342](https://github.com/flyingrobots/bijou/issues/342), [#343](https://github.com/flyingrobots/bijou/issues/343), landed release-story story [#335](https://github.com/flyingrobots/bijou/issues/335), and security patches [#357](https://github.com/flyingrobots/bijou/issues/357), [#370](https://github.com/flyingrobots/bijou/issues/370). | The v7.1 proof exists, but the release-video rehearsal exposed demo-breaking seams in localization, theme posture, Blocks docs, release-story surfaces, and mouse routing; GitHub/npm audit also reported narrow development-tooling and dependency advisories that are now triaged clean. | Workspace pointer fallthrough fixed, page-frame helper exports public, mouse test helpers available, DOGFOOD demo surfaces honest enough for release video, audit clean, #335 release-story surfaces implemented, and release-readiness green. |
-| `v8.0.0` | Runtime Graph And Scene IR Product Contract | Staged milestone tracker [#457](https://github.com/flyingrobots/bijou/issues/457), landed design packet [`DX-048`](./design/DX-048-v8-runtime-graph-scene-ir-contract.md), VISOR artifact bundle [#458](https://github.com/flyingrobots/bijou/issues/458), packed Bijou cell adapter [#459](https://github.com/flyingrobots/bijou/issues/459), and parent tracker [#302](https://github.com/flyingrobots/bijou/issues/302). | This is the current product direction after DX-043 through DX-046 and the VISOR planning turn: portable scenes, GraphQL blocks, deterministic debug facts, packed terminal cells, replay/capture evidence, and product fixtures need to become a stable contract. | Stable artifact semantics, DOGFOOD round-trip fixtures, terminal/frame-capture proof, lower-mode and source-map receipts, and failure tests. |
+| `v8.0.0` | Runtime Graph Release Closeout | Landed contract lineage [#302](https://github.com/flyingrobots/bijou/issues/302), [#457](https://github.com/flyingrobots/bijou/issues/457), [#458](https://github.com/flyingrobots/bijou/issues/458), and [#459](https://github.com/flyingrobots/bijou/issues/459); active security tracker [#482](https://github.com/flyingrobots/bijou/issues/482); competing remediation PRs [#492](https://github.com/flyingrobots/bijou/pull/492) and [#509](https://github.com/flyingrobots/bijou/pull/509). | The product contract is landed. V8 now needs one reproducible security outcome and a release packet, not another unfinished product campaign. | Select one remediation path, reach zero actionable advisories, preserve contract proof, and prepare release evidence. |
 | `v8.1.0` | Replay, Capture, And Render Witnesses | [#456](https://github.com/flyingrobots/bijou/issues/456), [#443](https://github.com/flyingrobots/bijou/issues/443), [#442](https://github.com/flyingrobots/bijou/issues/442), [#441](https://github.com/flyingrobots/bijou/issues/441), [#306](https://github.com/flyingrobots/bijou/issues/306), [#301](https://github.com/flyingrobots/bijou/issues/301), [#203](https://github.com/flyingrobots/bijou/issues/203), [#202](https://github.com/flyingrobots/bijou/issues/202), and [#209](https://github.com/flyingrobots/bijou/issues/209)-[#213](https://github.com/flyingrobots/bijou/issues/213). | Once V8 defines the contract, replay, capture, debugger, and graph witnesses become the next proof surface. | Deterministic replay/capture fixtures, stable hashes, debugger facts, and graph visualizations that consume Runtime Graph facts. |
-| `v8.2.0` | Quality Automation And Method Hardening | [#485](https://github.com/flyingrobots/bijou/issues/485), [#482](https://github.com/flyingrobots/bijou/issues/482), [#467](https://github.com/flyingrobots/bijou/pull/467), [#481](https://github.com/flyingrobots/bijou/issues/481), [#480](https://github.com/flyingrobots/bijou/issues/480), landed [#477](https://github.com/flyingrobots/bijou/issues/477), [#479](https://github.com/flyingrobots/bijou/issues/479), [#476](https://github.com/flyingrobots/bijou/issues/476), landed [#469](https://github.com/flyingrobots/bijou/issues/469), [#473](https://github.com/flyingrobots/bijou/issues/473), [#472](https://github.com/flyingrobots/bijou/issues/472), [#376](https://github.com/flyingrobots/bijou/issues/376), [#373](https://github.com/flyingrobots/bijou/issues/373), [#372](https://github.com/flyingrobots/bijou/issues/372), [#371](https://github.com/flyingrobots/bijou/issues/371), [#369](https://github.com/flyingrobots/bijou/issues/369), [#368](https://github.com/flyingrobots/bijou/issues/368), [#367](https://github.com/flyingrobots/bijou/issues/367), [#300](https://github.com/flyingrobots/bijou/issues/300), [#299](https://github.com/flyingrobots/bijou/issues/299), [#298](https://github.com/flyingrobots/bijou/issues/298), [#290](https://github.com/flyingrobots/bijou/issues/290), [#268](https://github.com/flyingrobots/bijou/issues/268), and [#249](https://github.com/flyingrobots/bijou/issues/249). | Quality gates now exist; this release should make them faster, more visible, and harder to drift. | PR-visible Code Dojo deltas, zero-growth runtime-cycle tracking, transport-safe local verification, tracker synchronization, fixture-backed tests, typed helpers, and honest CI seams. |
-| `v9.0.0` | Product Workbench And Operator Surfaces | [#455](https://github.com/flyingrobots/bijou/issues/455), [#454](https://github.com/flyingrobots/bijou/issues/454), [#352](https://github.com/flyingrobots/bijou/issues/352), [#347](https://github.com/flyingrobots/bijou/issues/347), [#336](https://github.com/flyingrobots/bijou/issues/336), [#318](https://github.com/flyingrobots/bijou/issues/318), [#317](https://github.com/flyingrobots/bijou/issues/317), [#315](https://github.com/flyingrobots/bijou/issues/315), [#311](https://github.com/flyingrobots/bijou/issues/311), [#272](https://github.com/flyingrobots/bijou/issues/272), [#248](https://github.com/flyingrobots/bijou/issues/248), [#218](https://github.com/flyingrobots/bijou/issues/218), [#217](https://github.com/flyingrobots/bijou/issues/217), [#216](https://github.com/flyingrobots/bijou/issues/216), [#214](https://github.com/flyingrobots/bijou/issues/214), [#208](https://github.com/flyingrobots/bijou/issues/208), [#207](https://github.com/flyingrobots/bijou/issues/207), [#206](https://github.com/flyingrobots/bijou/issues/206), [#205](https://github.com/flyingrobots/bijou/issues/205), and [#204](https://github.com/flyingrobots/bijou/issues/204). | Once V8 stabilizes the artifact contract, the next value is authoring and inspecting real product surfaces: BlockLab, Theme Lab, localization operations, artifact matrices, and docs/product review. | Storybook-grade BlockLab workflows, Theme Inspector/Lab provenance, localization workbench proof, artifact matrices, and structured release docs. |
-| `v10.0.0` | Renderer And Host Systems Integration | Landed [#468](https://github.com/flyingrobots/bijou/issues/468), [#321](https://github.com/flyingrobots/bijou/issues/321), [#351](https://github.com/flyingrobots/bijou/issues/351), [#350](https://github.com/flyingrobots/bijou/issues/350), [#349](https://github.com/flyingrobots/bijou/issues/349), [#348](https://github.com/flyingrobots/bijou/issues/348), [#346](https://github.com/flyingrobots/bijou/issues/346), [#316](https://github.com/flyingrobots/bijou/issues/316), [#215](https://github.com/flyingrobots/bijou/issues/215), and [#219](https://github.com/flyingrobots/bijou/issues/219). | Cross-repository integration should consume proven Bijou contracts rather than define them under release pressure. | A cross-repo release packet with explicit dependency ordering, renderer proof artifacts, terminal/native host boundaries, and rollback plans. |
+| `v8.2.0` | Quality Automation And Reliability | Governance [#514](https://github.com/flyingrobots/bijou/issues/514) / [#515](https://github.com/flyingrobots/bijou/pull/515), startup diagnostics [#507](https://github.com/flyingrobots/bijou/issues/507), dependency lineage [#467](https://github.com/flyingrobots/bijou/pull/467), public-signature and i18n truth [#490](https://github.com/flyingrobots/bijou/issues/490), [#491](https://github.com/flyingrobots/bijou/issues/491), [#508](https://github.com/flyingrobots/bijou/issues/508), plus Code Dojo, Method, CI, fixture, typing, and cache-authority work. | Quality gates now exist; this release should make them faster, visible, reliable, and resistant to tracker drift. | PR-visible Code Dojo deltas, transport-safe verification, tracker synchronization, conflict diagnostics, fixture-backed tests, typed helpers, and honest CI seams. |
+| `v9.0.0` | Product Workbench And Sapphire Design Language | Perceptual-colour tracker [#501](https://github.com/flyingrobots/bijou/issues/501) and cohort [#494](https://github.com/flyingrobots/bijou/issues/494)-[#506](https://github.com/flyingrobots/bijou/issues/506), interaction recipes [#512](https://github.com/flyingrobots/bijou/issues/512), State Atlas [#513](https://github.com/flyingrobots/bijou/issues/513), and the existing BlockLab, Theme Lab, localization, and product-review stories. | The next major combines authored identity with obvious interaction state, backed by one inspectable and capability-aware theme authority. | Storybook-grade workflows, recipe provenance, non-color cues, State Atlas degradation proof, localization operations, artifact matrices, and structured release docs. |
+| `v10.0.0` | Renderer And Host Systems Integration | Native GPU cell-host issue [#510](https://github.com/flyingrobots/bijou/issues/510) and design PR [#511](https://github.com/flyingrobots/bijou/pull/511), plus Geordi/Wesley, renderer, shader, raster, adaptive-budget, worker, and host-input follow-through. | Cross-repository integration should consume proven Bijou contracts rather than define them under release pressure. | A cross-repo release packet with explicit dependency ordering, GPU and terminal renderer proof, terminal/native host boundaries, and rollback plans. |
 
 ## Decision Points
 
@@ -388,36 +428,31 @@ These are planning recommendations from the open tracker state as of
   [#384](https://github.com/flyingrobots/bijou/pull/384), assigned to
   `v7.2.0`, commented, and closed as completed during the 2026-07-05 tracker
   triage.
-- **Next release**: `v8.0.0` is the active feature horizon for Runtime Graph and
-  Scene IR product-contract work.
-- **Next feature version**: `v8.0.0` is still the next intended feature horizon.
+- **Next release**: `v8.0.0` is in Runtime Graph release closeout; contract
+  implementation is landed and dependency security is the active blocker.
+- **Next feature version**: `v9.0.0` is the next major feature horizon for the
+  Product Workbench and Sapphire Design Language.
 - **V7.2 boundary**: do not pull broad Runtime Graph, BlockLab, Theme Lab,
   localization workbench, worker rendering, adaptive frame budgeting, or
   raster-surface APIs into `v7.2.0` unless a maintainer deliberately reshapes
   the milestone. Narrow security repairs may ride the release.
-- **V8 boundary**: Runtime Graph And Scene IR becomes the next major only when
-  the artifact, IR, receipt, source-map, lower-mode, debug, and capture
-  contracts are product-grade.
+- **V8 boundary**: keep the landed Runtime Graph and Scene IR contract green,
+  select one dependency remediation, and produce release evidence. Do not pull
+  unfinished Sapphire work back into V8.
 - **V8.1 boundary**: replay, capture, debugger, and graph witnesses should
   prove the V8 contract; they should not reopen source/artifact semantics.
 - **V8.2 boundary**: quality automation and Method hardening should improve the
   enforcement system without swallowing product-workbench scope.
-- **Immediate target**: [#458](https://github.com/flyingrobots/bijou/issues/458)
-  and [#459](https://github.com/flyingrobots/bijou/issues/459) have landed the
-  V8 source-side artifact and packed-cell contracts. Pull
-  [#480](https://github.com/flyingrobots/bijou/issues/480) through bounded
-  [WF-165](./design/WF-165-respecting-dojo-ratchet-12.md) tranches. Landed
-  tranche A lowered Code Dojo debt from `62` to `52`, and landed tranche B
-  lowered it to `42`. Landed tranche C
-  [#487](https://github.com/flyingrobots/bijou/pull/487) lowers it to `32`.
-  Landed tranche D [#488](https://github.com/flyingrobots/bijou/pull/488)
-  lowers it to `22`. Tranche E
-  [#489](https://github.com/flyingrobots/bijou/pull/489) implements the final
-  five splits and lowers the ledgers to `12` and `0`; merged goalpost evidence
-  precedes V8 tracker closeout.
-- **V9 boundary**: Product Workbench And Operator Surfaces should wait until V8
-  makes the source/artifact/IR contract stable enough to inspect and author
-  against.
+- **Immediate target**: compare dependency-security PRs
+  [#492](https://github.com/flyingrobots/bijou/pull/492) and
+  [#509](https://github.com/flyingrobots/bijou/pull/509) against issue
+  [#482](https://github.com/flyingrobots/bijou/issues/482), select one
+  reproducible remediation, and prepare V8 release evidence. The V8.2 quality
+  queue remains independent follow-through.
+- **V9 boundary**: Product Workbench And Sapphire Design Language should
+  compose perceptual colour, theme provenance, interaction recipes, State
+  Atlas proof, localization operations, and product surfaces over the landed
+  V8 contract.
 - **V10 boundary**: renderer, host, Geordi/Wesley, terminal shader, raster, and
   native-surface work should consume proven contracts from V8 and V9.
 - **DX-046 boundary**: Bijou-side only. Wesley and Geordi remain out of the
@@ -437,8 +472,9 @@ active backlog issues now carry explicit version milestones.
 
 ## Open Unmilestoned Triage
 
-No open issue is currently unmilestoned. Keep
-`gh search issues --repo flyingrobots/bijou --state open --no-milestone` empty
+No open issue or pull request is currently unmilestoned. Keep both
+`gh search issues --repo flyingrobots/bijou --state open --no-milestone` and
+`gh search prs --repo flyingrobots/bijou --state open --no-milestone` empty
 unless a maintainer is deliberately shaping work before release assignment.
 
 ## Dependency Security Lineage

--- a/docs/design/WF-167-roadmap-milestone-authority.md
+++ b/docs/design/WF-167-roadmap-milestone-authority.md
@@ -1,0 +1,483 @@
+# WF-167 Roadmap Milestone Authority
+
+Legend: [WF — Workflow and Delivery](../legends/WF-workflow-and-delivery.md)
+
+Tracker: [#514](https://github.com/flyingrobots/bijou/issues/514)
+
+## Sponsor Human
+
+James Ross.
+
+## Sponsor Agent
+
+Codex.
+
+## Decision Summary
+
+Restore one explainable release model across GitHub milestones,
+[`ROADMAP.md`](../ROADMAP.md), and [`BEARING.md`](../BEARING.md).
+
+Milestones own release horizons. Labels own work posture. Goalpost issues own
+dependency ordering inside a horizon. Documentation mirrors those authorities;
+it does not create a competing queue.
+
+The current `v8.0.0` milestone mixes a landed Runtime Graph and Scene IR
+contract, an active dependency-security blocker, an additive open Theme Lab
+pull request, and twenty-one unfinished perceptual-colour and product-surface
+issues. The unfinished colour campaign includes changes explicitly identified
+as semver-major. It belongs before the next major release, `v9.0.0`, rather
+than becoming a second product contract inside V8.
+
+This cycle therefore:
+
+1. returns `v8.0.0` to Runtime Graph release closeout and dependency security;
+2. preserves `v8.1.0` as replay, capture, debugger, graph, and render evidence;
+3. preserves `v8.2.0` as quality automation and reliability hardening;
+4. makes `v9.0.0` the Product Workbench **and Sapphire Design Language**
+   major, including interaction recipes and the State Atlas;
+5. keeps `v10.0.0` for renderer and host integration, including the Geordi
+   native-GPU cell host;
+6. removes stale title and label residue created by earlier Beyond-to-version
+   promotion;
+7. assigns every open pull request to its evidenced release horizon.
+
+No issue closes in this cycle. No implementation priority is inferred merely
+from a milestone move.
+
+## Hill
+
+A maintainer or agent can answer all of these from the live tracker and receive
+the same answer from the repository documentation:
+
+- What blocks V8?
+- Which work is evidence follow-through rather than release closeout?
+- Which visual changes belong to the next semver-major boundary?
+- Which ideas are committed, imminent, debt, or optional?
+- Which open pull requests participate in each release horizon?
+- What must be reconciled before an overlapping pull request can merge?
+
+The answer must not require reading historical comments, inferring semantics
+from an issue number, or treating a `lane:cool-ideas` label as a release
+commitment.
+
+## Current Truth
+
+The pre-cycle snapshot was taken from GitHub on 2026-08-09 against
+`origin/main` at `4412ec6dbce947887ed6ea2740ecbad0a66d122e`.
+
+### Milestone Items Before This Cycle
+
+GitHub milestone totals count issues and pull requests:
+
+| Milestone | Open items | Closed items | Open-issue interpretation |
+| :--- | ---: | ---: | :--- |
+| `v8.0.0` | 24 | 4 | 23 issues plus PR #509 |
+| `v8.1.0` | 13 | 0 | 13 issues |
+| `v8.2.0` | 23 | 5 | 22 issues plus PR #467 |
+| `v9.0.0` | 15 | 0 | 15 issues |
+| `v10.0.0` | 10 | 1 | 10 issues |
+| `Beyond` | 0 | 6 | no open work |
+
+Two additional open pull requests were unmilestoned:
+
+- V8 dependency-security PR
+  [#492](https://github.com/flyingrobots/bijou/pull/492);
+- V10 Geordi native-GPU design PR
+  [#511](https://github.com/flyingrobots/bijou/pull/511).
+
+The audit cohort therefore contained `83` open issues and `4` open pull
+requests. Opening governance issue #514 increases the live issue total to `84`
+and the `v8.2.0` milestone by one item during the cycle.
+
+### V8 Scope Drift
+
+The landed V8 source-side contract is carried by:
+
+- closed parent tracker
+  [#302](https://github.com/flyingrobots/bijou/issues/302);
+- closed goalpost
+  [#457](https://github.com/flyingrobots/bijou/issues/457);
+- landed VISOR artifact bundle
+  [#458](https://github.com/flyingrobots/bijou/issues/458);
+- landed packed-cell adapter
+  [#459](https://github.com/flyingrobots/bijou/issues/459).
+
+The active release prerequisite is dependency-security issue
+[#482](https://github.com/flyingrobots/bijou/issues/482). Pull requests #492
+and #509 overlap on that remediation and must be deduplicated before either is
+selected for merge.
+
+Issue #501 was subsequently retargeted from V9 into V8 with its foundation,
+correctness, Theme Lab, title-screen, and surface issues. That decision made
+the V8 release gate depend on work whose own tracker identifies three
+semver-major output changes:
+
+- #496 changes theme decision-rule results;
+- #497 changes every first-party theme colour;
+- #499 changes ANSI-256 rendered output.
+
+Those changes can land honestly before `v9.0.0`. They need not hold the already
+landed V8 product contract open.
+
+### Tracker Hygiene Drift
+
+The live tracker also contains mechanically identifiable residue:
+
+- issues promoted out of `Beyond` retain `[Beyond]` in their titles;
+- #204 carries both `lane:inbox` and `lane:cool-ideas`;
+- #214, #217, and #218 carry both current `lane:cool-ideas` and legacy
+  `lane:up-next`;
+- #219 remains `lane:inbox` despite an explicit V10 horizon;
+- #348 remains `lane:asap` despite an explicit V10 horizon;
+- #249 carries both `priority:medium` and `priority:low`;
+- #507 is `lane:bad-code` but lacks the repository's normal `BAD CODE:` title
+  signal;
+- milestone descriptions do not mention the recently added interaction-state,
+  State Atlas, or native-GPU stories.
+
+These are tracker defects, not implementation defects.
+
+## Authority Model
+
+### Milestone: Release Destination
+
+A versioned milestone answers: **if this work lands, which release boundary
+owns it?**
+
+A milestone does not mean every issue is committed or next. That posture comes
+from `lane:*`, `work-in-progress`, priority, design, and goalpost labels.
+
+### Lane: Commitment And Intake Posture
+
+- `lane:inbox`: not yet shaped;
+- `lane:asap`: imminent pull;
+- `lane:bad-code`: known debt or structural risk;
+- `lane:cool-ideas`: optional or uncommitted exploration;
+- `lane:release`: committed release-boundary work.
+
+An issue should carry one current lane. Historical `lane:up-next` residue does
+not coexist with the current lane model.
+
+### Goalpost: Dependency And Outcome Authority
+
+Goalpost issues such as #501 own dependency ordering within a release horizon.
+Moving a goalpost and its children between release horizons does not reorder
+the children. It changes the release boundary that may claim them.
+
+### Documentation: Human-Readable Mirror
+
+`ROADMAP.md` records release horizons, gates, and snapshot totals.
+`BEARING.md` records current execution gravity. Neither file overrides live
+GitHub state.
+
+## Target Milestone Model
+
+### `v8.0.0`: Runtime Graph Release Closeout
+
+Outcome:
+
+- Runtime Graph and Scene IR product contract is landed;
+- dependency advisories reach zero through one selected remediation path;
+- release preparation begins only after security truth is reproducible;
+- no unfinished colour-system campaign blocks the release.
+
+Expected open items after triage:
+
+- issue #482;
+- PR #492;
+- PR #509.
+
+The two PRs overlap. Their simultaneous presence records alternatives, not
+three independent release blockers.
+
+### `v8.1.0`: Replay, Capture, And Render Evidence
+
+No issue migration is required. The milestone remains the post-contract proof
+horizon for replay, capture, debugger, graph, browser, terminal, and parity
+witnesses.
+
+Expected open items after triage: `13`.
+
+### `v8.2.0`: Quality Automation And Reliability
+
+Add issue #507 because startup key-conflict reporting is quality enforcement,
+not Runtime Graph release scope. Governance issue #514 also lives here because
+tracker synchronization is an explicit V8.2 outcome.
+
+Expected open items after triage: `25`:
+
+- `24` open issues, including #507 and #514;
+- Dependabot PR #467.
+
+### `v9.0.0`: Product Workbench And Sapphire Design Language
+
+Move the full unfinished campaign cohort from V8:
+
+| Cohort | Issues |
+| :--- | :--- |
+| Theme and product surfaces | #311, #315, #317, #336, #455, #493, #494, #502 |
+| Perceptual foundation and generation | #318, #352, #495, #496, #497, #498, #501, #504 |
+| Correctness and accessibility | #499, #500, #505 |
+| Theme Lab structural debt | #503, #506 |
+
+The cohort contains `21` issues. It joins the existing `15` V9 issues,
+including interaction recipes #512 and State Atlas #513.
+
+Expected open items after triage: `36`.
+
+The count is large because this milestone is an explicit future major horizon,
+not because all `lane:cool-ideas` work has become committed. #501 and the
+existing Product Workbench stories provide the internal goalposts.
+
+### `v10.0.0`: Renderer And Host Systems Integration
+
+Keep the existing ten issues. Assign PR #511 to the milestone and update the
+description to name the Geordi native-GPU cell-host boundary.
+
+Expected open items after triage: `11`.
+
+### `Beyond`: Deliberate Incubation
+
+No issue moves into `Beyond` during this cycle. Explicit release destinations
+remain useful. The stale title prefix is removed from issues that already have
+a versioned destination.
+
+## Issue Title And Label Normalization
+
+### Remove Stale `[Beyond]` Prefix
+
+Rename these open issues without changing their substantive titles:
+
+- #202 through #219 where the current title begins `[Beyond]`:
+  #202, #203, #204, #205, #206, #207, #208, #209, #210, #211, #212, #213,
+  #214, #215, #216, #217, #218, and #219.
+
+Each already has an explicit versioned milestone. The prefix now contradicts
+the milestone and makes search results look parked when they are not.
+
+### Normalize Lanes And Priority
+
+- #204: remove `lane:inbox`; retain `lane:cool-ideas`.
+- #214, #217, #218: remove `lane:up-next`; retain `lane:cool-ideas`.
+- #219: replace `lane:inbox` with `lane:cool-ideas`.
+- #348: replace `lane:asap` with `lane:cool-ideas`; V10 is a future host and
+  renderer horizon, not the imminent V8 pull.
+- #249: remove `priority:medium`; retain `priority:low` for the optional
+  technical-teardown quality gate.
+- #507: rename to `BAD CODE: detect key binding conflicts at frame init` while
+  preserving the current debt lane and acceptance criteria.
+
+No blanket priority assignment is introduced. An absent priority is not a
+contradiction; two priorities are.
+
+## Pull Request Triage
+
+### PR #492
+
+Assign to `v8.0.0`. It implements the active dependency-security blocker.
+
+### PR #509
+
+Keep in `v8.0.0` because it also implements the same security blocker and its
+already-implemented Theme Lab changes are additive. Moving unfinished campaign
+issues to V9 does not remove the PR's V8 security relevance.
+
+The PR must reconcile its branch-local roadmap changes with WF-167 before
+merge. A significant-event comment will record that consequence.
+
+### PR #511
+
+Assign to `v10.0.0`. It is the design evidence for issue #510 and does not
+alter the V8 or V9 release gates.
+
+### PR #467
+
+Keep in `v8.2.0` as dependency-update lineage. Do not close it until one newer
+security remediation is selected and merged with evidence that
+`brace-expansion@5.0.9` or later is reproducible.
+
+## Migration Ordering
+
+The mutation order prevents documentation from claiming unperformed tracker
+state:
+
+1. publish this design and the non-draft cycle PR;
+2. update milestone descriptions;
+3. move the V9 cohort and #507;
+4. assign PR #492 and PR #511;
+5. normalize titles, lanes, and #249 priority;
+6. comment every release-horizon move;
+7. take a fresh milestone-item snapshot;
+8. update `ROADMAP.md`, `BEARING.md`, changelog, and tests to that snapshot;
+9. verify GitHub read-back and repository gates;
+10. update the cycle issue and PR only for material discrepancies.
+
+If any mutation fails, stop and read back the affected issue before retrying.
+Do not assume a partial batch succeeded.
+
+## Rollback And Recovery
+
+GitHub issue and milestone edits are individually reversible. The durable
+migration table in this design identifies every intended source and target.
+
+If review rejects the model:
+
+- issues can be moved back using the same explicit table;
+- titles can regain their previous prefix from GitHub history;
+- labels can be restored individually;
+- documentation changes can be superseded by a normal follow-up commit;
+- no force operation, rebase, amend, or history rewrite is required.
+
+Issue comments remain as provenance and should not be deleted. A rollback
+comment should explain the superseding decision.
+
+## Scope
+
+- Audit all open Bijou issues and pull requests at the cycle snapshot.
+- Refactor the live milestone assignments and descriptions described above.
+- Normalize the bounded title and label defects described above.
+- Update roadmap, bearing, changelog, and deterministic policy tests.
+- Link and explain the interaction-state, State Atlas, and native-GPU work in
+  the correct horizons.
+- Preserve the active security and colour branches without editing their
+  worktrees.
+
+## Non-Goals
+
+- No issue closure without implementation or explicit disposition evidence.
+- No pull request merge, release, tag, or package publication.
+- No selection between PR #492 and PR #509.
+- No changes to the user-owned dirty `cycle/v8-security-closeout` worktree.
+- No changes to the `cycle/colors` worktree.
+- No implementation of perceptual colour, Theme Lab debt, interaction
+  recipes, State Atlas, replay, or native-GPU rendering.
+- No new release milestone; the existing V8, V9, and V10 major boundaries
+  already express the required semver ordering.
+- No claim that a milestone assignment alone commits a cool idea to ship.
+
+## Tests To Write First
+
+1. Assert the roadmap snapshot contains the exact post-migration milestone-item
+   totals.
+2. Assert V8 names #482 and the overlapping #492/#509 remediation posture and
+   does not list #501 as a release gate.
+3. Assert V9 names #501, #512, and #513 and describes Sapphire Design Language
+   plus Product Workbench outcomes.
+4. Assert V10 names #510 and PR #511 and preserves the native-host claim
+   boundary.
+5. Assert BEARING reports the same totals and V8 next action.
+6. Preserve the milestone-item counting rule: counts include issues and pull
+   requests.
+7. Preserve the empty open-unmilestoned and open-Beyond policy statements only
+   after live GitHub read-back proves them.
+8. Keep historic shipped-release lineage unchanged.
+
+## Validation Plan
+
+```bash
+npx vitest run --config vitest.config.ts tests/cycles/WF-130
+npx vitest run --config vitest.config.ts tests/cycles/DX-050
+npx vitest run --config vitest.config.ts tests/cycles/RE-036
+npm run docs:inventory
+npm run typecheck:test
+npm run lint
+npm run code-dojo:changed
+git diff --check
+```
+
+The pre-commit and pre-push hooks remain required. Live GitHub verification is
+a separate read-back step because deterministic repository tests must not
+depend on network availability.
+
+## Acceptance Criteria
+
+- All `83` pre-cycle issues, issue #514, and all four open pull requests have a
+  recorded disposition.
+- V8 contains one issue and two competing security implementation PRs.
+- V9 contains the full twenty-one-issue Sapphire/design-language cohort.
+- V8.2 contains #507 and #514.
+- V10 contains PR #511.
+- No open issue or pull request is unmilestoned.
+- No versioned issue retains `[Beyond]` in its title.
+- #204, #214, #217, #218, #219, #348, and #249 have one coherent lane or
+  priority posture as specified.
+- Every issue moved across a release horizon has a migration comment.
+- Milestone descriptions, roadmap, bearing, changelog, and tests match the
+  verified post-migration snapshot.
+- PR #509 has a visible reconciliation note before its branch can overwrite
+  the new roadmap authority.
+- No unrelated worktree or GitHub state changes.
+
+## Playback Questions
+
+1. Can a reviewer identify the actual V8 blocker without reading #501 history?
+2. Does V9 contain every semver-major colour change and the interaction-state
+   work that consumes it?
+3. Do lanes still distinguish imminent work, debt, and optional exploration
+   inside each versioned horizon?
+4. Are every milestone-item total and open-unmilestoned claim backed by live
+   GitHub read-back?
+5. Did the cycle preserve all issues and dependency relationships instead of
+   hiding scope by closing or parking it?
+6. Can PR #509 merge later without silently restoring the superseded V8
+   campaign assignment?
+
+## Accessibility And Assistive Posture
+
+This is planning and workflow work. It changes no rendered interface. The
+roadmap explicitly keeps accessibility and capability-degradation work inside
+the V9 State Atlas and colour-distinctness stories rather than treating them as
+optional polish.
+
+The issue migration comments and repository documentation remain readable as
+plain Markdown without colour, diagrams, or screenshots.
+
+## Localization And Directionality Posture
+
+No localized product copy or runtime directionality behavior changes. V9
+continues to own the localization dashboard, portable preferences,
+translation workbench, and structured multilingual changelog stories.
+
+Milestone descriptions use concise English tracker metadata; they do not
+become application-facing strings.
+
+## Agent Inspectability And Explainability Posture
+
+An agent can inspect:
+
+- the complete source-to-target migration table;
+- exact before and after milestone totals;
+- which totals include pull requests;
+- title and label normalization rules;
+- overlapping PR posture;
+- release-horizon comments;
+- repository tests that bind the durable mirror.
+
+No agent must infer release scope from issue-number ranges, historical
+`[Beyond]` prefixes, or branch names.
+
+## Linked Invariants
+
+- [Work Doctrine](../METHOD.md)
+- [Documentation Standards](../DOCUMENTATION_STANDARDS.md)
+- [TypeScript Code Standards](../typescript-code-standards.editors-edition.md)
+- [Roadmap](../ROADMAP.md)
+- [Bearing](../BEARING.md)
+- [Release Policy](../method/releases/README.md)
+- Tracker synchronization idea:
+  [#268](https://github.com/flyingrobots/bijou/issues/268)
+- Perceptual-colour goalpost:
+  [#501](https://github.com/flyingrobots/bijou/issues/501)
+- Interaction recipes:
+  [#512](https://github.com/flyingrobots/bijou/issues/512)
+- State Atlas:
+  [#513](https://github.com/flyingrobots/bijou/issues/513)
+- Native GPU cell host:
+  [#510](https://github.com/flyingrobots/bijou/issues/510)
+
+## Retrospective And Closeout
+
+Open. Closeout requires live GitHub read-back, merged documentation evidence,
+and explicit reconciliation of PR #509's branch-local roadmap changes. This
+cycle does not close implementation issues or select a security remediation
+pull request.

--- a/docs/design/WF-167-roadmap-milestone-authority.md
+++ b/docs/design/WF-167-roadmap-milestone-authority.md
@@ -86,8 +86,9 @@ Two additional open pull requests were unmilestoned:
   [#511](https://github.com/flyingrobots/bijou/pull/511).
 
 The audit cohort therefore contained `83` open issues and `4` open pull
-requests. Opening governance issue #514 increases the live issue total to `84`
-and the `v8.2.0` milestone by one item during the cycle.
+requests. Opening governance issue #514 increases the live issue total to `84`;
+opening governance PR #515 increases the open pull request total to `5`. Both
+live in the `v8.2.0` milestone during the cycle.
 
 ### V8 Scope Drift
 
@@ -204,10 +205,11 @@ Add issue #507 because startup key-conflict reporting is quality enforcement,
 not Runtime Graph release scope. Governance issue #514 also lives here because
 tracker synchronization is an explicit V8.2 outcome.
 
-Expected open items after triage: `25`:
+Expected open items after triage: `26`:
 
 - `24` open issues, including #507 and #514;
-- Dependabot PR #467.
+- Dependabot PR #467;
+- governance PR #515.
 
 ### `v9.0.0`: Product Workbench And Sapphire Design Language
 
@@ -251,14 +253,21 @@ Rename these open issues without changing their substantive titles:
 - #202 through #219 where the current title begins `[Beyond]`:
   #202, #203, #204, #205, #206, #207, #208, #209, #210, #211, #212, #213,
   #214, #215, #216, #217, #218, and #219.
+- #311: remove the same stale prefix from the Theme Inspector drawer.
+- #502: replace its stale `v8 release` suffix with `V9 release` after the
+  milestone migration.
 
 Each already has an explicit versioned milestone. The prefix now contradicts
 the milestone and makes search results look parked when they are not.
 
 ### Normalize Lanes And Priority
 
-- #204: remove `lane:inbox`; retain `lane:cool-ideas`.
+- #204: remove `lane:inbox` and `priority:medium`; retain `lane:cool-ideas` and
+  `priority:low`.
+- #205: remove `lane:up-next`; retain `lane:cool-ideas`.
 - #214, #217, #218: remove `lane:up-next`; retain `lane:cool-ideas`.
+- #215: remove `lane:up-next` and `priority:medium`; retain
+  `lane:cool-ideas` and `priority:low`.
 - #219: replace `lane:inbox` with `lane:cool-ideas`.
 - #348: replace `lane:asap` with `lane:cool-ideas`; V10 is a future host and
   renderer horizon, not the imminent V8 pull.
@@ -391,16 +400,16 @@ depend on network availability.
 
 ## Acceptance Criteria
 
-- All `83` pre-cycle issues, issue #514, and all four open pull requests have a
-  recorded disposition.
+- All `83` pre-cycle issues, issue #514, the four pre-cycle pull requests, and
+  governance PR #515 have a recorded disposition.
 - V8 contains one issue and two competing security implementation PRs.
 - V9 contains the full twenty-one-issue Sapphire/design-language cohort.
 - V8.2 contains #507 and #514.
 - V10 contains PR #511.
 - No open issue or pull request is unmilestoned.
 - No versioned issue retains `[Beyond]` in its title.
-- #204, #214, #217, #218, #219, #348, and #249 have one coherent lane or
-  priority posture as specified.
+- #204, #205, #214, #215, #217, #218, #219, #348, and #249 have one coherent
+  lane or priority posture as specified.
 - Every issue moved across a release horizon has a migration comment.
 - Milestone descriptions, roadmap, bearing, changelog, and tests match the
   verified post-migration snapshot.

--- a/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
+++ b/tests/cycles/DL-013/design-token-theme-builder-spec.test.ts
@@ -46,7 +46,7 @@ describe('DL-013 design token and theme builder spec', () => {
     expect(roadmap).toContain(
       '| `Beyond` | [Beyond](https://github.com/flyingrobots/bijou/milestone/3) |',
     );
-    expect(roadmap).toContain('Product Workbench And Operator Surfaces');
+    expect(roadmap).toContain('Product Workbench And Sapphire Design Language');
     expect(roadmap).toContain('Theme Lab and Theme Inspector provenance surfaces backed by token facts');
     expect(roadmap).toContain('[#311](https://github.com/flyingrobots/bijou/issues/311)');
     expect(roadmap).toContain('[#315](https://github.com/flyingrobots/bijou/issues/315)');

--- a/tests/cycles/DX-050/profunctor-page-inspection-design.test.ts
+++ b/tests/cycles/DX-050/profunctor-page-inspection-design.test.ts
@@ -54,16 +54,16 @@ describe('DX-050 Profunctor Page inspection design', () => {
     const bearing = normalized('docs/BEARING.md');
 
     expectClaims(roadmap, [
-      'Last synced from GitHub milestone items: 2026-07-30.',
-      '| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 22 | 3 |',
+      'Last synced from GitHub milestone items: 2026-08-09.',
+      '| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 26 | 5 |',
       '[#485](https://github.com/flyingrobots/bijou/issues/485)',
       '[#472](https://github.com/flyingrobots/bijou/issues/472)',
       '[#473](https://github.com/flyingrobots/bijou/issues/473)',
       '[DX-050](./design/DX-050-profunctor-page-inspection.md)',
     ]);
     expectClaims(bearing, [
-      '`v8.2.0` milestone is quality automation and Method hardening: 22 open and 3 closed milestone items',
-      '`v8.0.0` milestone is the active feature horizon: 2 open milestone items and 2 closed milestone items',
+      '`v8.2.0` milestone is quality automation and reliability: 26 open and 5 closed milestone items',
+      '`v8.0.0` milestone is Runtime Graph release closeout: 3 open milestone items and 4 closed milestone items',
       '[DX-050](./design/DX-050-profunctor-page-inspection.md)',
       '[RE-036](./design/RE-036-packed-bijou-cells-surface-adapter.md)',
       'lowers current debt to `22` file/context and `10` code-size violations',

--- a/tests/cycles/RE-036/packed-bijou-cells-design.test.ts
+++ b/tests/cycles/RE-036/packed-bijou-cells-design.test.ts
@@ -49,8 +49,8 @@ describe('RE-036 packed-bijou-cells/1 Surface adapter design', () => {
 
     expectClaims(roadmap, [
       '[`RE-036`](./design/RE-036-packed-bijou-cells-surface-adapter.md)',
-      '| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 22 | 3 |',
-      '| `v10.0.0` | [v10.0.0](https://github.com/flyingrobots/bijou/milestone/10) | 9 | 1 |',
+      '| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 26 | 5 |',
+      '| `v10.0.0` | [v10.0.0](https://github.com/flyingrobots/bijou/milestone/10) | 11 | 1 |',
     ]);
     expectClaims(bearing, [
       'The bounded target [#468](https://github.com/flyingrobots/bijou/issues/468) landed through [#474](https://github.com/flyingrobots/bijou/pull/474)',
@@ -77,7 +77,7 @@ describe('RE-036 packed-bijou-cells/1 Surface adapter design', () => {
     );
     expectParagraphClaims(
       roadmapSource,
-      'The active prerequisite is the third Code Dojo goalpost',
+      'The V8.2 quality runway also records the third Code Dojo goalpost',
       [
         '[#480](https://github.com/flyingrobots/bijou/issues/480)',
         '[WF-165](./design/WF-165-respecting-dojo-ratchet-12.md)',

--- a/tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts
+++ b/tests/cycles/WF-126/v7-closeout-tracker-sync.test.ts
@@ -8,7 +8,7 @@ describe('WF-126 v7 closeout tracker sync', () => {
 
     expect(bearing).toContain('The latest shipped public release is `v7.2.0`');
     expect(normalizedBearing).toContain('are complete release lineage, not the next implementation target');
-    expect(bearing).toContain('The next feature horizon remains `v8.0.0`');
+    expect(bearing).toContain('The next major feature horizon is `v9.0.0`');
     expect(bearing).toContain('`v7.2.0` completed as a narrow stabilization and demo-integrity release');
     expect(bearing).not.toContain('Its current open count is three');
     expect(bearing).not.toContain('https://github.com/flyingrobots/bijou/issues/245');

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part02.test.ts
@@ -12,8 +12,8 @@ describe('WF-130 roadmap release state', () => {
 
     expectClaims(roadmap, [
       'This roadmap is the forward-looking release horizon for Bijou.',
-      'Last synced from GitHub milestone items: 2026-07-30.',
-      'These are planning recommendations from the open tracker state as of 2026-07-30.',
+      'Last synced from GitHub milestone items: 2026-08-09.',
+      'These are planning recommendations from the open tracker state as of 2026-08-09.',
       'The latest shipped public release is',
       '`v7.1.0` is complete post-V7 minor release lineage',
       '`v7.2.0` is complete narrow stabilization and demo-integrity release lineage.',
@@ -21,17 +21,17 @@ describe('WF-130 roadmap release state', () => {
       'Release Train Decision',
       '`v7.1.0`: Previous Shipped Post-V7 Minor',
       '`v7.2.0`: Shipped Stabilization And Demo Integrity',
-      '`v8.0.0`: Runtime Graph And Scene IR Product Contract',
+      '`v8.0.0`: Runtime Graph Release Closeout',
       '`v8.1.0`: Replay, Capture, And Render Witnesses',
-      '`v8.2.0`: Quality Automation And Method Hardening',
-      '`v9.0.0`: Product Workbench And Operator Surfaces',
+      '`v8.2.0`: Quality Automation And Reliability',
+      '`v9.0.0`: Product Workbench And Sapphire Design Language',
       '`v10.0.0`: Renderer And Host Systems Integration',
       '| `v7.2.0` | [v7.2.0](https://github.com/flyingrobots/bijou/milestone/5) | 0 | 19 |',
-      '| `v8.0.0` | [v8.0.0](https://github.com/flyingrobots/bijou/milestone/6) | 2 | 2 |',
+      '| `v8.0.0` | [v8.0.0](https://github.com/flyingrobots/bijou/milestone/6) | 3 | 4 |',
       '| `v8.1.0` | [v8.1.0](https://github.com/flyingrobots/bijou/milestone/7) | 13 | 0 |',
-      '| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 22 | 3 |',
-      '| `v9.0.0` | [v9.0.0](https://github.com/flyingrobots/bijou/milestone/9) | 20 | 0 |',
-      '| `v10.0.0` | [v10.0.0](https://github.com/flyingrobots/bijou/milestone/10) | 9 | 1 |',
+      '| `v8.2.0` | [v8.2.0](https://github.com/flyingrobots/bijou/milestone/8) | 26 | 5 |',
+      '| `v9.0.0` | [v9.0.0](https://github.com/flyingrobots/bijou/milestone/9) | 36 | 0 |',
+      '| `v10.0.0` | [v10.0.0](https://github.com/flyingrobots/bijou/milestone/10) | 11 | 1 |',
       '| `v7.1.0` | [v7.1.0](https://github.com/flyingrobots/bijou/milestone/4) | 0 | 4 |',
       '`Beyond`',
       '0 | 6',
@@ -56,16 +56,18 @@ describe('WF-130 roadmap release state', () => {
     expectClaims(row('v7.2.0'), ['issues/354', 'issues/344', 'issues/353']);
     expect(row('v8.0.0')).toContain('issues/302');
     expect(row('v8.2.0')).toContain('pull/467');
-    expect(normalized('docs/ROADMAP.md')).toContain(
-      'keep parent #302 in the active `v8.0.0` Runtime Graph horizon',
-    );
+    expectClaims(normalized('docs/ROADMAP.md'), [
+      '`v8.0.0` is in Runtime Graph release closeout',
+      'Landed contract lineage',
+      '[#482](https://github.com/flyingrobots/bijou/issues/482)',
+    ]);
   });
 
   it('keeps staged v8 tracker details and sync commands aligned to the milestone', () => {
     const roadmap = read('docs/ROADMAP.md');
     const v8 = sectionBetween(
       roadmap,
-      '### `v8.0.0`: Runtime Graph And Scene IR Product Contract',
+      '### `v8.0.0`: Runtime Graph Release Closeout',
       '### `v8.1.0`: Replay, Capture, And Render Witnesses',
     );
     const maintenance = sectionBetween(

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part03.test.ts
@@ -24,7 +24,7 @@ describe('WF-130 roadmap pull order', () => {
       'The bounded Profunctor Page inspection story [#468](https://github.com/flyingrobots/bijou/issues/468) landed through [#474](https://github.com/flyingrobots/bijou/pull/474)',
       '[`RE-036`](./design/RE-036-packed-bijou-cells-surface-adapter.md)',
       '[`DX-048`](./design/DX-048-v8-runtime-graph-scene-ir-contract.md)',
-      'Runtime Graph And Scene IR Product Contract',
+      'Runtime Graph Release Closeout',
       'VISOR',
       '#335 release-story surfaces implemented',
       'versioned artifact semantics',
@@ -32,7 +32,7 @@ describe('WF-130 roadmap pull order', () => {
       'Forward Goalposts',
       'Decision Points',
       'Demo Integrity And Framework Input Stabilization',
-      'Product Workbench And Operator Surfaces',
+      'Product Workbench And Sapphire Design Language',
       'Theme Lab and Theme Inspector provenance',
       'localization workbench proof',
       'Renderer And Host Systems Integration',
@@ -54,7 +54,7 @@ describe('WF-130 roadmap pull order', () => {
     );
     expectParagraphClaims(
       roadmapSource,
-      'The active prerequisite is the third Code Dojo goalpost',
+      'The V8.2 quality runway also records the third Code Dojo goalpost',
       [
         '[#480](https://github.com/flyingrobots/bijou/issues/480)',
         '[WF-165](./design/WF-165-respecting-dojo-ratchet-12.md)',
@@ -66,13 +66,13 @@ describe('WF-130 roadmap pull order', () => {
       '1. Treat the bounded Profunctor Page inspection proof in #468 as landed.',
       '2. Treat #458 as landed v8 foundation: the GraphQL block artifact bundle, replay facts, and visual scene facts are implemented.',
       '3. Treat #459 as landed through PR #483: `packed-bijou-cells/1` now validates and adapts into a synchronized terminal `Surface`.',
-      '4. Merge #489 after exact-head review to close #480 at Code Dojo debt `12`.',
-      '5. Close #302 and #457 only after merged goalpost evidence and V8 contract closeout agree.',
-      '6. Use `v8.1.0` for replay, capture, debugger, render-witness, and graph proof follow-through after V8 lands.',
-      '7. Use `v8.2.0` for Code Dojo, Method, tracker-sync, and fixture-backed quality automation.',
-      '8. Keep `v9.0.0` for Product Workbench and operator surfaces after V8 stabilizes the source/artifact/IR contract.',
-      '9. Keep `v10.0.0` for Geordi/Wesley, renderer, host, shader, raster, and native surface work after the Bijou contracts are proven.',
-      '10. Keep closed dependency PR #326 as superseded lineage, not active release work.',
+      '4. Compare #492 and #509 as competing implementations of #482; select one reproducible dependency-security path.',
+      '5. Close #482 only when the selected exact head proves zero actionable advisories through the documented audit commands.',
+      '6. Prepare the V8 release packet without pulling unfinished V9 design-language work into the release gate.',
+      '7. Use `v8.1.0` for replay, capture, debugger, render-witness, and graph proof follow-through after V8 lands.',
+      '8. Use `v8.2.0` for Code Dojo, Method, tracker sync, startup diagnostics, and fixture-backed quality automation.',
+      '9. Use `v9.0.0` for Product Workbench, Sapphire Design Language, interaction recipes, and State Atlas proof over the landed V8 contract.',
+      '10. Use `v10.0.0` for Geordi/Wesley, renderer, host, native GPU, shader, raster, and advanced input work after the Bijou contracts are proven.',
     ]);
     expectNoClaims(roadmap, [
       'No next public release version is selected.',

--- a/tests/cycles/WF-130/roadmap-goalpost-policy.part04.test.ts
+++ b/tests/cycles/WF-130/roadmap-goalpost-policy.part04.test.ts
@@ -20,7 +20,7 @@ describe('WF-130 roadmap supporting contracts', () => {
     expectClaims(roadmap, [
       'Open Unmilestoned Triage',
       'No open issue currently lives in `Beyond`',
-      'No open issue is currently unmilestoned.',
+      'No open issue or pull request is currently unmilestoned.',
       'Dependency Security Lineage',
       '[#357]',
       '[#358]',
@@ -37,7 +37,7 @@ describe('WF-130 roadmap supporting contracts', () => {
     ]);
     expectClaims(bearing, [
       'The latest shipped public release is `v7.2.0`',
-      'The next feature horizon remains `v8.0.0`',
+      'The next major feature horizon is `v9.0.0`',
       '[#477](https://github.com/flyingrobots/bijou/issues/477) has met its `112 -> 62` contract.',
       'Landed tranche A [#475](https://github.com/flyingrobots/bijou/pull/475) and landed tranche B [#478](https://github.com/flyingrobots/bijou/pull/478) each removed `25` counted violations.',
       'Landed tranche C [#487](https://github.com/flyingrobots/bijou/pull/487) lowers current debt to `22` file/context and `10` code-size violations with no mock-ban or ESLint debt.',
@@ -55,11 +55,11 @@ describe('WF-130 roadmap supporting contracts', () => {
       '[RE-036](./design/RE-036-packed-bijou-cells-surface-adapter.md)',
       '`v7.2.0` completed as a narrow stabilization and demo-integrity release',
       '`v7.2.0` milestone is complete release lineage: 0 open and 19 closed milestone items',
-      '`v8.0.0` milestone is the active feature horizon: 2 open milestone items and 2 closed milestone items',
+      '`v8.0.0` milestone is Runtime Graph release closeout: 3 open milestone items and 4 closed milestone items',
       '`v8.1.0` milestone is replay, capture, debugger, and render-witness follow-through',
-      '`v8.2.0` milestone is quality automation and Method hardening: 22 open and 3 closed milestone items',
+      '`v8.2.0` milestone is quality automation and reliability: 26 open and 5 closed milestone items',
       '[#485](https://github.com/flyingrobots/bijou/issues/485)',
-      'No open issue is currently unmilestoned',
+      'No open issue or pull request is currently unmilestoned',
       'The selected `v7.2.0` DOGFOOD product pull #335 has landed',
       'Keep Future Releases Explicit',
     ]);

--- a/tests/cycles/WF-167/roadmap-milestone-authority.test.ts
+++ b/tests/cycles/WF-167/roadmap-milestone-authority.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '../../..');
+
+function read(path: string): string {
+  return readFileSync(resolve(ROOT, path), 'utf8');
+}
+
+function normalized(path: string): string {
+  return read(path).replace(/\s+/g, ' ').trim();
+}
+
+describe('WF-167 roadmap milestone authority', () => {
+  it('binds the verified GitHub milestone-item snapshot', () => {
+    const roadmap = normalized('docs/ROADMAP.md');
+    const rows = [
+      ['v8.0.0', '6', '3', '4'],
+      ['v8.1.0', '7', '13', '0'],
+      ['v8.2.0', '8', '26', '5'],
+      ['v9.0.0', '9', '36', '0'],
+      ['v10.0.0', '10', '11', '1'],
+    ] as const;
+
+    expect(roadmap).toContain(
+      'Last synced from GitHub milestone items: 2026-08-09.',
+    );
+    for (const [name, number, open, closed] of rows) {
+      expect(roadmap).toContain(
+        `| \`${name}\` | [${name}](https://github.com/flyingrobots/bijou/milestone/${number}) | ${open} | ${closed} |`,
+      );
+    }
+  });
+
+  it('keeps each release boundary outcome-oriented', () => {
+    const roadmap = normalized('docs/ROADMAP.md');
+
+    expect(roadmap).toContain('`v8.0.0`: Runtime Graph Release Closeout');
+    expect(roadmap).toContain('competing remediation PRs [#492]');
+    expect(roadmap).toContain('`v8.2.0`: Quality Automation And Reliability');
+    expect(roadmap).toContain('Governance [#514]');
+    expect(roadmap).toContain(
+      '`v9.0.0`: Product Workbench And Sapphire Design Language',
+    );
+    expect(roadmap).toContain('campaign tracker [#501]');
+    expect(roadmap).toContain('compositional state recipes [#512]');
+    expect(roadmap).toContain('State Atlas [#513]');
+    expect(roadmap).toContain('native GPU cell-host issue [#510]');
+    expect(roadmap).toContain('design PR [#511]');
+  });
+
+  it('records the authority and no-unmilestoned contracts', () => {
+    const roadmap = normalized('docs/ROADMAP.md');
+    const bearing = normalized('docs/BEARING.md');
+    const design = normalized('docs/design/WF-167-roadmap-milestone-authority.md');
+
+    expect(roadmap).toContain(
+      'GitHub milestones, issues, pull requests, and labels are the live tracker.',
+    );
+    expect(roadmap).toContain(
+      'No open issue or pull request is currently unmilestoned.',
+    );
+    expect(bearing).toContain(
+      'GitHub Issues and milestones are now the canonical queue.',
+    );
+    expect(design).toContain('Expected open items after triage: `26`');
+    expect(design).toContain('No versioned issue retains `[Beyond]` in its title.');
+  });
+});


### PR DESCRIPTION
## Summary

- restore GitHub milestones as the canonical release-destination authority and make ROADMAP/BEARING mirror the verified live snapshot
- return V8 to landed Runtime Graph contract plus dependency-security closeout; move the unfinished 21-issue Sapphire/design-language campaign to V9
- make V8.2 own quality, reliability, diagnostics, and tracker synchronization; make V10 explicitly own the Geordi native-GPU cell-host proof
- remove stale `[Beyond]` and release-title residue and normalize contradictory lane/priority labels without closing implementation work
- bind the release model with a dedicated WF-167 contract suite and refreshed historical roadmap assertions

## Tracker

Closes #514.

Design: [`WF-167 Roadmap Milestone Authority`](docs/design/WF-167-roadmap-milestone-authority.md)

## Verified Snapshot

| Milestone | Open | Closed | Outcome |
| :--- | ---: | ---: | :--- |
| `v8.0.0` | 3 | 4 | Runtime Graph release closeout and dependency security |
| `v8.1.0` | 13 | 0 | Replay, capture, debugger, graph, and render evidence |
| `v8.2.0` | 26 | 5 | Quality automation and reliability |
| `v9.0.0` | 36 | 0 | Product Workbench and Sapphire Design Language |
| `v10.0.0` | 11 | 1 | Renderer and host systems integration |

Open `Beyond` and unmilestoned issue/PR queues are empty. Counts are GitHub milestone-item totals, including pull requests.

## Validation

- focused roadmap/design contracts: 29 tests across 9 files
- pre-push full suite: 4,102 tests across 20 chunks
- DOGFOOD i18n completeness, generated-catalog, and debt gates
- workspace lint, test typecheck, ESLint, code-size, Code Dojo, docs inventory, and `git diff --check`
- DOGFOOD/docs/landing smoke plus select, filter, textarea, and form-group scripted interaction smoke

## Coordination

PR #509 remains a V8 security-remediation candidate, but its branch-local roadmap assignment for unfinished #501 work is superseded by WF-167. Reconcile its ROADMAP, BEARING, and milestone contract tests before merge. This PR does not select between overlapping security PRs #492 and #509.
