### PR TITLE
chore(release): prepare v8.0.0-rc.1 release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,29 +337,35 @@ npm run blocklab:index
 API review. The older `storybook`, `storybook:index`, and `dogfood:storybook`
 script names remain as compatibility aliases during the rename window.
 
-## What's New in v7.2.0
+## What's New in v8.0.0-rc.1
 
-Bijou `v7.2.0` is a focused stabilization release for the V7 demo, TUI mouse
-input, DOGFOOD documentation, and release evidence.
+Bijou `v8.0.0-rc.1` is a release candidate. It is published so downstream
+consumers can validate two breaking changes before the stable `8.0.0` tag; treat
+it as a preview rather than a supported line.
 
-- TUI apps can request `press`, `drag`, or any-event SGR mouse tracking, and
-  the event bus now splits bundled mouse packets before parsing so hover-heavy
-  surfaces do not lose movement events.
-- Framework mouse fallthrough, page-scoped frame helper exports, and scripted
-  mouse driver builders make pointer regressions easier to replay and test.
-- DOGFOOD's release section now surfaces What's New, the real GraphQL Blocks
-  proof chain, and changelog history in the main reader flow instead of hiding
-  release-critical context in side metadata.
-- DOGFOOD demo surfaces are more honest for localization fallback, light-theme
-  readability, first-party theme variants, and Blocks app-binding snippets.
-- Release validation now records the v7.2.0 evidence packet, milestone-aware
-  tracker state for issues and pull requests, dev-inclusive security audit
-  proof, and Code Dojo ratchet progress.
+**Breaking.** `NO_COLOR` no longer changes the detected output mode. It disables
+colour, which is all [no-color.org](https://no-color.org) asks for — previously
+it also forced `'pipe'`, so a terminal with `NO_COLOR=1` in the environment lost
+the whole TUI rather than only its colour. Also, an unknown status key now
+resolves to `semantic.muted` rather than `status.muted`, so a mistyped or
+undefined key no longer renders struck through. See
+[`DX-052`](./docs/design/DX-052-no-color-is-not-a-capability.md).
+
+- `extendTheme()` now reaches all six token groups — `border` and `semantic`
+  join `status`, `ui`, `gradient`, and `surface`.
+- The Profunctor Page terminal inspection target validates the canonical
+  `profunctor-page/0` family and emits deterministic scene IR, surfaces,
+  receipts, and cell source maps across six inspection modes.
+- `createVisorArtifactBundleFromGraphql()` and the `visor-artifact-bundle/1`
+  types land the VISOR artifact bundle proof.
+- `RE-036` adds packed-cell receipt validation and `Surface` adaptation.
+- Dependency-security closeout, roadmap milestone authority, and Code Dojo
+  ratchet progress across tranches A–E.
 
 Read the short-form [changelog](./docs/CHANGELOG.md), the long-form
-[What's New guide](./docs/releases/7.2.0/whats-new.md), the
-[migration guide](./docs/releases/7.2.0/migration-guide.md), and the
-[release evidence packet](./docs/releases/7.2.0/README.md).
+[What's New guide](./docs/releases/8.0.0/whats-new.md), the
+[migration guide](./docs/releases/8.0.0/migration-guide.md), and the
+[release evidence packet](./docs/releases/8.0.0/README.md).
 
 ## Tests, Soak, and Performance
 

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-bench",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "Headless performance benchmarks for bijou — frame-time, memory, and interactive sandbox.",
   "private": true,
   "type": "module",
@@ -10,9 +10,9 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "7.2.0",
-    "@flyingrobots/bijou-node": "7.2.0",
-    "@flyingrobots/bijou-tui": "7.2.0"
+    "@flyingrobots/bijou": "8.0.0-rc.1",
+    "@flyingrobots/bijou-node": "8.0.0-rc.1",
+    "@flyingrobots/bijou-tui": "8.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
 
 ## [Unreleased]
 
+## [8.0.0-rc.1] - 2026-08-21
+
+Release candidate for `8.0.0`. Published so downstream consumers can validate the
+breaking theme and detection changes before the stable tag. The entries below are
+the accumulated `main` work since `7.2.0`; the stable `8.0.0` header will
+consolidate them.
+
 ### Added
 
 - **Profunctor Page terminal inspection target** —
@@ -69,6 +76,28 @@ All packages (`@flyingrobots/bijou`, `@flyingrobots/bijou-node`, `@flyingrobots/
   when the caller had said nothing of the kind. The new target matches the
   sibling `ui()` accessor, which already falls back into `semantic`.
   `status('muted')` itself is unchanged, strikethrough intact.
+- **DOGFOOD resolves release docs by release line, not exact version** — the docs
+  app read `docs/releases/${BIJOU_VERSION}/whats-new.md`, so cutting the first
+  prerelease crashed it on startup with an unhandled `ENOENT` before the first
+  frame: no `docs/releases/8.0.0-rc.1/` directory exists, and none should. A
+  prerelease is a candidate *for* a line and shares its What's New and migration
+  guide, and `release:readiness` keys the evidence-packet path off the target
+  milestone, which is the line too. `releaseLineOf()` in the new
+  `examples/docs/app-release-line.ts` strips `-(alpha|beta|rc).N`, and
+  `tests/cycles/DX-052/dogfood-release-line-docs.test.ts`
+  asserts the derived paths exist on disk without booting the app — the check
+  that would have caught it, since `smoke:dogfood` reported only `exited with
+  code 1`. `defaultMarkdownTemplateValues()` resolves `BIJOU_RELEASE_LINE` as
+  well as `BIJOU_VERSION`, because the i18n scanner turns templated path
+  literals into real files and an unresolvable token makes documents *vanish*
+  from the inventory instead of failing: the first cut of this fix dropped the
+  release What's New and migration guide and moved measured Markdown debt from
+  78 to 72, which reads as a six-point improvement while two documents go
+  unwatched. Both the resolution and the inventory membership are now asserted.
+  Release guide titles and ids in the DOGFOOD Release page also key off the line
+  rather than the exact version: they open the line's docs, and at 120x40
+  `What's New in v8.0.0-rc.1` overflowed the nav column and rendered as
+  `What's New in v8.0.0-rc.`. Document bodies keep the precise version.
 - **`extendTheme()` reaches all six token groups** — `border` and `semantic` join
   `status`, `ui`, `gradient`, and `surface` in the extension parameter. Both are
   overridable rather than extensible, since `Theme` fixes their key sets. This is

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,22 @@ consolidate them.
   when the caller had said nothing of the kind. The new target matches the
   sibling `ui()` accessor, which already falls back into `semantic`.
   `status('muted')` itself is unchanged, strikethrough intact.
+- **`release:preflight` actually runs now** — `scripts/release-metadata.ts` is the
+  CLI entry point but was a pure re-export shim that imported
+  `release-metadata.part04.js` for the side effect of that module's main guard.
+  The guard compares `import.meta.url` against `process.argv[1]`, which never
+  match when the process starts on the shim, so `npm run release:preflight`
+  exited 0 having validated nothing and written no `GITHUB_OUTPUT`.
+  `REL-META-VERSION-LOCKSTEP` is the release gate assigned to that command, so
+  version-mismatch detection was unenforced — `--version 9.9.9` against an
+  `8.0.0-rc.1` workspace exited 0. It surfaced only because the Release Dry Run's
+  notes job read the missing output as an empty tag and failed with
+  `gh: Missing tag_name parameter (HTTP 400)`. Every unit test of
+  `runReleaseMetadata()` passed throughout, because the function was correct and
+  nothing called it; the new
+  `tests/cycles/DX-052/release-metadata-entrypoint.test.ts` invokes the real entry
+  point as a child process. `part04`'s own guard also now resolves `argv[1]`, so
+  direct relative invocation works.
 - **DOGFOOD resolves release docs by release line, not exact version** — the docs
   app read `docs/releases/${BIJOU_VERSION}/whats-new.md`, so cutting the first
   prerelease crashed it on startup with an unhandled `ENOENT` before the first

--- a/docs/design/DX-052-no-color-is-not-a-capability.md
+++ b/docs/design/DX-052-no-color-is-not-a-capability.md
@@ -4,7 +4,7 @@ legend: DX
 lane: release
 priority: high
 github_issue: 518
-status: active
+status: landed
 keywords:
   - no-color
   - output-mode

--- a/docs/releases/8.0.0/README.md
+++ b/docs/releases/8.0.0/README.md
@@ -176,7 +176,7 @@ match.
 | Runtime dependency audit | `npm audit --omit=dev --audit-level=high` | Zero high or critical runtime vulnerabilities. | Verified here: `found 0 vulnerabilities`. |
 | Release gauntlet | `npm run release:readiness` | The fourteen-gate local gauntlet passes. | Verified here: `release-readiness: ok`. |
 | Milestone-aware readiness | `npm run release:readiness -- --milestone v8.0.0` | Target milestone has zero open tracker items and no `work-in-progress` labels. | Verified here: all six report gates PASS. Required first: closing #518 and clearing stale `work-in-progress` labels from the already-closed #482 and #458. |
-| Full test suite | `npm test` | Green. | Verified here on the DX-052 lineage: 930 test files / 4,104 tests. |
+| Full test suite | `npm test` | Green. | Verified here on this release-prep branch via the gauntlet: 933 test files / 4,130 tests, summed across the twenty vitest chunks. |
 | Lint | `npm run lint` | Clean across all workspace packages. | Verified here. |
 | Pre-push verification | `.githooks/pre-push` | Full dojo and repo verification, including scripted interactive example smoke. | Verified here: passed on every push in this lineage. |
 | PR CI | GitHub Actions on [#522](https://github.com/flyingrobots/bijou/pull/522) | All checks green. | Verified here: 10/10 green including both DOGFOOD smokes, TypeScript doctrine, and focused unit tests on ubuntu and windows. CodeRabbit passed. |

--- a/docs/releases/8.0.0/README.md
+++ b/docs/releases/8.0.0/README.md
@@ -34,7 +34,7 @@ into a GA tag would not be.
 - Version: `8.0.0-rc.1`
 - Previous public tag: `v7.2.0`
 - Release type: **prerelease** (release candidate)
-- Intended npm dist-tag: `rc` — **not** `latest`
+- npm dist-tag: **`next`** — not `latest`. `parseReleaseTag()` maps the `rc` channel to `next` (`scripts/release-metadata.part02.ts`), verified by `npx tsx scripts/release-metadata.ts --tag v8.0.0-rc.1` emitting `npm_dist_tag=next`. An earlier draft of this packet said `rc`, which was an assumption about the name rather than a reading of the mapping; the property that matters — a prerelease must not land on `latest` — holds either way, but the tag to verify after publish is `next`
 - Release-prep branch: `release/v8.0.0-rc.1`
 - Release date: 2026-08-21
 - Publish surface: npm workspace packages only, lock-step at `8.0.0-rc.1`
@@ -253,8 +253,9 @@ environment at all.
 4. Tag `v8.0.0-rc.1` on the exact merged `origin/main` commit.
 5. Verify Tag Guard, tag CI, and the publish workflow.
 6. Verify every package reports `8.0.0-rc.1` on npm.
-7. **Confirm the dist-tag is `rc`, not `latest`.** A prerelease published to
-   `latest` would silently upgrade every consumer on a caret range.
+7. **Confirm the dist-tag is `next`, not `latest`.** A prerelease published to
+   `latest` would silently upgrade every consumer running a bare
+   `npm install @flyingrobots/bijou`. `next` is what the `rc` channel maps to.
 
 ## Residual Risk
 
@@ -264,7 +265,19 @@ environment at all.
 2. **Three product goalposts carry inherited rather than replayed evidence.**
    DX-050, DX-049, and RE-036 landed with their own review and CI, but their
    witnesses were not replayed from this commit, which is what `docs/release.md`
-   requires. Owner: maintainer. Must be closed before GA.
+   requires: *"evidence is complete only when another operator can replay it from
+   the tag commit."*
+
+   Automated review raised this as a release-law objection — the Law says no
+   public tag may be created unless every gate is satisfied. The Law's own
+   provision for this case is that *"any accepted residual risk is named with
+   rationale, owner, and a follow-up issue"*, and that hidden accepted failures
+   are not allowed. So: accepted for the prerelease, owner maintainer, follow-up
+   [#527](https://github.com/flyingrobots/bijou/issues/527), which also carries
+   the six unreviewed human-review surfaces and is written so that closing it
+   means flipping five rows in this packet from Inherited to Verified here.
+
+   **The stable `8.0.0` tag must not be created while any row reads Inherited.**
 3. **The breaking changes are unvalidated against real consumers.** That is the
    point of the rc. `muniment` is the first consumer and will pin this version;
    `git-cas` carries a local `detectCliTuiMode` override that is now redundant
@@ -272,10 +285,25 @@ environment at all.
 4. **The changelog boundary will need consolidating at GA.** Twenty entries now
    sit under an rc header. The stable `8.0.0` header should absorb them rather
    than leave consumers reading release history split across a prerelease.
-5. **Open `priority:high` issue #473** (`BAD CODE: make SVG path parsing total
+5. **The lockfile was stale until review caught it.** `npm run version` rewrote
+   all eleven manifests and left `package-lock.json` byte-identical to `main`,
+   still recording `7.2.0` for every workspace package and internal pin — so a
+   clean `npm ci` would have resolved from metadata a full major behind the
+   manifests. Regenerated here with `npm install --package-lock-only`. Three
+   separate gates failed to notice, filed as
+   [#526](https://github.com/flyingrobots/bijou/issues/526): the version script
+   does not touch the lock, the pre-commit "lockfile consistency" check runs
+   `npm ls --all` which cannot detect the condition, and `release:preflight`
+   validates manifests only. Same family as
+   [#525](https://github.com/flyingrobots/bijou/issues/525) — gates that report
+   success without checking what their names promise.
+6. **DOGFOOD's "Current Release Story" guide still describes the v7.2 path** in
+   its summary, catalogs, and body, while the release page now presents v8.
+   Cosmetic for a prerelease, tracked in #527 for the stable tag.
+7. **Open `priority:high` issue #473** (`BAD CODE: make SVG path parsing total
    and non-stalling`) is milestoned `v8.2.0` and is not release-blocking for
    `8.0.0`. Named here rather than left implicit, per `REL-GH-PRIORITY-HIGH-ZERO`.
-6. **Known palette defects ship unchanged.** [#519](https://github.com/flyingrobots/bijou/issues/519)
+8. **Known palette defects ship unchanged.** [#519](https://github.com/flyingrobots/bijou/issues/519)
    records that both first-party presets alias one colour across the same ten
    token paths and that `error`/`success` collapse to ΔE 0.059 (dark) and 0.064
    (light) under protanopia, with `bijou-light`'s severity ladder inverted in

--- a/docs/releases/8.0.0/README.md
+++ b/docs/releases/8.0.0/README.md
@@ -1,0 +1,261 @@
+# Bijou 8.0.0 Release Evidence
+
+**Line status: open.** This packet covers the `8.0.0` release line and is opened
+by its first tag, `v8.0.0-rc.1`. The stable `8.0.0` tag completes it rather than
+starting a new one — which is why the residual-risk section below reads as a
+to-do list rather than a closure record.
+
+Bijou `8.0.0-rc.1` is a **release candidate**, not a stable release. It exists so
+downstream consumers can validate two breaking changes — the `NO_COLOR` detection
+change and the status-fallback change from
+[`DX-052`](../../design/DX-052-no-color-is-not-a-capability.md) — against real
+applications before the stable `8.0.0` tag is cut.
+
+## How to read this packet
+
+This packet is deliberately explicit about the difference between evidence
+gathered first-hand during release prep and evidence inherited from the cycles
+that landed on `main` before it.
+
+- **Verified here** means the command in the "replay" column was run on this
+  release-prep branch and its result observed.
+- **Inherited** means the goalpost landed through its own reviewed PR with its
+  own CI, and this packet cites that lineage without re-running the goalpost's
+  specific witnesses.
+
+Every `Inherited` row is a **release-law gap that must be closed before the
+stable `8.0.0` tag**. `docs/release.md` requires that a second operator can
+replay each witness from the tag commit, and an inherited citation does not meet
+that bar. Naming the gap is the honest disposition for a prerelease; carrying it
+into a GA tag would not be.
+
+## Release Summary
+
+- Version: `8.0.0-rc.1`
+- Previous public tag: `v7.2.0`
+- Release type: **prerelease** (release candidate)
+- Intended npm dist-tag: `rc` — **not** `latest`
+- Release-prep branch: `release/v8.0.0-rc.1`
+- Release date: 2026-08-21
+- Publish surface: npm workspace packages only, lock-step at `8.0.0-rc.1`
+- Target milestone: `v8.0.0` (0 open / 7 closed at prep time)
+
+## Tracker And Goalpost Map
+
+Twenty changelog entries accumulated on `main` since `7.2.0`. They group into
+four substantive goalposts, two workflow closeouts, and a maintenance band.
+
+### DX-052 — NO_COLOR is not a capability signal
+
+- Tracker: [#518](https://github.com/flyingrobots/bijou/issues/518) (closed)
+- Design: [`DX-052`](../../design/DX-052-no-color-is-not-a-capability.md)
+- PR: [#522](https://github.com/flyingrobots/bijou/pull/522)
+- Slices: 3 — `detectOutputMode` branch removal, `status()`/`inkStatus()`
+  fallback move, `extendTheme()` group coverage
+- Deterministic proof: `packages/bijou/src/core/detect/tty.test.ts`,
+  `tty.fuzz.test.ts`, `core/environment.part01.test.ts`,
+  `core/theme/accessors.test.ts`, `core/theme/extend.test.ts`,
+  `core/theme/resolve.part02.test.ts`, `factory.test.ts`
+- Replay: `npx vitest run packages/bijou/src/core/detect packages/bijou/src/core/theme packages/bijou/src/factory.test.ts`
+- Witness: the fuzz property asserts the contract directly — adding `NO_COLOR` to
+  any environment leaves that environment's detected mode unchanged (200 runs
+  across `''`/`'1'`/`'true'` × TTY × `CI` × `TERM`). `factory.test.ts` asserts
+  the pair that matters together: `mode === 'interactive'` **and**
+  `theme.noColor === true` **and** `ink()` undefined, over both `'1'` and `''`.
+- Evidence status: **Verified here.** Authored during this session; every listed
+  command was run.
+- Residual risk: intentional breaking change. A consumer relying on `NO_COLOR`
+  to force single-frame output now gets an interactive monochrome TUI. The
+  documented escape is `TERM=dumb`, which remains a genuine capability signal, or
+  an explicit `mode`. This is the specific risk the rc exists to expose.
+
+### DX-050 — Profunctor Page terminal inspection target
+
+- Design: [`DX-050`](../../design/DX-050-profunctor-page-inspection.md)
+- Deterministic proof: per its changelog entry — `lowerProfunctorPageArtifacts()`
+  validates the canonical `profunctor-page/0` family and emits deterministic
+  `ui-scene-ir/1`, `Surface`, target-map, receipt, cell-source-map, and text
+  evidence across six inspection modes
+- Evidence status: **Inherited.** Landed on `main` through its own reviewed PR
+  and CI before this branch existed. Its specific witnesses were not re-run here.
+- Residual risk: unsupported browser semantics remain explicit capability
+  residuals; semantic-document sources, application islands, and visible
+  unsupported blocks fail closed. Disposition inherited from the cycle, **not
+  re-reviewed for this packet**.
+
+### DX-049 — VISOR artifact bundle proof
+
+- Tracker: [#458](https://github.com/flyingrobots/bijou/issues/458)
+- Design: [`DX-049`](../../design/DX-049-visor-artifact-bundle-proof.md)
+- Deterministic proof: `createVisorArtifactBundleFromGraphql()`,
+  `createVisorArtifactBundle()`, `visor-artifact-bundle/1` types, wrapping the
+  checked-in DOGFOOD GraphQL fixture path
+- Evidence status: **Inherited.**
+- Residual risk: #459 packed-cell validation and external renderer/debugger work
+  were explicitly out of scope for the cycle.
+
+### RE-036 — packed-cell receipt validation and `Surface` adaptation
+
+- Design: [`RE-036`](../../design/RE-036-packed-bijou-cells-surface-adapter.md)
+- Deterministic proof: `adaptPackedBijouCellsToSurface()` copies validated bytes
+  and side-table entries without re-encoding cells
+- Evidence status: **Inherited.**
+
+### WF-166 — V8 dependency-security closeout
+
+- Design: [`WF-166`](../../design/WF-166-v8-dependency-security-closeout.md)
+- Deterministic proof: a regression binds the patched dependency floors and the
+  manifest override; a clean `npm ci` reproduces a zero-vulnerability audit
+- Replay: `npm audit --omit=dev --audit-level=high`
+- Evidence status: **Verified here** for the audit result; the floor-binding
+  regression is inherited.
+
+### WF-167 — roadmap milestone authority
+
+- Design: [`WF-167`](../../design/WF-167-roadmap-milestone-authority.md)
+- Evidence status: **Inherited.**
+
+### Maintenance band — Code Dojo ratchets and DOGFOOD documentation
+
+Eleven entries: WF-165 tranches A–E, the DX-050 Code Dojo prerequisites A and B,
+the focused ratchet, touched DOGFOOD localization debt, DOGFOOD split-source debt
+identity, the documentation contract, future-release milestone triage, and the
+DX-048 V8 Runtime Graph shaping record.
+
+- Deterministic proof: the ratchet baselines under
+  `scripts/code-dojo/baselines/` are the artifact; the gates are the proof
+- Replay: `npm run code-dojo:verify`, `npm run code-dojo:strict`,
+  `npm run code-dojo:debt`
+- Evidence status: **Verified here.** The pre-commit and pre-push dojo gates ran
+  on every commit in this lineage and reported `0 baselined files over 150 lines
+  or 12000 bytes`, `0 files over 500 lines`, and `0 baselined ESLint findings`.
+  Two files crossed the 150-line threshold while gaining tests during DX-052 and
+  were brought back under by tightening prose and collapsing two cases into one
+  `it.each`, rather than by adding baseline entries.
+
+### Prerelease gaps found and closed during prep
+
+Cutting the first prerelease this tooling has seen exposed four defects, all
+fixed on the release-prep branch and recorded in
+[#523](https://github.com/flyingrobots/bijou/issues/523):
+
+1. **DOGFOOD crashed on startup.** It resolved release docs as
+   `docs/releases/${BIJOU_VERSION}/`, so `8.0.0-rc.1` produced an unhandled
+   `ENOENT` at module load. `smoke:dogfood` reported only `exited with code 1` —
+   no path, no stack — so reproducing it meant running the capture entrypoint by
+   hand with the scenario environment reconstructed from the smoke library.
+2. **The two release gates disagreed** about where release docs live: the
+   readiness gate keys the packet path off the milestone, DOGFOOD keyed it off
+   the exact version. Resolved in favour of the release *line*, which is why this
+   packet lives at `docs/releases/8.0.0/`.
+3. **The i18n scanner silently stopped counting two documents.** Templating the
+   path with a token the static resolver did not know made the release What's New
+   and migration guide unresolvable, so they left the inventory rather than
+   failing, and measured Markdown debt fell 78 → 72. An unresolvable token reads
+   exactly like a six-point improvement. Fixed by teaching the resolver the
+   token; **no baseline lowered and no test edited** to accommodate it.
+4. **A prerelease version string overflows the DOGFOOD release nav.** At 120x40,
+   `What's New in v8.0.0-rc.1` rendered as `What's New in v8.0.0-rc.`. Release
+   guide titles and ids now key off the line, which is also what they describe.
+
+One ratchet was tightened rather than loosened: `app-guides-release`'s release
+overview summary interpolated the version mid-sentence, counting as two
+translatable literals split around an inserted value — word order a translator
+cannot rearrange. Moving the value to the end makes it one string, taking total
+raw-string debt 2317 → 2316 and the surface 7 → 6. Both baselines shrank to
+match.
+
+
+## Automated Evidence Matrix
+
+| Gate | Command or source | Expected result | Status |
+| :--- | :--- | :--- | :--- |
+| Workspace lock-step | `npm run version 8.0.0-rc.1` | All ten workspace packages and internal dependency pins report `8.0.0-rc.1`. | Verified here: all ten confirmed. |
+| Release metadata preflight | `npm run release:preflight` | Lock-step workspace metadata is valid. | Verified here: exit 0 on the release-prep branch. |
+| Docs inventory | `npm run docs:inventory` | Documentation manifest remains valid after release docs are added. | Verified here: exit 0. |
+| Runtime dependency audit | `npm audit --omit=dev --audit-level=high` | Zero high or critical runtime vulnerabilities. | Verified here: `found 0 vulnerabilities`. |
+| Release gauntlet | `npm run release:readiness` | The fourteen-gate local gauntlet passes. | Verified here: `release-readiness: ok`. |
+| Milestone-aware readiness | `npm run release:readiness -- --milestone v8.0.0` | Target milestone has zero open tracker items and no `work-in-progress` labels. | Verified here: all six report gates PASS. Required first: closing #518 and clearing stale `work-in-progress` labels from the already-closed #482 and #458. |
+| Full test suite | `npm test` | Green. | Verified here on the DX-052 lineage: 930 test files / 4,104 tests. |
+| Lint | `npm run lint` | Clean across all workspace packages. | Verified here. |
+| Pre-push verification | `.githooks/pre-push` | Full dojo and repo verification, including scripted interactive example smoke. | Verified here: passed on every push in this lineage. |
+| PR CI | GitHub Actions on [#522](https://github.com/flyingrobots/bijou/pull/522) | All checks green. | Verified here: 10/10 green including both DOGFOOD smokes, TypeScript doctrine, and focused unit tests on ubuntu and windows. CodeRabbit passed. |
+| Release Dry Run | `.github/workflows/release-dry-run.yml` | Packed files and publish dry-runs stay green. | Required before tagging. |
+| Tag Guard | `.github/workflows/tag-guard.yml` | The pushed tag resolves to the intended release commit. | Runs after tag push. |
+| Publish workflow | `.github/workflows/publish.yml` | Automated npm publishing succeeds for every workspace package. | Runs after tag push. |
+| npm registry verification | `npm view <package> version dist-tags --json` | Every package reports `8.0.0-rc.1`. | Required after publish. |
+
+## Human Review Matrix
+
+| Surface | Review disposition |
+| :--- | :--- |
+| `docs/CHANGELOG.md` | Twenty accumulated entries moved under a dated `8.0.0-rc.1` boundary with a note that the stable `8.0.0` header will consolidate them. `[Unreleased]` intentionally left in place and empty for post-rc work. |
+| `README.md` | What's New replaced with v8.0.0-rc.1, leading with the two breaking changes and marking the line as a preview rather than supported. |
+| `docs/BEARING.md` | Updated during DX-052 with two new tensions: environment signals are not capability signals, and cross-group token aliasing. **Does not yet describe an 8.0.0 release posture** — needs a maintainer pass before the stable tag. |
+| `docs/ROADMAP.md` | **Not reviewed for this release.** References v8.0.0 in ten places, which satisfies the readiness gate, but its content was not re-verified against milestone state. Required before the stable tag. |
+| `docs/design/DX-052-*.md` | Status moved to `landed`. |
+| `ARCHITECTURE.md` | **Not reviewed.** DX-052 changes no port, adapter, or package boundary, so no update is required *for that goalpost*. The three inherited goalposts touch rendering contracts and were not assessed here. |
+| `docs/VISION.md`, `docs/METHOD.md` | **Not reviewed.** No known change required. |
+| `docs/DOGFOOD.md` | **Not reviewed.** DOGFOOD smokes pass, but release-title and proof-surface posture for an 8.0.0 line was not assessed. |
+| Package READMEs, API references, MCP docs | **Not reviewed.** `extendTheme()`'s public signature gained two optional fields; whether any package README documents that signature was not checked. |
+
+Nine surfaces, three reviewed. That ratio is the honest state of this packet and
+is the reason this is an rc.
+
+## Deterministic Reproducibility
+
+Replayable from this commit with no external inputs:
+
+```bash
+npm ci
+npm run lint
+npm test
+npx vitest run packages/bijou/src/core/detect packages/bijou/src/core/theme packages/bijou/src/factory.test.ts
+npm run code-dojo:verify
+npm audit --omit=dev --audit-level=high
+```
+
+Normalization notes: the fuzz property in `tty.fuzz.test.ts` is seeded by
+`fast-check` defaults and runs 200 cases; it asserts an invariant (mode is
+unchanged by `NO_COLOR`) rather than a fixed value, so it does not require
+normalization for host colour mode, terminal size, or clock. `factory.test.ts`
+uses `mockRuntime`/`mockIO`/`plainStyle` and therefore does not read the host
+environment at all.
+
+## Package And Registry Verification Plan
+
+1. Merge the release-prep PR into `main`.
+2. Confirm local `main` is exactly `origin/main`.
+3. Run the Release Dry Run workflow against the release commit.
+4. Tag `v8.0.0-rc.1` on the exact merged `origin/main` commit.
+5. Verify Tag Guard, tag CI, and the publish workflow.
+6. Verify every package reports `8.0.0-rc.1` on npm.
+7. **Confirm the dist-tag is `rc`, not `latest`.** A prerelease published to
+   `latest` would silently upgrade every consumer on a caret range.
+
+## Residual Risk
+
+1. **Nine of eleven release-law human review gates are unreviewed** (see the
+   matrix). Acceptable for a prerelease whose stated purpose is downstream
+   validation; **blocking for the stable `8.0.0` tag**.
+2. **Three product goalposts carry inherited rather than replayed evidence.**
+   DX-050, DX-049, and RE-036 landed with their own review and CI, but their
+   witnesses were not replayed from this commit, which is what `docs/release.md`
+   requires. Owner: maintainer. Must be closed before GA.
+3. **The breaking changes are unvalidated against real consumers.** That is the
+   point of the rc. `muniment` is the first consumer and will pin this version;
+   `git-cas` carries a local `detectCliTuiMode` override that is now redundant
+   and can be removed once it moves off `^5.0.0`.
+4. **The changelog boundary will need consolidating at GA.** Twenty entries now
+   sit under an rc header. The stable `8.0.0` header should absorb them rather
+   than leave consumers reading release history split across a prerelease.
+5. **Open `priority:high` issue #473** (`BAD CODE: make SVG path parsing total
+   and non-stalling`) is milestoned `v8.2.0` and is not release-blocking for
+   `8.0.0`. Named here rather than left implicit, per `REL-GH-PRIORITY-HIGH-ZERO`.
+6. **Known palette defects ship unchanged.** [#519](https://github.com/flyingrobots/bijou/issues/519)
+   records that both first-party presets alias one colour across the same ten
+   token paths and that `error`/`success` collapse to ΔE 0.059 (dark) and 0.064
+   (light) under protanopia, with `bijou-light`'s severity ladder inverted in
+   lightness. `DX-052` makes this *escapable* — `extendTheme()` can now reach
+   every group — but does not fix it. Consumers relying on the shipped presets
+   for severity distinctions should read #519.

--- a/docs/releases/8.0.0/README.md
+++ b/docs/releases/8.0.0/README.md
@@ -157,6 +157,29 @@ fixed on the release-prep branch and recorded in
 4. **A prerelease version string overflows the DOGFOOD release nav.** At 120x40,
    `What's New in v8.0.0-rc.1` rendered as `What's New in v8.0.0-rc.`. Release
    guide titles and ids now key off the line, which is also what they describe.
+5. **`release:preflight` was a silent no-op, and this packet initially claimed it
+   passed.** `scripts/release-metadata.ts` is the CLI entry point but was a pure
+   re-export shim; it imported `release-metadata.part04.js` for the side effect of
+   *that* module's main guard, which compares `import.meta.url` against
+   `process.argv[1]` and therefore never fires when the process starts on the
+   shim. The command exited 0 having validated nothing, written no stdout, and
+   written no `GITHUB_OUTPUT`.
+
+   `REL-META-VERSION-LOCKSTEP` is the gate the release process assigns to
+   `release:preflight`, so version-mismatch detection was unenforced:
+   `--version 9.9.9` against an `8.0.0-rc.1` workspace exited 0. The Release Dry
+   Run surfaced it only indirectly — its notes job read the missing output as an
+   empty tag and failed with `gh: Missing tag_name parameter (HTTP 400)`.
+
+   Every unit test of `runReleaseMetadata()` passed throughout, because the
+   function was always correct; nothing called it.
+   `tests/cycles/DX-052/release-metadata-entrypoint.test.ts` now invokes the real
+   entry point as a child process, which is the only way to observe this class of
+   defect.
+
+   **A gate that reports success without running is worse than a missing gate**,
+   and the first version of this row in the matrix above recorded exactly that
+   false pass. It is corrected rather than quietly overwritten.
 
 One ratchet was tightened rather than loosened: `app-guides-release`'s release
 overview summary interpolated the version mid-sentence, counting as two
@@ -171,7 +194,7 @@ match.
 | Gate | Command or source | Expected result | Status |
 | :--- | :--- | :--- | :--- |
 | Workspace lock-step | `npm run version 8.0.0-rc.1` | All ten workspace packages and internal dependency pins report `8.0.0-rc.1`. | Verified here: all ten confirmed. |
-| Release metadata preflight | `npm run release:preflight` | Lock-step workspace metadata is valid. | Verified here: exit 0 on the release-prep branch. |
+| Release metadata preflight | `npm run release:preflight` | Lock-step workspace metadata is valid. | **Initially recorded as passing on exit 0, which was wrong** — the command was a no-op (see below). Fixed on this branch; now prints the eleven-package lock-step summary and exits 1 on a mismatch. |
 | Docs inventory | `npm run docs:inventory` | Documentation manifest remains valid after release docs are added. | Verified here: exit 0. |
 | Runtime dependency audit | `npm audit --omit=dev --audit-level=high` | Zero high or critical runtime vulnerabilities. | Verified here: `found 0 vulnerabilities`. |
 | Release gauntlet | `npm run release:readiness` | The fourteen-gate local gauntlet passes. | Verified here: `release-readiness: ok`. |

--- a/docs/releases/8.0.0/migration-guide.md
+++ b/docs/releases/8.0.0/migration-guide.md
@@ -1,0 +1,160 @@
+# Migrating to Bijou 8.0.0-rc.1
+
+This is a release candidate. Pin the exact version; do not use a caret range.
+
+```bash
+npm install @flyingrobots/bijou@8.0.0-rc.1 \
+            @flyingrobots/bijou-node@8.0.0-rc.1 \
+            @flyingrobots/bijou-tui@8.0.0-rc.1
+```
+
+All workspace packages are versioned in lock-step, so mixing `8.0.0-rc.1` with
+`7.2.0` packages is unsupported.
+
+Two breaking changes, both from
+[`DX-052`](../../design/DX-052-no-color-is-not-a-capability.md). Neither requires
+a code change for most applications; both change what your application *does* in
+situations you may not have tested.
+
+## 1. `NO_COLOR` no longer forces `'pipe'` mode
+
+### What changed
+
+`detectOutputMode()` no longer inspects `NO_COLOR`. The detection order is now:
+
+```text
+BIJOU_ACCESSIBLE=1  -> 'accessible'
+TERM=dumb           -> 'pipe'
+!stdout.isTTY       -> 'pipe'
+CI                  -> 'static'
+stdout.isTTY        -> 'interactive'
+```
+
+### Why
+
+`NO_COLOR` is a statement about colour. [no-color.org](https://no-color.org)
+specifies that its presence "prevents the addition of ANSI color" and says
+nothing about cursor addressing or interactivity. Mapping it to `'pipe'` meant a
+user who exported `NO_COLOR=1` in a shell profile — common, and reasonable — lost
+the entire TUI rather than only its colour: every component lowered to its
+single-frame form, and `shouldUseShellQuitConfirm()` began returning
+`'immediate'`.
+
+### What did *not* change
+
+Colour output. `NO_COLOR` is read independently by `createBijou()`,
+`createNodeContext()`, and `isNoColor()`, none of which consult the mode. With
+`NO_COLOR` set you still get `theme.noColor === true`, `ink()` returning
+`undefined`, and `styled()` returning unstyled text.
+
+To be precise about the scope: an interactive session does emit cursor movement,
+screen updates, and possibly alternate-screen sequences — it has to, or it is not
+a TUI. What `NO_COLOR` suppresses is **colour and style escapes**, which is what
+it asks for.
+
+### What you may need to do
+
+**If you relied on `NO_COLOR` to get single-frame output**, say in a script or a
+log-capturing harness, it no longer does that. Use whichever is accurate:
+
+```ts
+// The terminal genuinely cannot do cursor addressing:
+TERM=dumb
+
+// You are capturing output rather than driving a terminal:
+//   redirect stdout — a non-TTY stdout still yields 'pipe'
+
+// You want to force it from inside the app:
+const ctx = { ...createBijou(ports), mode: 'pipe' as const };
+```
+
+**If you set `NO_COLOR` because you wanted a monochrome TUI**, you now get one.
+No action needed; this is the fix.
+
+**If you wrote your own detector to work around this** — `git-cas` and `muniment`
+both did — you can delete it. Check that your override does not also encode
+something else you still want.
+
+## 2. An unknown status key no longer resolves to a struck-through token
+
+### What changed
+
+`ctx.status(key)` and `ResolvedTheme.inkStatus(key)` fall back to
+`semantic.muted` instead of `status.muted` when `key` is not in the theme.
+
+### Why
+
+`status.muted` carries `['dim', 'strikethrough']` in every shipped preset. That
+is reasonable for a token meaning "retired" — and wrong as the answer to "I don't
+know this key". Because `status(key)` accepts `string`, a typo, or a key an
+application forgot to add to its theme, silently rendered text with a line
+through it. A reader sees "cancelled"; the application said nothing of the kind.
+
+The new target matches the sibling `ui()` accessor, which already falls back to
+`semantic.primary`.
+
+### What you may need to do
+
+**Probably nothing.** `status.muted` and `semantic.muted` share a hex in every
+shipped preset, so the only visible difference is the absence of the
+strikethrough.
+
+**If you defined a theme where those two tokens have different hexes**, an
+unknown key now resolves to the `semantic.muted` hex. Check any custom preset.
+
+**If you were relying on the strikethrough fallback** as a way to spot undefined
+keys during development, it is gone. It was never a reliable signal — it only
+appeared when a code path actually ran.
+[#521](https://github.com/flyingrobots/bijou/issues/521) tracks typing the
+accessors so a missing key becomes a compile error instead.
+
+`ctx.status('muted')` itself is unchanged, strikethrough intact.
+
+## 3. Additive: `extendTheme()` reaches all six token groups
+
+Not breaking. `border` and `semantic` join `status`, `ui`, `gradient`, and
+`surface`:
+
+```ts
+const theme = extendTheme(BIJOU_DARK, {
+  status: { guarded: tv('#4cc9c3') },
+  border: { primary: tv('#75798d') },     // now possible
+  semantic: { accent: tv('#d6c5ff') },    // now possible
+});
+```
+
+Both are overridable rather than extensible with new keys, because `Theme` fixes
+their key sets.
+
+### Why this matters more than it looks
+
+The shipped presets alias heavily across groups. `bijou-dark` uses `#f2c45d` for
+`status.warning`, `status.active`, `semantic.warning`, `semantic.accent`,
+`ui.cursor`, `ui.focusGutter`, `ui.sectionHeader`, `ui.logo`, `border.secondary`
+**and** `border.warning` — ten tokens, one colour. `bijou-light` does the same
+with `#7a5200`.
+
+So `extendTheme(BIJOU_DARK, { status })` replaced your statuses and silently kept
+that amber for every heading, cursor, and border. If you have done that, your
+headings are probably the same colour as your `warning`. That is not hypothetical
+— it is how this was found, at ΔE 0.023 in OKLab, which is indistinguishable.
+
+If you override `status`, consider auditing `ui` and `border` too:
+
+```ts
+import { doctorTheme } from '@flyingrobots/bijou';
+console.log(doctorTheme(myTheme, { maxColorReuse: 2 }));
+```
+
+Note that `doctorTheme` checks contrast and reuse but not perceptual separation
+under colour-vision deficiency — see
+[#520](https://github.com/flyingrobots/bijou/issues/520) — and that the shipped
+presets do not currently satisfy it
+([#519](https://github.com/flyingrobots/bijou/issues/519)).
+
+## Reporting rc feedback
+
+This candidate exists to find out what these two changes break in real
+applications. Please file against
+[#518](https://github.com/flyingrobots/bijou/issues/518) or open a new issue with
+the `lane:release` label.

--- a/docs/releases/8.0.0/migration-guide.md
+++ b/docs/releases/8.0.0/migration-guide.md
@@ -77,12 +77,12 @@ something else you still want.
 
 ## 2. An unknown status key no longer resolves to a struck-through token
 
-### What changed
+### What changed about the fallback
 
 `ctx.status(key)` and `ResolvedTheme.inkStatus(key)` fall back to
 `semantic.muted` instead of `status.muted` when `key` is not in the theme.
 
-### Why
+### Why the fallback moved
 
 `status.muted` carries `['dim', 'strikethrough']` in every shipped preset. That
 is reasonable for a token meaning "retired" — and wrong as the answer to "I don't
@@ -93,7 +93,7 @@ through it. A reader sees "cancelled"; the application said nothing of the kind.
 The new target matches the sibling `ui()` accessor, which already falls back to
 `semantic.primary`.
 
-### What you may need to do
+### What you may need to do about the fallback
 
 **Probably nothing.** `status.muted` and `semantic.muted` share a hex in every
 shipped preset, so the only visible difference is the absence of the

--- a/docs/releases/8.0.0/whats-new.md
+++ b/docs/releases/8.0.0/whats-new.md
@@ -1,0 +1,103 @@
+# What's New in Bijou 8.0.0-rc.1
+
+A release candidate, published so the breaking changes below can be validated
+against real applications before `8.0.0` is cut. Pin the exact version; the
+dist-tag is `rc`, not `latest`.
+
+## The headline is a deletion
+
+`detectOutputMode()` no longer looks at `NO_COLOR`.
+
+That variable means one thing: do not send me colour. It has never meant "do not
+draw a user interface". Bijou read it as a capability signal, so a developer who
+had `NO_COLOR=1` in their shell profile did not get a monochrome TUI — they got no
+TUI. Every component dropped to its single-frame form, and the quit confirmation
+stopped asking.
+
+The tell was that two first-party consumers had each independently written their
+own detector to route around it. `git-cas` ships a `detectCliTuiMode` with a
+comment explaining the problem; `muniment` wrote the same override for the same
+reason. When consumers reimplement your detector, the detector is answering a
+question they did not ask.
+
+Colour is unaffected — it was never coupled to the mode in the implementation,
+only in the detector. `NO_COLOR` is read independently in three places, none of
+which consult `ctx.mode`, so with it set you still get `theme.noColor === true`
+and unstyled output. What you also get now is a working TUI.
+
+The test for this is the shape worth stealing. Rather than assert which mode
+`NO_COLOR` produces, the property asserts that adding `NO_COLOR` to *any*
+environment leaves that environment's mode unchanged — the contract stated
+directly, over 200 generated combinations of value, TTY state, `CI`, and `TERM`.
+
+## An unknown status key no longer looks cancelled
+
+`ctx.status('typo')` used to fall back to `status.muted`, and `status.muted`
+carries `strikethrough` in every shipped preset. So a mistyped key — or a key an
+application meant to define and didn't — rendered text with a line through it. The
+reader sees "cancelled". The application never said that.
+
+It now falls back to `semantic.muted`, which is dim and nothing else, matching
+what the sibling `ui()` accessor already did with `semantic.primary`.
+
+This one came out of a real application shipping the bug: a painter was declared,
+its status key was later dropped from the theme as a duplicate, and the painter
+kept resolving to the fallback. Nothing caught it — not the type checker, not a
+palette audit, not review — because no view had called it yet.
+[#521](https://github.com/flyingrobots/bijou/issues/521) tracks typing the
+accessors so that becomes a compile error.
+
+## `extendTheme()` can finally reach every group
+
+`Theme` has six token groups. `extendTheme()` accepted extensions for four, which
+sounds like an oversight and behaves like a trap, because the shipped presets
+alias one colour across the groups you could not reach.
+
+`bijou-dark` paints `status.warning`, `status.active`, `semantic.warning`,
+`semantic.accent`, `ui.cursor`, `ui.focusGutter`, `ui.sectionHeader`, `ui.logo`,
+`border.secondary` and `border.warning` in a single amber. Ten tokens. So
+`extendTheme(BIJOU_DARK, { status })` gave you your statuses and left that amber
+running every heading, cursor and border — and if one of your new statuses was
+also amber-ish, your headings became indistinguishable from your warnings. That
+is how this was found, at ΔE 0.023 in OKLab.
+
+`border` and `semantic` are now reachable. They are overridable rather than
+extensible, since `Theme` fixes their key sets.
+
+The alias itself is still there. `extendTheme()` makes it escapable, not fixed —
+see [#519](https://github.com/flyingrobots/bijou/issues/519), which also records
+that `error` and `success` collapse to ΔE 0.059 under protanopia in the dark
+preset and 0.064 in the light one, and that `bijou-light`'s severity ladder is
+inverted in lightness. If you rely on the shipped presets to distinguish
+severities, read that issue.
+
+## Also in this candidate
+
+Everything that accumulated on `main` since `7.2.0`:
+
+- **Profunctor Page terminal inspection** — `lowerProfunctorPageArtifacts()`
+  validates the canonical `profunctor-page/0` family and emits deterministic
+  scene IR, surfaces, target maps, receipts, cell source maps, and text evidence
+  across six inspection modes, with unsupported browser semantics kept as
+  explicit capability residuals.
+- **VISOR artifact bundle proof** — `createVisorArtifactBundleFromGraphql()`,
+  `createVisorArtifactBundle()`, and the `visor-artifact-bundle/1` types.
+- **RE-036 packed-cell receipts** — `adaptPackedBijouCellsToSurface()` copies
+  validated bytes and side-table entries without re-encoding cells.
+- **Dependency-security closeout** — patched floors across the resolved graph,
+  with a regression binding them and a clean `npm ci` reproducing a
+  zero-vulnerability audit.
+- **Code Dojo ratchet progress** — tranches A through E, plus the DX-050
+  prerequisites, DOGFOOD localization debt, and documentation-contract work.
+
+## What this candidate is for
+
+Two behaviour changes that are correct in principle and unproven in the field.
+If `NO_COLOR` or a custom theme matters to your application, this is the version
+to try before `8.0.0` exists.
+
+Read the [migration guide](./migration-guide.md) for the specific things to check,
+and the [release evidence packet](./README.md) — which is explicit about which
+evidence was replayed for this candidate and which was inherited, because nine of
+eleven release-law review gates are still unreviewed. That is exactly why this is
+an rc and not a release.

--- a/docs/releases/8.0.0/whats-new.md
+++ b/docs/releases/8.0.0/whats-new.md
@@ -2,7 +2,7 @@
 
 A release candidate, published so the breaking changes below can be validated
 against real applications before `8.0.0` is cut. Pin the exact version; the
-dist-tag is `rc`, not `latest`.
+dist-tag is `next`, not `latest`.
 
 ## The headline is a deletion
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -25,6 +25,9 @@ docs/releases/next/
 
 ## Current Shaped Release Docs
 
+- [What's New (v8.0.0)](./8.0.0/whats-new.md) — line open, first tag `v8.0.0-rc.1`
+- [Migration Guide (v8.0.0)](./8.0.0/migration-guide.md)
+- [Release Evidence (v8.0.0)](./8.0.0/README.md)
 - [What's New (v7.2.0)](./7.2.0/whats-new.md)
 - [Migration Guide (v7.2.0)](./7.2.0/migration-guide.md)
 - [Release Evidence (v7.2.0)](./7.2.0/README.md)

--- a/examples/docs/app-content.ts
+++ b/examples/docs/app-content.ts
@@ -5,7 +5,7 @@ import {
   standardBlockPreviewMarkdown,
 } from './app-standard-block-docs.js';
 import type { ReleaseStoryMarkdownPaths } from './app-release-story.js';
-import { BIJOU_VERSION } from './app-ids.js';
+import { BIJOU_RELEASE_LINE } from './app-release-line.js';
 
 export const GUIDES_START_HERE_TEXT = readMarkdownDoc(
   './content/guides-start-here.md',
@@ -79,8 +79,8 @@ export const RELEASE_OVERVIEW_MARKDOWN_PATHS: ReleaseStoryMarkdownPaths =
     fr: './content/release-overview.fr.md',
   });
 export const RELEASE_WHATS_NEW_TEXT = readMarkdownDoc(
-  `../../docs/releases/${BIJOU_VERSION}/whats-new.md`,
+  `../../docs/releases/${BIJOU_RELEASE_LINE}/whats-new.md`,
 );
 export const RELEASE_MIGRATION_GUIDE_TEXT = readMarkdownDoc(
-  `../../docs/releases/${BIJOU_VERSION}/migration-guide.md`,
+  `../../docs/releases/${BIJOU_RELEASE_LINE}/migration-guide.md`,
 );

--- a/examples/docs/app-guides-release.ts
+++ b/examples/docs/app-guides-release.ts
@@ -113,10 +113,6 @@ export const RELEASE_AND_THEME_GUIDES: readonly GuideDoc[] = [
     title: releaseWhatsNewTitle(),
     summary: releaseWhatsNewSummary(),
     body: RELEASE_WHATS_NEW_TEXT,
-    localizedTitle: (localization) =>
-      dogfoodText(localization, 'release.whatsNew.title', releaseWhatsNewTitle()),
-    localizedSummary: (localization) =>
-      dogfoodText(localization, 'release.whatsNew.summary', releaseWhatsNewSummary()),
   },
   ...RELEASE_STORY_GUIDES,
   {
@@ -125,9 +121,5 @@ export const RELEASE_AND_THEME_GUIDES: readonly GuideDoc[] = [
     title: releaseMigrationTitle(),
     summary: releaseMigrationSummary(),
     body: RELEASE_MIGRATION_GUIDE_TEXT,
-    localizedTitle: (localization) =>
-      dogfoodText(localization, 'release.migration.title', releaseMigrationTitle()),
-    localizedSummary: (localization) =>
-      dogfoodText(localization, 'release.migration.summary', releaseMigrationSummary()),
   },
 ];

--- a/examples/docs/app-guides-release.ts
+++ b/examples/docs/app-guides-release.ts
@@ -21,6 +21,23 @@ import {
   RELEASE_STORY_GUIDES,
 } from './app-release-story.js';
 import { dogfoodText } from './app-localization.js';
+import { BIJOU_RELEASE_LINE } from './app-release-line.js';
+
+function releaseWhatsNewTitle(): string {
+  return `What's New in v${BIJOU_RELEASE_LINE}`;
+}
+
+function releaseWhatsNewSummary(): string {
+  return `The long-form release story for the ${BIJOU_VERSION} line.`;
+}
+
+function releaseMigrationTitle(): string {
+  return `Migration Guide v${BIJOU_RELEASE_LINE}`;
+}
+
+function releaseMigrationSummary(): string {
+  return `Migration guidance for the ${BIJOU_VERSION} upgrade.`;
+}
 
 const releaseTitleGuide = (release: DogfoodReleaseTitle): GuideDoc => ({
   id: `release-title-${release.id}`,
@@ -75,26 +92,42 @@ export const RELEASE_AND_THEME_GUIDES: readonly GuideDoc[] = [
     id: 'release-overview',
     pageId: RELEASE_PAGE_ID,
     title: 'Release Overview',
+    // One translatable unit, not two. Interpolating mid-sentence split this into
+    // `...the detailed ` + `` + ` release docs.`, which the debt scanner counts
+    // twice and a translator cannot reorder — word order around an inserted
+    // value differs by language. Moving the value to the end fixes both.
     summary:
-      `How the current release line is shaped and where to read the detailed ${BIJOU_VERSION} release docs.`,
+      `How the current release line is shaped and where to read the detailed release docs for ${BIJOU_VERSION}.`,
     body: RELEASE_OVERVIEW_TEXT,
     localizedBody: localizedReleaseStoryMarkdownBody(
       RELEASE_OVERVIEW_MARKDOWN_PATHS,
     ),
   },
   {
-    id: `release-whats-new-${BIJOU_VERSION.replaceAll('.', '-')}`,
+    // Line, not exact version. These guides open `docs/releases/<line>/`, so the
+    // line is what they describe — and a prerelease string overflows the nav
+    // column: `What's New in v8.0.0-rc.1` rendered as `What's New in v8.0.0-rc.`
+    // at 120x40. See #523.
+    id: `release-whats-new-${BIJOU_RELEASE_LINE.replaceAll('.', '-')}`,
     pageId: RELEASE_PAGE_ID,
-    title: `What's New in v${BIJOU_VERSION}`,
-    summary: `The long-form release story for the ${BIJOU_VERSION} line.`,
+    title: releaseWhatsNewTitle(),
+    summary: releaseWhatsNewSummary(),
     body: RELEASE_WHATS_NEW_TEXT,
+    localizedTitle: (localization) =>
+      dogfoodText(localization, 'release.whatsNew.title', releaseWhatsNewTitle()),
+    localizedSummary: (localization) =>
+      dogfoodText(localization, 'release.whatsNew.summary', releaseWhatsNewSummary()),
   },
   ...RELEASE_STORY_GUIDES,
   {
-    id: `release-migration-${BIJOU_VERSION.replaceAll('.', '-')}`,
+    id: `release-migration-${BIJOU_RELEASE_LINE.replaceAll('.', '-')}`,
     pageId: RELEASE_PAGE_ID,
-    title: `Migration Guide v${BIJOU_VERSION}`,
-    summary: `Migration guidance for the ${BIJOU_VERSION} upgrade.`,
+    title: releaseMigrationTitle(),
+    summary: releaseMigrationSummary(),
     body: RELEASE_MIGRATION_GUIDE_TEXT,
+    localizedTitle: (localization) =>
+      dogfoodText(localization, 'release.migration.title', releaseMigrationTitle()),
+    localizedSummary: (localization) =>
+      dogfoodText(localization, 'release.migration.summary', releaseMigrationSummary()),
   },
 ];

--- a/examples/docs/app-release-line.ts
+++ b/examples/docs/app-release-line.ts
@@ -1,0 +1,22 @@
+import { BIJOU_VERSION } from './app-ids.js';
+
+const PRERELEASE_SUFFIX = /-(?:alpha|beta|rc)\.\d+$/u;
+
+/**
+ * The release *line* a version belongs to: `8.0.0-rc.1` resolves to `8.0.0`.
+ *
+ * Release docs live under `docs/releases/<line>/`, never
+ * `docs/releases/<exact-version>/`. A prerelease is a candidate *for* a line and
+ * shares its What's New and migration guide, and `release:readiness` keys the
+ * evidence-packet path off the target milestone, which is the line too.
+ *
+ * Reading the raw version instead meant the docs app threw an unhandled ENOENT
+ * at module load for any prerelease — before the first frame — because no
+ * `docs/releases/8.0.0-rc.1/` directory exists or should. See #523.
+ */
+export function releaseLineOf(version: string): string {
+  return version.replace(PRERELEASE_SUFFIX, '');
+}
+
+/** The release line of the version this build reports. */
+export const BIJOU_RELEASE_LINE = releaseLineOf(BIJOU_VERSION);

--- a/examples/docs/i18n-debt-baseline.ts
+++ b/examples/docs/i18n-debt-baseline.ts
@@ -2,7 +2,7 @@ import type { DogfoodI18nDebtBaseline } from './i18n-debt.js';
 import { DOGFOOD_STORY_I18N_DEBT_BASELINE } from './i18n-debt-baseline-stories.js';
 
 export const DOGFOOD_I18N_DEBT_BASELINE: DogfoodI18nDebtBaseline = Object.freeze({
-  total: 2317,
+  total: 2316,
   bySurface: Object.freeze({
     'app-components-layout': 4,
     'app-components-page': 1,

--- a/examples/docs/i18n-debt-baseline.ts
+++ b/examples/docs/i18n-debt-baseline.ts
@@ -17,7 +17,7 @@ export const DOGFOOD_I18N_DEBT_BASELINE: DogfoodI18nDebtBaseline = Object.freeze
     'app-guides-packages': 11,
     'app-guides-philosophy': 12,
     'app-guides-primary': 2,
-    'app-guides-release': 7,
+    'app-guides-release': 6,
     'app-ids': 14,
     'app-input-maps': 36,
     'app-landing-key-policy': 1,

--- a/examples/docs/i18n-debt-io.ts
+++ b/examples/docs/i18n-debt-io.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { releaseLineOf } from './app-release-line.js';
 import type {
   DogfoodI18nDebtInventory,
   DogfoodMarkdownLocalizationInventory,
@@ -30,7 +31,20 @@ export function defaultMarkdownTemplateValues(): Readonly<
     typeof parsed.version === 'string'
       ? parsed.version.trim()
       : '';
-  return Object.freeze({ BIJOU_VERSION: version });
+  // `BIJOU_RELEASE_LINE` must be resolvable here too, or the scanner silently
+  // stops counting the release docs.
+  //
+  // This table is how the static scanner turns a templated path literal into a
+  // real file to check. When `app-content.ts` moved from `${BIJOU_VERSION}` to
+  // `${BIJOU_RELEASE_LINE}` (see #523), the release What's New and migration
+  // guide became unresolvable, dropped out of the inventory, and the measured
+  // Markdown debt fell from 78 to 72 — a six-point "improvement" that was really
+  // two documents going unwatched. An unresolvable token reads exactly like
+  // progress, which is the dangerous part.
+  return Object.freeze({
+    BIJOU_VERSION: version,
+    BIJOU_RELEASE_LINE: releaseLineOf(version),
+  });
 }
 
 export function uniqueStringList(

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,12 @@
     },
     "bench": {
       "name": "@flyingrobots/bijou-bench",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "7.2.0",
-        "@flyingrobots/bijou-node": "7.2.0",
-        "@flyingrobots/bijou-tui": "7.2.0"
+        "@flyingrobots/bijou": "8.0.0-rc.1",
+        "@flyingrobots/bijou-node": "8.0.0-rc.1",
+        "@flyingrobots/bijou-tui": "8.0.0-rc.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -4172,7 +4172,7 @@
     },
     "packages/bijou": {
       "name": "@flyingrobots/bijou",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -4186,7 +4186,7 @@
     },
     "packages/bijou-i18n": {
       "name": "@flyingrobots/bijou-i18n",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -4199,10 +4199,10 @@
     },
     "packages/bijou-i18n-tools": {
       "name": "@flyingrobots/bijou-i18n-tools",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "7.2.0"
+        "@flyingrobots/bijou-i18n": "8.0.0-rc.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -4215,11 +4215,11 @@
     },
     "packages/bijou-i18n-tools-node": {
       "name": "@flyingrobots/bijou-i18n-tools-node",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "7.2.0",
-        "@flyingrobots/bijou-i18n-tools": "7.2.0"
+        "@flyingrobots/bijou-i18n": "8.0.0-rc.1",
+        "@flyingrobots/bijou-i18n-tools": "8.0.0-rc.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -4232,10 +4232,10 @@
     },
     "packages/bijou-i18n-tools-xlsx": {
       "name": "@flyingrobots/bijou-i18n-tools-xlsx",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n-tools": "7.2.0",
+        "@flyingrobots/bijou-i18n-tools": "8.0.0-rc.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
@@ -4249,7 +4249,7 @@
     },
     "packages/bijou-mcp": {
       "name": "@flyingrobots/bijou-mcp",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -4266,15 +4266,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "7.2.0"
+        "@flyingrobots/bijou": "8.0.0-rc.1"
       }
     },
     "packages/bijou-node": {
       "name": "@flyingrobots/bijou-node",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-tui": "7.2.0",
+        "@flyingrobots/bijou-tui": "8.0.0-rc.1",
         "chalk": "^5.6.2",
         "gifenc": "^1.0.3",
         "oled-font-5x7": "^1.0.3"
@@ -4287,15 +4287,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "7.2.0"
+        "@flyingrobots/bijou": "8.0.0-rc.1"
       }
     },
     "packages/bijou-tui": {
       "name": "@flyingrobots/bijou-tui",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "7.2.0"
+        "@flyingrobots/bijou-i18n": "8.0.0-rc.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -4306,16 +4306,16 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "7.2.0"
+        "@flyingrobots/bijou": "8.0.0-rc.1"
       }
     },
     "packages/bijou-tui-app": {
       "name": "@flyingrobots/bijou-tui-app",
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "7.2.0",
-        "@flyingrobots/bijou-tui": "7.2.0"
+        "@flyingrobots/bijou": "8.0.0-rc.1",
+        "@flyingrobots/bijou-tui": "8.0.0-rc.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -4327,7 +4327,7 @@
       }
     },
     "packages/create-bijou-tui-app": {
-      "version": "7.2.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "bin": {
         "create-bijou-tui-app": "dist/cli.js"

--- a/packages/bijou-i18n-tools-node/package.json
+++ b/packages/bijou-i18n-tools-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools-node",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "Node filesystem helpers for Bijou localization exchange workflows.",
   "type": "module",
   "sideEffects": false,
@@ -24,8 +24,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "7.2.0",
-    "@flyingrobots/bijou-i18n-tools": "7.2.0"
+    "@flyingrobots/bijou-i18n": "8.0.0-rc.1",
+    "@flyingrobots/bijou-i18n-tools": "8.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-i18n-tools-xlsx/package.json
+++ b/packages/bijou-i18n-tools-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools-xlsx",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "XLSX workbook adapters for Bijou localization exchange workflows.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n-tools": "7.2.0",
+    "@flyingrobots/bijou-i18n-tools": "8.0.0-rc.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {

--- a/packages/bijou-i18n-tools/package.json
+++ b/packages/bijou-i18n-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n-tools",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "Localization workflow tooling for Bijou — authoring catalogs, stale detection, tabular export/import, and runtime compilation.",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "7.2.0"
+    "@flyingrobots/bijou-i18n": "8.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-i18n/package.json
+++ b/packages/bijou-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-i18n",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "In-memory localization runtime for Bijou — catalogs, locale direction, and runtime-safe lookups.",
   "type": "module",
   "sideEffects": false,

--- a/packages/bijou-mcp/package.json
+++ b/packages/bijou-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-mcp",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "MCP server exposing Bijou terminal components as rendering tools.",
   "type": "module",
   "sideEffects": false,
@@ -32,7 +32,7 @@
     "zod": "^3.24.0"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "7.2.0"
+    "@flyingrobots/bijou": "8.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-node/package.json
+++ b/packages/bijou-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-node",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "Node.js adapter for bijou — chalk styling, readline I/O, process runtime.",
   "type": "module",
   "sideEffects": false,
@@ -24,13 +24,13 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-tui": "7.2.0",
+    "@flyingrobots/bijou-tui": "8.0.0-rc.1",
     "chalk": "^5.6.2",
     "gifenc": "^1.0.3",
     "oled-font-5x7": "^1.0.3"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "7.2.0"
+    "@flyingrobots/bijou": "8.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui-app/package.json
+++ b/packages/bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui-app",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "Batteries-included TUI app skeleton built on bijou-tui createFramedApp().",
   "type": "module",
   "sideEffects": false,
@@ -24,8 +24,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou": "7.2.0",
-    "@flyingrobots/bijou-tui": "7.2.0"
+    "@flyingrobots/bijou": "8.0.0-rc.1",
+    "@flyingrobots/bijou-tui": "8.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou-tui/package.json
+++ b/packages/bijou-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou-tui",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "TEA runtime for terminal UIs — model/update/view with keyboard input, alt screen, and layout helpers.",
   "type": "module",
   "sideEffects": false,
@@ -24,10 +24,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@flyingrobots/bijou-i18n": "7.2.0"
+    "@flyingrobots/bijou-i18n": "8.0.0-rc.1"
   },
   "peerDependencies": {
-    "@flyingrobots/bijou": "7.2.0"
+    "@flyingrobots/bijou": "8.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/bijou/package.json
+++ b/packages/bijou/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyingrobots/bijou",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "Themed terminal components for CLIs, loggers, and scripts — graceful degradation included.",
   "type": "module",
   "sideEffects": false,

--- a/packages/create-bijou-tui-app/package.json
+++ b/packages/create-bijou-tui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bijou-tui-app",
-  "version": "7.2.0",
+  "version": "8.0.0-rc.1",
   "description": "Scaffold a new Bijou TUI app with batteries-included defaults.",
   "type": "module",
   "bin": {

--- a/scripts/dogfood-i18n-debt.part02.test.ts
+++ b/scripts/dogfood-i18n-debt.part02.test.ts
@@ -80,7 +80,12 @@ describe('DOGFOOD i18n debt inventory', () => {
       const result = evaluateDogfoodI18nDebtRatchet(inventory);
       const surfaces = inventory.bySurface.map((surface) => surface.surface);
 
-      expect(inventory.total).toBe(2317);
+      // Ratchet tightened 2317 -> 2316 by DX-052: `app-guides-release`'s release
+      // overview summary interpolated the version mid-sentence, so it counted as
+      // two translatable literals split around an inserted value — an order a
+      // translator cannot rearrange. Moving the value to the end makes it one.
+      // A real reduction, so the baseline shrinks with it.
+      expect(inventory.total).toBe(2316);
       expect(surfaces).toContain('app-root-view');
       expect(surfaces).toContain('stories-story-guided-flow');
       expect(surfaces).not.toContain('docs-app');

--- a/scripts/release-metadata.part04.ts
+++ b/scripts/release-metadata.part04.ts
@@ -77,6 +77,9 @@ export function runReleaseMetadata(argv: readonly string[], io: ReleaseCommandIO
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+// Kept so this module stays directly runnable. `resolve()` matters: without it a
+// relative invocation such as `tsx ./scripts/release-metadata.part04.ts` compares
+// an absolute path against a relative one and silently does nothing.
+if (process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   process.exitCode = runReleaseMetadata(process.argv.slice(2));
 }

--- a/scripts/release-metadata.ts
+++ b/scripts/release-metadata.ts
@@ -1,5 +1,30 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 export type { PackageManifest, PrereleaseMetadata, ReleaseCommandIO, ReleaseCommandOutputs, ReleaseMetadata, StableReleaseMetadata, WorkspacePackage } from './release-metadata.part01.js';
 export { parseReleaseTag, readCurrentWorkspaceVersion, readWorkspacePackages, validateReleaseVersion } from './release-metadata.part02.js';
 export { formatReleaseOutputs, validateWorkspaceVersion, writeGithubOutput } from './release-metadata.part03.js';
 export { runReleaseMetadata } from './release-metadata.part04.js';
-import './release-metadata.part04.js';
+import { runReleaseMetadata } from './release-metadata.part04.js';
+
+/**
+ * This file is the CLI entry point, so the dispatch belongs here.
+ *
+ * It used to `import './release-metadata.part04.js'` purely for the side effect
+ * of that module's own main guard. That guard compares `import.meta.url` against
+ * `process.argv[1]`, which can never match when the process was started on
+ * *this* file — so `npm run release:preflight` exited 0 having done nothing at
+ * all: no lock-step check, no stdout, and no `GITHUB_OUTPUT`.
+ *
+ * The consequences were not cosmetic. `REL-META-VERSION-LOCKSTEP` is the gate
+ * the release process assigns to `release:preflight`, so version-mismatch
+ * detection was unenforced — `--version 9.9.9` against an `8.0.0-rc.1`
+ * workspace exited 0. And because no output was written, the Release Dry Run's
+ * notes job received an empty tag and failed with
+ * `gh: Missing tag_name parameter (HTTP 400)`, which is how this was found.
+ *
+ * A no-op gate is worse than a missing one: it reports success.
+ */
+if (process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  process.exitCode = runReleaseMetadata(process.argv.slice(2));
+}

--- a/tests/cycles/DF-023/publish-repo-package-and-release-guides-in-dogfood.test.ts
+++ b/tests/cycles/DF-023/publish-repo-package-and-release-guides-in-dogfood.test.ts
@@ -6,6 +6,7 @@ import { runScript } from '../../../packages/bijou-tui/src/driver.js';
 import { createDocsApp } from '../../../examples/docs/app.js';
 import { existsRepoPath, readRepoFile } from '../repo.js';
 import { must } from '@flyingrobots/bijou/adapters/test';
+import { BIJOU_RELEASE_LINE } from '../../../examples/docs/app-release-line.js';
 
 const PACKAGE_JSON = readFileSync(resolve(import.meta.dirname, '..', '..', '..', 'packages', 'bijou', 'package.json'), 'utf8');
 const BIJOU_VERSION = must(/"version":\s*"([^"]+)"/u.exec(PACKAGE_JSON)?.[1], 'bijou package version');
@@ -72,16 +73,21 @@ describe('DF-023 publish repo, package, and release guides in DOGFOOD', () => {
     expect(packageText).toContain('Surface primitives without abandoning');
   });
 
+  // Nav titles and guide ids key off the release LINE; document bodies keep the
+  // exact version. Two reasons, both surfaced by cutting the first prerelease
+  // (#523): these guides open `docs/releases/<line>/`, so the line is what they
+  // name; and `What's New in v8.0.0-rc.1` overflowed the nav column at 120x40,
+  // rendering as `What's New in v8.0.0-rc.` and failing this assertion.
   it('publishes the current release story and migration guide in Release', async () => {
-    const versionSlug = BIJOU_VERSION.replaceAll('.', '-');
+    const versionSlug = BIJOU_RELEASE_LINE.replaceAll('.', '-');
     const ctx = createTestContext({ mode: 'interactive', runtime: { columns: 120, rows: 40 } });
     const app = createDocsApp(ctx, { initialRoute: 'docs', initialPageId: 'release' });
     const opened = await runScript(app, [], { ctx });
     const releaseText = frameText(must(opened.frames.at(-1)));
 
     expect(opened.model.docsModel.activePageId).toBe('release');
-    expect(releaseText).toContain(`What's New in v${BIJOU_VERSION}`);
-    expect(releaseText).toContain(`Migration Guide v${BIJOU_VERSION}`);
+    expect(releaseText).toContain(`What's New in v${BIJOU_RELEASE_LINE}`);
+    expect(releaseText).toContain(`Migration Guide v${BIJOU_RELEASE_LINE}`);
 
     const whatsNew = await runScript(app, [
       { msg: { type: 'docs', msg: { type: 'select-guide', guideId: `release-whats-new-${versionSlug}` } } },

--- a/tests/cycles/DX-052/dogfood-release-line-docs.test.ts
+++ b/tests/cycles/DX-052/dogfood-release-line-docs.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { BIJOU_VERSION } from '../../../examples/docs/app-ids.js';
+import { BIJOU_RELEASE_LINE, releaseLineOf } from '../../../examples/docs/app-release-line.js';
+import { defaultMarkdownTemplateValues } from '../../../examples/docs/i18n-debt-io.js';
+import { collectDogfoodMarkdownLocalizationDebt } from '../../../examples/docs/i18n-debt-markdown-ratchet.js';
+
+/**
+ * Release docs live under `docs/releases/<line>/`, never
+ * `docs/releases/<exact-version>/`.
+ *
+ * Cutting `8.0.0-rc.1` was the first prerelease this code had seen, and the
+ * DOGFOOD docs app crashed on startup: it read the raw version, so it looked for
+ * a `docs/releases/8.0.0-rc.1/` directory that does not and should not exist. A
+ * prerelease is a candidate *for* a line and shares its What's New and migration
+ * guide, and `release:readiness` keys the evidence-packet path off the target
+ * milestone, which is the line too.
+ *
+ * The failure mode is worth naming: it was not a bad render, it was an
+ * unhandled ENOENT before the first frame, surfaced only by `smoke:dogfood`
+ * exiting 1 with no message about why.
+ */
+describe('DX-052 DOGFOOD resolves release docs by release line', () => {
+  it('strips a prerelease suffix from the release line', () => {
+    const strip = releaseLineOf;
+    expect(strip('8.0.0-rc.1')).toBe('8.0.0');
+    expect(strip('8.0.0-beta.12')).toBe('8.0.0');
+    expect(strip('8.0.0-alpha.1')).toBe('8.0.0');
+    expect(strip('8.0.0')).toBe('8.0.0');
+  });
+
+  it('leaves a stable version untouched', () => {
+    if (!BIJOU_VERSION.includes('-')) {
+      expect(BIJOU_RELEASE_LINE).toBe(BIJOU_VERSION);
+    } else {
+      expect(BIJOU_RELEASE_LINE).not.toBe(BIJOU_VERSION);
+      expect(BIJOU_VERSION.startsWith(`${BIJOU_RELEASE_LINE}-`)).toBe(true);
+    }
+  });
+
+  it('resolves to release docs that actually exist', () => {
+    // The assertion that would have caught the crash: the derived path must be
+    // on disk, checked without booting the app.
+    const root = resolve(import.meta.dirname, '../../..');
+    for (const name of ['whats-new.md', 'migration-guide.md', 'README.md']) {
+      const path = resolve(root, 'docs/releases', BIJOU_RELEASE_LINE, name);
+      expect(existsSync(path), `${path} is missing`).toBe(true);
+    }
+  });
+
+  it('the i18n scanner can resolve every token the docs app templates with', () => {
+    // Not a style point. The scanner turns templated path literals into real
+    // files to check, and an unresolvable token makes documents vanish from the
+    // inventory rather than fail loudly. Moving `app-content.ts` from
+    // `${BIJOU_VERSION}` to `${BIJOU_RELEASE_LINE}` dropped the release What's
+    // New and migration guide and took measured Markdown debt from 78 to 72 —
+    // reading as a six-point improvement while two documents went unwatched.
+    const values = defaultMarkdownTemplateValues();
+    expect(Object.keys(values)).toContain('BIJOU_VERSION');
+    expect(Object.keys(values)).toContain('BIJOU_RELEASE_LINE');
+    expect(values['BIJOU_RELEASE_LINE']).toBe(releaseLineOf(BIJOU_VERSION));
+  });
+
+  it('keeps the release docs inside the localization inventory', () => {
+    const inventory = collectDogfoodMarkdownLocalizationDebt();
+    const paths = inventory.documents.map((d) => (d as { path: string }).path);
+    expect(paths).toContain(`docs/releases/${BIJOU_RELEASE_LINE}/whats-new.md`);
+    expect(paths).toContain(`docs/releases/${BIJOU_RELEASE_LINE}/migration-guide.md`);
+  });
+});

--- a/tests/cycles/DX-052/release-metadata-entrypoint.test.ts
+++ b/tests/cycles/DX-052/release-metadata-entrypoint.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+/**
+ * `npm run release:preflight` must actually run.
+ *
+ * It did not. `scripts/release-metadata.ts` is the CLI entry point but was a
+ * pure re-export shim that imported `release-metadata.part04.js` for the side
+ * effect of *that* module's main guard — and the guard compares
+ * `import.meta.url` against `process.argv[1]`, which cannot match when the
+ * process was started on the shim. So the command exited 0 having done nothing:
+ * no lock-step validation, no stdout, no `GITHUB_OUTPUT`.
+ *
+ * Two things fell out of that. `REL-META-VERSION-LOCKSTEP` is the release gate
+ * assigned to `release:preflight`, so version-mismatch detection was unenforced.
+ * And the Release Dry Run's notes job read an empty tag from the missing output
+ * and failed with `gh: Missing tag_name parameter (HTTP 400)` — which is the only
+ * reason anyone looked.
+ *
+ * These tests invoke the real entry point as a child process, because that is
+ * the only way to observe the defect: every unit test of `runReleaseMetadata()`
+ * passed throughout, since the function was always correct. Nothing called it.
+ */
+describe('DX-052 release-metadata entry point dispatches', () => {
+  const root = resolve(import.meta.dirname, '../../..');
+  const entry = 'scripts/release-metadata.ts';
+
+  const run = (args: readonly string[]): { status: number; stdout: string } => {
+    try {
+      const stdout = execFileSync('npx', ['tsx', entry, ...args], {
+        cwd: root,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return { status: 0, stdout };
+    } catch (error) {
+      // execFileSync throws an Error carrying `status` and `stdout`; narrow
+      // rather than assert, so a different throw shape cannot be misread as a
+      // clean exit.
+      const status =
+        typeof error === 'object' && error !== null && 'status' in error && typeof error.status === 'number'
+          ? error.status
+          : 1;
+      const stdout =
+        typeof error === 'object' && error !== null && 'stdout' in error && typeof error.stdout === 'string'
+          ? error.stdout
+          : '';
+      return { status, stdout };
+    }
+  };
+
+  it('prints the lock-step package summary rather than exiting silently', () => {
+    const result = run(['--current-version']);
+    expect(result.status).toBe(0);
+    // The exact symptom: a no-op gate produced no output at all.
+    expect(result.stdout.trim()).not.toBe('');
+    expect(result.stdout).toContain('@flyingrobots/bijou');
+  }, 120_000);
+
+  it('writes the requested GitHub output file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bijou-release-meta-'));
+    const out = join(dir, 'github-output.txt');
+    const result = run(['--current-version', '--notes-tag-run-id', 'test', '--github-output', out]);
+
+    expect(result.status).toBe(0);
+    expect(existsSync(out), 'no GITHUB_OUTPUT was written').toBe(true);
+    const written = readFileSync(out, 'utf8');
+    // The dry-run notes job reads both of these; empty values made it send
+    // tag_name="" and fail with HTTP 400.
+    expect(written).toMatch(/^version=.+$/mu);
+    expect(written).toMatch(/^notes_tag=dry-run-v.+-test$/mu);
+  }, 120_000);
+
+  it('fails on a version the workspace does not match', () => {
+    // REL-META-VERSION-LOCKSTEP. This exited 0 while the gate was a no-op, which
+    // is the whole reason a no-op gate is worse than a missing one.
+    const result = run(['--version', '9.9.9']);
+    expect(result.status).not.toBe(0);
+  }, 120_000);
+
+  it('rejects an invalid release version', () => {
+    const result = run(['--version', 'not-a-version']);
+    expect(result.status).not.toBe(0);
+  }, 120_000);
+});


### PR DESCRIPTION
Release prep for **`v8.0.0-rc.1`** — a release candidate, not a stable release.

Follows [`docs/release.md`](docs/release.md) Phase 2. Refs #518, #523.

## What this contains

- Lock-step bump of all ten workspace packages and internal dependency pins to
  `8.0.0-rc.1`.
- Dated `[8.0.0-rc.1] - 2026-08-21` changelog boundary. `[Unreleased]` is left in
  place and empty for post-rc work; the stable `8.0.0` header will consolidate
  these twenty entries.
- README What's New leading with the two breaking changes and marking the line as
  a preview rather than supported.
- `docs/releases/8.0.0/` — evidence packet, What's New, migration guide.

## Why an rc rather than `8.0.0`

Two breaking changes from #518 are correct in principle and unproven against real
consumers. Publishing a candidate lets `muniment` (the first consumer) and
`git-cas` validate them before the stable tag exists.

The packet is explicit about what it can attest. Every goalpost is labelled
**Verified here** or **Inherited**, and the human review matrix records **three
reviewed surfaces out of nine**. DX-050, DX-049 and RE-036 are inherited: they
landed through their own reviewed PRs and CI, but their witnesses were not
replayed from this commit, which is what the Release Law requires. Those rows are
named as gaps that must close before GA rather than presented as closure.

## Prerelease gaps found and fixed here

This is the first prerelease this tooling has seen, and it broke four things.
All fixed on this branch, all recorded on #523.

1. **DOGFOOD crashed on startup.** It resolved release docs as
   `docs/releases/${BIJOU_VERSION}/`, so `8.0.0-rc.1` produced an unhandled
   `ENOENT` at module load, before the first frame. `smoke:dogfood` reported only
   `exited with code 1` — no path, no stack — so reproducing it meant running the
   capture entrypoint by hand with the scenario env reconstructed from the smoke
   library. `releaseLineOf()` now strips the prerelease suffix.
2. **Two release gates disagreed** about where release docs live: `release:readiness`
   keys the packet path off the milestone, DOGFOOD keyed it off the exact version.
   Both cannot be satisfied. Resolved in favour of the release *line*, so the
   packet is at `docs/releases/8.0.0/` and the stable tag completes that directory
   instead of starting a new one.
3. **The i18n scanner silently stopped counting two documents.** Once the release
   doc paths templated with a token its static resolver did not know, the What's
   New and migration guide became unresolvable and *left the inventory* rather
   than failing — measured Markdown localization debt fell 78 → 72.

   That is the shape worth calling out: an unresolvable template token reads
   exactly like a six-point improvement. `scripts/dogfood-i18n-debt.part02.test.ts`
   asserts the total is 78, so the quick fix was to lower it to 72 and record
   progress that had not happened while two documents went unwatched. Fixed by
   teaching the resolver the token instead — **no baseline lowered, no test
   edited** — and `tests/cycles/DX-052/dogfood-release-line-docs.test.ts` now
   asserts both that every token the docs app templates with is resolvable and
   that the release docs stay in the inventory.
4. **A prerelease version string overflows the DOGFOOD release nav.** At 120x40,
   `What's New in v8.0.0-rc.1` rendered as `What's New in v8.0.0-rc.` and failed
   `tests/cycles/DF-023/...`. Release guide titles and ids now key off the line —
   which is also what they describe, since they open `docs/releases/<line>/` —
   while document bodies keep the exact version. The nav has no ellipsis-aware
   assertion, so any clipped title fails as a missing string; noted on #523.

## One ratchet tightened, deliberately

The DOGFOOD touched-file rule blocked on `app-guides-release.ts`. Localizing
could not help: `dogfoodText` requires an inline fallback, so it adds literals
rather than removing them. But one entry was a summary interpolating the version
*mid-sentence*, counted as two translatable literals split around an inserted
value — word order a translator cannot rearrange. Moving the value to the end
makes it one string.

Raw-string debt 2317 → 2316, `app-guides-release` 7 → 6, both baselines shrunk to
match. Tightening is the allowed direction and the reduction is real, which is
precisely why it was right here and wrong for the 78 → 72 case above.

Separately: the first attempt put the new constant in `app-ids.ts`, whose 14 debt
entries are all machine identifiers (page ids, `'1fr'`). Cleaning those would mean
localizing identifiers, so the derivation moved to its own `app-release-line.ts`.

## Validation

| Gate | Result |
| :--- | :--- |
| `npm run version 8.0.0-rc.1` | All ten packages and internal pins at `8.0.0-rc.1`. |
| `npm run release:preflight` | exit 0 |
| `npm run docs:inventory` | exit 0 |
| `npm audit --omit=dev --audit-level=high` | `found 0 vulnerabilities` |
| `npm run lint` | clean across all workspace packages |
| `npm run release:readiness -- --milestone v8.0.0` | `release-readiness: ok` — all six milestone gates PASS, all fourteen gauntlet gates pass |

Required before tagging: the **Release Dry Run** workflow against this branch.

Required after tagging: confirm the npm dist-tag is **`rc`, not `latest`**. The
publish workflow derives `npm_dist_tag` from `is_prerelease` and passes it to
`npm publish --tag`, so this should hold — but a prerelease landing on `latest`
would silently become the default install for a bare `npm install`, so it gets
verified rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Bijou 8.0.0 release-candidate documentation, migration guidance, and release evidence.
  - Added release-line navigation for prerelease documentation.
  - Expanded theme customization with `border` and `semantic` groups.

- **Breaking Changes**
  - `NO_COLOR` no longer forces pipe mode.
  - Unknown status keys now use muted semantic styling without strikethrough.

- **Bug Fixes**
  - Corrected release metadata execution, documentation paths, localization resolution, and prerelease navigation.

- **Documentation**
  - Updated changelog, roadmap, security notes, and validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->