### PR TITLE
DX-052 NO_COLOR is not a capability: mode detection, status fallback, and extendTheme gaps

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -192,6 +192,20 @@ Current direction and active tensions. Historical ship data is in
 
 - **Closed Release Gravity**: `v6.0.0`, `v7.0.0`, `v7.1.0`, and `v7.2.0` are
   complete release lineage. Do not use those lanes for new feature work.
+- **Environment Signals Are Not Capability Signals**: `DX-052` removed
+  `NO_COLOR` from `detectOutputMode()` — it disables colour, and colour only.
+  Two first-party consumers (`git-cas`, `muniment`) had each shipped a local
+  detector override before this landed, which is the signal to watch: when a
+  consumer reimplements a detector, the detector is answering a question the
+  caller did not ask. `TERM=dumb` stays a capability signal because it genuinely
+  is one. Resist folding new environment variables into mode detection unless
+  they describe what the terminal *can do*.
+- **Cross-Group Token Aliasing**: the shipped presets use one colour for ten
+  token paths spanning `status`, `semantic`, `ui`, and `border` (#519), and
+  `error`/`success` collapse under protanopia in both. `extendTheme()` can now
+  reach every group (`DX-052`), so an app can escape the alias — but the presets
+  themselves still do not satisfy `doctorTheme`, and `doctorTheme` still cannot
+  see colour-vision-deficiency collapse (#520).
 - **Minor-Release Temptation**: Do not reopen `v7.2.0` as a full feature train.
   Adding a full workbench, theme lab, localization suite, Wesley path, or
   Geordi path turns the work into `v9.0.0` or `v10.0.0` scope.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,37 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ### Changed
 
+- **BREAKING: `NO_COLOR` no longer changes the detected output mode** —
+  [`DX-052`](design/DX-052-no-color-is-not-a-capability.md) removes the
+  `NO_COLOR` branch from `detectOutputMode()`. The variable is a statement about
+  colour, not about capability ([no-color.org](https://no-color.org): "prevents
+  the addition of ANSI color"), so mapping it to `'pipe'` took a real terminal
+  out of interactive mode entirely — a user who exported `NO_COLOR=1` in a shell
+  profile got no TUI rather than a monochrome one, with every component lowered
+  to its single-frame form and `shouldUseShellQuitConfirm()` returning
+  `'immediate'`. Colour output is unchanged: `NO_COLOR` is read independently by
+  `createBijou`, `createNodeContext`, and `isNoColor()`, none of which consult the
+  mode. `TERM=dumb`, a non-TTY stdout, `CI`, and `BIJOU_ACCESSIBLE=1` keep their
+  previous results. A property test now asserts the stronger contract: adding
+  `NO_COLOR` to any environment leaves the detected mode unchanged.
+- **BREAKING: an unknown status key no longer resolves to a struck-through
+  token** — the `status()` accessor and `inkStatus()` fall back to
+  `semantic.muted` instead of `status.muted`. Both carry the same hex in every
+  shipped preset, but `status.muted` also carries `strikethrough`, so a mistyped
+  or undefined key rendered text with a line through it — reading as "cancelled"
+  when the caller had said nothing of the kind. The new target matches the
+  sibling `ui()` accessor, which already falls back into `semantic`.
+  `status('muted')` itself is unchanged, strikethrough intact.
+- **`extendTheme()` reaches all six token groups** — `border` and `semantic` join
+  `status`, `ui`, `gradient`, and `surface` in the extension parameter. Both are
+  overridable rather than extensible, since `Theme` fixes their key sets. This is
+  additive and breaks nothing. It closes a gap that mattered because the shipped
+  presets alias heavily across groups: `bijou-dark` uses one amber for
+  `status.warning`, `status.active`, `semantic.warning`, `semantic.accent`,
+  `ui.cursor`, `ui.focusGutter`, `ui.sectionHeader`, `ui.logo`,
+  `border.secondary` and `border.warning`, so an app that could only replace
+  `status` silently kept that amber for every heading, cursor and border.
+
 - **V8 dependency-security closeout** — WF-166 replaces the vulnerable exact
   Hono override with the patched `^4.13.0` line and regenerates the workspace
   lock through npm. The resolved graph now carries

--- a/docs/design/DX-052-no-color-is-not-a-capability.md
+++ b/docs/design/DX-052-no-color-is-not-a-capability.md
@@ -1,0 +1,187 @@
+---
+title: DX-052 NO_COLOR Is Not a Capability
+legend: DX
+lane: release
+priority: high
+github_issue: 518
+status: active
+keywords:
+  - no-color
+  - output-mode
+  - detection
+  - theme
+  - accessors
+  - fallback
+  - extend-theme
+  - breaking-change
+  - v8.0.0
+---
+
+<!-- markdownlint-disable MD025 -->
+
+# DX-052 NO_COLOR Is Not a Capability
+
+## Problem
+
+Three defects found by an application (`muniment`) that had to work around all
+three locally before it could ship a readable palette. Each one is a case of
+bijou answering a question the caller did not ask.
+
+### 1. `NO_COLOR` takes the whole TUI down, not just the colour
+
+`detectOutputMode` (`packages/bijou/src/core/detect/tty.ts`) resolves in this
+order:
+
+```text
+BIJOU_ACCESSIBLE=1    -> 'accessible'
+NO_COLOR / TERM=dumb  -> 'pipe'
+!stdout.isTTY         -> 'pipe'
+CI                    -> 'static'
+stdout.isTTY          -> 'interactive'
+```
+
+The second line conflates two unrelated requests. [no-color.org][nc] defines
+`NO_COLOR` as a statement about **colour**: "when present, regardless of its
+value, prevents the addition of ANSI color". It says nothing about cursor
+addressing, alternate screens, or interactivity. bijou reads it as a statement
+about **capability**, so a user who exports `NO_COLOR=1` in their shell profile
+— a common, reasonable thing to do — does not get a monochrome TUI. They get no
+TUI: `ctx.mode` becomes `'pipe'`, every component lowers to its plain
+single-frame form, and `shouldUseShellQuitConfirm` starts returning
+`'immediate'`.
+
+Nothing is gained by the conflation, because **colour is already suppressed by a
+separate path** — three of them, in fact, each reading `NO_COLOR` directly and
+none consulting `mode`:
+
+| Site | Line | Effect |
+| :--- | :--- | :--- |
+| `packages/bijou/src/factory.ts` | 54 | `noColor` on the resolved theme |
+| `packages/bijou-node/src/node-context.ts` | 23 | `chalkStyle({ noColor, level: 0 })` |
+| `packages/bijou/src/core/theme/resolve.ts` | 20 | `isNoColor()` |
+
+So removing the line removes the interactivity damage and keeps every escape
+sequence suppressed. The two concerns were never actually coupled in the
+implementation; only in the detector.
+
+`git-cas` (`bin/ui/context.js`) already ships a `detectCliTuiMode` override for
+exactly this reason, with a comment saying so. When two first-party consumers
+independently re-implement a detector, the detector is wrong.
+
+[nc]: https://no-color.org
+
+### 2. An unknown status key renders struck through
+
+`createThemeAccessors` (`packages/bijou/src/core/theme/accessors.ts`):
+
+```ts
+status: (key) => {
+  try { return tokenGraph.get(`status.${key}`, mode); }
+  catch { return tokenGraph.get('status.muted', mode); }
+},
+```
+
+`status.muted` carries `['dim', 'strikethrough']` in **every** shipped preset —
+`bijou-dark`, `bijou-light`, `cyan-magenta`, `nord`, `catppuccin`,
+`teal-orange-pink`. That is a defensible token: "muted" as in retired, done,
+cancelled. It is the wrong thing to hand back for a key nobody defined.
+
+`status(key)` takes `string`, not a key union, so the failure is silent and
+total: a typo, or a key the app forgot to add to its theme, produces text with a
+line through it. A reader sees "cancelled". The app said nothing of the kind.
+The sibling accessor already does the right thing — `ui()` falls back to
+`semantic.primary`, a plain token in another group — so the fix is to make
+`status()` consistent with it and fall back to `semantic.muted`, which is `dim`
+and nothing else in every preset.
+
+Found in the field: an app declared a `paint.unreviewed()` helper, dropped the
+matching status key from its theme as a duplicate, and shipped a painter that
+resolved to the strikethrough fallback. No check caught it, because no view had
+called it yet. `inkStatus()` in `resolve.ts` has the same fallback and the same
+problem.
+
+### 3. `extendTheme` cannot reach `border` or `semantic`
+
+```ts
+export declare function extendTheme<S, U, G>(base: Theme, extensions: {
+  status?: ...; ui?: ...; gradient?: ...; surface?: ...;
+}): Theme<...>
+```
+
+`Theme` has six token groups. `extendTheme` can extend four. There is no way to
+override a border or semantic token through it, which matters because the
+shipped themes alias heavily across groups: `bijou-dark` uses `#f2c45d` for
+`status.warning`, `status.active`, `semantic.warning`, `semantic.accent`,
+`ui.cursor`, `ui.focusGutter`, `ui.sectionHeader`, `ui.logo`,
+`border.secondary` **and** `border.warning` — ten aliases of one amber.
+
+An app that calls `extendTheme(BIJOU_DARK, { status })` therefore replaces its
+statuses and silently keeps bijou's amber for every heading, cursor and border.
+In the case that prompted this, the app's section headings landed ΔE **0.023**
+from its own `warning` in OKLab — indistinguishable — and the only escape was to
+abandon `extendTheme` and author all six groups by hand.
+
+## Non-goals
+
+- **Changing `status.muted` itself.** Its strikethrough is deliberate and used.
+  Only the *fallback target* moves.
+- **Re-fitting the shipped palettes.** The `#f2c45d` ten-way alias and
+  `bijou-dark`'s error/success collapse under protanopia (ΔE 0.059) are real,
+  are what motivated non-goal-adjacent issues, and are filed separately.
+- **Adding OKLCH authoring or a CVD-aware palette audit to bijou.** Also filed
+  separately; `doctorTheme` covers contrast and reuse but not perceptual
+  separation under simulated colour-vision deficiency.
+- **Typing `status(key)` to a key union.** It would catch defect 2 at compile
+  time for typed callers, but it is a wider API change than this cycle wants and
+  would not help JS consumers. Filed as follow-up.
+
+## Playback questions
+
+1. With `NO_COLOR=1` and a real TTY on both stdio, is `ctx.mode`
+   `'interactive'`?
+2. With `NO_COLOR=1`, is `theme.noColor` still `true` and does `styled()` still
+   return unstyled text?
+3. Does `TERM=dumb` still yield `'pipe'`? Does a non-TTY stdout? Does `CI`
+   still yield `'static'`, and `BIJOU_ACCESSIBLE=1` still win outright?
+4. Does `status('nonexistent')` return a token with no `strikethrough`?
+5. Does `status('muted')` still return the real muted token, strikethrough
+   intact?
+6. Does `inkStatus('nonexistent')` agree with `status()` about the fallback?
+7. Does `extendTheme(base, { border, semantic })` merge those groups, preserve
+   unlisted keys within them, and leave the other four groups untouched?
+
+## Decision
+
+1. Delete the `NO_COLOR` branch from `detectOutputMode`. Update its docblock and
+   the `OutputMode` doc comment, which both currently document the old order.
+2. Point the `status()` accessor and `inkStatus()` fallbacks at
+   `semantic.muted`.
+3. Add optional `border` and `semantic` to `extendTheme`'s extension parameter.
+
+## Breaking-change note
+
+1 and 2 change observable behaviour that the current docblocks describe, so this
+lands as part of **8.0.0** rather than a minor.
+
+Two existing tests assert the behaviour being removed:
+
+- `tty.test.ts` — `'returns pipe when NO_COLOR is set'` and `'NO_COLOR takes
+  priority over CI'`.
+- `accessors.test.ts` — `'status() falls back to muted for unknown keys'`.
+
+They are not wrong about what the code did; they are the specification of the
+defect. They are rewritten to assert the new contract, and this paragraph exists
+so that the rewrite is a recorded decision rather than a test quietly edited to
+make a build go green. `'BIJOU_ACCESSIBLE takes priority over NO_COLOR'` becomes
+vacuous once `NO_COLOR` no longer affects mode and is replaced by a test that
+`NO_COLOR` leaves an interactive session interactive.
+
+3 is additive and breaks nothing.
+
+## Acceptance criteria
+
+- All seven playback questions have a passing test.
+- `npm run lint`, the full test suite, and the Code Dojo gates pass.
+- `docs/CHANGELOG.md` records all three under a `Changed` heading with the
+  breaking note, and `docs/BEARING.md` mentions the detection-semantics change.
+- No consumer-visible colour output changes when `NO_COLOR` is set.

--- a/docs/design/DX-052-no-color-is-not-a-capability.md
+++ b/docs/design/DX-052-no-color-is-not-a-capability.md
@@ -60,9 +60,12 @@ none consulting `mode`:
 | `packages/bijou-node/src/node-context.ts` | 23 | `chalkStyle({ noColor, level: 0 })` |
 | `packages/bijou/src/core/theme/resolve.ts` | 20 | `isNoColor()` |
 
-So removing the line removes the interactivity damage and keeps every escape
-sequence suppressed. The two concerns were never actually coupled in the
-implementation; only in the detector.
+So removing the line removes the interactivity damage while every **colour and
+style** escape stays suppressed. Not every escape: an interactive session by
+definition emits cursor movement, screen updates and possibly alternate-screen
+control sequences, and it should — a monochrome TUI is still a TUI. `NO_COLOR`
+asks for no colour, not for no terminal control. The two concerns were never
+coupled in the implementation; only in the detector.
 
 `git-cas` (`bin/ui/context.js`) already ships a `detectCliTuiMode` override for
 exactly this reason, with a comment saying so. When two first-party consumers
@@ -140,7 +143,8 @@ abandon `extendTheme` and author all six groups by hand.
 1. With `NO_COLOR=1` and a real TTY on both stdio, is `ctx.mode`
    `'interactive'`?
 2. With `NO_COLOR=1`, is `theme.noColor` still `true` and does `styled()` still
-   return unstyled text?
+   return unstyled text? And with `NO_COLOR=""` — the variable is presence-only,
+   so an implementation that special-cases `'1'` must not pass.
 3. Does `TERM=dumb` still yield `'pipe'`? Does a non-TTY stdout? Does `CI`
    still yield `'static'`, and `BIJOU_ACCESSIBLE=1` still win outright?
 4. Does `status('nonexistent')` return a token with no `strikethrough`?
@@ -163,18 +167,44 @@ abandon `extendTheme` and author all six groups by hand.
 1 and 2 change observable behaviour that the current docblocks describe, so this
 lands as part of **8.0.0** rather than a minor.
 
-Two existing tests assert the behaviour being removed:
+**Eight existing tests across five files** assert the behaviour being removed.
+Six of them encode the `NO_COLOR` → `'pipe'` mapping alone:
 
-- `tty.test.ts` — `'returns pipe when NO_COLOR is set'` and `'NO_COLOR takes
-  priority over CI'`.
-- `accessors.test.ts` — `'status() falls back to muted for unknown keys'`.
+| File | Test |
+| :--- | :--- |
+| `detect/tty.test.ts` | `'returns pipe when NO_COLOR is set'` |
+| `detect/tty.test.ts` | `'NO_COLOR takes priority over CI'` |
+| `detect/tty.test.ts` | `'BIJOU_ACCESSIBLE takes priority over NO_COLOR'` |
+| `detect/tty.fuzz.test.ts` | `'NO_COLOR always results in pipe or accessible mode'` |
+| `environment.part01.test.ts` | `'NO_COLOR set -> pipe mode regardless of TTY'` |
+| `environment.part01.test.ts` | `'NO_COLOR + TTY still produces pipe mode'` |
+| `theme/accessors.test.ts` | `'status() falls back to muted for unknown keys'` |
+| `theme/resolve.part02.test.ts` | `'inkStatus() falls back to muted hex for unknown status'` |
+
+Six tests reinforcing a rule usually means the rule was chosen deliberately. It
+was not. Every one is a characterization test restating the truth table, sitting
+in `describe` blocks named "detection logic" and "conflicting env vars", and no
+comment, docblock, or design note in the repository argues *why* `NO_COLOR`
+should imply non-interactive — the only justification is the detector's own
+docblock restating its own order. The tests are thorough about coverage, not
+about defending the choice.
 
 They are not wrong about what the code did; they are the specification of the
-defect. They are rewritten to assert the new contract, and this paragraph exists
-so that the rewrite is a recorded decision rather than a test quietly edited to
-make a build go green. `'BIJOU_ACCESSIBLE takes priority over NO_COLOR'` becomes
-vacuous once `NO_COLOR` no longer affects mode and is replaced by a test that
-`NO_COLOR` leaves an interactive session interactive.
+defect. They are rewritten to assert the new contract, and this section exists so
+that the rewrite is a recorded decision rather than tests quietly edited to make
+a build go green. Two of them change shape rather than expectation:
+
+- `'BIJOU_ACCESSIBLE takes priority over NO_COLOR'` becomes vacuous once
+  `NO_COLOR` no longer affects mode, and is reframed as priority over an
+  interactive TTY.
+- the fuzz property is strengthened rather than adjusted. Instead of asserting
+  which mode results, it now asserts that adding `NO_COLOR` to *any* environment
+  leaves that environment's mode unchanged — the contract stated directly.
+
+`resolve.part02.test.ts` is the one case with no observable behaviour change:
+`inkStatus()` returns a hex, and `status.muted` and `semantic.muted` share a hex
+in every shipped preset. It is updated anyway so the two fallbacks cannot
+disagree in a theme where the hexes differ.
 
 3 is additive and breaks nothing.
 

--- a/packages/bijou/src/core/detect/tty.fuzz.test.ts
+++ b/packages/bijou/src/core/detect/tty.fuzz.test.ts
@@ -56,21 +56,28 @@ describe('detectOutputMode fuzz (property-based)', () => {
     );
   });
 
-  it('NO_COLOR always results in pipe or accessible mode', () => {
+  // The strongest statement of the contract: NO_COLOR is not an input to mode at
+  // all. Rather than assert which mode results, assert that adding NO_COLOR to
+  // any environment changes nothing about the mode that environment produces.
+  it('NO_COLOR never changes the detected mode', () => {
     fc.assert(
       fc.property(
         fc.constantFrom('', '1', 'true'),
         fc.boolean(),
         fc.constantFrom(undefined, 'true', '1'),
-        (noColorVal, isTTY, ciVal) => {
-          const env: Record<string, string> = { NO_COLOR: noColorVal };
-          if (ciVal !== undefined) env['CI'] = ciVal;
-          const rt = mockRuntime({ env, stdoutIsTTY: isTTY });
-          const mode = detectOutputMode(rt);
-          expect(['pipe', 'accessible']).toContain(mode);
+        fc.constantFrom(undefined, 'dumb', 'xterm-256color'),
+        (noColorVal, isTTY, ciVal, termVal) => {
+          const base: Record<string, string> = {};
+          if (ciVal !== undefined) base['CI'] = ciVal;
+          if (termVal !== undefined) base['TERM'] = termVal;
+          const without = detectOutputMode(mockRuntime({ env: base, stdoutIsTTY: isTTY }));
+          const withIt = detectOutputMode(
+            mockRuntime({ env: { ...base, NO_COLOR: noColorVal }, stdoutIsTTY: isTTY }),
+          );
+          expect(withIt).toBe(without);
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 200 },
     );
   });
 });

--- a/packages/bijou/src/core/detect/tty.test.ts
+++ b/packages/bijou/src/core/detect/tty.test.ts
@@ -8,8 +8,22 @@ describe('detectOutputMode', () => {
     expect(detectOutputMode(rt)).toBe('accessible');
   });
 
-  it('returns pipe when NO_COLOR is set', () => {
+  // NO_COLOR is a statement about colour, not about capability. It must not
+  // downgrade a real terminal out of interactive mode; colour suppression happens
+  // on the theme/style path, which never consults `mode`.
+  it('leaves an interactive session interactive when NO_COLOR is set', () => {
     const rt = mockRuntime({ env: { NO_COLOR: '1' }, stdoutIsTTY: true });
+    expect(detectOutputMode(rt)).toBe('interactive');
+  });
+
+  it('returns pipe when NO_COLOR is set and stdout is not a TTY', () => {
+    // pipe because of the TTY, not because of NO_COLOR.
+    const rt = mockRuntime({ env: { NO_COLOR: '1' }, stdoutIsTTY: false });
+    expect(detectOutputMode(rt)).toBe('pipe');
+  });
+
+  it('returns pipe when NO_COLOR is combined with TERM=dumb', () => {
+    const rt = mockRuntime({ env: { NO_COLOR: '1', TERM: 'dumb' }, stdoutIsTTY: true });
     expect(detectOutputMode(rt)).toBe('pipe');
   });
 
@@ -33,7 +47,7 @@ describe('detectOutputMode', () => {
     expect(detectOutputMode(rt)).toBe('interactive');
   });
 
-  it('BIJOU_ACCESSIBLE takes priority over NO_COLOR', () => {
+  it('BIJOU_ACCESSIBLE takes priority over an interactive TTY', () => {
     const rt = mockRuntime({
       env: { BIJOU_ACCESSIBLE: '1', NO_COLOR: '1' },
       stdoutIsTTY: true,
@@ -41,12 +55,13 @@ describe('detectOutputMode', () => {
     expect(detectOutputMode(rt)).toBe('accessible');
   });
 
-  it('NO_COLOR takes priority over CI', () => {
+  it('CI still decides when NO_COLOR is also set', () => {
+    // Previously NO_COLOR short-circuited to pipe before CI was ever consulted.
     const rt = mockRuntime({
       env: { NO_COLOR: '1', CI: 'true' },
       stdoutIsTTY: true,
     });
-    expect(detectOutputMode(rt)).toBe('pipe');
+    expect(detectOutputMode(rt)).toBe('static');
   });
 });
 

--- a/packages/bijou/src/core/detect/tty.ts
+++ b/packages/bijou/src/core/detect/tty.ts
@@ -3,10 +3,20 @@
  *
  * Detection order (first match wins):
  *   BIJOU_ACCESSIBLE=1    -> 'accessible'  (screen-reader-friendly plain prompts)
- *   NO_COLOR / TERM=dumb  -> 'pipe'        (no ANSI escapes)
+ *   TERM=dumb             -> 'pipe'        (no cursor addressing available)
  *   !stdout.isTTY         -> 'pipe'        (piped/redirected)
  *   CI=true               -> 'static'      (single-frame rendering)
- *   stdout.isTTY          -> 'interactive'  (full experience)
+ *   stdout.isTTY          -> 'interactive' (full experience)
+ *
+ * `NO_COLOR` is deliberately absent. It is a statement about colour — see
+ * no-color.org, "prevents the addition of ANSI color" — and says nothing about
+ * cursor addressing or interactivity. Treating it as a capability signal took a
+ * real terminal out of interactive mode, so a user who exports `NO_COLOR=1` in a
+ * shell profile got no TUI rather than a monochrome one.
+ *
+ * Colour suppression does not depend on this function. `NO_COLOR` is read
+ * independently by `factory.ts`, `bijou-node`'s `createNodeContext`, and
+ * `isNoColor()` in `core/theme/resolve.ts`, none of which consult the mode.
  */
 
 import type { RuntimePort } from '../../ports/runtime.js';
@@ -17,7 +27,7 @@ import { createEnvAccessor, createTTYAccessor } from '../../ports/env.js';
  *
  * - `'interactive'` — full TUI experience with cursor movement and animation.
  * - `'static'` — single-frame rendering (e.g. CI environments).
- * - `'pipe'` — plain text, no ANSI escapes (piped stdout, `NO_COLOR`, `TERM=dumb`).
+ * - `'pipe'` — plain text, no cursor addressing (piped stdout, `TERM=dumb`).
  * - `'accessible'` — screen-reader-friendly plain prompts (`BIJOU_ACCESSIBLE=1`).
  */
 export type OutputMode = 'interactive' | 'static' | 'pipe' | 'accessible';
@@ -37,7 +47,6 @@ export function detectOutputMode(runtime: RuntimePort): OutputMode {
 
   if (env('BIJOU_ACCESSIBLE') === '1') return 'accessible';
 
-  if (env('NO_COLOR') !== undefined) return 'pipe';
   if (env('TERM') === 'dumb') return 'pipe';
 
   if (!stdoutIsTTY) return 'pipe';

--- a/packages/bijou/src/core/environment.part01.test.ts
+++ b/packages/bijou/src/core/environment.part01.test.ts
@@ -81,9 +81,9 @@ describe('environment integration', () => {
         expect(detectOutputMode(rt)).toBe('pipe');
       });
 
-      it('NO_COLOR set -> pipe mode regardless of TTY', () => {
+      it('NO_COLOR does not decide mode; a TTY stays interactive', () => {
         const rt = mockRuntime({ env: { NO_COLOR: '' }, stdoutIsTTY: true });
-        expect(detectOutputMode(rt)).toBe('pipe');
+        expect(detectOutputMode(rt)).toBe('interactive');
       });
 
       it('BIJOU_ACCESSIBLE=1 takes priority over everything', () => {
@@ -96,9 +96,9 @@ describe('environment integration', () => {
     });
 
   describe('conflicting env vars', () => {
-      it('NO_COLOR + TTY still produces pipe mode', () => {
+      it('NO_COLOR + TTY is a monochrome TUI, not a pipe', () => {
         const rt = mockRuntime({ env: { NO_COLOR: '1' }, stdoutIsTTY: true });
-        expect(detectOutputMode(rt)).toBe('pipe');
+        expect(detectOutputMode(rt)).toBe('interactive');
       });
 
       it('BIJOU_ACCESSIBLE overrides NO_COLOR + TERM=dumb', () => {

--- a/packages/bijou/src/core/theme/accessors.test.ts
+++ b/packages/bijou/src/core/theme/accessors.test.ts
@@ -33,9 +33,24 @@ describe('createThemeAccessors()', () => {
     );
   });
 
-  it('status() falls back to muted for unknown keys', () => {
+  // The fallback target is `semantic.muted`, not `status.muted`. Both carry the
+  // same hex in every shipped preset, so the observable difference is entirely in
+  // the modifiers: `status.muted` adds `strikethrough`, which reads as
+  // "cancelled" and is the wrong thing to say about a key nobody defined.
+  it('status() falls back to semantic.muted for unknown keys', () => {
+    const fallback = acc.status('nonexistent');
+    expect(fallback.hex).toBe(theme.theme.semantic.muted.hex);
+    expect(fallback.modifiers ?? []).toEqual(theme.theme.semantic.muted.modifiers ?? []);
+  });
+
+  it('status() never returns a struck-through token for an unknown key', () => {
+    expect(acc.status('nonexistent').modifiers ?? []).not.toContain('strikethrough');
+  });
+
+  it('status(\'muted\') still returns the real muted token, strikethrough intact', () => {
+    // The token itself is unchanged; only what an unknown key resolves to moved.
     const muted = acc.status('muted');
-    expect(acc.status('nonexistent').hex).toBe(muted.hex);
+    expect(muted.modifiers ?? []).toContain('strikethrough');
   });
 
   it('ui() falls back to semantic.primary for unknown keys', () => {

--- a/packages/bijou/src/core/theme/accessors.ts
+++ b/packages/bijou/src/core/theme/accessors.ts
@@ -13,7 +13,7 @@ export interface ThemeAccessors {
   border(key: keyof Theme['border']): TokenValue;
   /** Look up a surface color token. */
   surface(key: keyof Theme['surface']): TokenValue;
-  /** Look up a status color token with fallback to `'muted'`. */
+  /** Look up a status color token, falling back to `semantic.muted` when unknown. */
   status(key: string): TokenValue;
   /** Look up a UI element color token with fallback to `semantic.primary`. */
   ui(key: string): TokenValue;
@@ -43,7 +43,13 @@ export function createThemeAccessors(theme: ResolvedTheme): ThemeAccessors {
       try {
         return tokenGraph.get(`status.${key}`, mode);
       } catch {
-        return tokenGraph.get('status.muted', mode);
+        // `semantic.muted`, not `status.muted`. The two share a hex in every
+        // shipped preset, but `status.muted` also carries `strikethrough` — so an
+        // unknown key used to render struck through, which reads as "cancelled"
+        // rather than "de-emphasised" and says something the caller never did.
+        // This also matches the sibling `ui()` fallback, which already reaches
+        // into `semantic`.
+        return tokenGraph.get('semantic.muted', mode);
       }
     },
     ui: (key) => {

--- a/packages/bijou/src/core/theme/extend.test.ts
+++ b/packages/bijou/src/core/theme/extend.test.ts
@@ -58,6 +58,49 @@ describe('extendTheme', () => {
     expect(extended.status.success).toEqual(override);
   });
 
+  it('merges border overrides', () => {
+    const extended = extendTheme(CYAN_MAGENTA, {
+      border: { primary: { hex: '#123456' } },
+    });
+    expect(extended.border.primary.hex).toBe('#123456');
+  });
+
+  it('preserves unlisted border keys when overriding one', () => {
+    const extended = extendTheme(CYAN_MAGENTA, {
+      border: { primary: { hex: '#123456' } },
+    });
+    expect(extended.border.secondary).toEqual(CYAN_MAGENTA.border.secondary);
+    expect(extended.border.error).toEqual(CYAN_MAGENTA.border.error);
+  });
+
+  it('merges semantic overrides', () => {
+    const extended = extendTheme(CYAN_MAGENTA, {
+      semantic: { accent: { hex: '#abcdef' } },
+    });
+    expect(extended.semantic.accent.hex).toBe('#abcdef');
+  });
+
+  it('preserves unlisted semantic keys when overriding one', () => {
+    const extended = extendTheme(CYAN_MAGENTA, {
+      semantic: { accent: { hex: '#abcdef' } },
+    });
+    expect(extended.semantic.primary).toEqual(CYAN_MAGENTA.semantic.primary);
+    expect(extended.semantic.muted).toEqual(CYAN_MAGENTA.semantic.muted);
+  });
+
+  it('extending border and semantic leaves the other four groups untouched', () => {
+    // The reason this API gap mattered: an app overriding only `status` silently
+    // kept the base theme's colours in every other group.
+    const extended = extendTheme(CYAN_MAGENTA, {
+      border: { primary: { hex: '#123456' } },
+      semantic: { accent: { hex: '#abcdef' } },
+    });
+    expect(extended.status).toEqual(CYAN_MAGENTA.status);
+    expect(extended.ui).toEqual(CYAN_MAGENTA.ui);
+    expect(extended.gradient).toEqual(CYAN_MAGENTA.gradient);
+    expect(extended.surface).toEqual(CYAN_MAGENTA.surface);
+  });
+
   it('merges surface overrides', () => {
     const extended = extendTheme(CYAN_MAGENTA, {
       surface: { primary: { hex: '#111111', bg: '#222222' } },

--- a/packages/bijou/src/core/theme/extend.ts
+++ b/packages/bijou/src/core/theme/extend.ts
@@ -1,10 +1,17 @@
 import type { Theme, TokenValue, GradientStop, BaseStatusKey, BaseUiKey, BaseGradientKey } from './tokens.js';
 
 /**
- * Extend a base theme with additional status, UI, or gradient tokens.
+ * Extend a base theme, overriding or adding tokens in any of its six groups.
  *
  * Merges the extension records into the base theme's corresponding groups,
  * preserving all existing keys and adding new ones.
+ *
+ * `border` and `semantic` are overridable but not extensible with new keys —
+ * unlike `status`, `ui` and `gradient`, their key sets are fixed by `Theme`.
+ * They are reachable here because the shipped presets alias heavily across
+ * groups: `bijou-dark` uses one amber for ten tokens spanning `status`,
+ * `semantic`, `ui` and `border`, so an app that could only replace `status` kept
+ * that amber for every heading, cursor and border without being told.
  *
  * @template S - Additional status keys beyond BaseStatusKey.
  * @template U - Additional UI element keys beyond BaseUiKey.
@@ -22,6 +29,8 @@ export function extendTheme<
   ui?: Partial<Record<U, TokenValue>>;
   gradient?: Partial<Record<G, GradientStop[]>>;
   surface?: Partial<Theme['surface']>;
+  border?: Partial<Theme['border']>;
+  semantic?: Partial<Theme['semantic']>;
 }): Theme<BaseStatusKey | S, BaseUiKey | U, BaseGradientKey | G> {
   return {
     ...base,
@@ -29,6 +38,8 @@ export function extendTheme<
     ui: mergeRecord(base.ui, extensions.ui),
     gradient: mergeRecord(base.gradient, extensions.gradient),
     surface: { ...base.surface, ...extensions.surface },
+    border: { ...base.border, ...extensions.border },
+    semantic: { ...base.semantic, ...extensions.semantic },
   };
 }
 

--- a/packages/bijou/src/core/theme/resolve.part02.test.ts
+++ b/packages/bijou/src/core/theme/resolve.part02.test.ts
@@ -136,12 +136,14 @@ describe('createThemeResolver', () => {
       expect(t.inkStatus('success')).toBeUndefined();
     });
 
-    it('inkStatus() falls back to muted hex for unknown status', () => {
+    // Not observable in the shipped presets (both mutes share a hex); moved so
+    // the two fallbacks cannot disagree in a theme where they differ.
+    it('inkStatus() falls back to the semantic.muted hex for unknown status', () => {
       const rt = mockRuntime({});
       const resolver = createThemeResolver({ runtime: rt });
       const t = resolver.getTheme();
       const result = t.inkStatus('NONEXISTENT_STATUS');
-      expect(result).toBe(t.theme.status.muted.hex);
+      expect(result).toBe(t.theme.semantic.muted.hex);
     });
   });
 });

--- a/packages/bijou/src/core/theme/resolve.ts
+++ b/packages/bijou/src/core/theme/resolve.ts
@@ -44,8 +44,12 @@ export function createResolved(
 
     inkStatus(status: string): InkColor {
       const token = statusTokens.get(status);
-      const fallback = statusTokens.get('muted');
-      if (token === undefined) return noColor ? undefined : fallback?.hex;
+      // Kept in step with the `status()` accessor's fallback. This returns a hex
+      // and nothing else, and the two muted tokens share a hex in every shipped
+      // preset, so the change is not observable there — but the two fallbacks
+      // must not be able to disagree in a theme where the hexes differ.
+      const fallback = theme.semantic.muted;
+      if (token === undefined) return noColor ? undefined : fallback.hex;
       return noColor ? undefined : token.hex;
     },
 

--- a/packages/bijou/src/factory.test.ts
+++ b/packages/bijou/src/factory.test.ts
@@ -99,11 +99,12 @@ describe('createBijou()', () => {
     expect(ctx.mode).toBe('interactive');
   });
 
-  // The pair of assertions that matter together. `NO_COLOR` must disable colour
-  // without disabling the TUI: one context, monochrome and still interactive.
-  // Asserting either half alone is what let the two concerns get conflated.
-  it('NO_COLOR suppresses colour without leaving interactive mode', () => {
-    const ctx = createBijou(basePorts({ NO_COLOR: '1' }, true));
+  // The assertions that matter together: NO_COLOR must disable colour without
+  // disabling the TUI. Checking either half alone is what let the two concerns
+  // get conflated. Both values, because no-color.org specifies the variable as
+  // active "regardless of its value" -- special-casing '1' must not pass.
+  it.each(['1', ''])('NO_COLOR=%j suppresses colour but stays interactive', (value) => {
+    const ctx = createBijou(basePorts({ NO_COLOR: value }, true));
     expect(ctx.mode).toBe('interactive');
     expect(ctx.theme.noColor).toBe(true);
     expect(ctx.theme.ink(ctx.status('error'))).toBeUndefined();

--- a/packages/bijou/src/factory.test.ts
+++ b/packages/bijou/src/factory.test.ts
@@ -99,6 +99,16 @@ describe('createBijou()', () => {
     expect(ctx.mode).toBe('interactive');
   });
 
+  // The pair of assertions that matter together. `NO_COLOR` must disable colour
+  // without disabling the TUI: one context, monochrome and still interactive.
+  // Asserting either half alone is what let the two concerns get conflated.
+  it('NO_COLOR suppresses colour without leaving interactive mode', () => {
+    const ctx = createBijou(basePorts({ NO_COLOR: '1' }, true));
+    expect(ctx.mode).toBe('interactive');
+    expect(ctx.theme.noColor).toBe(true);
+    expect(ctx.theme.ink(ctx.status('error'))).toBeUndefined();
+  });
+
   it('detects pipe mode when stdout is not TTY', () => {
     const ctx = createBijou(basePorts({}, false));
     expect(ctx.mode).toBe('pipe');


### PR DESCRIPTION
Closes #518

Design doc: [`docs/design/DX-052-no-color-is-not-a-capability.md`](docs/design/DX-052-no-color-is-not-a-capability.md)

## What

Three places where bijou answers a question the caller did not ask.

1. **`NO_COLOR` no longer takes the TUI out of interactive mode.** It suppresses
   colour, which is what [no-color.org](https://no-color.org) actually specifies,
   and which three independent paths already do without consulting `mode`.
2. **An unknown status key no longer renders struck through.** `status()` and
   `inkStatus()` fall back to `semantic.muted` (dim) instead of `status.muted`
   (dim + strikethrough), matching what `ui()` already does with
   `semantic.primary`.
3. **`extendTheme` can reach all six token groups.** `border` and `semantic` were
   unreachable, which matters because the shipped themes alias one amber across
   ten tokens spanning those groups.

## Why now

Two first-party consumers had independently written workarounds for item 1
(`git-cas` `bin/ui/context.js`, and `muniment`). Item 2 shipped a real defect in
`muniment` — a painter that resolved to the strikethrough fallback and rendered
"cancelled"-looking text for a status the app had simply not defined. Item 3 is
why `muniment` had to abandon `extendTheme` and hand-author all six groups: its
section headings had inherited bijou's amber and sat ΔE 0.023 from its own
`warning` in OKLab.

## Breaking

Items 1 and 2 change behaviour the current docblocks describe, so this targets
**8.0.0**.

**Eight existing tests across five files** assert the removed behaviour — six of
them the `NO_COLOR` → `pipe` mapping alone (`tty.test.ts` ×3,
`tty.fuzz.test.ts` ×1, `environment.part01.test.ts` ×2), plus the two fallback
tests (`accessors.test.ts`, `resolve.part02.test.ts`).

That density deserves comment, because six tests reinforcing a rule usually means
the rule was chosen deliberately. It was not: every one of them is a
characterization test that restates the truth table, sitting in `describe` blocks
named "detection logic" and "conflicting env vars". No comment, docblock, or
design note anywhere in the repo argues *why* `NO_COLOR` should imply
non-interactive — the only justification is the detector's own docblock restating
its own order. The tests are thorough about coverage, not about defending the
choice.

They are the specification of the defect, so they are rewritten to the new
contract as a recorded decision in the design doc's "Breaking-change note",
rather than edited quietly to make a build go green.

## Out of scope

Filed separately while shaping this:

- #519 — the shipped presets alias one colour across ten token paths, and
  `error`/`success` collapse to ΔE 0.059 (dark) / 0.064 (light) under protanopia.
- #520 — no perceptual authoring primitive, and `doctorTheme` cannot see CVD
  collapse.
- #521 — `status()`/`ui()` take `string`, so a missing theme key fails silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for extending `border` and `semantic` theme settings.
  * Unknown status keys now use the muted semantic style as a fallback.

* **Bug Fixes**
  * `NO_COLOR` now suppresses color without forcing pipe mode.
  * Interactive output remains interactive when color is disabled.

* **Documentation**
  * Documented updated color, output-mode, status fallback, and theme extension behavior.
  * Added compatibility considerations, non-goals, testing updates, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->